### PR TITLE
Clang tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,5 +18,18 @@
 # Modified from the Apache Arrow project for the Terrier project.
 #
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,google-.*,modernize-.*,performance-.*,readablity-.*'
+Checks:     '
+            bugprone-*,
+            clang-analyzer-*,
+            google-*,
+            modernize-*,
+            performance-*,
+            portability-*,
+            readability-*,
+            -google-readability-braces-around-statements,
+            -google-readability-namespace-comments,
+            -readability-braces-around-statements,
+            '
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: true

--- a/cmake_modules/FindTBB.cmake
+++ b/cmake_modules/FindTBB.cmake
@@ -99,7 +99,7 @@ if(NOT TBB_FOUND)
     # https://www.threadingbuildingblocks.org/docs/help/reference/environment/feature_macros.html
     # https://www.threadingbuildingblocks.org/docs/help/reference/appendices/known_issues/linux_os.html
     #############################################
-    if (NOT TBB_USE_GLIBCXX_VERSION AND UNIX AND NOT APPLE)
+    if (NOT TBB_USE_GLIBCXX_VERSION AND LINUX)
         string(REPLACE "." "0" TBB_USE_GLIBCXX_VERSION ${CMAKE_CXX_COMPILER_VERSION})
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTBB_USE_GLIBCXX_VERSION=${TBB_USE_GLIBCXX_VERSION}")
     endif()

--- a/cmake_modules/FindTBB.cmake
+++ b/cmake_modules/FindTBB.cmake
@@ -94,6 +94,16 @@ include(FindPackageHandleStandardArgs)
 
 if(NOT TBB_FOUND)
 
+    #############################################
+    # Hack to make TBB and clang-tidy play nicely
+    # https://www.threadingbuildingblocks.org/docs/help/reference/environment/feature_macros.html
+    # https://www.threadingbuildingblocks.org/docs/help/reference/appendices/known_issues/linux_os.html
+    #############################################
+    if (NOT TBB_USE_GLIBCXX_VERSION AND UNIX AND NOT APPLE)
+        string(REPLACE "." "0" TBB_USE_GLIBCXX_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTBB_USE_GLIBCXX_VERSION=${TBB_USE_GLIBCXX_VERSION}")
+    endif()
+
     ##################################
     # Check the build type
     ##################################

--- a/src/include/common/container/concurrent_bitmap.h
+++ b/src/include/common/container/concurrent_bitmap.h
@@ -120,7 +120,7 @@ class RawConcurrentBitmap {
               return false;
             }
             // if we find a free bit, we return that.
-            bool is_set = static_cast<bool>(bits & ONE_HOT_MASK(pos));
+            auto is_set = static_cast<bool>(bits & ONE_HOT_MASK(pos));
             if (!is_set) {
               *out_pos = pos + byte_pos * BYTE_SIZE;
               return true;

--- a/src/include/common/json_serializable.h
+++ b/src/include/common/json_serializable.h
@@ -21,7 +21,7 @@ namespace terrier::common {
  */
 class JsonSerializable {
  public:
-  virtual ~JsonSerializable() {}
+  virtual ~JsonSerializable() = default;
 
   /** @brief Get the Json value about the state information. */
   virtual Json::Value GetJson() = 0;

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -112,7 +112,7 @@ class TupleSlot {
    * @param block the block this slot is in
    * @param offset the offset of this slot in its block
    */
-  TupleSlot(RawBlock *block, uint32_t offset) : bytes_((uintptr_t)block | offset) {
+  TupleSlot(RawBlock *block, uint32_t offset) : bytes_(reinterpret_cast<uintptr_t>(block) | offset) {
     // Assert that the address is aligned up to block size (i.e. last bits zero)
     PELOTON_ASSERT(!((static_cast<uintptr_t>(common::Constants::BLOCK_SIZE) - 1) & ((uintptr_t)block)));
     // Assert that the offset is smaller than the block size, so we can fit
@@ -163,7 +163,7 @@ class TupleSlot {
   friend struct std::hash<TupleSlot>;
   // Block pointers are always aligned to 1 mb, thus we get 5 free bytes to
   // store the offset.
-  uintptr_t bytes_;
+  uintptr_t bytes_{0};
 };
 
 /**


### PR DESCRIPTION
Fix #50.

1. Linux + clang + TBB = TBB cannot detect C++11 features.
We can manually tell TBB where the C++11 features are by setting -DTBB_USE_GLIBCXX_VERSION=V, where for gcc compiler version M.m.p, we have V = 10000 M + 100 m + p.
As a workaround, we know that clang-tidy reads the contents of compile_commands.json, which is itself generated by CMake. So we add the above TBB_USE_GLIBCXX_VERSION as a CXX flag.

2. The clang-tidy we modified from Arrow was pretty broken. We settled for bugprone, clang-analyzer, google, modernize, performance, portability, and readability checks. We also check header files now.