### PR TITLE
Garbage Collection

### DIFF
--- a/src/include/common/typedefs.h
+++ b/src/include/common/typedefs.h
@@ -168,6 +168,42 @@ class StrongTypeAlias {
   }
 
   /**
+   * less than
+   * @param rhs another strong typed value
+   * @return if this is less than the other value
+   */
+  bool operator<(const StrongTypeAlias &other) const {
+    return val_ < other.val_;
+  }
+
+  /**
+   * less than or equal to
+   * @param rhs another strong typed value
+   * @return if this is less than or equal to the other value
+   */
+  bool operator<=(const StrongTypeAlias &other) const {
+    return val_ <= other.val_;
+  }
+
+  /**
+   * greater than
+   * @param rhs another strong typed value
+   * @return if this is greater than the other value
+   */
+  bool operator>(const StrongTypeAlias &other) const {
+    return val_ > other.val_;
+  }
+
+  /**
+   * less than
+   * @param rhs another strong typed value
+   * @return if this is less than the other value
+   */
+  bool operator>=(const StrongTypeAlias &other) const {
+    return val_ >= other.val_;
+  }
+
+  /**
    * Outputs the StrongTypeAlias to the output stream.
    * @param os output stream to be written to.
    * @param alias StrongTypeAlias to be output.

--- a/src/include/common/typedefs.h
+++ b/src/include/common/typedefs.h
@@ -168,42 +168,6 @@ class StrongTypeAlias {
   }
 
   /**
-   * less than
-   * @param rhs another strong typed value
-   * @return if this is less than the other value
-   */
-  bool operator<(const StrongTypeAlias &other) const {
-    return val_ < other.val_;
-  }
-
-  /**
-   * less than or equal to
-   * @param rhs another strong typed value
-   * @return if this is less than or equal to the other value
-   */
-  bool operator<=(const StrongTypeAlias &other) const {
-    return val_ <= other.val_;
-  }
-
-  /**
-   * greater than
-   * @param rhs another strong typed value
-   * @return if this is greater than the other value
-   */
-  bool operator>(const StrongTypeAlias &other) const {
-    return val_ > other.val_;
-  }
-
-  /**
-   * less than
-   * @param rhs another strong typed value
-   * @return if this is less than the other value
-   */
-  bool operator>=(const StrongTypeAlias &other) const {
-    return val_ >= other.val_;
-  }
-
-  /**
    * Outputs the StrongTypeAlias to the output stream.
    * @param os output stream to be written to.
    * @param alias StrongTypeAlias to be output.

--- a/src/include/common/typedefs.h
+++ b/src/include/common/typedefs.h
@@ -123,7 +123,7 @@ class StrongTypeAlias {
    * @param operand another int type
    * @return sum of the underlying value and given operand
    */
-  StrongTypeAlias operator+(const IntType &operand) { return StrongTypeAlias(val_ + operand); }
+  StrongTypeAlias operator+(const IntType &operand) const { return StrongTypeAlias(val_ + operand); }
 
   /**
    * addition and assignment
@@ -155,7 +155,7 @@ class StrongTypeAlias {
    * @param operand another int type
    * @return difference between the underlying value and given operand
    */
