### PR TITLE
Extended first writer wins logic for HasConflict

### DIFF
--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -95,13 +95,16 @@ class DataTable {
   // contention
   void AtomicallyWriteVersionPtr(TupleSlot slot, const TupleAccessStrategy &accessor, DeltaRecord *desired);
 
-  // If there will be a write-write conflict.
-  bool HasConflict(DeltaRecord *version_ptr, timestamp_t txn_id) {
+  bool HasConflict(DeltaRecord *const version_ptr, transaction::TransactionContext *const txn) {
     if (version_ptr == nullptr) return false;  // Nobody owns this tuple's write lock, no older version visible
-    timestamp_t version_timestamp = version_ptr->Timestamp().load();
-    return version_timestamp != txn_id  // This tuple's write lock is already owned by the txn
-                                        // Nobody owns this tuple's write lock, older version still visible
-           && !transaction::TransactionUtil::Committed(version_timestamp);
+    const timestamp_t version_timestamp = version_ptr->Timestamp().load();
+    const timestamp_t txn_id = txn->TxnId();
+    const timestamp_t start_time = txn->StartTime();
+    return (!transaction::TransactionUtil::Committed(version_timestamp) && version_timestamp != txn_id)
+           // Someone else owns this tuple, write-write-conflict
+           || (transaction::TransactionUtil::Committed(version_timestamp) &&
+               transaction::TransactionUtil::NewerThan(version_timestamp, start_time));
+    // Someone else already committed an update to this tuple while we were running, we can't update this under SI
   }
 
   // Compares and swaps the version pointer to be the undo record, only if its value is equal to the expected one.

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -383,8 +383,8 @@ class DeltaRecord {
   TupleSlot Slot() { return slot_; }
 
   /**
-   * Access the next version in the delta chain
-   * @return pointer to the next version
+   * Access the ProjectedRow containing this record's modifications
+   * @return pointer to the delta (modifications)
    */
   ProjectedRow *Delta() { return reinterpret_cast<ProjectedRow *>(varlen_contents_); }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -65,7 +65,7 @@ bool DataTable::Update(transaction::TransactionContext *txn,
   DeltaRecord *version_ptr = AtomicallyReadVersionPtr(slot, accessor_);
   // Since we disallow write-write conflicts, the version vector pointer is essentially an implicit
   // write lock on the tuple.
-  if (HasConflict(version_ptr, txn->TxnId())) return false;
+  if (HasConflict(version_ptr, txn)) return false;
 
   // Update the next pointer of the new head of the version chain
   undo->Next() = version_ptr;

--- a/test/storage/data_table_concurrent_test.cpp
+++ b/test/storage/data_table_concurrent_test.cpp
@@ -140,7 +140,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentUpdateOneWriterWins) {
       fake_txns.emplace_back(layout,
                              &tested,
                              null_ratio_(generator_),
-                             timestamp_t(0),
+                             timestamp_t(2),
                              timestamp_t(static_cast<uint64_t>(-thread - 1)),
                              &buffer_pool_);
     std::atomic<uint32_t> success = 0, fail = 0;


### PR DESCRIPTION
This is based on the scenario described in Slack last night that @tli2 found with his large scale randomized concurrency control tests.

I extended the logic for HasConflict(), and added a test case for the scenario. I also had to make a change in the concurrent DataTable test that was violating this new constraint.

I also fixed an unrelated comment in DeltaRecord that @yangjuns asked me about this morning.