### PR TITLE
Concurrent Bitmap speedup

### DIFF
--- a/src/include/storage/tuple_access_strategy.h
+++ b/src/include/storage/tuple_access_strategy.h
@@ -224,16 +224,6 @@ class TupleAccessStrategy {
       }
     }
 
-    pos = 0;
-
-    while (bitmap->FirstUnsetPos(layout_.num_slots_ - start, pos, &pos)) {
-      if (bitmap->Flip(pos, false)) {
-        *slot = TupleSlot(block, pos);
-        block->num_records_++;
-        return true;
-      }
-    }
-
     return false;
   }
 


### PR DESCRIPTION
1. Aligns atomic loads. (Assumes byte 0 is aligned for 64-bit loads)
2. Now respects the starting position. (Previously might have returned a position < start_pos, added some tests for that)

My laptop is pretty terrible for benchmarking. I ran it a few times and picked the runs with the lowest variance. 

Before:
BM_SimpleInsert/repeats:10/real_time_mean              204 ms        204 ms          3   9.80427MB/s
BM_SimpleInsert/repeats:10/real_time_median            202 ms        201 ms          3   9.90511MB/s
BM_SimpleInsert/repeats:10/real_time_stddev              7 ms          6 ms          3   331.179kB/s
BM_ConcurrentInsert/repeats:10/real_time_mean           98 ms          0 ms          7   20.3687MB/s
BM_ConcurrentInsert/repeats:10/real_time_median         98 ms          0 ms          7   20.4429MB/s
BM_ConcurrentInsert/repeats:10/real_time_stddev          2 ms          0 ms          7   338.206kB/s

After:
BM_SimpleInsert/repeats:10/real_time_mean              198 ms        198 ms          3   10.0776MB/s
BM_SimpleInsert/repeats:10/real_time_median            199 ms        198 ms          3    10.069MB/s
BM_SimpleInsert/repeats:10/real_time_stddev              0 ms          0 ms          3   22.6165kB/s
BM_ConcurrentInsert/repeats:10/real_time_mean           96 ms          0 ms          7   20.8996MB/s
BM_ConcurrentInsert/repeats:10/real_time_median         95 ms          0 ms          7    20.959MB/s
BM_ConcurrentInsert/repeats:10/real_time_stddev          1 ms          0 ms          7   170.646kB/s