### PR TITLE
Benchmarks refactor

### DIFF
--- a/benchmark/include/util/storage_benchmark_util.h
+++ b/benchmark/include/util/storage_benchmark_util.h
@@ -14,14 +14,6 @@ namespace terrier {
 struct TupleAccessStrategyBenchmarkUtil {
   TupleAccessStrategyBenchmarkUtil() = delete;
 
-  // Fill the given location with the specified amount of random bytes, using the
-  // given generator as a source of randomness.
-  template <typename Random>
-  static void FillWithRandomBytes(uint32_t num_bytes, byte *out, Random *generator) {
-    std::uniform_int_distribution<uint8_t> dist(0, UINT8_MAX);
-    for (uint32_t i = 0; i < num_bytes; i++) out[i] = static_cast<byte>(dist(*generator));
-  }
-
   // Write the given tuple (projected row) into a block using the given access strategy,
   // at the specified offset
   static void InsertTuple(const storage::ProjectedRow &tuple, const storage::TupleAccessStrategy *tested,

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -12,6 +12,11 @@
 
 namespace terrier {
 
+// This benchmark simulates a key-value store inserting a large number of tuples. This provides a good baseline and
+// reference to other fast data structures (indexes) to compare against. We are interested in the DataTable's raw
+// performance, so the tuple's contents are intentionally left garbage and we don't verify correctness. That's the job
+// of the Google Tests.
+
 class DataTableBenchmark : public benchmark::Fixture {
  public:
   void SetUp(const benchmark::State &state) final {
@@ -49,8 +54,7 @@ class DataTableBenchmark : public benchmark::Fixture {
   storage::ProjectedRow *redo_;
 };
 
-// Test raw DataTable insert time. Generate a fixed layout allocate undo and redo buffers, and then reuse them to
-// repeatedly insert the same garbage tuple over and over into the DataTable to test throughput.
+// Insert the num_inserts_ of tuples into a DataTable in a single thread
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
   // NOLINTNEXTLINE
@@ -66,8 +70,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
 }
 
 
-// Test raw DataTable insert time concurrently. Generate a fixed layout allocate undo and redo buffers, and then reuse
-// them to repeatedly insert the same garbage tuple over and over into the DataTable to test throughput.
+// Insert the num_inserts_ of tuples into a DataTable concurrently
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state) {
   // NOLINTNEXTLINE

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -60,7 +60,6 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
     }
   }
 
-  state.SetBytesProcessed(state.iterations() * num_inserts_ * (redo_size_ + undo_size_));
   state.SetItemsProcessed(state.iterations() * num_inserts_);
 }
 
@@ -80,7 +79,6 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state
     MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads_, workload);
   }
 
-  state.SetBytesProcessed(state.iterations() * num_inserts_ * (redo_size_ + undo_size_));
   state.SetItemsProcessed(state.iterations() * num_inserts_);
 }
 

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -1,6 +1,3 @@
-#include <unordered_map>
-#include <utility>
-#include <vector>
 #include "benchmark/benchmark.h"
 #include "common/typedefs.h"
 #include "storage/data_table.h"
@@ -13,96 +10,86 @@
 
 namespace terrier {
 
+class DataTableBenchmark : public benchmark::Fixture {
+ public:
+  void SetUp(const benchmark::State &state) final {
+    redo_buffer_ = new byte[redo_size_];
+
+    // generate a random redo ProjectedRow to Insert
+    redo_ = storage::ProjectedRow::InitializeProjectedRow(redo_buffer_, all_col_ids_, layout_);
+    StorageTestUtil::PopulateRandomRow(redo_, layout_, 0, &generator_);
+  }
+  void TearDown(const benchmark::State &state) final {
+    delete[] redo_buffer_;
+  }
+
+  // Workload
+  const uint32_t num_inserts_ = 10000000;
+  const uint32_t num_threads_ = 8;
+
+  // Test infrastructure
+  std::default_random_engine generator_;
+  storage::BlockStore block_store_{1000};
+  common::ObjectPool<transaction::UndoBufferSegment> buffer_pool_{num_inserts_};
+
+  // Tuple layout
+  const uint16_t num_columns_ = 2;
+  const uint8_t column_size_ = 8;
+  const storage::BlockLayout layout_{num_columns_, {column_size_, column_size_}};
+
+  // Tuple properties
+  const std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout_)};
+  const uint32_t redo_size_ = storage::ProjectedRow::Size(layout_, all_col_ids_);
+  const uint32_t undo_size_ = storage::DeltaRecord::Size(layout_, all_col_ids_);
+
+  // Insert buffer pointers
+  byte *redo_buffer_;
+  storage::ProjectedRow *redo_;
+};
+
 // Test raw DataTable insert time. Generate a fixed layout allocate undo and redo buffers, and then reuse them to
 // repeatedly insert the same garbage tuple over and over into the DataTable to test throughput.
 // NOLINTNEXTLINE
