### PR TITLE
Boost filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -y update && \
       doxygen \
       git \
       g++-7 \
+      libboost-filesystem-dev \
       libjemalloc-dev \
       libjsoncpp-dev \
       libtbb-dev \

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -261,6 +261,11 @@ find_package(TBB REQUIRED)
 include_directories(SYSTEM ${TBB_INCLUDE_DIRS})
 list(APPEND TERRIER_LINK_LIBS ${TBB_LIBRARIES})
 
+# Boost filesystem
+find_package(Boost COMPONENTS filesystem REQUIRED)
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+list(APPEND TERRIER_LINK_LIBS ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+
 # LLVM 6.0+
 find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -70,6 +70,7 @@ install_mac() {
   # Update Homebrew.
   brew update
   # Install packages.
+  brew ls --versions boost || brew install boost
   brew ls --versions cmake || brew install cmake
   brew ls --versions doxygen || brew install doxygen
   brew ls --versions git || brew install git
@@ -92,6 +93,7 @@ install_linux() {
       doxygen \
       git \
       g++-7 \
+      libboost-filesystem-dev \
       libjemalloc-dev \
       libjsoncpp-dev \
       libtbb-dev \


### PR DESCRIPTION
Adds Boost filesystem as a required dependency for @aaron-tian's logging. Adds the package to the automation scripts.

Eventually we want to look into replacing this with C++17's native filesystem library, but Clang support isn't there yet.