### PR TITLE
Enable clang-format on benchmark and test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,17 +252,30 @@ endif (UNIX)
 # "make format" and "make check-format" targets
 ###########################################################
 
+# we modified the format script to take multiple args
+
+string(CONCAT FORMAT_DIRS
+        "${CMAKE_CURRENT_SOURCE_DIR}/benchmark,"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src,"
+        "${CMAKE_CURRENT_SOURCE_DIR}/test,"
+        )
+
 # runs clang format and updates files in place.
 add_custom_target(format ${BUILD_SUPPORT_DIR}/run_clang_format.py
-  ${CLANG_FORMAT_BIN}
-  ${BUILD_SUPPORT_DIR}/clang_format_exclusions.txt
-  ${CMAKE_CURRENT_SOURCE_DIR}/src --fix ${TERRIER_LINT_QUIET})
+        ${CLANG_FORMAT_BIN}
+        ${BUILD_SUPPORT_DIR}/clang_format_exclusions.txt
+        --source_dirs
+        ${FORMAT_DIRS}
+        --fix
+        ${TERRIER_LINT_QUIET})
 
 # runs clang format and exits with a non-zero exit code if any files need to be reformatted
 add_custom_target(check-format ${BUILD_SUPPORT_DIR}/run_clang_format.py
-   ${CLANG_FORMAT_BIN}
-   ${BUILD_SUPPORT_DIR}/clang_format_exclusions.txt
-   ${CMAKE_CURRENT_SOURCE_DIR}/src ${TERRIER_LINT_QUIET})
+        ${CLANG_FORMAT_BIN}
+        ${BUILD_SUPPORT_DIR}/clang_format_exclusions.txt
+        --source_dirs
+        ${FORMAT_DIRS}
+        ${TERRIER_LINT_QUIET})
 
 ###########################################################
 # "make check-clang-tidy" target

--- a/benchmark/include/util/storage_benchmark_util.h
+++ b/benchmark/include/util/storage_benchmark_util.h
@@ -27,15 +27,14 @@ struct TupleAccessStrategyBenchmarkUtil {
   static void InsertTuple(const storage::ProjectedRow &tuple, const storage::TupleAccessStrategy *tested,
                           const storage::BlockLayout &layout, const storage::TupleSlot slot) {
     // Skip the version vector for tuples
-    for (uint16_t col = 1; col < layout.num_cols_  ; col++) {
+    for (uint16_t col = 1; col < layout.num_cols_; col++) {
       const byte *val_ptr = tuple.AccessWithNullCheck(static_cast<uint16_t>(col - 1));
       if (val_ptr == nullptr) {
         tested->SetNull(slot, col);
       } else {
         // Read the value
         uint64_t val = storage::StorageUtil::ReadBytes(layout.attr_sizes_[col], val_ptr);
-        storage::StorageUtil::WriteBytes(layout.attr_sizes_[col], val,
-                                         tested->AccessForceNotNull(slot, col));
+        storage::StorageUtil::WriteBytes(layout.attr_sizes_[col], val, tested->AccessForceNotNull(slot, col));
       }
     }
   }

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -142,8 +142,7 @@ struct StorageTestUtil {
       const byte *other_content = other->AccessWithNullCheck(projection_list_index);
 
       if (one_content == nullptr || other_content == nullptr) {
-        if (one_content == other_content)
-          continue;
+        if (one_content == other_content) continue;
         return false;
       }
 


### PR DESCRIPTION
We now format benchmark, src, and test. Codebase fixed accordingly.