### PR TITLE
Bugfix: bits_left should account for start_pos.

### DIFF
--- a/src/include/common/container/concurrent_bitmap.h
+++ b/src/include/common/container/concurrent_bitmap.h
@@ -104,7 +104,7 @@ class RawConcurrentBitmap {
 
     uint32_t num_bytes = BitmapSize(bitmap_num_bits);  // maximum number of bytes in the bitmap
     uint32_t byte_pos = start_pos / BYTE_SIZE;         // current byte position
-    uint32_t bits_left = bitmap_num_bits;              // number of bits remaining
+    uint32_t bits_left = bitmap_num_bits - start_pos;  // number of bits remaining
     bool found_unset_bit = false;                      // whether we found an unset bit previously
 
     while (byte_pos < num_bytes && bits_left > 0) {


### PR DESCRIPTION
Previously forgot to account for starting at an offset.