### PR TITLE
Beef up tests for bitmap, concurrent bitmap and tuple access strategy

### DIFF
--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -1,7 +1,7 @@
-#include <bitset>
 #include <random>
 #include <thread>  // NOLINT
 #include <unordered_set>
+#include <vector>
 #include "gtest/gtest.h"
 #include "common/container/bitmap.h"
 #include "util/container_test_util.h"
@@ -24,13 +24,13 @@ TEST(BitmapTests, ByteMultipleCorrectnessTest) {
   }
 
   // Randomly permute bitmap and STL bitmap and compare equality
-  std::bitset<num_elements_aligned> stl_bitmap;
+  std::vector<bool> stl_bitmap = std::vector<bool>(num_elements_aligned);
   ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements_aligned>(*aligned_bitmap, stl_bitmap);
   for (uint32_t i = 0; i < num_iterations; ++i) {
     auto element =
         std::uniform_int_distribution(0, static_cast<int>(num_elements_aligned - 1))(generator);
     aligned_bitmap->Flip(element);
-    stl_bitmap.flip(element);
+    stl_bitmap[element] = !stl_bitmap[element];
     ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements_aligned>(*aligned_bitmap, stl_bitmap);
   }
 
@@ -53,13 +53,13 @@ TEST(BitmapTests, NonByteMultipleCorrectnessTest) {
   }
 
   // Randomly permute bitmap and STL bitmap and compare equality
-  std::bitset<num_elements_unaligned> stl_bitmap;
+  std::vector<bool> stl_bitmap = std::vector<bool>(num_elements_unaligned);
   ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements_unaligned>(*non_multiple_bitmap, stl_bitmap);
   for (uint32_t i = 0; i < num_iterations; ++i) {
     auto element =
         std::uniform_int_distribution(0, static_cast<int>(num_elements_unaligned - 1))(generator);
     non_multiple_bitmap->Flip(element);
-    stl_bitmap.flip(element);
+    stl_bitmap[element] = !stl_bitmap[element];
     ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements_unaligned>(*non_multiple_bitmap,
                                                                                        stl_bitmap);
   }
@@ -95,13 +95,13 @@ TEST(BitmapTests, WordUnalignedCorrectnessTest) {
   }
 
   // Randomly permute bitmap and STL bitmap and compare equality