-static void BM_SimpleInsert(benchmark::State &state) {
-  std::default_random_engine generator;
-  const uint32_t num_inserts = 100000;
-
-  storage::BlockStore block_store{1000};
-  common::ObjectPool<transaction::UndoBufferSegment> buffer_pool{num_inserts};
-  transaction::TransactionManager txn_manager(&buffer_pool);
-
-  // Tuple layout
-  uint16_t num_columns = 2;
-  uint8_t column_size = 8;
-  storage::BlockLayout layout(num_columns, {column_size, column_size});
-
-  std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout)};
-  uint32_t redo_size_ = storage::ProjectedRow::Size(layout, all_col_ids_);
-  uint32_t undo_size_ = storage::DeltaRecord::Size(layout, all_col_ids_);
-
-  // generate a random redo ProjectedRow to Insert
-  auto *redo_buffer = new byte[redo_size_];
-  storage::ProjectedRow *redo = storage::ProjectedRow::InitializeProjectedRow(redo_buffer, all_col_ids_, layout);
-  StorageTestUtil::PopulateRandomRow(redo, layout, 0, &generator);
-
-  // Populate the table with tuples
-  while (state.KeepRunning()) {
-    storage::DataTable table(&block_store, layout);
-    transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool);
-    for (uint32_t i = 0; i < num_inserts; ++i) {
-      table.Insert(&txn, *redo);
+BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
+  // NOLINTNEXTLINE
+  for (auto _ : state) {
+    storage::DataTable table(&block_store_, layout_);
+    transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool_);
+    for (uint32_t i = 0; i < num_inserts_; ++i) {
+      table.Insert(&txn, *redo_);
     }
   }
 
-  delete[] redo_buffer;
-
-  state.SetBytesProcessed(state.iterations() * num_inserts * (redo_size_ + undo_size_));
-  state.SetItemsProcessed(state.iterations() * num_inserts);
+  state.SetBytesProcessed(state.iterations() * num_inserts_ * (redo_size_ + undo_size_));
+  state.SetItemsProcessed(state.iterations() * num_inserts_);
 }
 
 
 // Test raw DataTable insert time concurrently. Generate a fixed layout allocate undo and redo buffers, and then reuse
-// them to repeatedly insert the same garbage tuple over and over into the DataTable to test throughput. Expect high
-// contention on this benchmark right now due to inserting into a single block in the DataTable.
+// them to repeatedly insert the same garbage tuple over and over into the DataTable to test throughput.
 // NOLINTNEXTLINE
-static void BM_ConcurrentInsert(benchmark::State &state) {
-  std::default_random_engine generator;
-  const uint32_t num_inserts = 100000;
-
-  storage::BlockStore block_store{1000};
-  common::ObjectPool<transaction::UndoBufferSegment> buffer_pool{num_inserts};
-
-  // Tuple layout
-  uint16_t num_columns = 2;
-  uint8_t column_size = 8;
-  storage::BlockLayout layout(num_columns, {column_size, column_size});
-
-  std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout)};
-  uint32_t redo_size_ = storage::ProjectedRow::Size(layout, all_col_ids_);
-  uint32_t undo_size_ = storage::DeltaRecord::Size(layout, all_col_ids_);
-
-  const uint32_t num_threads = 8;
-
-  // generate a random redo ProjectedRow to Insert
-  auto *redo_buffer = new byte[redo_size_];
-  storage::ProjectedRow *redo = storage::ProjectedRow::InitializeProjectedRow(redo_buffer, all_col_ids_, layout);
-  StorageTestUtil::PopulateRandomRow(redo, layout, 0, &generator);
-
-  while (state.KeepRunning()) {
-    storage::DataTable table(&block_store, layout);
+BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state) {
+  // NOLINTNEXTLINE
+  for (auto _ : state) {
+    storage::DataTable table(&block_store_, layout_);
     auto workload = [&](uint32_t id) {
-      transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool);
-      for (uint32_t i = 0; i < num_inserts / num_threads; i++)
-        table.Insert(&txn, *redo);
+      transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool_);
+      for (uint32_t i = 0; i < num_inserts_ / num_threads_; i++)
+        table.Insert(&txn, *redo_);
     };
