### PR TITLE
Modify jemalloc to be linked to the terrier_shared library

### DIFF
--- a/cmake_modules/SetupCxxFlags.cmake
+++ b/cmake_modules/SetupCxxFlags.cmake
@@ -147,7 +147,7 @@ endif ()
 # jemalloc flags
 if (LINUX)
   set(JEMALLOC_LINK_FLAGS "-Wl,--no-as-needed")
-  set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS}" ${JEMALLOC_LINK_FLAGS})
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}" ${JEMALLOC_LINK_FLAGS})
 endif ()
 
 if ("${CMAKE_CXX_FLAGS}" MATCHES "-DNDEBUG")

--- a/cmake_modules/SetupCxxFlags.cmake
+++ b/cmake_modules/SetupCxxFlags.cmake
@@ -143,6 +143,13 @@ else()
   message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
 endif ()
 
+
+# jemalloc flags
+if (LINUX)
+  set(JEMALLOC_LINK_FLAGS "-Wl,--no-as-needed")
+  set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS}" ${JEMALLOC_LINK_FLAGS})
+endif ()
+
 if ("${CMAKE_CXX_FLAGS}" MATCHES "-DNDEBUG")
   set(TERRIER_DEFINITION_FLAGS "-DNDEBUG")
 else()

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -249,7 +249,7 @@ set(TERRIER_LINK_LIBS "")
 # JeMalloc
 find_package(jemalloc REQUIRED)
 include_directories(SYSTEM ${JEMALLOC_INCLUDE_DIR})
-#list(APPEND TERRIER_LINK_LIBS ${JEMALLOC_LIBRARIES})
+list(APPEND TERRIER_LINK_LIBS ${JEMALLOC_LIBRARIES})
 
 # Jsoncpp
 find_package(Jsoncpp REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,10 +22,4 @@ target_link_libraries(terrier_shared ${TERRIER_LINK_LIBS})
 # Terrier executable
 ###############################################
 add_executable(terrier main/terrier.cpp)
-target_link_libraries(terrier terrier_shared ${JEMALLOC_LIBRARIES})
-
-# link jemalloc to executable
-if (LINUX)
-  set(JEMALLOC_LINK_FLAGS "-Wl,--no-as-needed")
-  set_target_properties(${exe_name} PROPERTIES LINK_FLAGS ${JEMALLOC_LINK_FLAGS})
-endif ()
+target_link_libraries(terrier terrier_shared)


### PR DESCRIPTION
While profiling the new DataTable tests tonight, I realized that jemalloc was only linked against the terrier binary. This is probably a mistake. It should be linked to the terrier_shared library, otherwise we're using the system's native malloc for any other executables (Google Test, etc.)

In researching how we ended up with this behavior, I learned that Peloton also only links jemalloc against its executable, rather than the Peloton library. I'm not sure if this was intentional.

edit: [Related Peloton discussion](https://github.com/cmu-db/peloton/issues/220)