-  std::bitset<num_elements> stl_bitmap;
+  std::vector<bool> stl_bitmap = std::vector<bool>(num_elements);
   ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements>(*unaligned_bitmap, stl_bitmap);
   for (uint32_t i = 0; i < num_iterations; ++i) {
     auto element =
         std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
     unaligned_bitmap->Flip(element);
-    stl_bitmap.flip(element);
+    stl_bitmap[element] = !stl_bitmap[element];
     ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements>(*unaligned_bitmap, stl_bitmap);
   }
 

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -11,100 +11,123 @@ namespace terrier {
 // tests a RawBitmap whose base pointer is word aligned, and the num_elements is a multiple of 8 (byte size)
 TEST(BitmapTests, ByteMultipleCorrectnessTest) {
   std::default_random_engine generator;
+  // Number of bitmap sizes to test.
+  const uint32_t num_bitmap_sizes = 300;
+  // Maximum bitmap size multiplier.
+  const uint32_t max_size_multiplier = 100;
   // Number of times to randomly permute bitmap
-  uint32_t num_iterations = 1000;
+  const uint32_t num_iterations = 1000;
 
-  // Test a bitmap that whose size is byte multiple
-  const uint32_t num_elements_aligned = 16;
-  common::RawBitmap *aligned_bitmap = common::RawBitmap::Allocate(num_elements_aligned);
+  for (uint32_t iter = 0; iter < num_bitmap_sizes; ++iter) {
+    // Test a byte-multiple sized bitmap
+    auto multiplier = std::uniform_int_distribution(1u, max_size_multiplier)(generator);
+    const uint32_t num_elements_aligned = 16 * multiplier;
 
-  // Verify bitmap initialized to all 0s
-  for (uint32_t i = 0; i < num_elements_aligned; ++i) {
-    EXPECT_FALSE(aligned_bitmap->Test(i));
+    common::RawBitmap *aligned_bitmap = common::RawBitmap::Allocate(num_elements_aligned);
+
+    // Verify bitmap initialized to all 0s
+    for (uint32_t i = 0; i < num_elements_aligned; ++i) {
+      EXPECT_FALSE(aligned_bitmap->Test(i));
+    }
+
+    // Randomly permute bitmap and STL bitmap and compare equality
+    std::vector<bool> stl_bitmap = std::vector<bool>(num_elements_aligned);
+    ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*aligned_bitmap, stl_bitmap, num_elements_aligned);
+    for (uint32_t i = 0; i < num_iterations; ++i) {
+      auto element =
+          std::uniform_int_distribution(0, static_cast<int>(num_elements_aligned - 1))(generator);
+      aligned_bitmap->Flip(element);
+      stl_bitmap[element] = !stl_bitmap[element];
+      ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*aligned_bitmap, stl_bitmap, num_elements_aligned);
+    }
+
+    common::RawBitmap::Deallocate(aligned_bitmap);
   }
-
-  // Randomly permute bitmap and STL bitmap and compare equality
-  std::vector<bool> stl_bitmap = std::vector<bool>(num_elements_aligned);
-  ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements_aligned>(*aligned_bitmap, stl_bitmap);
-  for (uint32_t i = 0; i < num_iterations; ++i) {
-    auto element =
-        std::uniform_int_distribution(0, static_cast<int>(num_elements_aligned - 1))(generator);
-    aligned_bitmap->Flip(element);
-    stl_bitmap[element] = !stl_bitmap[element];
-    ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements_aligned>(*aligned_bitmap, stl_bitmap);
-  }
-
-  common::RawBitmap::Deallocate(aligned_bitmap);
 }
 
 // tests a RawBitmap whose base pointer is word aligned, but the num_elements is not a multiple of 8 (byte size)
 TEST(BitmapTests, NonByteMultipleCorrectnessTest) {
   std::default_random_engine generator;
+  // Number of bitmap sizes to test.
+  const uint32_t num_bitmap_sizes = 300;
+  // Maximum bitmap size multiplier.
+  const uint32_t max_size_multiplier = 100;
   // Number of times to randomly permute bitmap
-  uint32_t num_iterations = 1000;
+  const uint32_t num_iterations = 1000;
 
-  // Test a bitmap that whose size is not byte multiple
-  const uint32_t num_elements_unaligned = 19;
-  common::RawBitmap *non_multiple_bitmap = common::RawBitmap::Allocate(num_elements_unaligned);
+  for (uint32_t iter = 0; iter < num_bitmap_sizes; ++iter) {
+    // Test a non-byte-multiple sized bitmap
+    auto multiplier = std::uniform_int_distribution(1u, max_size_multiplier)(generator);
+    auto offset = std::uniform_int_distribution(1u, BYTE_SIZE - 1)(generator);
+    const uint32_t num_elements_aligned = 16 * multiplier + offset;
 
-  // Verify bitmap initialized to all 0s
-  for (uint32_t i = 0; i < num_elements_unaligned; ++i) {
-    EXPECT_FALSE(non_multiple_bitmap->Test(i));
+    common::RawBitmap *aligned_bitmap = common::RawBitmap::Allocate(num_elements_aligned);
+
+    // Verify bitmap initialized to all 0s
+    for (uint32_t i = 0; i < num_elements_aligned; ++i) {
+      EXPECT_FALSE(aligned_bitmap->Test(i));
+    }
+
+    // Randomly permute bitmap and STL bitmap and compare equality
+    std::vector<bool> stl_bitmap = std::vector<bool>(num_elements_aligned);
+    ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*aligned_bitmap, stl_bitmap, num_elements_aligned);
+    for (uint32_t i = 0; i < num_iterations; ++i) {
+      auto element =
+          std::uniform_int_distribution(0, static_cast<int>(num_elements_aligned - 1))(generator);
+      aligned_bitmap->Flip(element);
+      stl_bitmap[element] = !stl_bitmap[element];
+      ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*aligned_bitmap, stl_bitmap, num_elements_aligned);
+    }
+
+    common::RawBitmap::Deallocate(aligned_bitmap);
   }
