### PR TITLE
Replace unsafe call to strcpy in StringUtil

### DIFF
--- a/src/util/string_util.cpp
+++ b/src/util/string_util.cpp
@@ -156,7 +156,7 @@ std::string StringUtil::Format(const std::string fmt_str, ...) {
   while (true) {
     // Wrap the plain char array into the unique_ptr
     formatted = std::make_unique<char[]>(static_cast<size_t>(n));
-    strcpy(&formatted[0], fmt_str.c_str());
+    strncpy(&formatted[0], fmt_str.c_str(), fmt_str.length());
     va_start(ap, fmt_str);
     final_n = vsnprintf(&formatted[0],
                         static_cast<size_t>(n), fmt_str.c_str(), ap);


### PR DESCRIPTION
Resolves an issue found by make check-clang-tidy.

../terrier/src/util/string_util.cpp:159:5: warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119 [clang-analyzer-security.insecureAPI.strcpy]
    strcpy(&formatted[0], fmt_str.c_str());
    ^