-    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads_, workload);
   }
 
-  delete[] redo_buffer;
-
-  state.SetBytesProcessed(state.iterations() * num_inserts * (redo_size_ + undo_size_));
-  state.SetItemsProcessed(state.iterations() * num_inserts);
+  state.SetBytesProcessed(state.iterations() * num_inserts_ * (redo_size_ + undo_size_));
+  state.SetItemsProcessed(state.iterations() * num_inserts_);
 }
 
-BENCHMARK(BM_SimpleInsert)
+BENCHMARK_REGISTER_F(DataTableBenchmark, SimpleInsert)
     ->Repetitions(10)
     ->Unit(benchmark::kMillisecond)
     ->UseRealTime();
 
-BENCHMARK(BM_ConcurrentInsert)
+BENCHMARK_REGISTER_F(DataTableBenchmark, ConcurrentInsert)
     ->Repetitions(10)
     ->Unit(benchmark::kMillisecond)
     ->UseRealTime();

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -42,12 +42,12 @@ class DataTableBenchmark : public benchmark::Fixture {
   // Workload
   const uint32_t num_inserts_ = 10000000;
   const uint32_t num_threads_ = 8;
-  
+
   // Test infrastructure
   std::default_random_engine generator_;
   storage::BlockStore block_store_{1000};
   common::ObjectPool<transaction::UndoBufferSegment> buffer_pool_{num_inserts_};
-  
+
   // Insert buffer pointers
   byte *redo_buffer_;
   storage::ProjectedRow *redo_;

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -20,9 +20,8 @@ namespace terrier {
 class DataTableBenchmark : public benchmark::Fixture {
  public:
   void SetUp(const benchmark::State &state) final {
-    redo_buffer_ = new byte[redo_size_];
-
     // generate a random redo ProjectedRow to Insert
+    redo_buffer_ = new byte[redo_size_];
     redo_ = storage::ProjectedRow::InitializeProjectedRow(redo_buffer_, all_col_ids_, layout_);
     StorageTestUtil::PopulateRandomRow(redo_, layout_, 0, &generator_);
   }
@@ -68,7 +67,6 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
 
   state.SetItemsProcessed(state.iterations() * num_inserts_);
 }
-
 
 // Insert the num_inserts_ of tuples into a DataTable concurrently
 // NOLINTNEXTLINE

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -29,15 +29,6 @@ class DataTableBenchmark : public benchmark::Fixture {
     delete[] redo_buffer_;
   }
 
-  // Workload
-  const uint32_t num_inserts_ = 10000000;
-  const uint32_t num_threads_ = 8;
-
-  // Test infrastructure
-  std::default_random_engine generator_;
-  storage::BlockStore block_store_{1000};
-  common::ObjectPool<transaction::UndoBufferSegment> buffer_pool_{num_inserts_};
-
   // Tuple layout
   const uint16_t num_columns_ = 2;
   const uint8_t column_size_ = 8;
@@ -48,6 +39,15 @@ class DataTableBenchmark : public benchmark::Fixture {
   const uint32_t redo_size_ = storage::ProjectedRow::Size(layout_, all_col_ids_);
   const uint32_t undo_size_ = storage::DeltaRecord::Size(layout_, all_col_ids_);
 
+  // Workload
+  const uint32_t num_inserts_ = 10000000;
+  const uint32_t num_threads_ = 8;
+  
+  // Test infrastructure
+  std::default_random_engine generator_;
+  storage::BlockStore block_store_{1000};
+  common::ObjectPool<transaction::UndoBufferSegment> buffer_pool_{num_inserts_};
+  
   // Insert buffer pointers
   byte *redo_buffer_;
   storage::ProjectedRow *redo_;

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "benchmark/benchmark.h"
 #include "common/typedefs.h"
 #include "storage/data_table.h"

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -10,6 +10,11 @@
 
 namespace terrier {
 
+// This benchmark simulates a key-value store inserting a large number of tuples. This provides a good baseline and
+// reference to other fast data structures (indexes) to compare against. We are interested in the TAS' raw
+// performance, so the tuple's contents are intentionally left garbage and we don't verify correctness. That's the job
+// of the Google Tests.
+
 class TupleAccessStrategyBenchmark : public benchmark::Fixture {
  public:
   void SetUp(const benchmark::State &state) final {
@@ -45,7 +50,7 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
   storage::ProjectedRow *redo_;
 };
 
-// Roughly corresponds to TEST_F(TupleAccessStrategyTests, SimpleInsert)
+// Insert the maximum number of tuples into a Block in a single thread
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State &state) {
   storage::TupleAccessStrategy tested(layout_);
@@ -57,7 +62,6 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
     PELOTON_MEMSET(raw_block_, 0, sizeof(storage::RawBlock));
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));
 
-    // Insert the maximum number of tuples into this Block
     for (uint32_t j = 0; j < layout_.num_slots_; j++) {
       storage::TupleSlot slot;
       tested.Allocate(raw_block_, &slot);
@@ -72,7 +76,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
   state.SetItemsProcessed(state.iterations() * layout_.num_slots_);
 }
 
-// Roughly corresponds to TEST_F(TupleAccessStrategyTests, ConcurrentInsert)
+// Insert the maximum number of tuples into a Block concurrently
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::State &state) {
   storage::TupleAccessStrategy tested(layout_);

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -18,9 +18,8 @@ namespace terrier {
 class TupleAccessStrategyBenchmark : public benchmark::Fixture {
  public:
   void SetUp(const benchmark::State &state) final {
-    redo_buffer_ = new byte[redo_size_];
-
     // generate a random redo ProjectedRow to Insert
+    redo_buffer_ = new byte[redo_size_];
     redo_ = storage::ProjectedRow::InitializeProjectedRow(redo_buffer_, all_col_ids_, layout_);
     StorageTestUtil::PopulateRandomRow(redo_, layout_, 0, &generator_);
   }

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -68,10 +68,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
     }
     block_store_.Release(raw_block_);
   }
-  // We want to approximate the amount of data processed so Google Benchmark can print stats for us
-  // We'll say it 2x RawBlock because we zero it, and then populate it. This is likely an underestimation
-  size_t bytes_per_repeat = 2 * sizeof(storage::RawBlock);
-  state.SetBytesProcessed(state.iterations() * bytes_per_repeat);
+
   state.SetItemsProcessed(state.iterations() * layout_.num_slots_);
 }
 
@@ -102,10 +99,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::St
     MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads_, workload);
     block_store_.Release(raw_block_);
   }
