### PR TITLE
Data Table insert benchmarks and performance fixes

### DIFF
--- a/benchmark/include/util/storage_benchmark_util.h
+++ b/benchmark/include/util/storage_benchmark_util.h
@@ -16,7 +16,7 @@ struct TupleAccessStrategyBenchmarkUtil {
 
   // Fill the given location with the specified amount of random bytes, using the
   // given generator as a source of randomness.
-  template<typename Random>
+  template <typename Random>
   static void FillWithRandomBytes(uint32_t num_bytes, byte *out, Random *generator) {
     std::uniform_int_distribution<uint8_t> dist(0, UINT8_MAX);
     for (uint32_t i = 0; i < num_bytes; i++) out[i] = static_cast<byte>(dist(*generator));
@@ -39,10 +39,9 @@ struct TupleAccessStrategyBenchmarkUtil {
 
   // Using the given random generator, attempts to allocate a slot and write a
   // random tuple into it.
-  template<typename Random>
-  static void TryInsertFakeTuple(
-      const storage::BlockLayout &layout, const storage::TupleAccessStrategy &tested, storage::RawBlock *block,
-      Random *generator) {
+  template <typename Random>
+  static void TryInsertFakeTuple(const storage::BlockLayout &layout, const storage::TupleAccessStrategy &tested,
+                                 storage::RawBlock *block, Random *generator) {
     storage::TupleSlot slot;
     // There should always be enough slots.
     tested.Allocate(block, &slot);

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -105,7 +105,7 @@ static void BM_ConcurrentInsert(benchmark::State &state) {
 }
 
 BENCHMARK(BM_SimpleInsert)
-    ->Repetitions(1)
+    ->Repetitions(10)
     ->Unit(benchmark::kMillisecond)
     ->UseRealTime();
 

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -11,10 +11,12 @@
 
 namespace terrier {
 
-//  TODO(Matt): document
+// Test raw DataTable insert time. Generate a fixed layout allocate undo and redo buffers, and then reuse them to
+// repeatedly insert the same garbage tuple over and over into the DataTable to test throughput.
+// NOLINTNEXTLINE
 static void BM_SimpleInsert(benchmark::State &state) {
   std::default_random_engine generator;
-  const uint32_t num_inserts = 100000;
+  const uint32_t num_inserts = 10000000;
 
   storage::BlockStore block_store{1000};
 
@@ -52,60 +54,64 @@ static void BM_SimpleInsert(benchmark::State &state) {
   state.SetItemsProcessed(state.iterations() * num_inserts);
 }
 
-//  TODO(Matt): document
-//static void BM_ConcurrentInsert(benchmark::State &state) {
-//  std::default_random_engine generator;
-//
-//  const uint32_t num_inserts = 10000000;
-//
-//  storage::BlockStore block_store{1000};
-//
-//  // Tuple layout
-//  uint16_t num_columns = 2;
-//  uint8_t column_size = 8;
-//  storage::BlockLayout layout(num_columns, {column_size, column_size});
-//
-//  std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout)};
-//  uint32_t redo_size_ = storage::ProjectedRow::Size(layout, all_col_ids_);
-//  uint32_t undo_size_ = storage::DeltaRecord::Size(layout, all_col_ids_);
-//
-//  const uint32_t num_threads = 8;
-//
-//  // generate a random redo ProjectedRow to Insert
-//  byte *redo_buffer = new byte[redo_size_];
-//  storage::ProjectedRow *redo = storage::ProjectedRow::InitializeProjectedRow(redo_buffer, all_col_ids_, layout);
-//  StorageTestUtil::PopulateRandomRow(redo, layout, 0, &generator);
-//
-//  while (state.KeepRunning()) {
-//    storage::DataTable table(&block_store, layout);
-//    auto workload = [&](uint32_t id) {
-//      // generate an undo DeltaRecord to populate on Insert
-//      byte *undo_buffer = new byte[undo_size_];
-//      storage::DeltaRecord *undo =
-//          storage::DeltaRecord::InitializeDeltaRecord(undo_buffer, timestamp_t(0), layout, all_col_ids_);
-//
-//      for (uint32_t i = 0; i < num_inserts / num_threads; i++)
-//        table.Insert(*redo, undo);
-//
-//      delete[] undo_buffer;
-//    };
-//    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
-//  }
-//
-//  delete[] redo_buffer;
-//
-//  state.SetBytesProcessed(state.iterations() * num_inserts * (redo_size_ + undo_size_));
-//  state.SetItemsProcessed(state.iterations() * num_inserts);
-//}
+
+// Test raw DataTable insert time concurrently. Generate a fixed layout allocate undo and redo buffers, and then reuse
+// them to repeatedly insert the same garbage tuple over and over into the DataTable to test throughput. Expect high
+// contention on this benchmark right now due to inserting into a single block in the DataTable.
+// NOLINTNEXTLINE
+static void BM_ConcurrentInsert(benchmark::State &state) {
+  std::default_random_engine generator;
+
+  const uint32_t num_inserts = 10000000;
+
+  storage::BlockStore block_store{1000};
+
+  // Tuple layout
+  uint16_t num_columns = 2;
+  uint8_t column_size = 8;
+  storage::BlockLayout layout(num_columns, {column_size, column_size});
+
+  std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout)};
+  uint32_t redo_size_ = storage::ProjectedRow::Size(layout, all_col_ids_);
+  uint32_t undo_size_ = storage::DeltaRecord::Size(layout, all_col_ids_);
+
+  const uint32_t num_threads = 8;
+
+  // generate a random redo ProjectedRow to Insert
+  byte *redo_buffer = new byte[redo_size_];
+  storage::ProjectedRow *redo = storage::ProjectedRow::InitializeProjectedRow(redo_buffer, all_col_ids_, layout);
+  StorageTestUtil::PopulateRandomRow(redo, layout, 0, &generator);
+
+  while (state.KeepRunning()) {
+    storage::DataTable table(&block_store, layout);
+    auto workload = [&](uint32_t id) {
+      // generate an undo DeltaRecord to populate on Insert
+      byte *undo_buffer = new byte[undo_size_];
+      storage::DeltaRecord *undo =
+          storage::DeltaRecord::InitializeDeltaRecord(undo_buffer, timestamp_t(0), layout, all_col_ids_);
+
+      for (uint32_t i = 0; i < num_inserts / num_threads; i++)
+        table.Insert(*redo, undo);
+
+      delete[] undo_buffer;
+    };
+    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+  }
+
+  delete[] redo_buffer;
+
+  state.SetBytesProcessed(state.iterations() * num_inserts * (redo_size_ + undo_size_));
+  state.SetItemsProcessed(state.iterations() * num_inserts);
+}
 
 BENCHMARK(BM_SimpleInsert)
     ->Repetitions(1)
     ->Unit(benchmark::kMillisecond)
     ->UseRealTime();
 
-//BENCHMARK(BM_ConcurrentInsert)
-//    ->Repetitions(10)
-//    ->Unit(benchmark::kMillisecond)
-//    ->UseRealTime();
+BENCHMARK(BM_ConcurrentInsert)
+    ->Repetitions(10)
+    ->Unit(benchmark::kMillisecond)
+    ->UseRealTime();
 
 }  // namespace terrier

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -1,0 +1,111 @@
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "benchmark/benchmark.h"
+#include "common/typedefs.h"
+#include "storage/data_table.h"
+#include "storage/storage_util.h"
+#include "util/storage_test_util.h"
+#include "util/multi_threaded_test_util.h"
+#include "util/storage_benchmark_util.h"
+
+namespace terrier {
+
+//  TODO(Matt): document
+static void BM_SimpleInsert(benchmark::State &state) {
+  std::default_random_engine generator;
+  const uint32_t num_inserts = 100000;
+
+  storage::BlockStore block_store{1000};
+
+  // Tuple layout
+  uint16_t num_columns = 2;
+  uint8_t column_size = 8;
+  storage::BlockLayout layout(num_columns, {column_size, column_size});
+
+  std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout)};
+  uint32_t redo_size_ = storage::ProjectedRow::Size(layout, all_col_ids_);
+  uint32_t undo_size_ = storage::DeltaRecord::Size(layout, all_col_ids_);
+
+  // generate a random redo ProjectedRow to Insert
+  byte *redo_buffer = new byte[redo_size_];
+  storage::ProjectedRow *redo = storage::ProjectedRow::InitializeProjectedRow(redo_buffer, all_col_ids_, layout);
+  StorageTestUtil::PopulateRandomRow(redo, layout, 0, &generator);
+
+  // generate an undo DeltaRecord to populate on Insert
+  byte *undo_buffer = new byte[undo_size_];
+  storage::DeltaRecord *undo =
+      storage::DeltaRecord::InitializeDeltaRecord(undo_buffer, timestamp_t(0), layout, all_col_ids_);
+
+  // Populate the table with tuples
+  while (state.KeepRunning()) {
+    storage::DataTable table(&block_store, layout);
+    for (uint32_t i = 0; i < num_inserts; ++i) {
+      table.Insert(*redo, undo);
+    }
+  }
+
+  delete[] redo_buffer;
+  delete[] undo_buffer;
+
+  state.SetBytesProcessed(state.iterations() * num_inserts * (redo_size_ + undo_size_));
+  state.SetItemsProcessed(state.iterations() * num_inserts);
+}
+
+//  TODO(Matt): document
+//static void BM_ConcurrentInsert(benchmark::State &state) {
+//  std::default_random_engine generator;
+//
+//  const uint32_t num_inserts = 10000000;
+//
+//  storage::BlockStore block_store{1000};
+//
+//  // Tuple layout
+//  uint16_t num_columns = 2;
+//  uint8_t column_size = 8;
+//  storage::BlockLayout layout(num_columns, {column_size, column_size});
+//
+//  std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout)};
+//  uint32_t redo_size_ = storage::ProjectedRow::Size(layout, all_col_ids_);
+//  uint32_t undo_size_ = storage::DeltaRecord::Size(layout, all_col_ids_);
+//
+//  const uint32_t num_threads = 8;
+//
+//  // generate a random redo ProjectedRow to Insert
+//  byte *redo_buffer = new byte[redo_size_];
+//  storage::ProjectedRow *redo = storage::ProjectedRow::InitializeProjectedRow(redo_buffer, all_col_ids_, layout);
+//  StorageTestUtil::PopulateRandomRow(redo, layout, 0, &generator);
+//
+//  while (state.KeepRunning()) {
+//    storage::DataTable table(&block_store, layout);
+//    auto workload = [&](uint32_t id) {
+//      // generate an undo DeltaRecord to populate on Insert
+//      byte *undo_buffer = new byte[undo_size_];
+//      storage::DeltaRecord *undo =
+//          storage::DeltaRecord::InitializeDeltaRecord(undo_buffer, timestamp_t(0), layout, all_col_ids_);
+//
+//      for (uint32_t i = 0; i < num_inserts / num_threads; i++)
+//        table.Insert(*redo, undo);
+//
+//      delete[] undo_buffer;
+//    };
+//    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+//  }
+//
+//  delete[] redo_buffer;
+//
+//  state.SetBytesProcessed(state.iterations() * num_inserts * (redo_size_ + undo_size_));
+//  state.SetItemsProcessed(state.iterations() * num_inserts);
+//}
+
+BENCHMARK(BM_SimpleInsert)
+    ->Repetitions(1)
+    ->Unit(benchmark::kMillisecond)
+    ->UseRealTime();
+
+//BENCHMARK(BM_ConcurrentInsert)
+//    ->Repetitions(10)
+//    ->Unit(benchmark::kMillisecond)
+//    ->UseRealTime();
+
+}  // namespace terrier

--- a/src/include/common/container/concurrent_bitmap.h
+++ b/src/include/common/container/concurrent_bitmap.h
@@ -141,6 +141,16 @@ class RawConcurrentBitmap {
     return false;
   }
 
+  /**
+   * Clears the bitmap by setting bits to 0.
+   * @param num_bits number of bits to clear.
+   * @warning this is not thread safe!
+   */
+  void UnsafeClear(uint32_t num_bits) {
+    auto size = BitmapSize(num_bits);
+    PELOTON_MEMSET(bits_, 0, size);
+  }
+
   // TODO(Tianyu): We will eventually need optimization for bulk checks and
   // bulk flips. This thing is embarrassingly easy to vectorize.
 

--- a/src/include/common/object_pool.h
+++ b/src/include/common/object_pool.h
@@ -86,15 +86,13 @@ class ObjectPool {
   // or even to elastically grow or shrink the memory size depending on use pattern.
 
   /**
-   * Returns a piece of memory to hold an object of T. The memory is always
-   * 0-initialized.
+   * Returns a piece of memory to hold an object of T.
    *
    * @return pointer to memory that can hold T
    */
   T *Get() {
     T *result = nullptr;
     if (!reuse_queue_.Dequeue(&result)) result = alloc_.New();
-    PELOTON_MEMSET(result, 0, sizeof(T));
     return result;
   }
 

--- a/src/include/common/object_pool.h
+++ b/src/include/common/object_pool.h
@@ -15,32 +15,23 @@ struct ByteAllocator {
    * Allocates a new byte array sized to hold a T.
    * @return a pointer to the byte array allocated.
    */
-  T *New() { return reinterpret_cast<T *>(new byte[sizeof(T)]); }
+  T *New() {
+    T *result = reinterpret_cast<T *>(new byte[sizeof(T)]);
+    Reuse(result);
+    return result;
+  }
+
+  /**
+   * Reuse a reused chunk of memory to be handed out again
+   * @param reused memory location, possibly filled with junk bytes
+   */
+  void Reuse(T *reused) { PELOTON_MEMSET(reused, 0, sizeof(T)); }
 
   /**
    * Deletes the byte array.
    * @param ptr pointer to the byte array to be deleted.
    */
   void Delete(T *ptr) { delete[] ptr; }
-};
-
-/**
- * Allocator that calls the default constructor and destructor.
- * @tparam T object whose default constructor and destructor will be used.
- */
-template <typename T>
-struct DefaultConstructorAllocator {
-  /**
-   * Allocates a new object by calling its constructor.
-   * @return a pointer to the allocated object.
-   */
-  T *New() { return new T(); }
-
-  /**
-   * Deletes the object by calling its destructor.
-   * @param ptr a pointer to the object to be deleted.
-   */
-  void Delete(T *ptr) { delete ptr; }
 };
 
 // TODO(Tianyu): Should this be by size or by class type?
@@ -92,7 +83,10 @@ class ObjectPool {
    */
   T *Get() {
     T *result = nullptr;
-    if (!reuse_queue_.Dequeue(&result)) result = alloc_.New();
+    if (!reuse_queue_.Dequeue(&result))
+      result = alloc_.New();
+    else
+      alloc_.Reuse(result);
     return result;
   }
 

--- a/src/include/common/object_pool.h
+++ b/src/include/common/object_pool.h
@@ -16,7 +16,7 @@ struct ByteAllocator {
    * @return a pointer to the byte array allocated.
    */
   T *New() {
-    T *result = reinterpret_cast<T *>(new byte[sizeof(T)]);
+    auto *result = reinterpret_cast<T *>(new byte[sizeof(T)]);
     Reuse(result);
     return result;
   }

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -87,6 +87,10 @@ class DataTable {
   // Atomically read out the version pointer value.
   DeltaRecord *AtomicallyReadVersionPtr(TupleSlot slot, const TupleAccessStrategy &accessor) const;
 
+  // Atomically write the version pointer value. Should only be used by Insert where there is guaranteed to be no
+  // contention
+  void AtomicallyWriteVersionPtr(const TupleSlot slot, const TupleAccessStrategy &accessor, DeltaRecord *desired);
+
   // If there will be a write-write conflict.
   bool HasConflict(DeltaRecord *version_ptr, DeltaRecord *undo) {
     return version_ptr != nullptr  // Nobody owns this tuple's write lock, no older version visible

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -72,13 +72,15 @@ class DataTable {
 
  private:
   BlockStore *block_store_;
-  // TODO(Tianyu): For now this will only have one element in it until we support concurrent schema.
-  // TODO(Matt): consider a vector instead if lookups are faster
-  common::ConcurrentMap<layout_version_t, TupleAccessStrategy> layouts_;
+  // TODO(Tianyu): this is here for when we support concurrent schema, for now we only have one per DataTable
+  // common::ConcurrentMap<layout_version_t, TupleAccessStrategy> layouts_;
   // TODO(Tianyu): Again, change when supporting concurrent schema.
-  const layout_version_t curr_layout_version_{0};
+  // const layout_version_t curr_layout_version_{0};
   // TODO(Tianyu): For now, on insertion, we simply sequentially go through a block and allocate a
   // new one when the current one is full. Needless to say, we will need to revisit this when writing GC.
+
+  // TODO(Matt): remove this TAS when using concurrent schema
+  TupleAccessStrategy accessor_;
   common::ConcurrentVector<RawBlock *> blocks_;
   std::atomic<RawBlock *> insertion_head_ = nullptr;
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -89,7 +89,7 @@ class DataTable {
 
   // Atomically write the version pointer value. Should only be used by Insert where there is guaranteed to be no
   // contention
-  void AtomicallyWriteVersionPtr(const TupleSlot slot, const TupleAccessStrategy &accessor, DeltaRecord *desired);
+  void AtomicallyWriteVersionPtr(TupleSlot slot, const TupleAccessStrategy &accessor, DeltaRecord *desired);
 
   // If there will be a write-write conflict.
   bool HasConflict(DeltaRecord *version_ptr, DeltaRecord *undo) {

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -74,13 +74,13 @@ class DataTable {
   BlockStore *block_store_;
   // TODO(Tianyu): this is here for when we support concurrent schema, for now we only have one per DataTable
   // common::ConcurrentMap<layout_version_t, TupleAccessStrategy> layouts_;
-  // TODO(Tianyu): Again, change when supporting concurrent schema.
-  // const layout_version_t curr_layout_version_{0};
+  // layout_version_t curr_layout_version_{0};
   // TODO(Tianyu): For now, on insertion, we simply sequentially go through a block and allocate a
   // new one when the current one is full. Needless to say, we will need to revisit this when writing GC.
 
-  // TODO(Matt): remove this TAS when using concurrent schema
+  // TODO(Matt): remove this single TAS when using concurrent schema
   TupleAccessStrategy accessor_;
+
   common::ConcurrentVector<RawBlock *> blocks_;
   std::atomic<RawBlock *> insertion_head_ = nullptr;
 

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -88,7 +88,7 @@ struct BlockLayout {
 
   uint32_t HeaderSize() {
     return static_cast<uint32_t>(sizeof(uint32_t) * 3  // layout_version, num_records, num_slots
-        + num_cols_ * sizeof(uint32_t) + sizeof(uint16_t) + num_cols_ * sizeof(uint8_t));
+                                 + num_cols_ * sizeof(uint32_t) + sizeof(uint16_t) + num_cols_ * sizeof(uint8_t));
   }
 
   uint32_t NumSlots() {
@@ -117,7 +117,7 @@ class TupleSlot {
    * @param offset the offset of this slot in its block
    */
   TupleSlot(RawBlock *block, uint32_t offset) : bytes_(reinterpret_cast<uintptr_t>(block) | offset) {
-    PELOTON_ASSERT(!((static_cast<uintptr_t>(common::Constants::BLOCK_SIZE) - 1) & ((uintptr_t) block)),
+    PELOTON_ASSERT(!((static_cast<uintptr_t>(common::Constants::BLOCK_SIZE) - 1) & ((uintptr_t)block)),
                    "Address must be aligned to block size (last bits zero).");
     PELOTON_ASSERT(offset < common::Constants::BLOCK_SIZE,
                    "Offset must be smaller than block size (to fit in the last bits).");
@@ -183,7 +183,8 @@ struct BlockAllocator {
    * Reuse a reused chunk of memory to be handed out again
    * @param reused memory location, possibly filled with junk bytes
    */
-  void Reuse(RawBlock *reused) { /* no operation required */ }
+  void Reuse(RawBlock *reused) { /* no operation required */
+  }
 
   /**
    * Deletes the object by calling its destructor.
@@ -191,7 +192,6 @@ struct BlockAllocator {
    */
   void Delete(RawBlock *ptr) { delete ptr; }
 };
-
 
 /**
  * A block store is essentially an object pool. However, all blocks should be
@@ -383,7 +383,7 @@ namespace std {
 /**
  * Implements std::hash for TupleSlot.
  */
-template<>
+template <>
 struct hash<terrier::storage::TupleSlot> {
   /**
    * Returns the hash of the slot's contents.

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -308,6 +308,15 @@ class ProjectedRow {
     Bitmap().Set(offset, false);
   }
 
+  /**
+   * Set the attribute in the ProjectedRow to be null using the internal bitmap
+   * @param offset The 0-indexed element to access in this ProjectedRow
+   */
+  void SetNotNull(const uint16_t offset) {
+    PELOTON_ASSERT(offset < num_cols_, "Column offset out of bounds.");
+    Bitmap().Set(offset, true);
+  }
+
  private:
   uint16_t num_cols_;
   byte varlen_contents_[0];

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -309,7 +309,7 @@ class ProjectedRow {
   }
 
   /**
-   * Set the attribute in the ProjectedRow to be null using the internal bitmap
+   * Set the attribute in the ProjectedRow to be not null using the internal bitmap
    * @param offset The 0-indexed element to access in this ProjectedRow
    */
   void SetNotNull(const uint16_t offset) {

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -72,7 +72,7 @@ struct BlockLayout {
     // space to pad each individual bitmap to full bytes (every attribute is
     // at least a byte). Somebody can come and fix this later, because I don't
     // feel like thinking about this now.
-    return 8 * (common::Constants::BLOCK_SIZE - header_size_) / (8 * tuple_size_ + num_cols_) - 1;
+    return 8 * (common::Constants::BLOCK_SIZE - header_size_) / (8 * tuple_size_ + num_cols_) - 2;
   }
 };
 
@@ -88,7 +88,7 @@ struct RawBlock {
   /**
    * Number of records.
    */
-  uint32_t num_records_;
+  std::atomic<uint32_t> num_records_;
   /**
    * Contents of the raw block.
    */

--- a/src/include/storage/tuple_access_strategy.h
+++ b/src/include/storage/tuple_access_strategy.h
@@ -18,13 +18,15 @@ namespace terrier::storage {
  */
 class TupleAccessStrategy {
  private:
-
-  // TODO(Tianyu): document
-  static uint32_t PadOffsetToSize(const uint8_t word_size, const uint32_t address) {
-    uint32_t remainder = address % word_size;
-    return remainder == 0
-           ? address
-           : address + word_size - remainder;
+  /**
+   * Given an address offset, aligns it to the word_size
+   * @param word_size size in bytes to align offset to
+   * @param offset address to be aligned
+   * @return modified version of address padded to align to word_size
+   */
+  static uint32_t PadOffsetToSize(const uint8_t word_size, const uint32_t offset) {
+    uint32_t remainder = offset % word_size;
+    return remainder == 0 ? offset : offset + word_size - remainder;
   }
 
   // TODO(Tianyu): These two classes should be aligned for LLVM

--- a/src/storage/storage_defs.cpp
+++ b/src/storage/storage_defs.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 
 #include "storage/storage_defs.h"
+#include "storage/storage_util.h"
 
 namespace terrier::storage {
 uint32_t ProjectedRow::Size(const BlockLayout &layout, const std::vector<uint16_t> &col_ids) {
@@ -11,8 +12,8 @@ uint32_t ProjectedRow::Size(const BlockLayout &layout, const std::vector<uint16_
 }
 
 ProjectedRow *ProjectedRow::InitializeProjectedRow(byte *head,
-                                                  const std::vector<uint16_t> &col_ids,
-                                                  const BlockLayout &layout) {
+                                                   const std::vector<uint16_t> &col_ids,
+                                                   const BlockLayout &layout) {
   auto *result = reinterpret_cast<ProjectedRow *>(head);
   result->num_cols_ = static_cast<uint16_t>(col_ids.size());
   auto val_offset =

--- a/src/storage/tuple_access_strategy.cpp
+++ b/src/storage/tuple_access_strategy.cpp
@@ -1,3 +1,4 @@
+#include <utility>
 #include "common/container/concurrent_bitmap.h"
 #include "storage/tuple_access_strategy.h"
 
@@ -10,8 +11,8 @@ TupleAccessStrategy::TupleAccessStrategy(BlockLayout layout)
   uint32_t acc_offset = PadOffsetToSize(sizeof(uint64_t), layout_.header_size_);
   for (uint16_t i = 0; i < layout_.num_cols_; i++) {
     column_offsets_[i] = acc_offset;
-    uint32_t column_size = layout_.attr_sizes_[i] * layout_.num_slots_ // content
-        + PadOffsetToSize(layout_.attr_sizes_[i], common::BitmapSize(layout_.num_slots_)); // padded-bitmap size
+    uint32_t column_size = layout_.attr_sizes_[i] * layout_.num_slots_  // content
+        + PadOffsetToSize(layout_.attr_sizes_[i], common::BitmapSize(layout_.num_slots_));  // padded-bitmap size
     acc_offset += PadOffsetToSize(sizeof(uint64_t), column_size);
   }
 }

--- a/src/storage/tuple_access_strategy.cpp
+++ b/src/storage/tuple_access_strategy.cpp
@@ -3,6 +3,19 @@
 
 namespace terrier::storage {
 
+TupleAccessStrategy::TupleAccessStrategy(BlockLayout layout)
+    : layout_(std::move(layout)), column_offsets_(layout.num_cols_) {
+  // Calculate the start position of each column
+  // we use 64-bit vectorized scans on bitmaps.
+  uint32_t acc_offset = PadOffsetToSize(sizeof(uint64_t), layout_.header_size_);
+  for (uint16_t i = 0; i < layout_.num_cols_; i++) {
+    column_offsets_[i] = acc_offset;
+    uint32_t column_size = layout_.attr_sizes_[i] * layout_.num_slots_ // content
+        + PadOffsetToSize(layout_.attr_sizes_[i], common::BitmapSize(layout_.num_slots_)); // padded-bitmap size
+    acc_offset += PadOffsetToSize(sizeof(uint64_t), column_size);
+  }
+}
+
 void TupleAccessStrategy::InitializeRawBlock(RawBlock *raw,
                                              const layout_version_t layout_version) {
   // Intentional unsafe cast
@@ -10,14 +23,9 @@ void TupleAccessStrategy::InitializeRawBlock(RawBlock *raw,
   raw->num_records_ = 0;
   auto *result = reinterpret_cast<TupleAccessStrategy::Block *>(raw);
   result->NumSlots() = layout_.num_slots_;
-  uint32_t acc_offset = PadAddressToSize(8, layout_.header_size_);
-  uint32_t *offsets = result->AttrOffets();
-  for (uint16_t i = 0; i < layout_.num_cols_; i++) {
-    offsets[i] = acc_offset;
-    uint32_t column_size = layout_.attr_sizes_[i] * layout_.num_slots_
-        + PadAddressToSize(layout_.attr_sizes_[i], common::BitmapSize(layout_.num_slots_));
-    acc_offset += PadAddressToSize(8, column_size);
-  }
+
+  for (uint16_t i = 0; i < layout_.num_cols_; i++)
+    result->AttrOffets()[i] = column_offsets_[i];
 
   result->NumAttrs(layout_) = layout_.num_cols_;
 

--- a/src/storage/tuple_access_strategy.cpp
+++ b/src/storage/tuple_access_strategy.cpp
@@ -2,28 +2,28 @@
 #include "storage/tuple_access_strategy.h"
 
 namespace terrier::storage {
+
 void TupleAccessStrategy::InitializeRawBlock(RawBlock *raw,
-                        const layout_version_t layout_version) {
+                                             const layout_version_t layout_version) {
   // Intentional unsafe cast
   raw->layout_version_ = layout_version;
   raw->num_records_ = 0;
   auto *result = reinterpret_cast<TupleAccessStrategy::Block *>(raw);
   result->NumSlots() = layout_.num_slots_;
-  // TODO(Tianyu): For now, columns start right after the header without
-  // alignment considerations. This logic will need to change when switching
-  // to LLVM.
-  uint32_t acc_offset = layout_.header_size_;
+  uint32_t acc_offset = PadAddressToSize(8, layout_.header_size_);
   uint32_t *offsets = result->AttrOffets();
   for (uint16_t i = 0; i < layout_.num_cols_; i++) {
     offsets[i] = acc_offset;
     uint32_t column_size = layout_.attr_sizes_[i] * layout_.num_slots_
-        + common::BitmapSize(layout_.num_slots_);
-    acc_offset += column_size;
+        + PadAddressToSize(layout_.attr_sizes_[i], common::BitmapSize(layout_.num_slots_));
+    acc_offset += PadAddressToSize(8, column_size);
   }
 
   result->NumAttrs(layout_) = layout_.num_cols_;
 
   for (uint16_t i = 0; i < layout_.num_cols_; i++)
     result->AttrSizes(layout_)[i] = layout_.attr_sizes_[i];
+
+  result->Column(PRESENCE_COLUMN_ID)->PresenceBitmap()->UnsafeClear(layout_.num_slots_);
 }
 }  // namespace terrier::storage

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -188,18 +188,6 @@ struct FakeRawTuple {
 
 struct TupleAccessStrategyTestUtil {
   TupleAccessStrategyTestUtil() = delete;
-  // Returns a random layout that is guaranteed to be valid.
-  template<typename Random>
-  static storage::BlockLayout RandomLayout(Random *generator, uint16_t max_cols = UINT16_MAX) {
-    PELOTON_ASSERT(max_cols > 1, "There should be at least two cols (first is version).");
-    // We probably won't allow tables with 0 columns
-    uint16_t num_attrs = std::uniform_int_distribution<uint16_t>(1, max_cols)(*generator);
-    std::vector<uint8_t> possible_attr_sizes{1, 2, 4, 8}, attr_sizes(num_attrs);
-    for (uint16_t i = 0; i < num_attrs; i++)
-      attr_sizes[i] = *MultiThreadedTestUtil::UniformRandomElement(&possible_attr_sizes, generator);
-    return {num_attrs, attr_sizes};
-  }
-
   // Fill the given location with the specified amount of random bytes, using the
   // given generator as a source of randomness.
   template<typename Random>

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -29,7 +29,7 @@ TEST_F(TupleAccessStrategyTests, NullTest) {
   const uint32_t max_cols = 1000;
   std::default_random_engine generator;
   for (uint32_t i = 0; i < repeat; i++) {
-    storage::BlockLayout layout = TupleAccessStrategyTestUtil::RandomLayout(&generator, max_cols);
+    storage::BlockLayout layout = StorageTestUtil::RandomLayout(max_cols, &generator);
     storage::TupleAccessStrategy tested(layout);
     PELOTON_MEMSET(raw_block_, 0, sizeof(storage::RawBlock));
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));
@@ -72,7 +72,7 @@ TEST_F(TupleAccessStrategyTests, SimpleInsert) {
   const uint32_t max_inserts = 1000;
   std::default_random_engine generator;
   for (uint32_t i = 0; i < repeat; i++) {
-    storage::BlockLayout layout = TupleAccessStrategyTestUtil::RandomLayout(&generator);
+    storage::BlockLayout layout = StorageTestUtil::RandomLayout(MAX_COL, &generator);
     storage::TupleAccessStrategy tested(layout);
     PELOTON_MEMSET(raw_block_, 0, sizeof(storage::RawBlock));
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));
@@ -103,10 +103,9 @@ TEST_F(TupleAccessStrategyTests, SimpleInsert) {
 // go out of page boundary. (In other words, memory safe.)
 TEST_F(TupleAccessStrategyTests, MemorySafety) {
   const uint32_t repeat = 500;
-  const uint32_t max_cols = 1000;
   std::default_random_engine generator;
   for (uint32_t i = 0; i < repeat; i++) {
-    storage::BlockLayout layout = TupleAccessStrategyTestUtil::RandomLayout(&generator, max_cols);
+    storage::BlockLayout layout = StorageTestUtil::RandomLayout(MAX_COL, &generator);
     storage::TupleAccessStrategy tested(layout);
     // here we don't need to 0-initialize the block because we only
     // test layout, not the content.
@@ -156,7 +155,7 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsertTest) {
     // in a block. This allows us to test out more inter-leavings.
     const uint32_t num_threads = 8;
     const uint16_t max_cols = 1000;
-    storage::BlockLayout layout = TupleAccessStrategyTestUtil::RandomLayout(&generator, max_cols);
+    storage::BlockLayout layout = StorageTestUtil::RandomLayout(max_cols, &generator);
     storage::TupleAccessStrategy tested(layout);
     PELOTON_MEMSET(raw_block_, 0, sizeof(storage::RawBlock));
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));
@@ -203,7 +202,7 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsertDelete) {
     const uint32_t num_threads = 8;
     const uint16_t max_cols = 1000;
 
-    storage::BlockLayout layout = TupleAccessStrategyTestUtil::RandomLayout(&generator, max_cols);
+    storage::BlockLayout layout = StorageTestUtil::RandomLayout(max_cols, &generator);
     storage::TupleAccessStrategy tested(layout);
     PELOTON_MEMSET(raw_block_, 0, sizeof(storage::RawBlock));
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -150,9 +150,7 @@ TEST_F(TupleAccessStrategyTests, MemorySafety) {
 TEST_F(TupleAccessStrategyTests, Alignment) {
   const uint32_t repeat = 500;
   std::default_random_engine generator;
-  
   StorageTestUtil::CheckAlignment(raw_block_, common::Constants::BLOCK_SIZE);
-  
   for (uint32_t i = 0; i < repeat; i++) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(MAX_COL, &generator);
     storage::TupleAccessStrategy tested(layout);

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -150,6 +150,9 @@ TEST_F(TupleAccessStrategyTests, MemorySafety) {
 TEST_F(TupleAccessStrategyTests, Alignment) {
   const uint32_t repeat = 500;
   std::default_random_engine generator;
+  
+  StorageTestUtil::CheckAlignment(raw_block_, common::Constants::BLOCK_SIZE);
+  
   for (uint32_t i = 0; i < repeat; i++) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(MAX_COL, &generator);
     storage::TupleAccessStrategy tested(layout);


### PR DESCRIPTION
Went from ~1M tuples/sec to ~14M tuples/sec on single-threaded insert. Still looking at a couple small tweaks before review, but we're ready to see how it does on CI.

At a high level:
- removed code related to concurrent schema. We can still support it, but the metadata structures aren't necessary at the moment
- optimized ObjectPool for BlockStore use
- optimized starting point for bitmap scan for Allocate
- aligned NullBitmaps to 64-bit and columns to their attribute sizes, yielding a large performance speedup (added a test case for this)
- the offsets for columns are now computed at TAS construction, rather than when initializing each RawBlock
- added simple DataTable insert tests