-
-  // Randomly permute bitmap and STL bitmap and compare equality
-  std::vector<bool> stl_bitmap = std::vector<bool>(num_elements_unaligned);
-  ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements_unaligned>(*non_multiple_bitmap, stl_bitmap);
-  for (uint32_t i = 0; i < num_iterations; ++i) {
-    auto element =
-        std::uniform_int_distribution(0, static_cast<int>(num_elements_unaligned - 1))(generator);
-    non_multiple_bitmap->Flip(element);
-    stl_bitmap[element] = !stl_bitmap[element];
-    ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements_unaligned>(*non_multiple_bitmap,
-                                                                                       stl_bitmap);
-  }
-
-  common::RawBitmap::Deallocate(non_multiple_bitmap);
 }
 
 // tests a RawBitmap whose base pointer is not word aligned
 TEST(BitmapTests, WordUnalignedCorrectnessTest) {
   std::default_random_engine generator;
+  // Number of bitmap sizes to test.
+  const uint32_t num_bitmap_sizes = 300;
+  // Maximum bitmap size multiplier.
+  const uint32_t max_size_multiplier = 100;
   // Number of times to randomly permute bitmap
-  uint32_t num_iterations = 1000;
+  const uint32_t num_iterations = 1000;
 
-  // Test a bitmap that whose size is byte multiple
-  const uint32_t num_elements = 16;
+  for (uint32_t iter = 0; iter < num_bitmap_sizes; ++iter) {
+    // Test a byte-multiple sized bitmap
+    auto multiplier = std::uniform_int_distribution(1u, max_size_multiplier)(generator);
+    const uint32_t num_elements = 16 * multiplier;
 
-  // provision enough space for the bitmap elements, plus padding because we're going to make it unaligned to wordsize
-  auto size = common::BitmapSize(num_elements) + sizeof(uint64_t);
-  auto allocated_buffer = new uint8_t[size];
-  PELOTON_MEMSET(allocated_buffer, 0, size);
+    // provision enough space for the bitmap elements, plus padding because we're going to make it unaligned to wordsize
+    auto size = common::BitmapSize(num_elements) + sizeof(uint64_t);
+    auto allocated_buffer = new uint8_t[size];
+    PELOTON_MEMSET(allocated_buffer, 0, size);
 
-  // make the bitmap not word-aligned
-  auto unaligned_buffer = allocated_buffer;
-  while (reinterpret_cast<uintptr_t>(unaligned_buffer) % sizeof(uint64_t) != 3) {
-    unaligned_buffer++;
+    // make the bitmap not word-aligned
+    auto unaligned_buffer = allocated_buffer;
+    while (reinterpret_cast<uintptr_t>(unaligned_buffer) % sizeof(uint64_t) != 3) {
+      unaligned_buffer++;
+    }
+
+    auto unaligned_bitmap = reinterpret_cast<common::RawBitmap *>(unaligned_buffer);
+
+    // Verify bitmap initialized to all 0s
+    for (uint32_t i = 0; i < num_elements; ++i) {
+      EXPECT_FALSE(unaligned_bitmap->Test(i));
+    }
+
+    // Randomly permute bitmap and STL bitmap and compare equality
+    std::vector<bool> stl_bitmap = std::vector<bool>(num_elements);
+    ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*unaligned_bitmap, stl_bitmap, num_elements);
+    for (uint32_t i = 0; i < num_iterations; ++i) {
+      auto element =
+          std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
+      unaligned_bitmap->Flip(element);
+      stl_bitmap[element] = !stl_bitmap[element];
+      ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*unaligned_bitmap, stl_bitmap, num_elements);
+    }
+
+    delete[] allocated_buffer;
   }
