### PR TITLE
Update spin_latch to use TBB spin_mutex

### DIFF
--- a/src/include/common/spin_latch.h
+++ b/src/include/common/spin_latch.h
@@ -1,66 +1,38 @@
 #pragma once
 
-#include <wmmintrin.h>
-#include <atomic>
-
-#include "common/macros.h"
+#include <tbb/spin_mutex.h>
 
 namespace terrier::common {
 
 /**
- * Latch states composing of UNLOCKED and LOCKED
- */
-enum class LatchState : bool { UNLOCKED, LOCKED };
-
-/**
- * A cheap and easy spin latch.
+ * A cheap and easy spin latch, currently wraps tbb::spin_mutex to optimize for various architectures' PAUSE
+ * characteristics. See:
+ * https://software.intel.com/en-us/articles/a-common-construct-to-avoid-the-contention-of-threads-architecture-agnostic-spin-wait-loops
  */
 class SpinLatch {
  public:
-  /**
-   * Initializes a spin latch and set its state to UNLOCKED
-   */
-  SpinLatch() : state_(LatchState::UNLOCKED) {}
-
   /**
    * @brief Locks the spin latch.
    *
    * If another thread has already locked the spin latch, a call to lock will
    * block execution until the lock is acquired.
    */
-  void Lock() {
-    while (!TryLock()) {
-      _mm_pause();  // helps the cpu to detect busy-wait loop
-    }
-  }
-
-  /**
-   * @brief Checks whether the spin latch is locked.
-   *
-   * @return Returns true if the spin latch is locked, otherwise returns false.
-   */
-  bool IsLocked() { return state_.load() == LatchState::LOCKED; }
+  void Lock() { latch_.lock(); }
 
   /**
    * @brief Tries to lock the spin latch.
    *
    * @return On successful lock acquisition returns true, otherwise returns false.
    */
-  bool TryLock() {
-    // exchange returns the value before locking, thus we need
-    // to make sure the lock wasn't already in LOCKED state before
-    return state_.exchange(LatchState::LOCKED, std::memory_order_acquire) != LatchState::LOCKED;
-  }
+  bool TryLock() { return latch_.try_lock(); }
 
   /**
    * @brief Unlocks the spin latch.
    */
-  void Unlock() { state_.store(LatchState::UNLOCKED, std::memory_order_release); }
+  void Unlock() { latch_.unlock(); }
 
  private:
-  /** The exchange method on this atomic is compiled to a lockfree xchgl
-   * instruction */
-  std::atomic<LatchState> state_;
+  tbb::spin_mutex latch_;
 };
 
 }  // namespace terrier::common


### PR DESCRIPTION
Fix #83 

Replace our spin_latch implementation with TBB's. Skylake and newer processors increase the PAUSE latency by an order of magnitude, so efficient spinning requires more work. Intel handles this for us in their spin_mutex with tbb::internal::atomic_backoff.

References:
https://software.intel.com/en-us/articles/a-common-construct-to-avoid-the-contention-of-threads-architecture-agnostic-spin-wait-loops
https://github.com/01org/tbb/blob/tbb_2018/include/tbb/spin_mutex.h
https://github.com/01org/tbb/blob/tbb_2018/include/tbb/tbb_machine.h