-  // We want to approximate the amount of data processed so Google Benchmark can print stats for us
-  // We'll say it 2x RawBlock because we zero it, and then populate it. This is likely an underestimation
-  size_t bytes_per_repeat = 2 * sizeof(storage::RawBlock);
-  state.SetBytesProcessed(state.iterations() * bytes_per_repeat);
+
   state.SetItemsProcessed(state.iterations() * layout_.num_slots_);
 }
 

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "benchmark/benchmark.h"
 #include "common/typedefs.h"
 #include "storage/storage_util.h"
@@ -38,7 +40,6 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
   const uint32_t redo_size_ = storage::ProjectedRow::Size(layout_, all_col_ids_);
 
   storage::RawBlock *raw_block_;
-  
   // Insert buffer pointers
   byte *redo_buffer_;
   storage::ProjectedRow *redo_;
@@ -47,7 +48,6 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
 // Roughly corresponds to TEST_F(TupleAccessStrategyTests, SimpleInsert)
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State &state) {
-
   storage::TupleAccessStrategy tested(layout_);
 
   // NOLINTNEXTLINE
@@ -75,7 +75,6 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
 // Roughly corresponds to TEST_F(TupleAccessStrategyTests, ConcurrentInsert)
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::State &state) {
-
   storage::TupleAccessStrategy tested(layout_);
 
   // NOLINTNEXTLINE

--- a/cmake_modules/FindClangTools.cmake
+++ b/cmake_modules/FindClangTools.cmake
@@ -33,7 +33,7 @@
 #  CLANG_TIDY_FOUND, Whether clang format was found
 
 if (DEFINED ENV{HOMEBREW_PREFIX})
-  set(HOMEBREW_PREFIX "${ENV{HOMEBREW_PREFIX}")
+  set(HOMEBREW_PREFIX "$ENV{HOMEBREW_PREFIX}")
 else()
   set(HOMEBREW_PREFIX "/usr/local")
 endif()


### PR DESCRIPTION
Refactored the DataTable and TAS benchmarks to use fixtures. We might want to consolidate these once we have an idea of what our long-term benchmark workloads are going to be.

Note the DataTable benchmarks aren't using really beginning and committing transactions. We just want to test DataTable performance. We should add a TransactionManager benchmark this week to test that.