-
-  auto unaligned_bitmap = reinterpret_cast<common::RawBitmap *>(unaligned_buffer);
-
-  // Verify bitmap initialized to all 0s
-  for (uint32_t i = 0; i < num_elements; ++i) {
-    EXPECT_FALSE(unaligned_bitmap->Test(i));
-  }
-
-  // Randomly permute bitmap and STL bitmap and compare equality
-  std::vector<bool> stl_bitmap = std::vector<bool>(num_elements);
-  ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements>(*unaligned_bitmap, stl_bitmap);
-  for (uint32_t i = 0; i < num_iterations; ++i) {
-    auto element =
-        std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
-    unaligned_bitmap->Flip(element);
-    stl_bitmap[element] = !stl_bitmap[element];
-    ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap, num_elements>(*unaligned_bitmap, stl_bitmap);
-  }
-
-  delete[] allocated_buffer;
 }
 }  // namespace terrier

--- a/test/common/concurrent_bitmap_test.cpp
+++ b/test/common/concurrent_bitmap_test.cpp
@@ -22,7 +22,7 @@ TEST(ConcurrentBitmapTests, SimpleCorrectnessTest) {
   }
 
   // Randomly permute bitmap and STL bitmap and compare equality
-  std::bitset<num_elements> stl_bitmap;
+  std::vector<bool> stl_bitmap = std::vector<bool>(num_elements);
   ContainerTestUtil::CheckReferenceBitmap<common::RawConcurrentBitmap, num_elements>(*bitmap, stl_bitmap);
   uint32_t num_iterations = 32;
   std::default_random_engine generator;
@@ -30,7 +30,7 @@ TEST(ConcurrentBitmapTests, SimpleCorrectnessTest) {
     auto element =
         std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
     EXPECT_TRUE(bitmap->Flip(element, bitmap->Test(element)));
-    stl_bitmap.flip(element);
+    stl_bitmap[element] = !stl_bitmap[element];
     ContainerTestUtil::CheckReferenceBitmap<common::RawConcurrentBitmap, num_elements>(*bitmap, stl_bitmap);
   }
 

