### PR TITLE
Include <cstddef> to use std::byte on Ubuntu.

### DIFF
--- a/src/include/common/common_defs.h
+++ b/src/include/common/common_defs.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 #include <iosfwd>


### PR DESCRIPTION
I think it worked on Mac because we had an explicit stdlib=libc++.
This allows cmake to build on Ubuntu with gcc/g++ 7.