-  StrongTypeAlias operator-(const IntType &operand) { return StrongTypeAlias(val_ - operand); }
+  StrongTypeAlias operator-(const IntType &operand) const { return StrongTypeAlias(val_ - operand); }
 
   /**
    * subtraction and assignment

--- a/src/include/loggers/transaction_logger.h
+++ b/src/include/loggers/transaction_logger.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/spdlog.h"
+
+namespace terrier::transaction {
+extern std::shared_ptr<spdlog::logger> transaction_logger;
+
+void init_transaction_logger();
+}  // namespace terrier::transaction
+
+#define TXN_LOG_TRACE(...) ::terrier::transaction::transaction_logger->trace(__VA_ARGS__);
+
+#define TXN_LOG_DEBUG(...) ::terrier::transaction::transaction_logger->debug(__VA_ARGS__);
+
+#define TXN_LOG_INFO(...) ::terrier::transaction::transaction_logger->info(__VA_ARGS__);
+
+#define TXN_LOG_WARN(...) ::terrier::transaction::transaction`_logger->warn(__VA_ARGS__);
+
+#define TXN_LOG_ERROR(...) ::terrier::transaction::transaction_logger->error(__VA_ARGS__);

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -74,6 +74,8 @@ class DataTable {
   void Rollback(timestamp_t txn_id, TupleSlot slot);
 
  private:
+  friend class GarbageCollector;
+
   BlockStore *block_store_;
   // TODO(Tianyu): this is here for when we support concurrent schema, for now we only have one per DataTable
   // common::ConcurrentMap<layout_version_t, TupleAccessStrategy> layouts_;

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <thread>
+#include <queue>
 #include <utility>
-#include <vector>
 #include "common/container/concurrent_queue.h"
 #include "common/macros.h"
 #include "loggers/storage_logger.h"
@@ -16,76 +15,57 @@ namespace terrier::storage {
 static constexpr uint32_t MAX_ATTEMPTS = 1000000;
 
 class GarbageCollector {
-
  public:
   GarbageCollector() = delete;
-  explicit GarbageCollector(transaction::TransactionManager *txn_manager) : txn_manager_(txn_manager) {}
+  explicit GarbageCollector(transaction::TransactionManager *txn_manager) : txn_manager_(txn_manager), last_run_{0} {}
   ~GarbageCollector() = default;
 
-  bool ThreadRunning() const { return running_; }
-
   std::pair<uint32_t, uint32_t> RunGC() {
-    oldest_txn_ = txn_manager_->OldestTransactionStartTime();
     uint32_t garbage_cleared = ClearGarbage();
     uint32_t txns_cleared = ClearTransactions();
     last_run_ = txn_manager_->Time();
     return std::make_pair(garbage_cleared, txns_cleared);
   }
 
-  void StartGCThread() {
-    PELOTON_ASSERT(!running_ && gc_thread_ == nullptr, "Should only be invoking this on a GC that is not running.");
-    gc_thread_ = new std::thread(&GarbageCollector::ThreadLoop, this);
-    running_ = true;
-  }
-
-  void StopGCThread() {
-    PELOTON_ASSERT(running_ && gc_thread_ != nullptr, "Should only be invoking this on a GC that is running.");
-    running_ = false;
-    gc_thread_->join();
-    delete gc_thread_;
-    oldest_txn_ = txn_manager_->OldestTransactionStartTime();
-    ClearGarbage();
-    ClearTransactions();
-    last_run_ = txn_manager_->Time();
-    gc_thread_ = nullptr;
-  }
-
  private:
-  bool running_ = false;
   transaction::TransactionManager *txn_manager_;
-  std::thread *gc_thread_ = nullptr;
-  timestamp_t oldest_txn_{0};
-  timestamp_t last_run_{0};
-  std::vector<transaction::TransactionContext *> garbage_txns_;
+  timestamp_t last_run_;
+  // queue of txns that have been unlinked, and should possible be deleted on next GC run
+  std::queue<transaction::TransactionContext *> garbage_txns_;
+  // queue of txns that need to be unlinked
+  std::queue<transaction::TransactionContext *> completed_txns_;
 
   uint32_t ClearGarbage() {
     uint32_t garbage_cleared = 0;
     transaction::TransactionContext *txn = nullptr;
-    std::vector<transaction::TransactionContext *> requeue;
+    std::queue<transaction::TransactionContext *> requeue;
     while (!garbage_txns_.empty()) {
-      txn = garbage_txns_.back();
-      garbage_txns_.pop_back();
+      txn = garbage_txns_.front();
+      garbage_txns_.pop();
       if (transaction::TransactionUtil::NewerThan(last_run_, txn->TxnId())) {
         delete txn;
         garbage_cleared++;
       } else {
-        requeue.emplace_back(txn);
+        requeue.push(txn);
       }
     }
 
-    for (auto &i : requeue) {
-      garbage_txns_.emplace_back(std::move(i));
-    }
+    // requeue any txns that we weren't able to delete yet
+    garbage_txns_ = requeue;
 
     return garbage_cleared;
   }
 
   uint32_t ClearTransactions() {
+    const timestamp_t oldest_txn_ = txn_manager_->OldestTransactionStartTime();
     uint32_t txns_cleared = 0;
     uint32_t attempts = 0;
     transaction::TransactionContext *txn = nullptr;
-    std::vector<transaction::TransactionContext *> requeue;
-    while (txn_manager_->CompletedTransactions().Dequeue(&txn) && attempts < MAX_ATTEMPTS) {
+    std::queue<transaction::TransactionContext *> requeue;
+    completed_txns_ = txn_manager_->CompletedTransactions();
+    while (!completed_txns_.empty() && attempts < MAX_ATTEMPTS) {
+      txn = completed_txns_.front();
+      completed_txns_.pop();
       attempts++;
       if (transaction::TransactionUtil::NewerThan(oldest_txn_, txn->TxnId())) {
         transaction::UndoBuffer &undos = txn->GetUndoBuffer();
@@ -98,16 +78,12 @@ class GarbageCollector {
           if (next == nullptr) {
             PELOTON_ASSERT(curr->Timestamp().load() == txn->TxnId(),
                            "There's only one element in the version chain. This must be our DeltaRecord.");
-            if (table->CompareAndSwapVersionPtr(slot, accessor, curr, next)) {
-              // We successfully swapped it
-              continue;
-            } else {
-              // Someone swooped the VersionPointer while we were trying to swap it, start iterating
-              curr = table->AtomicallyReadVersionPtr(slot, accessor);
-              next = curr->Next();
-              PELOTON_ASSERT(next != nullptr,
-                             "Somehow we failed the CAS but Next isn't nullptr? That shouldn't happen.");
-            }
+            if (table->CompareAndSwapVersionPtr(slot, accessor, curr, next)) continue;
+
+            // Someone swooped the VersionPointer while we were trying to swap it, start iterating
+            curr = table->AtomicallyReadVersionPtr(slot, accessor);
+            next = curr->Next();
+            PELOTON_ASSERT(next != nullptr, "Somehow we failed the CAS but Next isn't nullptr? That shouldn't happen.");
           } else {
             while (next->Timestamp().load() != txn->TxnId()) {
               curr = next;
@@ -115,32 +91,29 @@ class GarbageCollector {
             }
             UNUSED_ATTRIBUTE bool result = curr->Next().compare_exchange_strong(next, next->Next().load());
             PELOTON_ASSERT(result,
-                           "We shouldn't be able to fail this CAS later in the version chain since there should be no other writers.");
+                           "We shouldn't be able to fail this CAS later in the version chain since there should be no "
+                           "other writers.");
           }
         }
-        garbage_txns_.emplace_back(txn);
+        garbage_txns_.push(txn);
         txns_cleared++;
       } else {
-        requeue.emplace_back(txn);
+        requeue.push(txn);
       }
     }
 
-    for (auto &i : requeue) {
-      txn_manager_->CompletedTransactions().Enqueue(std::move(i));
+    if (!requeue.empty() && !completed_txns_.empty()) {
+      while (!requeue.empty()) {
+        txn = requeue.front();
+        requeue.pop();
+        completed_txns_.push(txn);
+      }
+    } else if (!requeue.empty() && completed_txns_.empty()) {
+      completed_txns_ = requeue;
     }
 
     return txns_cleared;
   }
-
-  void ThreadLoop() {
-    while (running_) {
-      if (!txn_manager_->CompletedTransactions().Empty() || !garbage_txns_.empty()) {
-        RunGC();
-      }
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-  }
-
 };
 
 }  // namespace terrier::storage

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -2,13 +2,8 @@
 
 #include <queue>
 #include <utility>
-#include "common/container/concurrent_queue.h"
-#include "common/macros.h"
-#include "loggers/storage_logger.h"
-#include "storage/data_table.h"
 #include "transaction/transaction_context.h"
 #include "transaction/transaction_manager.h"
-#include "transaction/transaction_util.h"
 
 namespace terrier::storage {
 
@@ -25,7 +20,8 @@ class GarbageCollector {
    * GC to invoke the TM's function for handing off the completed transactions queue.
    * @param txn_manager pointer to the TransactionManager
    */
