### PR TITLE
Packages cleanup, new Travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,26 +11,46 @@ matrix:
       install:
         - ./script/installation/packages.sh
         - export PATH=/usr/local/opt/llvm/bin:$PATH
-      script:
-        - mkdir build
-        - cd build
-        - cmake ..
-        - make check-clang-tidy
-        - make check-format
-        - make
-        - make test
     - os: linux
       dist: trusty
       env:
-        - NAME="Docker gcc"
+        - NAME="Docker[packages.sh]"
+        - DOCKER=true
+      install:
+        - docker pull ubuntu:18.04
+        - docker run -itd --name build ubuntu:18.04
+        - docker cp . build:/repo
+        - docker exec build /repo/script/installation/packages.sh
+    - os: linux
+      dist: trusty
+      env:
+        - NAME="Docker[Dockerfile]"
+        - DOCKER=true
       install:
         - docker build -t cmu-db/terrier .
         - docker run -itd --name build cmu-db/terrier
         - docker cp . build:/repo
-      script:
-        - docker exec build mkdir -p /repo/build
-        - docker exec build /bin/sh -c "cd /repo/build && cmake .."
-        - docker exec build /bin/sh -c "cd /repo/build && make check-clang-tidy"
-        - docker exec build /bin/sh -c "cd /repo/build && make check-format"
-        - docker exec build /bin/sh -c "cd /repo/build && make"
-        - docker exec build /bin/sh -c "cd /repo/build && make test"
+
+script:
+  - if [[ "$DOCKER" = true ]]; then
+      docker exec build update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 99 &&
+      docker exec build update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 99 &&
+      docker exec build update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 99 &&
+      docker exec build update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 99 &&
+      docker exec build update-alternatives --set cc /usr/bin/gcc &&
+      docker exec build update-alternatives --set c++ /usr/bin/g++ &&
+      docker exec build /bin/sh -c "mkdir -p /repo/build" &&
+      docker exec build /bin/sh -c "cd /repo/build && cmake .." &&
+      docker exec build /bin/sh -c "cd /repo/build && make check-clang-tidy" &&
+      docker exec build /bin/sh -c "cd /repo/build && make check-format" &&
+      docker exec build /bin/sh -c "cd /repo/build && make" &&
+      docker exec build /bin/sh -c "cd /repo/build && make test" ;
+    else
+      mkdir build &&
+      cd build &&
+      cmake .. &&
+      make check-clang-tidy &&
+      make check-format &&
+      make &&
+      make test ;
+    fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,31 +5,14 @@ CMD bash
 # Please add packages in alphabetical order.
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
-    apt-get -y install apt-utils && \
     apt-get -y install \
-      autoconf \
-      automake \
-      curl \
-      clang-6.0 \
-      clang-format \
-      clang-tidy \
+      clang-format-6.0 \
+      clang-tidy-6.0 \
       cmake \
-      doxygen \
-      gcc-7 \
-      g++-7 \
       git \
-      graphviz \
-      lcov \
-      libgflags-dev \
-      libboost-dev \
-      libboost-filesystem-dev \
-      libboost-thread-dev \
+      g++-7 \
       libjemalloc-dev \
       libjsoncpp-dev \
       libtbb-dev \
-      libtool \
       libz-dev \
-      llvm-6.0 \
-      make \
-      python3-pip \
-      valgrind
+      llvm-6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ CMD bash
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install \
+      clang-6.0 \
       clang-format-6.0 \
       clang-tidy-6.0 \
       cmake \

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -69,6 +69,7 @@ install_linux() {
   apt-get -y update
   # Install packages.
   apt-get -y install \
+      clang-6.0 \
       clang-format-6.0 \
       clang-tidy-6.0 \
       cmake \


### PR DESCRIPTION
Addresses #31.

We now only support Ubuntu 18.04 and MacOS.

1. Simplifies and removes the packages installed by packages.sh to a bare minimum.
2. We are not using Brewfiles. We will specify version in brew install whenever possible.
3. Added a new machine to Travis that will install requirements via packages.sh instead of Dockerfile.