### PR TITLE
Added bitmap and bitmap_test

### DIFF
--- a/src/include/common/concurrent_bitmap.h
+++ b/src/include/common/concurrent_bitmap.h
@@ -1,33 +1,14 @@
 #pragma once
 #include <memory>
 #include "common/common_defs.h"
+#include "common/container/bitmap.h"
 
-#ifndef BYTE_SIZE
-#define BYTE_SIZE 8u
-#endif
-
-// Some platforms would have already defined the macro. But its presence is
-// not standard and thus not portable. Pretty sure this is always 8 bits.
-// If not, consider getting a new machine, and preferably not from another
-// dimension :)
-static_assert(BYTE_SIZE == 8u, "BYTE_SIZE should be set to 8!");
-
-// Our way for dealing with concurrency assumes that the underlying
-// implementation uses compare and swap hardware instructions and that
-// std::atomic for literal types have the same underlying representation
-// as the plain type.
-//
 // This code should not compile if these assumptions are not true.
 static_assert(sizeof(std::atomic<uint8_t>) == sizeof(uint8_t), "unexpected std::atomic size for 8-bit ints");
 static_assert(sizeof(std::atomic<uint64_t>) == sizeof(uint64_t), "unexpected std::atomic size for 64-bit ints");
 
-// n must be [0, 7], all 0 except for 1 on the nth bit
-#define ONE_HOT_MASK(n) (1u << (BYTE_SIZE - (n)-1u))
-// n must be [0, 7], all 1 except for 0 on the nth bit
-#define ONE_COLD_MASK(n) (0xFF - ONE_HOT_MASK(n))
-
 namespace terrier {
-constexpr uint32_t BitmapSize(uint32_t n) { return n % BYTE_SIZE == 0 ? n / BYTE_SIZE : n / BYTE_SIZE + 1; }
+namespace common {
 
 /**
  * A RawConcurrentBitmap is a bitmap that does not have the compile-time
@@ -118,4 +99,5 @@ class RawConcurrentBitmap {
 // exact layout. Changes include marking a function as virtual (or use the
 // FAKED_IN_TESTS macro), as that adds a Vtable to the class layout,
 static_assert(sizeof(RawConcurrentBitmap) == 0, "Unexpected RawConcurrentBitmap layout!");
+}  // namespace common
 }  // namespace terrier

--- a/src/include/common/concurrent_bitmap.h
+++ b/src/include/common/concurrent_bitmap.h
@@ -87,21 +87,6 @@ class RawConcurrentBitmap {
   bool operator[](uint32_t pos) const { return Test(pos); }
 
   /**
-   * Sets the bit value at position to be val. This is not safe to call
-   * concurrently.
-   * @param pos position to test
-   * @param val value to set to
-   * @return self-reference for chaining
-   */
-  RawConcurrentBitmap &UnsafeSet(uint32_t pos, bool val) {
-    if (val)
-      bits_[pos / BYTE_SIZE] |= ONE_HOT_MASK(pos);
-    else
-      bits_[pos / BYTE_SIZE] &= ONE_COLD_MASK(pos);
-    return *this;
-  }
-
-  /**
    * @brief Flip the bit only if current value is actually expected_val
    * The expected_val is needed to guard against the following situation:
    * Caller 1 flips from 0 to 1, Caller 2 flips from 0 to 1, without using

--- a/src/include/common/container/bitmap.h
+++ b/src/include/common/container/bitmap.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
 #include "common/common_defs.h"
+#include "common/concurrent_bitmap.h"
 
 #ifndef BYTE_SIZE
 #define BYTE_SIZE 8u
@@ -49,7 +50,8 @@ class RawBitmap {
    * @param size number of bits in the bitmap
    * @return ptr to new RawBitmap
    */
-  static RawBitmap *Allocate(uint32_t size) {
+  static RawBitmap *Allocate(uint32_t num_elements) {
+    auto size = BitmapSize(num_elements);
     auto *result = new uint8_t[size];
     PELOTON_MEMSET(result, 0, size);
     return reinterpret_cast<RawBitmap *>(result);
@@ -97,9 +99,6 @@ class RawBitmap {
       Set(pos, true);
     return *this;
   }
-
-  // TODO(Tianyu): We will eventually need optimization for bulk checks and
-  // bulk flips. This thing is embarrassingly easy to vectorize.
 
  private:
   uint8_t bits_[0];

--- a/src/include/common/container/bitmap.h
+++ b/src/include/common/container/bitmap.h
@@ -93,10 +93,7 @@ class RawBitmap {
   }
 
   RawBitmap &Flip(uint32_t pos) {
-    if (Test(pos))
-      Set(pos, false);
-    else
-      Set(pos, true);
+    bits_[pos / BYTE_SIZE] ^= ONE_HOT_MASK(pos % BYTE_SIZE);
     return *this;
   }
 

--- a/src/include/common/container/bitmap.h
+++ b/src/include/common/container/bitmap.h
@@ -78,8 +78,7 @@ class RawBitmap {
   bool operator[](uint32_t pos) const { return Test(pos); }
 
   /**
-   * Sets the bit value at position to be val. This is not safe to call
-   * concurrently.
+   * Sets the bit value at position to be true.
    * @param pos position to test
    * @param val value to set to
    * @return self-reference for chaining
@@ -92,6 +91,11 @@ class RawBitmap {
     return *this;
   }
 
+  /**
+   * @brief Flip the bit
+   * @param pos the position of the bit to flip
+   * @return self-reference for chaining
+   */
   RawBitmap &Flip(uint32_t pos) {
     bits_[pos / BYTE_SIZE] ^= ONE_HOT_MASK(pos % BYTE_SIZE);
     return *this;

--- a/src/include/common/container/bitmap.h
+++ b/src/include/common/container/bitmap.h
@@ -1,0 +1,114 @@
+#pragma once
+#include <memory>
+#include "common/common_defs.h"
+
+#ifndef BYTE_SIZE
+#define BYTE_SIZE 8u
+#endif
+
+// Some platforms would have already defined the macro. But its presence is
+// not standard and thus not portable. Pretty sure this is always 8 bits.
+// If not, consider getting a new machine, and preferably not from another
+// dimension :)
+static_assert(BYTE_SIZE == 8u, "BYTE_SIZE should be set to 8!");
+
+// n must be [0, 7], all 0 except for 1 on the nth bit
+#define ONE_HOT_MASK(n) (1u << (BYTE_SIZE - (n)-1u))
+// n must be [0, 7], all 1 except for 0 on the nth bit
+#define ONE_COLD_MASK(n) (0xFF - ONE_HOT_MASK(n))
+
+namespace terrier {
+namespace common {
+
+/**
+ * A RawBitmap is a bitmap that does not have the compile-time
+ * information about sizes, because we expect it to be reinterpreted from
+ * raw memory bytes.
+ *
+ * Therefore, you should never construct an instance of a RawBitmap.
+ * Reinterpret an existing block of memory that you know will be a valid bitmap.
+ *
+ * Use @see terrier::BitmapSize to get the correct size for a bitmap of n
+ * elements. Beware that because the size information is lost at compile time,
+ * there is ABSOLUTELY no bounds check and you have to rely on programming
+ * discipline to ensure safe access.
+ *
+ * For easy initialization in tests and such, use the static Allocate and
+ * Deallocate methods
+ */
+class RawBitmap {
+ public:
+  // Always reinterpret_cast from raw memory.
+  RawBitmap() = delete;
+  DISALLOW_COPY_AND_MOVE(RawBitmap);
+  ~RawBitmap() = delete;
+
+  /**
+   * Allocates a new RawBitmap of size. Up to the caller to call
+   * Deallocate on its return value
+   * @param size number of bits in the bitmap
+   * @return ptr to new RawBitmap
+   */
+  static RawBitmap *Allocate(uint32_t size) {
+    auto *result = new uint8_t[size];
+    PELOTON_MEMSET(result, 0, size);
+    return reinterpret_cast<RawBitmap *>(result);
+  }
+
+  /**
+   * Deallocates a RawBitmap. Only call on pointers given out by Allocate
+   * @param map the map to deallocate
+   */
+  static void Deallocate(RawBitmap *map) { delete reinterpret_cast<uint8_t *>(map); }
+
+  /**
+   * Test the bit value at the given position
+   * @param pos position to test
+   * @return true if 1, false if 0
+   */
+  bool Test(uint32_t pos) const { return static_cast<bool>(bits_[pos / BYTE_SIZE] & ONE_HOT_MASK(pos % BYTE_SIZE)); }
+
+  /**
+   * Test the bit value at the given position
+   * @param pos position to test
+   * @return true if 1, false if 0
+   */
+  bool operator[](uint32_t pos) const { return Test(pos); }
+
+  /**
+   * Sets the bit value at position to be val. This is not safe to call
+   * concurrently.
+   * @param pos position to test
+   * @param val value to set to
+   * @return self-reference for chaining
+   */
+  RawBitmap &Set(uint32_t pos, bool val) {
+    if (val)
+      bits_[pos / BYTE_SIZE] |= ONE_HOT_MASK(pos % BYTE_SIZE);
+    else
+      bits_[pos / BYTE_SIZE] &= ONE_COLD_MASK(pos % BYTE_SIZE);
+    return *this;
+  }
+
+  RawBitmap &Flip(uint32_t pos) {
+    if (Test(pos))
+      Set(pos, false);
+    else
+      Set(pos, true);
+    return *this;
+  }
+
+  // TODO(Tianyu): We will eventually need optimization for bulk checks and
+  // bulk flips. This thing is embarrassingly easy to vectorize.
+
+ private:
+  uint8_t bits_[0];
+};
+
+// WARNING: DO NOT CHANGE THE CLASS LAYOUT OF RawBitmap.
+// The correctness of our storage code depends in this class having this
+// exact layout. Changes include marking a function as virtual (or use the
+// FAKED_IN_TESTS macro), as that adds a Vtable to the class layout,
+static_assert(sizeof(RawBitmap) == 0, "Unexpected RawBitmap layout!");
+}  // namespace common
+}  // namespace terrier

--- a/src/include/common/container/bitmap.h
+++ b/src/include/common/container/bitmap.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <memory>
 #include "common/common_defs.h"
-#include "common/concurrent_bitmap.h"
 
 #ifndef BYTE_SIZE
 #define BYTE_SIZE 8u
@@ -20,6 +19,7 @@ static_assert(BYTE_SIZE == 8u, "BYTE_SIZE should be set to 8!");
 
 namespace terrier {
 namespace common {
+constexpr uint32_t BitmapSize(uint32_t n) { return n % BYTE_SIZE == 0 ? n / BYTE_SIZE : n / BYTE_SIZE + 1; }
 
 /**
  * A RawBitmap is a bitmap that does not have the compile-time

--- a/src/include/common/spin_latch.h
+++ b/src/include/common/spin_latch.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <atomic>
 #include <wmmintrin.h>
+#include <atomic>
 
 #include "common/macros.h"
 
@@ -10,10 +10,7 @@ namespace terrier {
 /**
  * Latch states composing of UNLOCKED and LOCKED
  */
-enum class LatchState : bool {
-  UNLOCKED,
-  LOCKED
-};
+enum class LatchState : bool { UNLOCKED, LOCKED };
 
 /**
  * A cheap and easy spin latch.
@@ -52,16 +49,13 @@ class SpinLatch {
   bool TryLock() {
     // exchange returns the value before locking, thus we need
     // to make sure the lock wasn't already in LOCKED state before
-    return state_.exchange(LatchState::LOCKED, std::memory_order_acquire) !=
-           LatchState::LOCKED;
+    return state_.exchange(LatchState::LOCKED, std::memory_order_acquire) != LatchState::LOCKED;
   }
 
   /**
    * @brief Unlocks the spin latch.
    */
-  void Unlock() {
-    state_.store(LatchState::UNLOCKED, std::memory_order_release);
-  }
+  void Unlock() { state_.store(LatchState::UNLOCKED, std::memory_order_release); }
 
  private:
   /** The exchange method on this atomic is compiled to a lockfree xchgl

--- a/src/include/storage/tuple_access_strategy.h
+++ b/src/include/storage/tuple_access_strategy.h
@@ -87,12 +87,14 @@ struct MiniBlock {
    * @param layout the layout of this block
    * @return a pointer to the start of the column. (use as an array)
    */
-  byte *ColumnStart(const BlockLayout &layout) { return varlen_contents_ + BitmapSize(layout.num_slots_); }
+  byte *ColumnStart(const BlockLayout &layout) { return varlen_contents_ + common::BitmapSize(layout.num_slots_); }
 
   /**
    * @return The null-bitmap of this column
    */
-  RawConcurrentBitmap *NullBitmap() { return reinterpret_cast<RawConcurrentBitmap *>(varlen_contents_); }
+  common::RawConcurrentBitmap *NullBitmap() {
+    return reinterpret_cast<common::RawConcurrentBitmap *>(varlen_contents_);
+  }
 
   // Because where the other fields start will depend on the specific layout,
   // reinterpreting the rest as bytes is the best we can do without LLVM.
@@ -188,7 +190,7 @@ class TupleAccessStrategy {
    * @param col offset representing the column
    * @return pointer to the bitmap of the specified column on the given block
    */
-  RawConcurrentBitmap *ColumnNullBitmap(RawBlock *block, uint16_t col) {
+  common::RawConcurrentBitmap *ColumnNullBitmap(RawBlock *block, uint16_t col) {
     return reinterpret_cast<Block *>(block)->Column(col)->NullBitmap();
   }
 
@@ -247,7 +249,7 @@ class TupleAccessStrategy {
   bool Allocate(RawBlock *block, TupleSlot &slot) {
     // TODO(Tianyu): Really inefficient for now. Again, embarrassingly
     // vectorizable. Optimize later.
-    RawConcurrentBitmap *bitmap = ColumnNullBitmap(block, PRIMARY_KEY_OFFSET);
+    common::RawConcurrentBitmap *bitmap = ColumnNullBitmap(block, PRIMARY_KEY_OFFSET);
     for (uint32_t i = 0; i < layout_.num_slots_; i++) {
       if (bitmap->Flip(i, false)) {
         slot = TupleSlot(block, i);

--- a/src/include/storage/varlen_pool.h
+++ b/src/include/storage/varlen_pool.h
@@ -3,8 +3,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <unordered_set>
-#include <common/common_defs.h>
-
+#include "common/common_defs.h"
 #include "common/spin_latch.h"
 
 namespace terrier {

--- a/src/storage/tuple_access_strategy.cpp
+++ b/src/storage/tuple_access_strategy.cpp
@@ -7,7 +7,7 @@ namespace {
 uint32_t ColumnSize(const BlockLayout &layout,
                     uint16_t col_offset) {
   return layout.attr_sizes_[col_offset] * layout.num_slots_
-      + BitmapSize(layout.num_slots_);
+      + common::BitmapSize(layout.num_slots_);
 }
 }
 

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -1,20 +1,14 @@
 #include <bitset>
+#include <random>
 #include <thread>
 #include <unordered_set>
-
 #include "gtest/gtest.h"
-#include "common/test_util.h"
 #include "common/container/bitmap.h"
+#include "util/container_test_util.h"
 
 namespace terrier {
-template<uint32_t num_elements>
-void CheckReferenceBitmap(const common::RawBitmap &tested,
-                          const std::bitset<num_elements> &reference) {
-  for (uint32_t i = 0; i < num_elements; ++i) {
-    EXPECT_EQ(reference[i], tested[i]);
-  }
-}
 
+// tests a RawBitmap whose base pointer is word aligned, and the num_elements is a multiple of 8 (byte size)
 TEST(BitmapTests, ByteMultipleCorrectnessTest) {
   std::default_random_engine generator;
   // Number of times to randomly permute bitmap
@@ -31,18 +25,19 @@ TEST(BitmapTests, ByteMultipleCorrectnessTest) {
 
   // Randomly permute bitmap and STL bitmap and compare equality
   std::bitset<num_elements_aligned> stl_bitmap;
-  CheckReferenceBitmap<num_elements_aligned>(*aligned_bitmap, stl_bitmap);
+  CheckReferenceBitmap<common::RawBitmap, num_elements_aligned>(*aligned_bitmap, stl_bitmap);
   for (uint32_t i = 0; i < num_iterations; ++i) {
     auto element =
         std::uniform_int_distribution(0, (int) num_elements_aligned - 1)(generator);
     aligned_bitmap->Flip(element);
     stl_bitmap.flip(element);
-    CheckReferenceBitmap<num_elements_aligned>(*aligned_bitmap, stl_bitmap);
+    CheckReferenceBitmap<common::RawBitmap, num_elements_aligned>(*aligned_bitmap, stl_bitmap);
   }
 
   common::RawBitmap::Deallocate(aligned_bitmap);
 }
 
+// tests a RawBitmap whose base pointer is word aligned, but the num_elements is not a multiple of 8 (byte size)
 TEST(BitmapTests, NonByteMultipleCorrectnessTest) {
   std::default_random_engine generator;
   // Number of times to randomly permute bitmap
@@ -59,18 +54,19 @@ TEST(BitmapTests, NonByteMultipleCorrectnessTest) {
 
   // Randomly permute bitmap and STL bitmap and compare equality
   std::bitset<num_elements_unaligned> stl_bitmap;
-  CheckReferenceBitmap<num_elements_unaligned>(*non_multiple_bitmap, stl_bitmap);
+  CheckReferenceBitmap<common::RawBitmap, num_elements_unaligned>(*non_multiple_bitmap, stl_bitmap);
   for (uint32_t i = 0; i < num_iterations; ++i) {
     auto element =
         std::uniform_int_distribution(0, (int) num_elements_unaligned - 1)(generator);
     non_multiple_bitmap->Flip(element);
     stl_bitmap.flip(element);
-    CheckReferenceBitmap<num_elements_unaligned>(*non_multiple_bitmap, stl_bitmap);
+    CheckReferenceBitmap<common::RawBitmap, num_elements_unaligned>(*non_multiple_bitmap, stl_bitmap);
   }
 
   common::RawBitmap::Deallocate(non_multiple_bitmap);
 }
 
+// tests a RawBitmap whose base pointer is not word aligned
 TEST(BitmapTests, WordUnalignedCorrectnessTest) {
   std::default_random_engine generator;
   // Number of times to randomly permute bitmap
@@ -80,7 +76,7 @@ TEST(BitmapTests, WordUnalignedCorrectnessTest) {
   const uint32_t num_elements = 16;
 
   // provision enough space for the bitmap elements, plus 3 extra because we're going to make it unaligned to wordsize
-  auto size = BitmapSize(num_elements) + 3;
+  auto size = common::BitmapSize(num_elements) + 3;
   auto allocated_buffer = new uint8_t[size];
   PELOTON_MEMSET(allocated_buffer, 0, size);
 
@@ -99,13 +95,13 @@ TEST(BitmapTests, WordUnalignedCorrectnessTest) {
 
   // Randomly permute bitmap and STL bitmap and compare equality
   std::bitset<num_elements> stl_bitmap;
-  CheckReferenceBitmap<num_elements>(*unaligned_bitmap, stl_bitmap);
+  CheckReferenceBitmap<common::RawBitmap, num_elements>(*unaligned_bitmap, stl_bitmap);
   for (uint32_t i = 0; i < num_iterations; ++i) {
     auto element =
         std::uniform_int_distribution(0, (int) num_elements - 1)(generator);
     unaligned_bitmap->Flip(element);
     stl_bitmap.flip(element);
-    CheckReferenceBitmap<num_elements>(*unaligned_bitmap, stl_bitmap);
+    CheckReferenceBitmap<common::RawBitmap, num_elements>(*unaligned_bitmap, stl_bitmap);
   }
 
   delete[] allocated_buffer;

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -75,8 +75,8 @@ TEST(BitmapTests, WordUnalignedCorrectnessTest) {
   // Test a bitmap that whose size is byte multiple
   const uint32_t num_elements = 16;
 
-  // provision enough space for the bitmap elements, plus 3 extra because we're going to make it unaligned to wordsize
-  auto size = common::BitmapSize(num_elements) + 3;
+  // provision enough space for the bitmap elements, plus padding because we're going to make it unaligned to wordsize
+  auto size = common::BitmapSize(num_elements) + sizeof(uint64_t);
   auto allocated_buffer = new uint8_t[size];
   PELOTON_MEMSET(allocated_buffer, 0, size);
 

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -52,24 +52,65 @@ TEST(BitmapTests, NonByteMultipleCorrectnessTest) {
 
   // Test a bitmap that whose size is not byte multiple
   const uint32_t num_elements_unaligned = 19;
-  common::RawBitmap *unaligned_bitmap = common::RawBitmap::Allocate(num_elements_unaligned);
+  common::RawBitmap *non_multiple_bitmap = common::RawBitmap::Allocate(num_elements_unaligned);
 
   // Verify bitmap initialized to all 0s
   for (uint32_t i = 0; i < num_elements_unaligned; ++i) {
+    EXPECT_FALSE(non_multiple_bitmap->Test(i));
+  }
+
+  // Randomly permute bitmap and STL bitmap and compare equality
+  std::bitset<num_elements_unaligned> stl_bitmap;
+  CheckReferenceBitmap<num_elements_unaligned>(*non_multiple_bitmap, stl_bitmap);
+  for (uint32_t i = 0; i < num_iterations; ++i) {
+    auto element =
+        std::uniform_int_distribution(0, (int) num_elements_unaligned - 1)(generator);
+    non_multiple_bitmap->Flip(element);
+    stl_bitmap.flip(element);
+    CheckReferenceBitmap<num_elements_unaligned>(*non_multiple_bitmap, stl_bitmap);
+  }
+
+  common::RawBitmap::Deallocate(non_multiple_bitmap);
+}
+
+TEST(BitmapTests, WordUnalignedCorrectnessTest) {
+  std::default_random_engine generator;
+  // Number of times to randomly permute bitmap
+  uint32_t num_iterations = 1000;
+
+  // Test a bitmap that whose size is byte multiple
+  const uint32_t num_elements = 16;
+//  common::RawBitmap *aligned_bitmap = common::RawBitmap::Allocate(num_elements);
+
+  // provision enough space for the bitmap elements, plus 3 extra because we're going to make it unaligned to wordsize
+  auto size = BitmapSize(num_elements) + 3;
+  auto allocated_buffer = new uint8_t[size];
+  PELOTON_MEMSET(allocated_buffer, 0, size);
+
+  // make the bitmap not word-aligned
+  auto unaligned_buffer = allocated_buffer;
+  while (reinterpret_cast<uintptr_t>(unaligned_buffer) % sizeof(uint64_t) != 3) {
+    unaligned_buffer++;
+  }
+
+  auto unaligned_bitmap = reinterpret_cast<common::RawBitmap *>(unaligned_buffer);
+
+  // Verify bitmap initialized to all 0s
+  for (uint32_t i = 0; i < num_elements; ++i) {
     EXPECT_FALSE(unaligned_bitmap->Test(i));
   }
 
   // Randomly permute bitmap and STL bitmap and compare equality
-  std::bitset<num_elements_unaligned> unaligned_stl_bitmap;
-  CheckReferenceBitmap<num_elements_unaligned>(*unaligned_bitmap, unaligned_stl_bitmap);
+  std::bitset<num_elements> stl_bitmap;
+  CheckReferenceBitmap<num_elements>(*unaligned_bitmap, stl_bitmap);
   for (uint32_t i = 0; i < num_iterations; ++i) {
     auto element =
-        std::uniform_int_distribution(0, (int) num_elements_unaligned - 1)(generator);
+        std::uniform_int_distribution(0, (int) num_elements - 1)(generator);
     unaligned_bitmap->Flip(element);
-    unaligned_stl_bitmap.flip(element);
-    CheckReferenceBitmap<num_elements_unaligned>(*unaligned_bitmap, unaligned_stl_bitmap);
+    stl_bitmap.flip(element);
+    CheckReferenceBitmap<num_elements>(*unaligned_bitmap, stl_bitmap);
   }
 
-  common::RawBitmap::Deallocate(unaligned_bitmap);
+  delete[] allocated_buffer;
 }
 }

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -17,12 +17,12 @@ void CheckReferenceBitmap(const common::RawBitmap &tested,
   }
 }
 
-TEST(BitmapTests, AlignedCorrectnessTest) {
+TEST(BitmapTests, ByteMultipleCorrectnessTest) {
   std::default_random_engine generator;
   // Number of times to randomly permute bitmap
   uint32_t num_iterations = 1000;
 
-  // Test a bitmap that is byte aligned for correctness
+  // Test a bitmap that whose size is byte multiple
   const uint32_t num_elements_aligned = 16;
   common::RawBitmap *aligned_bitmap = common::RawBitmap::Allocate(num_elements_aligned);
 
@@ -45,11 +45,12 @@ TEST(BitmapTests, AlignedCorrectnessTest) {
   common::RawBitmap::Deallocate(aligned_bitmap);
 }
 
-TEST(BitmapTests, UnalignedCorrectnessTest) {
+TEST(BitmapTests, NonByteMultipleCorrectnessTest) {
   std::default_random_engine generator;
   // Number of times to randomly permute bitmap
   uint32_t num_iterations = 1000;
 
+  // Test a bitmap that whose size is not byte multiple
   const uint32_t num_elements_unaligned = 19;
   common::RawBitmap *unaligned_bitmap = common::RawBitmap::Allocate(num_elements_unaligned);
 

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -1,0 +1,74 @@
+#include <algorithm>
+#include <atomic>
+#include <bitset>
+#include <thread>
+#include <unordered_set>
+
+#include "gtest/gtest.h"
+#include "common/test_util.h"
+#include "common/container/bitmap.h"
+
+namespace terrier {
+template<uint32_t num_elements>
+void CheckReferenceBitmap(const common::RawBitmap &tested,
+                          const std::bitset<num_elements> &reference) {
+  for (uint32_t i = 0; i < num_elements; ++i) {
+    EXPECT_EQ(reference[i], tested[i]);
+  }
+}
+
+TEST(BitmapTests, AlignedCorrectnessTest) {
+  std::default_random_engine generator;
+  // Number of times to randomly permute bitmap
+  uint32_t num_iterations = 1000;
+
+  // Test a bitmap that is byte aligned for correctness
+  const uint32_t num_elements_aligned = 16;
+  common::RawBitmap *aligned_bitmap = common::RawBitmap::Allocate(num_elements_aligned);
+
+  // Verify bitmap initialized to all 0s
+  for (uint32_t i = 0; i < num_elements_aligned; ++i) {
+    EXPECT_FALSE(aligned_bitmap->Test(i));
+  }
+
+  // Randomly permute bitmap and STL bitmap and compare equality
+  std::bitset<num_elements_aligned> stl_bitmap;
+  CheckReferenceBitmap<num_elements_aligned>(*aligned_bitmap, stl_bitmap);
+  for (uint32_t i = 0; i < num_iterations; ++i) {
+    auto element =
+        std::uniform_int_distribution(0, (int) num_elements_aligned - 1)(generator);
+    aligned_bitmap->Flip(element);
+    stl_bitmap.flip(element);
+    CheckReferenceBitmap<num_elements_aligned>(*aligned_bitmap, stl_bitmap);
+  }
+
+  common::RawBitmap::Deallocate(aligned_bitmap);
+}
+
+TEST(BitmapTests, UnalignedCorrectnessTest) {
+  std::default_random_engine generator;
+  // Number of times to randomly permute bitmap
+  uint32_t num_iterations = 1000;
+
+  const uint32_t num_elements_unaligned = 19;
+  common::RawBitmap *unaligned_bitmap = common::RawBitmap::Allocate(num_elements_unaligned);
+
+  // Verify bitmap initialized to all 0s
+  for (uint32_t i = 0; i < num_elements_unaligned; ++i) {
+    EXPECT_FALSE(unaligned_bitmap->Test(i));
+  }
+
+  // Randomly permute bitmap and STL bitmap and compare equality
+  std::bitset<num_elements_unaligned> unaligned_stl_bitmap;
+  CheckReferenceBitmap<num_elements_unaligned>(*unaligned_bitmap, unaligned_stl_bitmap);
+  for (uint32_t i = 0; i < num_iterations; ++i) {
+    auto element =
+        std::uniform_int_distribution(0, (int) num_elements_unaligned - 1)(generator);
+    unaligned_bitmap->Flip(element);
+    unaligned_stl_bitmap.flip(element);
+    CheckReferenceBitmap<num_elements_unaligned>(*unaligned_bitmap, unaligned_stl_bitmap);
+  }
+
+  common::RawBitmap::Deallocate(unaligned_bitmap);
+}
+}

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-#include <atomic>
 #include <bitset>
 #include <thread>
 #include <unordered_set>
@@ -80,7 +78,6 @@ TEST(BitmapTests, WordUnalignedCorrectnessTest) {
 
   // Test a bitmap that whose size is byte multiple
   const uint32_t num_elements = 16;
-//  common::RawBitmap *aligned_bitmap = common::RawBitmap::Allocate(num_elements);
 
   // provision enough space for the bitmap elements, plus 3 extra because we're going to make it unaligned to wordsize
   auto size = BitmapSize(num_elements) + 3;

--- a/test/include/util/container_test_util.h
+++ b/test/include/util/container_test_util.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bitset>
+
+namespace terrier {
+template<typename Bitmap, uint32_t num_elements>
+void CheckReferenceBitmap(const Bitmap &tested,
+                          const std::bitset<num_elements> &reference) {
+  for (uint32_t i = 0; i < num_elements; ++i) {
+    EXPECT_EQ(reference[i], tested[i]);
+  }
+}
+}

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -112,7 +112,7 @@ TEST_F(TupleAccessStrategyTests, MemorySafetyTest) {
                               upper_bound);
       lower_bound =
           testutil::IncrementByBytes(tested.ColumnNullBitmap(raw_block_, col),
-                                     BitmapSize(layout.num_slots_));
+                                     common::BitmapSize(layout.num_slots_));
 
       testutil::CheckInBounds(tested.ColumnStart(raw_block_, col),
                               lower_bound,


### PR DESCRIPTION
We need a bitmap for our tuple buffers being passed around, but don't need it to be concurrent. This is  basically ConcurrentBitmap without the CAS.

Also removed UnsafeSet from ConcurrentBitmap and ran formatter.