-  explicit GarbageCollector(transaction::TransactionManager *txn_manager) : txn_manager_(txn_manager), last_run_{0} {
+  explicit GarbageCollector(transaction::TransactionManager *txn_manager)
+      : txn_manager_(txn_manager), last_unlinked_{0} {
     PELOTON_ASSERT(txn_manager_->GCEnabled(),
                    "The TransactionManager needs to be instantiated with gc_enabled true for GC to work!");
   }
@@ -38,44 +34,20 @@ class GarbageCollector {
    * @return A pair of numbers: the first is the number of transactions deallocated (deleted) on this iteration, while
    * the second is the number of transactions unlinked on this iteration.
    */
-  std::pair<uint64_t, uint32_t> RunGC() {
-    uint64_t txns_deallocated = Deallocate();
-    uint32_t txns_unlinked = Unlink();
-    last_run_ = txn_manager_->GetTimestamp();
-    return std::make_pair(txns_deallocated, txns_unlinked);
-  }
+  std::pair<uint64_t, uint32_t> RunGC();
 
  private:
-  transaction::TransactionManager *txn_manager_;
-  // timestamp of the last time GC completed. We need this to know when unlinked versions are safe to deallocate.
-  timestamp_t last_run_;
-  // queue of txns that have been unlinked, and should possible be deleted on next GC run
-  std::queue<transaction::TransactionContext *> txns_to_deallocate_;
-  // queue of txns that need to be unlinked
-  std::queue<transaction::TransactionContext *> txns_to_unlink_;
-
   /**
    * Process the deallocate queue
    * @return number of txns deallocated (not DeltaRecords) for debugging/testing
    */
-  uint64_t Deallocate() {
-    const timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
-    uint64_t garbage_cleared = 0;
-    transaction::TransactionContext *txn = nullptr;
+  uint64_t Deallocate();
 
-    if (transaction::TransactionUtil::NewerThan(oldest_txn, last_run_)) {
-      // All of the transactions in my deallocation queue were unlinked before the oldest running txn in the system.
-      // We are now safe to deallocate these txns because no one should hold a reference to them anymore
-      garbage_cleared = txns_to_deallocate_.size();
-      while (!txns_to_deallocate_.empty()) {
-        txn = txns_to_deallocate_.front();
-        txns_to_deallocate_.pop();
-        delete txn;
-      }
-    }
-
-    return garbage_cleared;
-  }
+  /**
+   * Process the unlink queue
+   * @return number of txns unlinked (not DeltaRecords) for debugging/testing
+   */
+  uint32_t Unlink();
 
   /**
    * Given a DeltaRecord that has been deemed safe to unlink by the GC, removes it from the version chain. This requires
@@ -83,92 +55,15 @@ class GarbageCollector {
    * @param txn pointer to the transaction that created this DeltaRecord
    * @param undo_record DeltaRecord to be unlinked
    */
-  void UnlinkDeltaRecord(transaction::TransactionContext *const txn, const DeltaRecord &undo_record) {
-    PELOTON_ASSERT(txn->TxnId() == undo_record.Timestamp().load(), "This undo_record does not belong to this txn.");
-    DataTable *const table = undo_record.Table();
-    const TupleSlot slot = undo_record.Slot();
-    const TupleAccessStrategy &accessor = table->accessor_;
+  void UnlinkDeltaRecord(transaction::TransactionContext *const txn, const DeltaRecord &undo_record) const;
 
-    DeltaRecord *version_ptr;
-    do {
-      version_ptr = table->AtomicallyReadVersionPtr(slot, accessor);
-      PELOTON_ASSERT(version_ptr != nullptr, "GC should not be trying to unlink in an empty version chain.");
-
-      if (version_ptr->Timestamp().load() == txn->TxnId()) {
-        // Our DeltaRecord is the first in the chain, handle contention on the write lock with CAS
-        if (table->CompareAndSwapVersionPtr(slot, accessor, version_ptr, version_ptr->Next())) break;
-        // Someone swooped the VersionPointer while we were trying to swap it (aka took the write lock)
-        version_ptr = table->AtomicallyReadVersionPtr(slot, accessor);
-      }
-      // a version chain is guaranteed to not change when not at the head (assuming single-threaded GC), so we are safe
-      // to traverse and update pointers without CAS
-      DeltaRecord *curr = version_ptr;
-      DeltaRecord *next = curr->Next();
-
-      // traverse until we hit the DeltaRecord that we want to unlink
-      while (next != nullptr && next->Timestamp().load() != txn->TxnId()) {
-        curr = next;
-        next = curr->Next();
-      }
-      // we're in position with next being the DeltaRecord to be unlinked
-      if (next != nullptr && next->Timestamp().load() == txn->TxnId()) {
-        curr->Next().store(next->Next().load());
-        break;
-      }
-      // If that process didn't work (interleaved abort) then try again
-    } while (true);
-  }
-
-  /**
-   * Process the unlink queue
-   * @return number of txns unlinked (not DeltaRecords) for debugging/testing
-   */
-  uint32_t Unlink() {
-    const timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
-    transaction::TransactionContext *txn = nullptr;
-
-    // Get the completed transactions from the TransactionManager
-    std::queue<transaction::TransactionContext *> from_txn_manager = txn_manager_->CompletedTransactions();
-
-    // Append to our local unlink queue
-    while (!from_txn_manager.empty()) {
-      txn = from_txn_manager.front();
-      from_txn_manager.pop();
-      txns_to_unlink_.push(txn);
-    }
-
-    uint32_t txns_cleared = 0;
-    std::queue<transaction::TransactionContext *> requeue;
-    // Process every transaction in the unlink queue
-    while (!txns_to_unlink_.empty()) {
-      txn = txns_to_unlink_.front();
-      txns_to_unlink_.pop();
-      if (!transaction::TransactionUtil::Committed(txn->TxnId())) {
-        // this is an aborted txn. There is nothing to unlink because Rollback() handled that already, but we still need
-        // to safely free the txn
-        txns_to_deallocate_.push(txn);
-        txns_cleared++;
-      } else if (transaction::TransactionUtil::NewerThan(oldest_txn, txn->TxnId())) {
-        // this is a committed txn that is no visible to any running txns. Proceed with unlinking its DeltaRecords
-        transaction::UndoBuffer &undos = txn->GetUndoBuffer();
-        for (auto &undo_record : undos) {
-          UnlinkDeltaRecord(txn, undo_record);
-        }
-        txns_to_deallocate_.push(txn);
-        txns_cleared++;
-      } else {
-        // this is a committed txn that is still visible, requeue for next GC run
-        requeue.push(txn);
-      }
-    }
-
-    // requeue any txns that we were still visible to running transactions
-    if (!requeue.empty()) {
-      txns_to_unlink_ = requeue;
-    }
-
-    return txns_cleared;
-  }
+  transaction::TransactionManager *txn_manager_;
+  // timestamp of the last time GC unlinked anything. We need this to know when unlinked versions are safe to deallocate
+  timestamp_t last_unlinked_;
+  // queue of txns that have been unlinked, and should possible be deleted on next GC run
+  std::queue<transaction::TransactionContext *> txns_to_deallocate_;
+  // queue of txns that need to be unlinked
+  std::queue<transaction::TransactionContext *> txns_to_unlink_;
 };
 
 }  // namespace terrier::storage

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -18,11 +18,11 @@ class GarbageCollector {
   explicit GarbageCollector(transaction::TransactionManager *txn_manager) : txn_manager_(txn_manager), last_run_{0} {}
   ~GarbageCollector() = default;
 
-  std::pair<uint32_t, uint32_t> RunGC() {
-    uint32_t garbage_cleared = Deallocate();
-    uint32_t txns_cleared = Unlink();
+  std::pair<uint64_t, uint32_t> RunGC() {
+    uint64_t txns_deallocated = Deallocate();
+    uint32_t txns_unlinked = Unlink();
     last_run_ = txn_manager_->GetTimestamp();
-    return std::make_pair(garbage_cleared, txns_cleared);
+    return std::make_pair(txns_deallocated, txns_unlinked);
   }
 
  private:
@@ -33,9 +33,9 @@ class GarbageCollector {
   // queue of txns that need to be unlinked
   std::queue<transaction::TransactionContext *> txns_to_unlink_;
 
-  uint32_t Deallocate() {
+  uint64_t Deallocate() {
     const timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
-    uint32_t garbage_cleared = 0;
+    uint64_t garbage_cleared = 0;
     transaction::TransactionContext *txn = nullptr;
 
     if (transaction::TransactionUtil::NewerThan(oldest_txn, last_run_)) {

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -55,7 +55,7 @@ class GarbageCollector {
    * @param txn pointer to the transaction that created this DeltaRecord
    * @param undo_record DeltaRecord to be unlinked
    */
-  void UnlinkDeltaRecord(transaction::TransactionContext *const txn, const DeltaRecord &undo_record) const;
+  void UnlinkDeltaRecord(transaction::TransactionContext *txn, const DeltaRecord &undo_record) const;
 
   transaction::TransactionManager *txn_manager_;
   // timestamp of the last time GC unlinked anything. We need this to know when unlinked versions are safe to deallocate

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+#include "common/container/concurrent_queue.h"
+#include "storage/data_table.h"
+#include "transaction/transaction_context.h"
+#include "transaction/transaction_util.h"
+
+namespace terrier::storage {
+
+class GarbageCollector {
+ private:
+  timestamp_t oldest_txn_{0};
+  timestamp_t last_run_{0};
+  common::ConcurrentQueue<transaction::TransactionContext *> completed_txns_;
+  std::vector<transaction::TransactionContext *> garbage_txns_;
+
+  uint32_t ClearGarbage() {
+    uint32_t garbage_cleared = 0;
+
+    transaction::TransactionContext *txn = nullptr;
+    std::vector<transaction::TransactionContext *> requeue;
+    while (!garbage_txns_.empty()) {
+      txn = garbage_txns_.back();
+      garbage_txns_.pop_back();
+      if (transaction::TransactionUtil::NewerThan(last_run_, txn->TxnId())) {
+        delete txn;
+        garbage_cleared++;
+      } else {
+        requeue.emplace_back(txn);
+      }
+    }
+
+    for (auto &i : requeue) {
+      garbage_txns_.emplace_back(std::move(i));
+    }
+
+    return garbage_cleared;
+  }
+
+  uint32_t ClearTransactions() {
+    uint32_t txns_cleared = 0;
+    transaction::TransactionContext *txn = nullptr;
+    std::vector<transaction::TransactionContext *> requeue;
+    while (completed_txns_.Dequeue(&txn)) {
+      if (transaction::TransactionUtil::NewerThan(oldest_txn_, txn->TxnId())) {
+        transaction::UndoBuffer &undos = txn->GetUndoBuffer();
+        for (UNUSED_ATTRIBUTE auto &undo_record : undos) {
+          // prune version chain
+        }
+        garbage_txns_.emplace_back(txn);
+        txns_cleared++;
+      } else {
+        requeue.emplace_back(txn);
+      }
+    }
+
+    for (auto &i : requeue) {
+      completed_txns_.Enqueue(std::move(i));
+    }
+
+    return txns_cleared;
+  }
+
+  void Running() {
+    ClearGarbage();
+    ClearTransactions();
+  }
+
+ public:
+  void AddGarbage(transaction::TransactionContext *txn) { completed_txns_.Enqueue(std::move(txn)); }
+};
+
+}  // namespace terrier::storage

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -34,14 +34,14 @@ class GarbageCollector {
    * @return A pair of numbers: the first is the number of transactions deallocated (deleted) on this iteration, while
    * the second is the number of transactions unlinked on this iteration.
    */
-  std::pair<uint64_t, uint32_t> RunGC();
+  std::pair<uint32_t, uint32_t> RunGC();
 
  private:
   /**
    * Process the deallocate queue
    * @return number of txns deallocated (not DeltaRecords) for debugging/testing
    */
-  uint64_t Deallocate();
+  uint32_t Deallocate();
 
   /**
    * Process the unlink queue

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -20,7 +20,6 @@ namespace terrier::storage {
  */
 class GarbageCollector {
  public:
-  GarbageCollector() = delete;
   /**
    * Constructor for the Garbage Collector that requires a pointer to the TransactionManager. This is necessary for the
    * GC to invoke the TM's function for handing off the completed transactions queue.
@@ -30,7 +29,6 @@ class GarbageCollector {
     PELOTON_ASSERT(txn_manager_->GCEnabled(),
                    "The TransactionManager needs to be instantiated with gc_enabled true for GC to work!");
   }
-  ~GarbageCollector() = default;
 
   /**
    * Deallocates transactions that can no longer be references by running transactions, and unlinks DeltaRecords that
@@ -131,16 +129,12 @@ class GarbageCollector {
 
     // Get the completed transactions from the TransactionManager
     std::queue<transaction::TransactionContext *> from_txn_manager = txn_manager_->CompletedTransactions();
-    if (!txns_to_unlink_.empty()) {
-      // Append to our non-empty unlink queue
-      while (!from_txn_manager.empty()) {
-        txn = from_txn_manager.front();
-        from_txn_manager.pop();
-        txns_to_unlink_.push(txn);
-      }
-    } else {
-      // Overwrite our empty unlink queue
-      txns_to_unlink_ = from_txn_manager;
+
+    // Append to our local unlink queue
+    while (!from_txn_manager.empty()) {
+      txn = from_txn_manager.front();
+      from_txn_manager.pop();
+      txns_to_unlink_.push(txn);
     }
 
     uint32_t txns_cleared = 0;

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <ostream>
 #include <utility>
 #include <vector>
-#include <ostream>
 #include "common/constants.h"
 #include "common/container/bitmap.h"
 #include "common/macros.h"

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -380,12 +380,12 @@ class DeltaRecord {
   /**
    * @return the DataTable this DeltaRecord points to
    */
-  DataTable *Table() { return table_; }
+  DataTable *Table() const { return table_; }
 
   /**
    * @return the TupleSlot this DeltaRecord points to
    */
-  TupleSlot Slot() { return slot_; }
+  TupleSlot Slot() const { return slot_; }
 
   /**
    * Access the ProjectedRow containing this record's modifications

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -378,6 +378,11 @@ class DeltaRecord {
   std::atomic<timestamp_t> &Timestamp() { return timestamp_; }
 
   /**
+   * @return Timestamp up to which the old projected row was visible.
+   */
+  const std::atomic<timestamp_t> &Timestamp() const { return timestamp_; }
+
+  /**
    * @return the DataTable this DeltaRecord points to
    */
   DataTable *Table() const { return table_; }

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -2,9 +2,9 @@
 
 #include <utility>
 #include <vector>
+#include <ostream>
 #include "common/constants.h"
 #include "common/container/bitmap.h"
-#include "common/json_serializable.h"
 #include "common/macros.h"
 #include "common/object_pool.h"
 #include "common/typedefs.h"

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -370,7 +370,7 @@ class DeltaRecord {
   /**
    * @return Pointer to the next element in the version chain
    */
-  DeltaRecord *&Next() { return next_; }
+  std::atomic<DeltaRecord *> &Next() { return next_; }
 
   /**
    * @return Timestamp up to which the old projected row was visible.
@@ -461,8 +461,7 @@ class DeltaRecord {
   }
 
  private:
-  // TODO(Tianyu): Always padded?
-  DeltaRecord *next_;
+  std::atomic<DeltaRecord *> next_;
   std::atomic<timestamp_t> timestamp_;
   DataTable *table_;
   TupleSlot slot_;

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -168,6 +168,11 @@ class UndoBuffer {
    */
   Iterator end() { return {buffers_.end(), 0}; }
 
+  /**
+   * @return true if UndoBuffer contains no DeltaRecords, false otherwise
+   */
+  bool Empty() const { return buffers_.empty(); }
+
  private:
   friend class TransactionContext;
   storage::DeltaRecord *NewEntry(const uint32_t size) {

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -207,7 +207,12 @@ class TransactionContext {
   /**
    * @return id of this transaction
    */
-  timestamp_t TxnId() const { return txn_id_; }
+  const timestamp_t &TxnId() const { return txn_id_; }
+
+  /**
+   * @return id of this transaction
+   */
+  timestamp_t &TxnId() { return txn_id_; }
 
   /**
    * @return the undo buffer of this transaction
@@ -246,7 +251,7 @@ class TransactionContext {
 
  private:
   const timestamp_t start_time_;
-  const timestamp_t txn_id_;
+  timestamp_t txn_id_;
   UndoBuffer undo_buffer_;
 };
 }  // namespace terrier::transaction

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -161,12 +161,12 @@ class UndoBuffer {
   /**
    * @return Iterator to the first element
    */
-  Iterator Begin() { return {buffers_.begin(), 0}; }
+  Iterator begin() { return {buffers_.begin(), 0}; }
 
   /**
    * @return Iterator to the element following the last element
    */
-  Iterator End() { return {buffers_.end(), 0}; }
+  Iterator end() { return {buffers_.end(), 0}; }
 
  private:
   friend class TransactionContext;

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -50,12 +50,12 @@ class TransactionManager {
    */
   timestamp_t Commit(TransactionContext *txn) {
     common::ReaderWriterLatch::ScopedWriterLatch guard(&commit_latch_);
-    timestamp_t commit_time = time_++;
+    const timestamp_t commit_time = time_++;
     // Flip all timestamps to be committed
     UndoBuffer &undos = txn->GetUndoBuffer();
     for (auto &it : undos) it.Timestamp().store(commit_time);
     table_latch_.Lock();
-    timestamp_t start_time = txn->StartTime();
+    const timestamp_t start_time = txn->StartTime();
     auto it = curr_running_txns_.find(start_time);
     PELOTON_ASSERT(it != curr_running_txns_.end(), "committed transaction did not exist in global transactions table");
     curr_running_txns_.erase(it);

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -85,7 +85,8 @@ class TransactionManager {
    */
   timestamp_t OldestTransactionStartTime() const {
     table_latch_.Lock();
-    timestamp_t result = curr_running_txns_.begin()->second->StartTime();
+    auto oldest_txn = curr_running_txns_.begin();
+    timestamp_t result = (oldest_txn != curr_running_txns_.end()) ? oldest_txn->second->StartTime() : time_.load();
     table_latch_.Unlock();
     return result;
   }

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -91,6 +91,14 @@ class TransactionManager {
     return result;
   }
 
+  /**
+   * Get the oldest transaction alive in the system at this time. Because of concurrent operations, it
+   * is not guaranteed that upon return the txn is still alive. However, it is guaranteed that the return
+   * timestamp is older than any transactions live.
+   * @return timestamp that is older than any transactions alive
+   */
+  timestamp_t Time() const { return time_.load(); }
+
  private:
   common::ObjectPool<UndoBufferSegment> *buffer_pool_;
   // TODO(Tianyu): Timestamp generation needs to be more efficient

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -52,7 +52,7 @@ class TransactionManager {
     timestamp_t commit_time = time_++;
     // Flip all timestamps to be committed
     UndoBuffer &undos = txn->GetUndoBuffer();
-    for (auto it = undos.Begin(); it != undos.End(); ++it) it->Timestamp().store(commit_time);
+    for (auto &it : undos) it.Timestamp().store(commit_time);
     table_latch_.Lock();
     timestamp_t start_time = txn->StartTime();
     auto it = curr_running_txns_.find(start_time);
@@ -69,7 +69,7 @@ class TransactionManager {
   void Abort(TransactionContext *txn) {
     // no latch required on undo since all operations are transaction-local
     UndoBuffer &undos = txn->GetUndoBuffer();
-    for (auto it = undos.Begin(); it != undos.End(); ++it) it->Table()->Rollback(txn->TxnId(), it->Slot());
+    for (auto &it : undos) it.Table()->Rollback(txn->TxnId(), it.Slot());
     table_latch_.Lock();
     timestamp_t start_time = txn->StartTime();
     auto ret UNUSED_ATTRIBUTE = curr_running_txns_.erase(start_time);

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "common/rw_latch.h"
+#include <map>
+#include "common/rw_latch.h"
 #include "common/spin_latch.h"
 #include "common/typedefs.h"
 #include "storage/data_table.h"
@@ -27,13 +29,23 @@ class TransactionManager {
   TransactionContext *BeginTransaction() {
     common::ReaderWriterLatch::ScopedReaderLatch guard(&commit_latch_);
     timestamp_t id = time_++;
-    // An uncommitted transaction has "commit timestamp" larger than any transaction ("negative" values)
-    return new TransactionContext{id, id + INT64_MIN, buffer_pool_};
+    // TODO(Tianyu):
+    // Maybe embed this into the data structure, or use an object pool?
+    // Doing this with std::map or other data structure is risky though, as they may not
+    // guarantee that the iterator or underlying pointer is stable across operations.
+    // (That is, they may change as concurrent inserts and deletes happen)
+    auto *result = new TransactionContext(id, id + INT64_MIN, buffer_pool_);
+    table_latch_.Lock();
+    auto ret UNUSED_ATTRIBUTE = curr_running_txns_.emplace(result->StartTime(), result);
+    PELOTON_ASSERT(ret.second, "commit start time should be globally unique");
+    table_latch_.Unlock();
+    return result;
   }
 
   /**
    * Commits a transaction, making all of its changes visible to others.
    * @param txn the transaction to commit
+   * @return commit timestamp of this transaction
    */
   timestamp_t Commit(TransactionContext *txn) {
     common::ReaderWriterLatch::ScopedWriterLatch guard(&commit_latch_);
@@ -41,6 +53,12 @@ class TransactionManager {
     // Flip all timestamps to be committed
     UndoBuffer &undos = txn->GetUndoBuffer();
     for (auto it = undos.Begin(); it != undos.End(); ++it) it->Timestamp().store(commit_time);
+    table_latch_.Lock();
+    timestamp_t start_time = txn->StartTime();
+    auto it = curr_running_txns_.find(start_time);
+    PELOTON_ASSERT(it != curr_running_txns_.end(), "committed transaction did not exist in global transactions table");
+    curr_running_txns_.erase(it);
+    table_latch_.Unlock();
     return commit_time;
   }
 
@@ -52,6 +70,24 @@ class TransactionManager {
     // no latch required on undo since all operations are transaction-local
     UndoBuffer &undos = txn->GetUndoBuffer();
     for (auto it = undos.Begin(); it != undos.End(); ++it) it->Table()->Rollback(txn->TxnId(), it->Slot());
+    table_latch_.Lock();
+    timestamp_t start_time = txn->StartTime();
+    auto ret UNUSED_ATTRIBUTE = curr_running_txns_.erase(start_time);
+    PELOTON_ASSERT(ret == 1, "aborted transaction did not exist in global transactions table");
+    table_latch_.Unlock();
+  }
+
+  /**
+   * Get the oldest transaction alive in the system at this time. Because of concurrent operations, it
+   * is not guaranteed that upon return the txn is still alive. However, it is guaranteed that the return
+   * timestamp is older than any transactions live.
+   * @return timestamp that is older than any transactions alive
+   */
+  timestamp_t OldestTransactionStartTime() const {
+    table_latch_.Lock();
+    timestamp_t result = curr_running_txns_.begin()->second->StartTime();
+    table_latch_.Unlock();
+    return result;
   }
 
  private:
@@ -60,7 +96,14 @@ class TransactionManager {
   // TODO(Tianyu): We don't handle timestamp wrap-arounds. I doubt this would be an issue though.
   std::atomic<timestamp_t> time_{timestamp_t(0)};
 
-  // TODO(Tianyu): This is the famed HyPer Latch. Re-evaluate performance later.
-  common::ReaderWriterLatch commit_latch_;
+  // TODO(Tianyu): Maybe don't use tbb?
+  // TODO(Tianyu): This is the famed HyPer Latch. We will need to re-evaluate performance later.
+  mutable common::ReaderWriterLatch commit_latch_;
+
+  // TODO(Tianyu): Get a better data structure for this.
+  // TODO(Tianyu): Also, we are leveraging off the fact that we know start time to be globally unique, so we should
+  // think about this when refactoring the txn id thing.
+  mutable common::SpinLatch table_latch_;
+  std::map<timestamp_t, TransactionContext *> curr_running_txns_;
 };
 }  // namespace terrier::transaction

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -20,6 +20,7 @@ class TransactionManager {
    * Initializes a new transaction manager. Transactions will use the given object pool as source of their undo
    * buffers.
    * @param buffer_pool the buffer pool to use for transaction undo buffers
+   * @param gc_enabled true if txns should be stored in a local queue to hand off to the GC, false otherwise
    */
   explicit TransactionManager(common::ObjectPool<UndoBufferSegment> *buffer_pool, bool gc_enabled)
       : buffer_pool_(buffer_pool), gc_enabled_(gc_enabled) {}
@@ -99,7 +100,15 @@ class TransactionManager {
     return result;
   }
 
+  /**
+   * @return unique timestamp based on current time, and advances one tick
+   */
   timestamp_t GetTimestamp() { return time_++; }
+
+  /**
+   * @return true if gc_enabled and storing completed txns in local queue, false otherwise
+   */
+  bool GCEnabled() const { return gc_enabled_; }
 
   /**
    * Return the completed txns queue and empty it

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -61,7 +61,7 @@ class TransactionManager {
     curr_running_txns_.erase(it);
     table_latch_.Unlock();
     txn->TxnId() = commit_time;
-    if (gc_enabled_ && undos.begin() != undos.end()) {
+    if (gc_enabled_ && !undos.Empty()) {
       completed_txns_.Enqueue(std::move(txn));
     }
     return commit_time;

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -106,10 +106,14 @@ class TransactionManager {
    */
   timestamp_t Time() const { return time_.load(); }
 
+  /**
+   * Return the completed txns queue and empty it
+   * @return
+   */
   std::queue<transaction::TransactionContext *> CompletedTransactions() {
     table_latch_.Lock();
     std::queue<transaction::TransactionContext *> hand_to_gc(std::move(completed_txns_));
-    PELOTON_ASSERT(completed_txns_.empty(), "Transaction manager's queue should now be empty.");
+    PELOTON_ASSERT(completed_txns_.empty(), "TransactionManager's queue should now be empty.");
     table_latch_.Unlock();
     return hand_to_gc;
   }
@@ -122,7 +126,7 @@ class TransactionManager {
 
   // TODO(Tianyu): Maybe don't use tbb?
   // TODO(Tianyu): This is the famed HyPer Latch. We will need to re-evaluate performance later.
-  mutable common::ReaderWriterLatch commit_latch_;
+  common::ReaderWriterLatch commit_latch_;
 
   // TODO(Tianyu): Get a better data structure for this.
   // TODO(Tianyu): Also, we are leveraging off the fact that we know start time to be globally unique, so we should

--- a/src/loggers/transaction_logger.cpp
+++ b/src/loggers/transaction_logger.cpp
@@ -1,0 +1,14 @@
+#include <memory>
+#include "loggers/main_logger.h"
+#include "loggers/transaction_logger.h"
+
+namespace terrier::transaction {
+
+std::shared_ptr<spdlog::logger> transaction_logger;
+
+  void init_transaction_logger() {
+  transaction_logger = std::make_shared<spdlog::logger>("transaction_logger", ::default_sink);
+  spdlog::register_logger(transaction_logger);
+}
+
+}  // namespace terrier::transaction

--- a/src/main/terrier.cpp
+++ b/src/main/terrier.cpp
@@ -1,13 +1,15 @@
 #include <iostream>
 #include "loggers/main_logger.h"
 #include "loggers/storage_logger.h"
+#include "loggers/transaction_logger.h"
 
 int main() {
   // initialize loggers
   try {
     init_main_logger();
     // initialize namespace specific loggers
-    ::terrier::storage::init_storage_logger();
+    terrier::storage::init_storage_logger();
+    terrier::transaction::init_transaction_logger();
 
     // Flush all *registered* loggers using a worker thread.
     // Registered loggers must be thread safe for this to work correctly

--- a/src/main/terrier.cpp
+++ b/src/main/terrier.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include "loggers/main_logger.h"
 #include "loggers/storage_logger.h"
-#include "storage/garbage_collector.h"
 
 int main() {
   // initialize loggers

--- a/src/main/terrier.cpp
+++ b/src/main/terrier.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include "loggers/main_logger.h"
 #include "loggers/storage_logger.h"
-
+#include "storage/garbage_collector.h"
 
 int main() {
   // initialize loggers

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -1,0 +1,126 @@
+#include <queue>
+#include <utility>
+#include "common/container/concurrent_queue.h"
+#include "common/macros.h"
+#include "loggers/storage_logger.h"
+#include "storage/data_table.h"
+#include "storage/garbage_collector.h"
+#include "transaction/transaction_context.h"
+#include "transaction/transaction_manager.h"
+#include "transaction/transaction_util.h"
+
+namespace terrier::storage {
+
+std::pair<uint64_t, uint32_t> GarbageCollector::RunGC() {
+  uint64_t txns_deallocated = Deallocate();
+  uint32_t txns_unlinked = Unlink();
+  if (txns_unlinked > 0) {
+    last_unlinked_ = txn_manager_->GetTimestamp();
+  }
+  return std::make_pair(txns_deallocated, txns_unlinked);
+}
+
+uint64_t GarbageCollector::Deallocate() {
+  const timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
+  uint64_t garbage_cleared = 0;
+  transaction::TransactionContext *txn = nullptr;
+
+  if (transaction::TransactionUtil::NewerThan(oldest_txn, last_unlinked_)) {
+    // All of the transactions in my deallocation queue were unlinked before the oldest running txn in the system.
+    // We are now safe to deallocate these txns because no one should hold a reference to them anymore
+    garbage_cleared = txns_to_deallocate_.size();
+    while (!txns_to_deallocate_.empty()) {
+      txn = txns_to_deallocate_.front();
+      txns_to_deallocate_.pop();
+      delete txn;
+    }
+  }
+
+  return garbage_cleared;
+}
+
+uint32_t GarbageCollector::Unlink() {
+  const timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
+  transaction::TransactionContext *txn = nullptr;
+
+  // Get the completed transactions from the TransactionManager
+  std::queue<transaction::TransactionContext *> from_txn_manager = txn_manager_->CompletedTransactions();
+
+  // Append to our local unlink queue
+  while (!from_txn_manager.empty()) {
+    txn = from_txn_manager.front();
+    from_txn_manager.pop();
+    txns_to_unlink_.push(txn);
+  }
+
+  uint32_t txns_cleared = 0;
+  std::queue<transaction::TransactionContext *> requeue;
+  // Process every transaction in the unlink queue
+  while (!txns_to_unlink_.empty()) {
+    txn = txns_to_unlink_.front();
+    txns_to_unlink_.pop();
+    if (!transaction::TransactionUtil::Committed(txn->TxnId())) {
+      // this is an aborted txn. There is nothing to unlink because Rollback() handled that already, but we still need
+      // to safely free the txn
+      txns_to_deallocate_.push(txn);
+      txns_cleared++;
+    } else if (transaction::TransactionUtil::NewerThan(oldest_txn, txn->TxnId())) {
+      // this is a committed txn that is no visible to any running txns. Proceed with unlinking its DeltaRecords
+      transaction::UndoBuffer &undos = txn->GetUndoBuffer();
+      for (auto &undo_record : undos) {
+        UnlinkDeltaRecord(txn, undo_record);
+      }
+      txns_to_deallocate_.push(txn);
+      txns_cleared++;
+    } else {
+      // this is a committed txn that is still visible, requeue for next GC run
+      requeue.push(txn);
+    }
+  }
+
+  // requeue any txns that we were still visible to running transactions
+  if (!requeue.empty()) {
+    txns_to_unlink_ = requeue;
+  }
+
+  return txns_cleared;
+}
+
+void GarbageCollector::UnlinkDeltaRecord(transaction::TransactionContext *const txn,
+                                         const DeltaRecord &undo_record) const {
+  PELOTON_ASSERT(txn->TxnId() == undo_record.Timestamp().load(), "This undo_record does not belong to this txn.");
+  DataTable *const table = undo_record.Table();
+  const TupleSlot slot = undo_record.Slot();
+  const TupleAccessStrategy &accessor = table->accessor_;
+
+  DeltaRecord *version_ptr;
+  do {
+    version_ptr = table->AtomicallyReadVersionPtr(slot, accessor);
+    PELOTON_ASSERT(version_ptr != nullptr, "GC should not be trying to unlink in an empty version chain.");
+
+    if (version_ptr->Timestamp().load() == txn->TxnId()) {
+      // Our DeltaRecord is the first in the chain, handle contention on the write lock with CAS
+      if (table->CompareAndSwapVersionPtr(slot, accessor, version_ptr, version_ptr->Next())) break;
+      // Someone swooped the VersionPointer while we were trying to swap it (aka took the write lock)
+      version_ptr = table->AtomicallyReadVersionPtr(slot, accessor);
+    }
+    // a version chain is guaranteed to not change when not at the head (assuming single-threaded GC), so we are safe
+    // to traverse and update pointers without CAS
+    DeltaRecord *curr = version_ptr;
+    DeltaRecord *next = curr->Next();
+
+    // traverse until we hit the DeltaRecord that we want to unlink
+    while (next != nullptr && next->Timestamp().load() != txn->TxnId()) {
+      curr = next;
+      next = curr->Next();
+    }
+    // we're in position with next being the DeltaRecord to be unlinked
+    if (next != nullptr && next->Timestamp().load() == txn->TxnId()) {
+      curr->Next().store(next->Next().load());
+      break;
+    }
+    // If that process didn't work (interleaved abort) then try again
+  } while (true);
+}
+
+}  // namespace terrier::storage

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -11,8 +11,8 @@
 
 namespace terrier::storage {
 
-std::pair<uint64_t, uint32_t> GarbageCollector::RunGC() {
-  uint64_t txns_deallocated = Deallocate();
+std::pair<uint32_t, uint32_t> GarbageCollector::RunGC() {
+  uint32_t txns_deallocated = Deallocate();
   uint32_t txns_unlinked = Unlink();
   if (txns_unlinked > 0) {
     last_unlinked_ = txn_manager_->GetTimestamp();
@@ -20,15 +20,15 @@ std::pair<uint64_t, uint32_t> GarbageCollector::RunGC() {
   return std::make_pair(txns_deallocated, txns_unlinked);
 }
 
-uint64_t GarbageCollector::Deallocate() {
+uint32_t GarbageCollector::Deallocate() {
   const timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
-  uint64_t garbage_cleared = 0;
+  uint32_t garbage_cleared = 0;
   transaction::TransactionContext *txn = nullptr;
 
   if (transaction::TransactionUtil::NewerThan(oldest_txn, last_unlinked_)) {
     // All of the transactions in my deallocation queue were unlinked before the oldest running txn in the system.
     // We are now safe to deallocate these txns because no one should hold a reference to them anymore
-    garbage_cleared = txns_to_deallocate_.size();
+    garbage_cleared = static_cast<uint32_t>(txns_to_deallocate_.size());
     while (!txns_to_deallocate_.empty()) {
       txn = txns_to_deallocate_.front();
       txns_to_deallocate_.pop();

--- a/test/include/util/test_harness.h
+++ b/test/include/util/test_harness.h
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 #include "loggers/main_logger.h"
 #include "loggers/storage_logger.h"
+#include "loggers/transaction_logger.h"
 
 namespace terrier {
 
@@ -13,7 +14,8 @@ class TerrierTest : public ::testing::Test {
 
     init_main_logger();
     // initialize namespace specific loggers
-    ::terrier::storage::init_storage_logger();
+    terrier::storage::init_storage_logger();
+    terrier::transaction::init_transaction_logger();
   }
 
   void TearDown() override {

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -1,0 +1,108 @@
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "common/object_pool.h"
+#include "storage/data_table.h"
+#include "storage/garbage_collector.h"
+#include "storage/storage_util.h"
+#include "util/storage_test_util.h"
+#include "transaction/transaction_context.h"
+#include "transaction/transaction_manager.h"
+
+namespace terrier {
+// Not thread-safe
+class GarbageCollectorDataTableTestObject {
+ public:
+  template<class Random>
+  GarbageCollectorDataTableTestObject(storage::BlockStore *block_store,
+                                      const uint16_t max_col,
+                                      Random *generator)
+      : layout_(StorageTestUtil::RandomLayout(max_col, generator)),
+        table_(block_store, layout_) {}
+
+  ~GarbageCollectorDataTableTestObject() {
+    for (auto ptr : loose_pointers_)
+      delete[] ptr;
+    for (auto ptr : loose_txns_)
+      delete ptr;
+    delete[] select_buffer_;
+  }
+
+  const storage::BlockLayout &Layout() const { return layout_; }
+
+  template<class Random>
+  storage::ProjectedRow *GenerateRandomTuple(Random *generator) {
+    auto *buffer = new byte[redo_size_];
+    loose_pointers_.push_back(buffer);
+    storage::ProjectedRow
+        *redo = storage::ProjectedRow::InitializeProjectedRow(buffer, all_col_ids_, layout_);
+    StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
+    return redo;
+  }
+
+  template<class Random>
+  storage::ProjectedRow *GenerateRandomUpdate(Random *generator) {
+    std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
+    auto *buffer = new byte[storage::ProjectedRow::Size(layout_, update_col_ids)];
+    loose_pointers_.push_back(buffer);
+    storage::ProjectedRow *update =
+        storage::ProjectedRow::InitializeProjectedRow(buffer, update_col_ids, layout_);
+    StorageTestUtil::PopulateRandomRow(update, layout_, null_bias_, generator);
+    return update;
+  }
+
+  storage::ProjectedRow *GenerateVersionFromUpdate(const storage::ProjectedRow &delta,
+                                                   const storage::ProjectedRow &previous) {
+    auto *buffer = new byte[redo_size_];
+    loose_pointers_.push_back(buffer);
+    // Copy previous version
+    PELOTON_MEMCPY(buffer, &previous, redo_size_);
+    auto *version = reinterpret_cast<storage::ProjectedRow *>(buffer);
+    std::unordered_map<uint16_t, uint16_t> col_to_projection_list_index;
+    for (uint16_t i = 0; i < version->NumColumns(); i++)
+      col_to_projection_list_index.emplace(version->ColumnIds()[i], i);
+    storage::StorageUtil::ApplyDelta(layout_, delta, version, col_to_projection_list_index);
+    return version;
+  }
+
+  storage::ProjectedRow *SelectIntoBuffer(transaction::TransactionContext *const txn,
+                                          const storage::TupleSlot slot,
+                                          const std::vector<uint16_t> &col_ids) {
+    // generate a redo ProjectedRow for Select
+    storage::ProjectedRow *select_row = storage::ProjectedRow::InitializeProjectedRow(select_buffer_, col_ids, layout_);
+    table_.Select(txn, slot, select_row);
+    return select_row;
+  }
+
+  storage::BlockLayout layout_;
+  storage::DataTable table_;
+  // We want null_bias_ to be zero when testing CC. We already evaluate null correctness in other directed tests, and
+  // we don't want the logically deleted field to end up set NULL.
+  const double null_bias_ = 0;
+  std::vector<byte *> loose_pointers_;
+  std::vector<transaction::TransactionContext *> loose_txns_;
+  std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout_)};
+  // These always over-provision in the case of partial selects or deltas, which is fine.
+  uint32_t redo_size_ = storage::ProjectedRow::Size(layout_, all_col_ids_);
+  byte *select_buffer_ = new byte[redo_size_];
+};
+
+struct GarbageCollectorTests : public ::testing::Test {
+  storage::BlockStore block_store_{100};
+  common::ObjectPool<transaction::UndoBufferSegment> buffer_pool_{10000};
+  std::default_random_engine generator_;
+  const uint32_t num_iterations_ = 1000;
+  const uint16_t max_columns_ = 100;
+};
+
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, BasicTest) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+
+    storage::GarbageCollector gc(&txn_manager);
+  }
+}
+
+}  // namespace terrier

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -6,6 +6,7 @@
 #include "storage/garbage_collector.h"
 #include "storage/storage_util.h"
 #include "util/storage_test_util.h"
+#include "util/test_harness.h"
 #include "transaction/transaction_context.h"
 #include "transaction/transaction_manager.h"
 
@@ -87,11 +88,11 @@ class GarbageCollectorDataTableTestObject {
   byte *select_buffer_ = new byte[redo_size_];
 };
 
-struct GarbageCollectorTests : public ::testing::Test {
+struct GarbageCollectorTests : public ::terrier::TerrierTest {
   storage::BlockStore block_store_{100};
   common::ObjectPool<transaction::UndoBufferSegment> buffer_pool_{10000};
   std::default_random_engine generator_;
-  const uint32_t num_iterations_ = 1000;
+  const uint32_t num_iterations_ = 5;
   const uint16_t max_columns_ = 100;
 };
 
@@ -100,8 +101,10 @@ TEST_F(GarbageCollectorTests, BasicTest) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
     transaction::TransactionManager txn_manager{&buffer_pool_};
     GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
-
     storage::GarbageCollector gc(&txn_manager);
+    gc.StartGC();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    gc.StopGC();
   }
 }
 

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -10,36 +10,6 @@
 #include "transaction/transaction_context.h"
 #include "transaction/transaction_manager.h"
 
-
-//
-//  void StartGCThread() {
-//    PELOTON_ASSERT(!running_ && gc_thread_ == nullptr, "Should only be invoking this on a GC that is not running.");
-//    gc_thread_ = new std::thread(&GarbageCollector::ThreadLoop, this);
-//    running_ = true;
-//  }
-//
-//  void StopGCThread() {
-//    PELOTON_ASSERT(running_ && gc_thread_ != nullptr, "Should only be invoking this on a GC that is running.");
-//    running_ = false;
-//    gc_thread_->join();
-//    delete gc_thread_;
-//    oldest_txn_ = txn_manager_->OldestTransactionStartTime();
-//    ClearGarbage();
-//    ClearTransactions();
-//    last_run_ = txn_manager_->Time();
-//    gc_thread_ = nullptr;
-//  }
-
-
-//  void ThreadLoop() {
-//    while (running_) {
-//      if (!txn_manager_->CompletedTransactions().Empty() || !txns_to_deallocate.empty()) {
-//        RunGC();
-//      }
-//      std::this_thread::sleep_for(std::chrono::seconds(1));
-//    }
-//  }
-
 namespace terrier {
 // Not thread-safe
 class GarbageCollectorDataTableTestObject {

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -103,8 +103,10 @@ TEST_F(GarbageCollectorTests, BasicTest) {
     GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
     storage::GarbageCollector gc(&txn_manager);
     gc.StartGC();
+    EXPECT_TRUE(gc.Running());
     std::this_thread::sleep_for(std::chrono::seconds(5));
     gc.StopGC();
+    EXPECT_FALSE(gc.Running());
   }
 }
 

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -33,7 +33,7 @@
 
 //  void ThreadLoop() {
 //    while (running_) {
-//      if (!txn_manager_->CompletedTransactions().Empty() || !garbage_txns_.empty()) {
+//      if (!txn_manager_->CompletedTransactions().Empty() || !txns_to_deallocate.empty()) {
 //        RunGC();
 //      }
 //      std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -128,7 +128,7 @@ class LargeTransactionTestObject {
         generator_(generator),
         layout_(StorageTestUtil::RandomLayout(max_columns, generator_)),
         table_(block_store, layout_),
-        txn_manager_(buffer_pool),
+        txn_manager_(buffer_pool, false),
         initial_txn_(layout_, &table_, &txn_manager_, all_slots_) {
     // Bootstrap the table to have the specified number of tuples
     for (uint32_t i = 0; i < initial_table_size; i++)

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -118,7 +118,7 @@ class MVCCTests : public ::terrier::TerrierTest {
 // NOLINTNEXTLINE
 TEST_F(MVCCTests, CommitInsert1) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
-    transaction::TransactionManager txn_manager{&buffer_pool_};
+    transaction::TransactionManager txn_manager{&buffer_pool_, false};
     MVCCDataTableTestObject tested(&block_store_, max_columns_, &generator_);
 
     auto *txn0 = txn_manager.BeginTransaction();
@@ -174,7 +174,7 @@ TEST_F(MVCCTests, CommitInsert1) {
 // NOLINTNEXTLINE
 TEST_F(MVCCTests, CommitInsert2) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
-    transaction::TransactionManager txn_manager{&buffer_pool_};
+    transaction::TransactionManager txn_manager{&buffer_pool_, false};
     MVCCDataTableTestObject tested(&block_store_, max_columns_, &generator_);
 
     auto *txn0 = txn_manager.BeginTransaction();
@@ -230,7 +230,7 @@ TEST_F(MVCCTests, CommitInsert2) {
 // NOLINTNEXTLINE
 TEST_F(MVCCTests, AbortInsert1) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
-    transaction::TransactionManager txn_manager{&buffer_pool_};
+    transaction::TransactionManager txn_manager{&buffer_pool_, false};
     MVCCDataTableTestObject tested(&block_store_, max_columns_, &generator_);
 
     auto *txn0 = txn_manager.BeginTransaction();
@@ -286,7 +286,7 @@ TEST_F(MVCCTests, AbortInsert1) {
 // NOLINTNEXTLINE
 TEST_F(MVCCTests, AbortInsert2) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
-    transaction::TransactionManager txn_manager{&buffer_pool_};
+    transaction::TransactionManager txn_manager{&buffer_pool_, false};
     MVCCDataTableTestObject tested(&block_store_, max_columns_, &generator_);
 
     auto *txn0 = txn_manager.BeginTransaction();
@@ -342,7 +342,7 @@ TEST_F(MVCCTests, AbortInsert2) {
 // NOLINTNEXTLINE
 TEST_F(MVCCTests, CommitUpdate1) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
-    transaction::TransactionManager txn_manager{&buffer_pool_};
+    transaction::TransactionManager txn_manager{&buffer_pool_, false};
     MVCCDataTableTestObject tested(&block_store_, max_columns_, &generator_);
 
     auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
@@ -409,7 +409,7 @@ TEST_F(MVCCTests, CommitUpdate1) {
 // NOLINTNEXTLINE
 TEST_F(MVCCTests, CommitUpdate2) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
-    transaction::TransactionManager txn_manager{&buffer_pool_};
+    transaction::TransactionManager txn_manager{&buffer_pool_, false};
     MVCCDataTableTestObject tested(&block_store_, max_columns_, &generator_);
 
     auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
@@ -476,7 +476,7 @@ TEST_F(MVCCTests, CommitUpdate2) {
 // NOLINTNEXTLINE
 TEST_F(MVCCTests, AbortUpdate1) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
-    transaction::TransactionManager txn_manager{&buffer_pool_};
+    transaction::TransactionManager txn_manager{&buffer_pool_, false};
     MVCCDataTableTestObject tested(&block_store_, max_columns_, &generator_);
 
     auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
@@ -543,7 +543,7 @@ TEST_F(MVCCTests, AbortUpdate1) {
 // NOLINTNEXTLINE
 TEST_F(MVCCTests, AbortUpdate2) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
-    transaction::TransactionManager txn_manager{&buffer_pool_};
+    transaction::TransactionManager txn_manager{&buffer_pool_, false};
     MVCCDataTableTestObject tested(&block_store_, max_columns_, &generator_);
 
     auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
@@ -606,7 +606,7 @@ TEST_F(MVCCTests, AbortUpdate2) {
 // NOLINTNEXTLINE
 TEST_F(MVCCTests, InsertUpdate1) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
-    transaction::TransactionManager txn_manager{&buffer_pool_};
+    transaction::TransactionManager txn_manager{&buffer_pool_, false};
     MVCCDataTableTestObject tested(&block_store_, max_columns_, &generator_);
 
     auto *txn0 = txn_manager.BeginTransaction();


### PR DESCRIPTION
Fix #110.

This is a simple garbage collector for the storage layer that will unlink obsolete versions from version chains and then free TransactionContexts once no one else can hold a reference to them.

There are also a few API changes to support GC, as well as minor bug fixes.