--- a/test/common/concurrent_bitmap_test.cpp
+++ b/test/common/concurrent_bitmap_test.cpp
@@ -13,75 +13,105 @@
 namespace terrier {
 
 TEST(ConcurrentBitmapTests, SimpleCorrectnessTest) {
-  const uint32_t num_elements = 16;
-  common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
-
-  // Verify bitmap initialized to all 0s
-  for (uint32_t i = 0; i < num_elements; ++i) {
-    EXPECT_FALSE(bitmap->Test(i));
-  }
-
-  // Randomly permute bitmap and STL bitmap and compare equality
-  std::vector<bool> stl_bitmap = std::vector<bool>(num_elements);
-  ContainerTestUtil::CheckReferenceBitmap<common::RawConcurrentBitmap, num_elements>(*bitmap, stl_bitmap);
-  uint32_t num_iterations = 32;
   std::default_random_engine generator;
-  for (uint32_t i = 0; i < num_iterations; ++i) {
+  // Number of bitmap sizes to test.
+  const uint32_t num_bitmap_sizes = 1000;
+  // Maximum bitmap size.
+  const uint32_t max_bitmap_size = 1000;
+
+  for (uint32_t iter = 0; iter < num_bitmap_sizes; ++iter) {
+    auto num_elements = std::uniform_int_distribution(1u, max_bitmap_size)(generator);
+    common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
+
+    // Verify bitmap initialized to all 0s
+    for (uint32_t i = 0; i < num_elements; ++i) {
+      EXPECT_FALSE(bitmap->Test(i));
+    }
+
+    // Randomly permute bitmap and STL bitmap and compare equality
+    std::vector<bool> stl_bitmap = std::vector<bool>(num_elements);
+    ContainerTestUtil::CheckReferenceBitmap<common::RawConcurrentBitmap>(*bitmap, stl_bitmap, num_elements);
+    uint32_t num_iterations = 32;
+    std::default_random_engine generator;
+    for (uint32_t i = 0; i < num_iterations; ++i) {
+      auto element =
+          std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
+      EXPECT_TRUE(bitmap->Flip(element, bitmap->Test(element)));
+      stl_bitmap[element] = !stl_bitmap[element];
+      ContainerTestUtil::CheckReferenceBitmap<common::RawConcurrentBitmap>(*bitmap, stl_bitmap, num_elements);
+    }
+
+    // Verify that Flip fails if expected_val doesn't match current value
     auto element =
         std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
-    EXPECT_TRUE(bitmap->Flip(element, bitmap->Test(element)));
-    stl_bitmap[element] = !stl_bitmap[element];
-    ContainerTestUtil::CheckReferenceBitmap<common::RawConcurrentBitmap, num_elements>(*bitmap, stl_bitmap);
+    EXPECT_FALSE(bitmap->Flip(element, !bitmap->Test(element)));
+    common::RawConcurrentBitmap::Deallocate(bitmap);
   }
-
-  // Verify that Flip fails if expected_val doesn't match current value
-  auto element =
-      std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
-  EXPECT_FALSE(bitmap->Flip(element, !bitmap->Test(element)));
-  common::RawConcurrentBitmap::Deallocate(bitmap);
 }
 // The test exercises FirstUnsetPos in a single-threaded context
 TEST(ConcurrentBitmapTests, FirstUnsetPosTest) {
-  const uint32_t num_elements = 18;
-  common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
+  std::default_random_engine generator;
+  // Number of bitmap sizes to test.
+  const uint32_t num_bitmap_sizes = 1000;
+  // Maximum bitmap size.
+  const uint32_t max_bitmap_size = 1000;
   uint32_t pos;
 
-  // should return false if we start searching out of range
-  EXPECT_FALSE(bitmap->FirstUnsetPos(num_elements, num_elements, &pos));
-  EXPECT_FALSE(bitmap->FirstUnsetPos(num_elements, num_elements + 1, &pos));
+  // test a wide range of sizes
+  for (uint32_t iter = 0; iter < num_bitmap_sizes; ++iter) {
+    auto num_elements = std::uniform_int_distribution(1u, max_bitmap_size)(generator);
+    common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
 
-  // as we flip bits from start to end, verify that the position of the next unset pos is correct
-  for (uint32_t i = 0; i < num_elements; ++i) {
-    EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
-    EXPECT_EQ(pos, i);
-    EXPECT_TRUE(bitmap->Flip(i, false));
+    // should return false if we start searching out of range
+    EXPECT_FALSE(bitmap->FirstUnsetPos(num_elements, num_elements, &pos));
+    EXPECT_FALSE(bitmap->FirstUnsetPos(num_elements, num_elements + 1, &pos));
+
+    // as we flip bits from start to end, verify that the position of the next unset pos is correct
+    for (uint32_t i = 0; i < num_elements; ++i) {
+      EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
+      EXPECT_EQ(pos, i);
+      EXPECT_TRUE(bitmap->Flip(i, false));
+    }
+    // once the bitmap is full, we should not be able to find an unset bit
+    EXPECT_FALSE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
+
+    common::RawConcurrentBitmap::Deallocate(bitmap);
   }
-  // once the bitmap is full, we should not be able to find an unset bit
-  EXPECT_FALSE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
 
-  // try to find specific unset bits, x = set, _ = unset
-  uint32_t flip_idx[3] = {5, 12, 13};
-  // x _ x should return middle
-  EXPECT_TRUE(bitmap->Flip(flip_idx[1], true));
-  EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
-  EXPECT_EQ(pos, flip_idx[1]);
-  // _ _ x should return first
-  EXPECT_TRUE(bitmap->Flip(flip_idx[0], true));
-  EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
-  EXPECT_EQ(pos, flip_idx[0]);
-  // _ _ x should return middle if searching from middle
-  EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 11, &pos));
-  EXPECT_EQ(pos, flip_idx[1]);
-  EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 12, &pos));
-  EXPECT_EQ(pos, flip_idx[1]);
-  // x x _ should return last
-  EXPECT_TRUE(bitmap->Flip(flip_idx[0], false));
-  EXPECT_TRUE(bitmap->Flip(flip_idx[1], false));
-  EXPECT_TRUE(bitmap->Flip(flip_idx[2], true));
-  EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
-  EXPECT_EQ(pos, flip_idx[2]);
+  // manual targeted test for specific bits
+  {
+    const uint32_t num_elements = 16;
+    common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
+    uint32_t flip_idx[3] = {5, 12, 13};
 
-  common::RawConcurrentBitmap::Deallocate(bitmap);
+    // x = set, _ = unset
+    // fill everything, resulting in x x x
+    for (uint32_t i = 0; i < num_elements; ++i) {
+      EXPECT_TRUE(bitmap->Flip(i, false));
+    }
+
+    // x _ x should return middle
+    EXPECT_TRUE(bitmap->Flip(flip_idx[1], true));
+    EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
+    EXPECT_EQ(pos, flip_idx[1]);
+    // _ _ x should return first
+    EXPECT_TRUE(bitmap->Flip(flip_idx[0], true));
+    EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
+    EXPECT_EQ(pos, flip_idx[0]);
+    // _ _ x should return middle if searching from middle
+    EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 11, &pos));
+    EXPECT_EQ(pos, flip_idx[1]);
+    EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 12, &pos));
+    EXPECT_EQ(pos, flip_idx[1]);
+    // x x _ should return last
+    EXPECT_TRUE(bitmap->Flip(flip_idx[0], false));
+    EXPECT_TRUE(bitmap->Flip(flip_idx[1], false));
+    EXPECT_TRUE(bitmap->Flip(flip_idx[2], true));
+    EXPECT_TRUE(bitmap->FirstUnsetPos(num_elements, 0, &pos));
+    EXPECT_EQ(pos, flip_idx[2]);
+
+    common::RawConcurrentBitmap::Deallocate(bitmap);
+  }
 }
 // The test exercises FirstUnsetPos with edge-case sizes
 TEST(ConcurrentBitmapTests, FirstUnsetPosSizeTest) {
@@ -99,6 +129,7 @@ TEST(ConcurrentBitmapTests, FirstUnsetPosSizeTest) {
     common::RawConcurrentBitmap::Deallocate(bitmap);
   }
   // fill the first 128, then try to find unset bit 129
+  // meant to test if we are reading out of bounds (naively reading 64+64+64 should trigger ASAN)
   {
     const uint32_t num_elements = 129;
     common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
@@ -118,41 +149,45 @@ TEST(ConcurrentBitmapTests, FirstUnsetPosSizeTest) {
 }
 // The test attempts to concurrently flip every bit from 0 to 1 using FirstUnsetPos
 TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
-  const uint32_t num_elements = 10000;
+  std::default_random_engine generator;
+  const uint32_t num_iters = 500;
+  const uint32_t max_elements = 10000;
   const uint32_t num_threads = 8;
-  common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
-  std::vector<std::vector<uint32_t>> elements(num_threads);
 
-  auto workload = [&](uint32_t thread_id) {
-    uint32_t pos = 0;
-    for (uint32_t i = 0; i < num_elements; ++i) {
-      if (bitmap->FirstUnsetPos(num_elements, 0, &pos)) {
-        if (bitmap->Flip(pos, false)) {
+  for (uint32_t iter = 0; iter < num_iters; ++iter) {
+    const uint32_t num_elements = std::uniform_int_distribution(1u, max_elements)(generator);
+    common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
+    std::vector<std::vector<uint32_t>> elements(num_threads);
+
+    auto workload = [&](uint32_t thread_id) {
+      uint32_t pos = 0;
+      for (uint32_t i = 0; i < num_elements; ++i) {
+        if (bitmap->FirstUnsetPos(num_elements, 0, &pos) && bitmap->Flip(pos, false)) {
           elements[thread_id].push_back(pos);
         }
       }
+    };
+
+    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+
+    // Coalesce the thread-local result vectors into one vector, and
+    // then sort the results
+    std::vector<uint32_t> all_elements;
+    for (uint32_t i = 0; i < num_threads; ++i)
+      all_elements.insert(all_elements.end(),
+                          elements[i].begin(),
+                          elements[i].end());
+
+    // Verify coalesced result size
+    EXPECT_EQ(num_elements, all_elements.size());
+    std::sort(all_elements.begin(), all_elements.end());
+    // Verify 1:1 mapping of indices to element value
+    // This represents that every slot was grabbed by only one thread
+    for (uint32_t i = 0; i < num_elements; ++i) {
+      EXPECT_EQ(i, all_elements[i]);
     }
-  };
-
-  MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
-
-  // Coalesce the thread-local result vectors into one vector, and
-  // then sort the results
-  std::vector<uint32_t> all_elements;
-  for (uint32_t i = 0; i < num_threads; ++i)
-    all_elements.insert(all_elements.end(),
-                        elements[i].begin(),
-                        elements[i].end());
-
-  // Verify coalesced result size
-  EXPECT_EQ(num_elements, all_elements.size());
-  std::sort(all_elements.begin(), all_elements.end());
-  // Verify 1:1 mapping of indices to element value
-  // This represents that every slot was grabbed by only one thread
-  for (uint32_t i = 0; i < num_elements; ++i) {
-    EXPECT_EQ(i, all_elements[i]);
+    common::RawConcurrentBitmap::Deallocate(bitmap);
   }
-  common::RawConcurrentBitmap::Deallocate(bitmap);
 }
 
 // The test attempts to concurrently flip every bit from 0 to 1, and
@@ -160,34 +195,40 @@ TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
 // This is equivalent to grabbing a free slot if used in an
 // allocator
 TEST(ConcurrentBitmapTests, ConcurrentCorrectnessTest) {
-  const uint32_t num_elements = 1000000;
+  std::default_random_engine generator;
+  const uint32_t num_iters = 250;
+  const uint32_t max_elements = 1000000;
   const uint32_t num_threads = 8;
-  common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
-  std::vector<std::vector<uint32_t>> elements(num_threads);
 
-  auto workload = [&](uint32_t thread_id) {
-    for (uint32_t i = 0; i < num_elements; ++i)
-      if (bitmap->Flip(i, false)) elements[thread_id].push_back(i);
-  };
+  for (uint32_t iter = 0; iter < num_iters; ++iter) {
+    const uint32_t num_elements = std::uniform_int_distribution(1u, max_elements)(generator);
+    common::RawConcurrentBitmap *bitmap = common::RawConcurrentBitmap::Allocate(num_elements);
+    std::vector<std::vector<uint32_t>> elements(num_threads);
 
-  MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+    auto workload = [&](uint32_t thread_id) {
+      for (uint32_t i = 0; i < num_elements; ++i)
+        if (bitmap->Flip(i, false)) elements[thread_id].push_back(i);
+    };
 
-  // Coalesce the thread-local result vectors into one vector, and
-  // then sort the results
-  std::vector<uint32_t> all_elements;
-  for (uint32_t i = 0; i < num_threads; ++i)
-    all_elements.insert(all_elements.end(),
-                        elements[i].begin(),
-                        elements[i].end());
+    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
 
-  // Verify coalesced result size
-  EXPECT_EQ(num_elements, all_elements.size());
-  std::sort(all_elements.begin(), all_elements.end());
-  // Verify 1:1 mapping of indices to element value
-  // This represents that every slot was grabbed by only one thread
-  for (uint32_t i = 0; i < num_elements; ++i) {
-    EXPECT_EQ(i, all_elements[i]);
+    // Coalesce the thread-local result vectors into one vector, and
+    // then sort the results
+    std::vector<uint32_t> all_elements;
+    for (uint32_t i = 0; i < num_threads; ++i)
+      all_elements.insert(all_elements.end(),
+                          elements[i].begin(),
+                          elements[i].end());
+
+    // Verify coalesced result size
+    EXPECT_EQ(num_elements, all_elements.size());
+    std::sort(all_elements.begin(), all_elements.end());
+    // Verify 1:1 mapping of indices to element value
+    // This represents that every slot was grabbed by only one thread
+    for (uint32_t i = 0; i < num_elements; ++i) {
+      EXPECT_EQ(i, all_elements[i]);
+    }
+    common::RawConcurrentBitmap::Deallocate(bitmap);
   }
-  common::RawConcurrentBitmap::Deallocate(bitmap);
 }
 }  // namespace terrier

--- a/test/include/util/container_test_util.h
+++ b/test/include/util/container_test_util.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <bitset>
+#include <vector>
 
 namespace terrier {
 /**
@@ -10,7 +10,7 @@ struct ContainerTestUtil {
   ContainerTestUtil() = delete;
 
   template <typename Bitmap, uint32_t num_elements>
-  static void CheckReferenceBitmap(const Bitmap &tested, const std::bitset<num_elements> &reference) {
+  static void CheckReferenceBitmap(const Bitmap &tested, const std::vector<bool> &reference) {
     for (uint32_t i = 0; i < num_elements; ++i) {
       EXPECT_EQ(reference[i], tested[i]);
     }

--- a/test/include/util/container_test_util.h
+++ b/test/include/util/container_test_util.h
@@ -9,8 +9,8 @@ namespace terrier {
 struct ContainerTestUtil {
   ContainerTestUtil() = delete;
 
-  template <typename Bitmap, uint32_t num_elements>
-  static void CheckReferenceBitmap(const Bitmap &tested, const std::vector<bool> &reference) {
+  template <typename Bitmap>
+  static void CheckReferenceBitmap(const Bitmap &tested, const std::vector<bool> &reference, uint32_t num_elements) {
     for (uint32_t i = 0; i < num_elements; ++i) {
       EXPECT_EQ(reference[i], tested[i]);
     }


### PR DESCRIPTION
Fix #70.

1. Beefs up tests for bitmap, concurrent_bitmap and tuple_access_strategy. Mainly tweaks number of iterations, bitmap sizes tested, number of columns in layouts generated.
2. Changed from `std::bitset<N>` to `std::vector<bool>` for dynamic bitsets. (`vector<bool>` still specialized in C++17, §26.3.12).

On my laptop,
```
make unittest
    Start 1: bitmap_test
1/7 Test #1: bitmap_test ......................   Passed   45.40 sec
    Start 2: concurrent_bitmap_test
2/7 Test #2: concurrent_bitmap_test ...........   Passed   44.39 sec
    Start 3: object_pool_test
3/7 Test #3: object_pool_test .................   Passed    0.29 sec
    Start 4: data_table_concurrent_test
4/7 Test #4: data_table_concurrent_test .......   Passed    1.98 sec
    Start 5: data_table_test
5/7 Test #5: data_table_test ..................   Passed    1.02 sec
    Start 6: tuple_access_strategy_test
6/7 Test #6: tuple_access_strategy_test .......   Passed   54.56 sec
    Start 7: varlen_pool_test
7/7 Test #7: varlen_pool_test .................   Passed    2.81 sec

100% tests passed, 0 tests failed out of 7

Label Time Summary:
unittest    = 150.46 sec*proc (7 tests)

Total Test time (real) = 150.48 sec
```