### PR TITLE
Fix clang-format for .cpp files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ endif ()
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 ###########################################################
-# "make lint" target
+# "make check-lint" target
 ###########################################################
 if (NOT TERRIER_VERBOSE_LINT)
   set(TERRIER_LINT_QUIET "--quiet")

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -4,11 +4,11 @@
 #include "common/typedefs.h"
 #include "storage/data_table.h"
 #include "storage/storage_util.h"
-#include "util/storage_test_util.h"
-#include "util/test_thread_pool.h"
-#include "util/storage_benchmark_util.h"
 #include "transaction/transaction_context.h"
 #include "transaction/transaction_manager.h"
+#include "util/storage_benchmark_util.h"
+#include "util/storage_test_util.h"
+#include "util/test_thread_pool.h"
 
 namespace terrier {
 
@@ -25,9 +25,7 @@ class DataTableBenchmark : public benchmark::Fixture {
     redo_ = initializer_.InitializeRow(redo_buffer_);
     StorageTestUtil::PopulateRandomRow(redo_, layout_, 0, &generator_);
   }
-  void TearDown(const benchmark::State &state) final {
-    delete[] redo_buffer_;
-  }
+  void TearDown(const benchmark::State &state) final { delete[] redo_buffer_; }
 
   // Tuple layout
   const uint16_t num_columns_ = 2;
@@ -77,8 +75,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state
     auto workload = [&](uint32_t id) {
       // We can use dummy timestamps here since we're not invoking concurrency control
       transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool_);
-      for (uint32_t i = 0; i < num_inserts_ / num_threads_; i++)
-        table.Insert(&txn, *redo_);
+      for (uint32_t i = 0; i < num_inserts_ / num_threads_; i++) table.Insert(&txn, *redo_);
     };
     thread_pool.RunThreadsUntilFinish(num_threads_, workload);
   }
@@ -86,12 +83,8 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state
   state.SetItemsProcessed(state.iterations() * num_inserts_);
 }
 
-BENCHMARK_REGISTER_F(DataTableBenchmark, SimpleInsert)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
+BENCHMARK_REGISTER_F(DataTableBenchmark, SimpleInsert)->Unit(benchmark::kMillisecond)->UseRealTime();
 
-BENCHMARK_REGISTER_F(DataTableBenchmark, ConcurrentInsert)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
+BENCHMARK_REGISTER_F(DataTableBenchmark, ConcurrentInsert)->Unit(benchmark::kMillisecond)->UseRealTime();
 
 }  // namespace terrier

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -4,9 +4,9 @@
 #include "common/typedefs.h"
 #include "storage/storage_util.h"
 #include "storage/tuple_access_strategy.h"
+#include "util/storage_benchmark_util.h"
 #include "util/storage_test_util.h"
 #include "util/test_thread_pool.h"
-#include "util/storage_benchmark_util.h"
 
 namespace terrier {
 
@@ -24,9 +24,7 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
     StorageTestUtil::PopulateRandomRow(redo_, layout_, 0, &generator_);
   }
 
-  void TearDown(const benchmark::State &state) final {
-    delete[] redo_buffer_;
-  }
+  void TearDown(const benchmark::State &state) final { delete[] redo_buffer_; }
 
   // Tuple layout_
   const uint16_t num_columns_ = 2;
@@ -45,7 +43,7 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
   std::default_random_engine generator_;
   storage::BlockStore block_store_{num_blocks_};
 
-  std::vector<storage::RawBlock *>raw_blocks_;
+  std::vector<storage::RawBlock *> raw_blocks_;
   // Insert buffer pointers
   byte *redo_buffer_;
   storage::ProjectedRow *redo_;
@@ -67,10 +65,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
       for (uint32_t j = 0; j < layout_.NumSlots(); j++) {
         storage::TupleSlot slot;
         tested.Allocate(raw_block, &slot);
-        TupleAccessStrategyBenchmarkUtil::InsertTuple(*redo_,
-                                                      &tested,
-                                                      layout_,
-                                                      slot);
+        TupleAccessStrategyBenchmarkUtil::InsertTuple(*redo_, &tested, layout_, slot);
       }
     }
     // return all of the used blocks to the BlockStore
@@ -101,10 +96,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::St
         for (uint32_t j = 0; j < layout_.NumSlots() / num_threads_; j++) {
           storage::TupleSlot slot;
           tested.Allocate(raw_block, &slot);
-          TupleAccessStrategyBenchmarkUtil::InsertTuple(*redo_,
-                                                        &tested,
-                                                        layout_,
-                                                        slot);
+          TupleAccessStrategyBenchmarkUtil::InsertTuple(*redo_, &tested, layout_, slot);
         }
       };
 
@@ -119,12 +111,8 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::St
   state.SetItemsProcessed(state.iterations() * layout_.NumSlots() * num_blocks_);
 }
 
-BENCHMARK_REGISTER_F(TupleAccessStrategyBenchmark, SimpleInsert)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
+BENCHMARK_REGISTER_F(TupleAccessStrategyBenchmark, SimpleInsert)->Unit(benchmark::kMillisecond)->UseRealTime();
 
-BENCHMARK_REGISTER_F(TupleAccessStrategyBenchmark, ConcurrentInsert)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
+BENCHMARK_REGISTER_F(TupleAccessStrategyBenchmark, ConcurrentInsert)->Unit(benchmark::kMillisecond)->UseRealTime();
 
 }  // namespace terrier

--- a/benchmark/util/benchmark_main.cpp
+++ b/benchmark/util/benchmark_main.cpp
@@ -19,7 +19,7 @@
 
 #include "benchmark/benchmark.h"
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();
   return 0;

--- a/build-support/run_clang_format.py
+++ b/build-support/run_clang_format.py
@@ -34,7 +34,7 @@ def check(arguments, source_dir):
         fullpaths = (os.path.join(directory, filename)
                      for filename in filenames)
         source_files = [x for x in fullpaths
-                        if x.endswith(".h") or x.endswith(".cc")]
+                        if x.endswith(".h") or x.endswith(".cpp")]
         formatted_filenames.extend(
             # Filter out files that match the globs in the globs file
             [filename for filename in source_files

--- a/src/loggers/main_logger.cpp
+++ b/src/loggers/main_logger.cpp
@@ -1,5 +1,5 @@
-#include <memory>
 #include "loggers/main_logger.h"
+#include <memory>
 
 std::shared_ptr<spdlog::sinks::stdout_sink_mt> default_sink;
 std::shared_ptr<spdlog::logger> main_logger;

--- a/src/loggers/storage_logger.cpp
+++ b/src/loggers/storage_logger.cpp
@@ -1,12 +1,12 @@
+#include "loggers/storage_logger.h"
 #include <memory>
 #include "loggers/main_logger.h"
-#include "loggers/storage_logger.h"
 
 namespace terrier::storage {
 
 std::shared_ptr<spdlog::logger> storage_logger;
 
-  void init_storage_logger() {
+void init_storage_logger() {
   storage_logger = std::make_shared<spdlog::logger>("storage_logger", ::default_sink);
   spdlog::register_logger(storage_logger);
 }

--- a/src/loggers/transaction_logger.cpp
+++ b/src/loggers/transaction_logger.cpp
@@ -1,12 +1,12 @@
+#include "loggers/transaction_logger.h"
 #include <memory>
 #include "loggers/main_logger.h"
-#include "loggers/transaction_logger.h"
 
 namespace terrier::transaction {
 
 std::shared_ptr<spdlog::logger> transaction_logger;
 
-  void init_transaction_logger() {
+void init_transaction_logger() {
   transaction_logger = std::make_shared<spdlog::logger>("transaction_logger", ::default_sink);
   spdlog::register_logger(transaction_logger);
 }

--- a/src/main/terrier.cpp
+++ b/src/main/terrier.cpp
@@ -14,8 +14,7 @@ int main() {
     // Flush all *registered* loggers using a worker thread.
     // Registered loggers must be thread safe for this to work correctly
     spdlog::flush_every(std::chrono::seconds(DEBUG_LOG_FLUSH_INTERVAL));
-  }
-  catch (const spdlog::spdlog_ex &ex) {
+  } catch (const spdlog::spdlog_ex &ex) {
     std::cout << "debug log init failed " << ex.what() << std::endl;
     return 1;
   }

--- a/src/storage/delta_record.cpp
+++ b/src/storage/delta_record.cpp
@@ -1,8 +1,8 @@
-#include <vector>
-#include <utility>
-#include <functional>
-#include <algorithm>
 #include "storage/delta_record.h"
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <vector>
 #include "storage/storage_util.h"
 
 namespace terrier::storage {
@@ -17,8 +17,7 @@ ProjectedRow *ProjectedRow::CopyProjectedRowLayout(void *head, const ProjectedRo
 // TODO(Tianyu): I don't think we can reasonably fit these into a cache line?
 ProjectedRowInitializer::ProjectedRowInitializer(const terrier::storage::BlockLayout &layout,
                                                  std::vector<uint16_t> col_ids)
-    : col_ids_(std::move(col_ids)),
-      offsets_(col_ids_.size()) {
+    : col_ids_(std::move(col_ids)), offsets_(col_ids_.size()) {
   TERRIER_ASSERT(!col_ids_.empty(), "cannot initialize an empty ProjectedRow");
   TERRIER_ASSERT(col_ids.size() < layout.NumCols(),
                  "projected row should have number of columns smaller than the table's");
@@ -40,9 +39,8 @@ ProjectedRowInitializer::ProjectedRowInitializer(const terrier::storage::BlockLa
   for (uint32_t i = 0; i < col_ids_.size(); i++) {
     offsets_[i] = size_;
     // Pad up to either the next value's size, or 8 bytes at the end of the ProjectedRow.
-    auto next_size = static_cast<uint8_t>(i == col_ids_.size() - 1
-                                          ? sizeof(uint64_t)
-                                          : layout.AttrSize(col_ids_[i + 1]));
+    auto next_size =
+        static_cast<uint8_t>(i == col_ids_.size() - 1 ? sizeof(uint64_t) : layout.AttrSize(col_ids_[i + 1]));
     size_ = StorageUtil::PadUpToSize(next_size, size_ + layout.AttrSize(col_ids_[i]));
   }
 }
@@ -60,10 +58,7 @@ ProjectedRow *ProjectedRowInitializer::InitializeRow(void *head) const {
   return result;
 }
 
-UndoRecord *UndoRecord::Initialize(void *head,
-                                   timestamp_t timestamp,
-                                   TupleSlot slot,
-                                   DataTable *table,
+UndoRecord *UndoRecord::Initialize(void *head, timestamp_t timestamp, TupleSlot slot, DataTable *table,
                                    const ProjectedRowInitializer &initializer) {
   auto *result = reinterpret_cast<UndoRecord *>(head);
 

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -1,9 +1,9 @@
+#include "storage/garbage_collector.h"
 #include <utility>
 #include "common/container/concurrent_queue.h"
 #include "common/macros.h"
 #include "loggers/storage_logger.h"
 #include "storage/data_table.h"
-#include "storage/garbage_collector.h"
 #include "transaction/transaction_context.h"
 #include "transaction/transaction_defs.h"
 #include "transaction/transaction_manager.h"

--- a/src/storage/storage_util.cpp
+++ b/src/storage/storage_util.cpp
@@ -1,18 +1,22 @@
-#include <unordered_map>
 #include "storage/storage_util.h"
-#include "storage/tuple_access_strategy.h"
+#include <unordered_map>
 #include "storage/delta_record.h"
+#include "storage/tuple_access_strategy.h"
 
 namespace terrier::storage {
 void StorageUtil::WriteBytes(const uint8_t attr_size, const uint64_t val, byte *const pos) {
   switch (attr_size) {
-    case sizeof(uint8_t):*reinterpret_cast<uint8_t *>(pos) = static_cast<uint8_t>(val);
+    case sizeof(uint8_t):
+      *reinterpret_cast<uint8_t *>(pos) = static_cast<uint8_t>(val);
       break;
-    case sizeof(uint16_t):*reinterpret_cast<uint16_t *>(pos) = static_cast<uint16_t>(val);
+    case sizeof(uint16_t):
+      *reinterpret_cast<uint16_t *>(pos) = static_cast<uint16_t>(val);
       break;
-    case sizeof(uint32_t):*reinterpret_cast<uint32_t *>(pos) = static_cast<uint32_t>(val);
+    case sizeof(uint32_t):
+      *reinterpret_cast<uint32_t *>(pos) = static_cast<uint32_t>(val);
       break;
-    case sizeof(uint64_t):*reinterpret_cast<uint64_t *>(pos) = static_cast<uint64_t>(val);
+    case sizeof(uint64_t):
+      *reinterpret_cast<uint64_t *>(pos) = static_cast<uint64_t>(val);
       break;
     default:
       // Invalid attr size
@@ -22,19 +26,21 @@ void StorageUtil::WriteBytes(const uint8_t attr_size, const uint64_t val, byte *
 
 uint64_t StorageUtil::ReadBytes(const uint8_t attr_size, const byte *const pos) {
   switch (attr_size) {
-    case sizeof(uint8_t):return *reinterpret_cast<const uint8_t *>(pos);
-    case sizeof(uint16_t):return *reinterpret_cast<const uint16_t *>(pos);
-    case sizeof(uint32_t):return *reinterpret_cast<const uint32_t *>(pos);
-    case sizeof(uint64_t):return *reinterpret_cast<const uint64_t *>(pos);
+    case sizeof(uint8_t):
+      return *reinterpret_cast<const uint8_t *>(pos);
+    case sizeof(uint16_t):
+      return *reinterpret_cast<const uint16_t *>(pos);
+    case sizeof(uint32_t):
+      return *reinterpret_cast<const uint32_t *>(pos);
+    case sizeof(uint64_t):
+      return *reinterpret_cast<const uint64_t *>(pos);
     default:
       // Invalid attr size
       throw std::runtime_error("Invalid byte write value");
   }
 }
 
-void StorageUtil::CopyWithNullCheck(const byte *const from,
-                                    ProjectedRow *const to,
-                                    const uint8_t size,
+void StorageUtil::CopyWithNullCheck(const byte *const from, ProjectedRow *const to, const uint8_t size,
                                     const uint16_t col_id) {
   if (from == nullptr)
     to->SetNull(col_id);
@@ -42,9 +48,7 @@ void StorageUtil::CopyWithNullCheck(const byte *const from,
     WriteBytes(size, ReadBytes(size, from), to->AccessForceNotNull(col_id));
 }
 
-void StorageUtil::CopyWithNullCheck(const byte *const from,
-                                    const TupleAccessStrategy &accessor,
-                                    const TupleSlot to,
+void StorageUtil::CopyWithNullCheck(const byte *const from, const TupleAccessStrategy &accessor, const TupleSlot to,
                                     const uint16_t col_id) {
   if (from == nullptr) {
     accessor.SetNull(to, col_id);
@@ -54,27 +58,22 @@ void StorageUtil::CopyWithNullCheck(const byte *const from,
   }
 }
 
-void StorageUtil::CopyAttrIntoProjection(const TupleAccessStrategy &accessor,
-                                         const TupleSlot from,
-                                         ProjectedRow *const to,
-                                         const uint16_t projection_list_offset) {
+void StorageUtil::CopyAttrIntoProjection(const TupleAccessStrategy &accessor, const TupleSlot from,
+                                         ProjectedRow *const to, const uint16_t projection_list_offset) {
   uint16_t col_id = to->ColumnIds()[projection_list_offset];
   uint8_t attr_size = accessor.GetBlockLayout().AttrSize(col_id);
   byte *stored_attr = accessor.AccessWithNullCheck(from, col_id);
   CopyWithNullCheck(stored_attr, to, attr_size, projection_list_offset);
 }
 
-void StorageUtil::CopyAttrFromProjection(const TupleAccessStrategy &accessor,
-                                         const TupleSlot to,
-                                         const ProjectedRow &from,
-                                         const uint16_t projection_list_offset) {
+void StorageUtil::CopyAttrFromProjection(const TupleAccessStrategy &accessor, const TupleSlot to,
+                                         const ProjectedRow &from, const uint16_t projection_list_offset) {
   uint16_t col_id = from.ColumnIds()[projection_list_offset];
   const byte *stored_attr = from.AccessWithNullCheck(projection_list_offset);
   CopyWithNullCheck(stored_attr, accessor, to, col_id);
 }
 
-void StorageUtil::ApplyDelta(const terrier::storage::BlockLayout &layout,
-                             const terrier::storage::ProjectedRow &delta,
+void StorageUtil::ApplyDelta(const terrier::storage::BlockLayout &layout, const terrier::storage::ProjectedRow &delta,
                              terrier::storage::ProjectedRow *buffer) {
   // the projection list in delta and buffer have to be sorted in the same way for this to work,
   // which should be guaranteed if both are constructed correctly using ProjectedRowInitializer,

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -1,5 +1,5 @@
-#include <utility>
 #include "transaction/transaction_manager.h"
+#include <utility>
 
 namespace terrier::transaction {
 TransactionContext *TransactionManager::BeginTransaction() {
@@ -24,8 +24,7 @@ timestamp_t TransactionManager::Commit(TransactionContext *const txn) {
   const timestamp_t commit_time = time_++;
   // Flip all timestamps to be committed
   storage::UndoBuffer &undos = txn->GetUndoBuffer();
-  for (auto &it : undos)
-    it.Timestamp().store(commit_time);
+  for (auto &it : undos) it.Timestamp().store(commit_time);
   table_latch_.Lock();
   const timestamp_t start_time = txn->StartTime();
   size_t result UNUSED_ATTRIBUTE = curr_running_txns_.erase(start_time);
@@ -68,8 +67,7 @@ TransactionQueue TransactionManager::CompletedTransactionsForGC() {
 void TransactionManager::Rollback(const timestamp_t txn_id, const storage::UndoRecord &record) const {
   storage::DataTable *const table = record.Table();
   const storage::TupleSlot slot = record.Slot();
-  storage::UndoRecord
-      *const version_ptr = table->AtomicallyReadVersionPtr(slot, table->accessor_);
+  storage::UndoRecord *const version_ptr = table->AtomicallyReadVersionPtr(slot, table->accessor_);
   // We do not hold the lock. Should just return
   if (version_ptr == nullptr || version_ptr->Timestamp().load() != txn_id) return;
   // Re-apply the before image

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -1,9 +1,9 @@
+#include "common/container/bitmap.h"
 #include <random>
 #include <thread>  // NOLINT
 #include <unordered_set>
 #include <vector>
 #include "gtest/gtest.h"
-#include "common/container/bitmap.h"
 #include "util/container_test_util.h"
 
 namespace terrier {
@@ -35,8 +35,7 @@ TEST(BitmapTests, ByteMultipleCorrectnessTest) {
     std::vector<bool> stl_bitmap = std::vector<bool>(num_elements_aligned);
     ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*aligned_bitmap, stl_bitmap, num_elements_aligned);
     for (uint32_t i = 0; i < num_iterations; ++i) {
-      auto element =
-          std::uniform_int_distribution(0, static_cast<int>(num_elements_aligned - 1))(generator);
+      auto element = std::uniform_int_distribution(0, static_cast<int>(num_elements_aligned - 1))(generator);
       aligned_bitmap->Flip(element);
       stl_bitmap[element] = !stl_bitmap[element];
       ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*aligned_bitmap, stl_bitmap, num_elements_aligned);
@@ -74,8 +73,7 @@ TEST(BitmapTests, NonByteMultipleCorrectnessTest) {
     std::vector<bool> stl_bitmap = std::vector<bool>(num_elements_aligned);
     ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*aligned_bitmap, stl_bitmap, num_elements_aligned);
     for (uint32_t i = 0; i < num_iterations; ++i) {
-      auto element =
-          std::uniform_int_distribution(0, static_cast<int>(num_elements_aligned - 1))(generator);
+      auto element = std::uniform_int_distribution(0, static_cast<int>(num_elements_aligned - 1))(generator);
       aligned_bitmap->Flip(element);
       stl_bitmap[element] = !stl_bitmap[element];
       ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*aligned_bitmap, stl_bitmap, num_elements_aligned);
@@ -123,8 +121,7 @@ TEST(BitmapTests, WordUnalignedCorrectnessTest) {
     std::vector<bool> stl_bitmap = std::vector<bool>(num_elements);
     ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*unaligned_bitmap, stl_bitmap, num_elements);
     for (uint32_t i = 0; i < num_iterations; ++i) {
-      auto element =
-          std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
+      auto element = std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
       unaligned_bitmap->Flip(element);
       stl_bitmap[element] = !stl_bitmap[element];
       ContainerTestUtil::CheckReferenceBitmap<common::RawBitmap>(*unaligned_bitmap, stl_bitmap, num_elements);

--- a/test/common/concurrent_bitmap_test.cpp
+++ b/test/common/concurrent_bitmap_test.cpp
@@ -5,10 +5,10 @@
 #include <unordered_set>
 #include <vector>
 
-#include "gtest/gtest.h"
-#include "util/test_thread_pool.h"
 #include "common/container/concurrent_bitmap.h"
+#include "gtest/gtest.h"
 #include "util/container_test_util.h"
+#include "util/test_thread_pool.h"
 
 namespace terrier {
 
@@ -36,16 +36,14 @@ TEST(ConcurrentBitmapTests, SimpleCorrectnessTest) {
     uint32_t num_iterations = 32;
     std::default_random_engine generator;
     for (uint32_t i = 0; i < num_iterations; ++i) {
-      auto element =
-          std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
+      auto element = std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
       EXPECT_TRUE(bitmap->Flip(element, bitmap->Test(element)));
       stl_bitmap[element] = !stl_bitmap[element];
       ContainerTestUtil::CheckReferenceBitmap<common::RawConcurrentBitmap>(*bitmap, stl_bitmap, num_elements);
     }
 
     // Verify that Flip fails if expected_val doesn't match current value
-    auto element =
-        std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
+    auto element = std::uniform_int_distribution(0, static_cast<int>(num_elements - 1))(generator);
     EXPECT_FALSE(bitmap->Flip(element, !bitmap->Test(element)));
     common::RawConcurrentBitmap::Deallocate(bitmap);
   }
@@ -192,9 +190,7 @@ TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
     // then sort the results
     std::vector<uint32_t> all_elements;
     for (uint32_t i = 0; i < num_threads; ++i)
-      all_elements.insert(all_elements.end(),
-                          elements[i].begin(),
-                          elements[i].end());
+      all_elements.insert(all_elements.end(), elements[i].begin(), elements[i].end());
 
     // Verify coalesced result size
     EXPECT_EQ(num_elements, all_elements.size());
@@ -235,9 +231,7 @@ TEST(ConcurrentBitmapTests, ConcurrentCorrectnessTest) {
     // then sort the results
     std::vector<uint32_t> all_elements;
     for (uint32_t i = 0; i < num_threads; ++i)
-      all_elements.insert(all_elements.end(),
-                          elements[i].begin(),
-                          elements[i].end());
+      all_elements.insert(all_elements.end(), elements[i].begin(), elements[i].end());
 
     // Verify coalesced result size
     EXPECT_EQ(num_elements, all_elements.size());

--- a/test/storage/data_table_concurrent_test.cpp
+++ b/test/storage/data_table_concurrent_test.cpp
@@ -1,29 +1,25 @@
+#include <memory>
 #include <unordered_map>
 #include <vector>
-#include <memory>
 #include "storage/data_table.h"
-#include "util/storage_test_util.h"
-#include "util/test_thread_pool.h"
 #include "transaction/transaction_context.h"
+#include "util/storage_test_util.h"
 #include "util/test_harness.h"
+#include "util/test_thread_pool.h"
 
 namespace terrier {
 class FakeTransaction {
  public:
-  FakeTransaction(const storage::BlockLayout &layout,
-                  storage::DataTable *table,
-                  const double null_bias,
-                  const timestamp_t start_time,
-                  const timestamp_t txn_id,
+  FakeTransaction(const storage::BlockLayout &layout, storage::DataTable *table, const double null_bias,
+                  const timestamp_t start_time, const timestamp_t txn_id,
                   common::ObjectPool<storage::BufferSegment> *buffer_pool)
       : layout_(layout), table_(table), null_bias_(null_bias), txn_(start_time, txn_id, buffer_pool) {}
 
   ~FakeTransaction() {
-    for (auto ptr : loose_pointers_)
-      delete[] ptr;
+    for (auto ptr : loose_pointers_) delete[] ptr;
   }
 
-  template<class Random>
+  template <class Random>
   storage::TupleSlot InsertRandomTuple(Random *generator) {
     // generate a random redo ProjectedRow to Insert
     auto *redo_buffer = common::AllocationUtil::AllocateAligned(redo_initializer_.ProjectedRowSize());
@@ -37,7 +33,7 @@ class FakeTransaction {
     return slot;
   }
 
-  template<class Random>
+  template <class Random>
   bool RandomlyUpdateTuple(const storage::TupleSlot slot, Random *generator) {
     // generate random update
     std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
@@ -52,9 +48,7 @@ class FakeTransaction {
     return result;
   }
 
-  transaction::TransactionContext *GetTxn() {
-    return &txn_;
-  }
+  transaction::TransactionContext *GetTxn() { return &txn_; }
 
   const std::vector<storage::TupleSlot> &InsertedTuples() const { return inserted_slots_; }
 
@@ -99,16 +93,11 @@ TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
     std::vector<std::unique_ptr<FakeTransaction>> fake_txns;
     for (uint32_t thread = 0; thread < num_threads; thread++)
       // timestamps are irrelevant for inserts
-      fake_txns.emplace_back(std::make_unique<FakeTransaction>(layout,
-                                                               &tested,
-                                                               null_ratio_(generator_),
-                                                               timestamp_t(0),
-                                                               timestamp_t(0),
-                                                               &buffer_pool_));
+      fake_txns.emplace_back(std::make_unique<FakeTransaction>(layout, &tested, null_ratio_(generator_), timestamp_t(0),
+                                                               timestamp_t(0), &buffer_pool_));
     auto workload = [&](uint32_t id) {
       std::default_random_engine thread_generator(id);
-      for (uint32_t i = 0; i < num_inserts / num_threads; i++)
-        fake_txns[id]->InsertRandomTuple(&thread_generator);
+      for (uint32_t i = 0; i < num_inserts / num_threads; i++) fake_txns[id]->InsertRandomTuple(&thread_generator);
     };
 
     thread_pool.RunThreadsUntilFinish(num_threads, workload);
@@ -116,8 +105,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
     auto *select_buffer = common::AllocationUtil::AllocateAligned(select_initializer.ProjectedRowSize());
     for (auto &fake_txn : fake_txns) {
       for (auto slot : fake_txn->InsertedTuples()) {
-        storage::ProjectedRow
-            *select_row = select_initializer.InitializeRow(select_buffer);
+        storage::ProjectedRow *select_row = select_initializer.InitializeRow(select_buffer);
         tested.Select(fake_txn->GetTxn(), slot, select_row);
         EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(layout, fake_txn->GetReferenceTuple(slot), select_row));
       }
@@ -145,12 +133,9 @@ TEST_F(DataTableConcurrentTests, ConcurrentUpdateOneWriterWins) {
     std::vector<std::unique_ptr<FakeTransaction>> fake_txns;
     for (uint64_t thread = 0; thread < num_threads; thread++)
       // need negative timestamp to denote uncommitted
-      fake_txns.emplace_back(std::make_unique<FakeTransaction>(layout,
-                                              &tested,
-                                              null_ratio_(generator_),
-                                              timestamp_t(2),
-                                              timestamp_t(static_cast<uint64_t>(-thread - 1)),
-                                              &buffer_pool_));
+      fake_txns.emplace_back(std::make_unique<FakeTransaction>(layout, &tested, null_ratio_(generator_), timestamp_t(2),
+                                                               timestamp_t(static_cast<uint64_t>(-thread - 1)),
+                                                               &buffer_pool_));
     std::atomic<uint32_t> success = 0, fail = 0;
     auto workload = [&](uint32_t id) {
       std::default_random_engine thread_generator(id);

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -1,35 +1,31 @@
+#include "storage/garbage_collector.h"
 #include <unordered_map>
 #include <utility>
 #include <vector>
 #include "common/object_pool.h"
 #include "storage/data_table.h"
-#include "storage/garbage_collector.h"
 #include "storage/storage_util.h"
-#include "util/storage_test_util.h"
-#include "util/test_harness.h"
 #include "transaction/transaction_context.h"
 #include "transaction/transaction_manager.h"
+#include "util/storage_test_util.h"
+#include "util/test_harness.h"
 
 namespace terrier {
 // Not thread-safe
 class GarbageCollectorDataTableTestObject {
  public:
-  template<class Random>
-  GarbageCollectorDataTableTestObject(storage::BlockStore *block_store,
-                                      const uint16_t max_col,
-                                      Random *generator)
-      : layout_(StorageTestUtil::RandomLayout(max_col, generator)),
-        table_(block_store, layout_) {}
+  template <class Random>
+  GarbageCollectorDataTableTestObject(storage::BlockStore *block_store, const uint16_t max_col, Random *generator)
+      : layout_(StorageTestUtil::RandomLayout(max_col, generator)), table_(block_store, layout_) {}
 
   ~GarbageCollectorDataTableTestObject() {
-    for (auto ptr : loose_pointers_)
-      delete[] ptr;
+    for (auto ptr : loose_pointers_) delete[] ptr;
     delete[] select_buffer_;
   }
 
   const storage::BlockLayout &Layout() const { return layout_; }
 
-  template<class Random>
+  template <class Random>
   storage::ProjectedRow *GenerateRandomTuple(Random *generator) {
     auto *buffer = common::AllocationUtil::AllocateAligned(initializer_.ProjectedRowSize());
     loose_pointers_.push_back(buffer);
@@ -38,7 +34,7 @@ class GarbageCollectorDataTableTestObject {
     return redo;
   }
 
-  template<class Random>
+  template <class Random>
   storage::ProjectedRow *GenerateRandomUpdate(Random *generator) {
     std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
     storage::ProjectedRowInitializer update_initializer(layout_, update_col_ids);
@@ -60,8 +56,7 @@ class GarbageCollectorDataTableTestObject {
     return version;
   }
 
-  storage::ProjectedRow *SelectIntoBuffer(transaction::TransactionContext *const txn,
-                                          const storage::TupleSlot slot) {
+  storage::ProjectedRow *SelectIntoBuffer(transaction::TransactionContext *const txn, const storage::TupleSlot slot) {
     // generate a redo ProjectedRow for Select
     storage::ProjectedRow *select_row = initializer_.InitializeRow(select_buffer_);
     table_.Select(txn, slot, select_row);

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -1,7 +1,7 @@
 #include <vector>
-#include "util/transaction_test_util.h"
-#include "storage/garbage_collector.h"
 #include "gtest/gtest.h"
+#include "storage/garbage_collector.h"
+#include "util/transaction_test_util.h"
 
 namespace terrier {
 class LargeGCTests : public TerrierTest {
@@ -9,9 +9,7 @@ class LargeGCTests : public TerrierTest {
   void StartGC(transaction::TransactionManager *txn_manager, uint32_t gc_period_milli) {
     gc_ = new storage::GarbageCollector(txn_manager);
     run_gc_ = true;
-    gc_thread_ = std::thread([gc_period_milli, this] {
-      GCThreadLoop(gc_period_milli);
-    });
+    gc_thread_ = std::thread([gc_period_milli, this] { GCThreadLoop(gc_period_milli); });
   }
 
   void EndGC() {
@@ -55,15 +53,8 @@ TEST_F(LargeGCTests, MixedReadWriteWithGC) {
   const std::vector<double> update_select_ratio = {0.3, 0.7};
   const uint32_t num_concurrent_txns = 4;
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
-    LargeTransactionTestObject tested(max_columns,
-                                      initial_table_size,
-                                      txn_length,
-                                      update_select_ratio,
-                                      &block_store_,
-                                      &buffer_pool_,
-                                      &generator_,
-                                      true,
-                                      true);
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, true, true);
     StartGC(tested.GetTxnManager(), 10);
     for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);

--- a/test/storage/projected_row_test.cpp
+++ b/test/storage/projected_row_test.cpp
@@ -3,9 +3,9 @@
 #include <vector>
 #include "common/object_pool.h"
 #include "storage/data_table.h"
+#include "storage/storage_defs.h"
 #include "storage/storage_util.h"
 #include "util/storage_test_util.h"
-#include "storage/storage_defs.h"
 #include "util/test_harness.h"
 
 namespace terrier {
@@ -32,7 +32,6 @@ TEST_F(ProjectedRowTests, Nulls) {
     auto *update_buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
     storage::ProjectedRow *update = initializer.InitializeRow(update_buffer);
     StorageTestUtil::PopulateRandomRow(update, layout, null_ratio_(generator_), &generator_);
-
 
     // generator a binary vector and set nulls according to binary vector. For null attributes, we set value to be 0.
     std::bernoulli_distribution coin(null_ratio_(generator_));
@@ -83,8 +82,8 @@ TEST_F(ProjectedRowTests, CopyProjectedRowLayout) {
     for (uint16_t i = 0; i < row->NumColumns(); i++) {
       EXPECT_EQ(row->ColumnIds()[i], copied_row->ColumnIds()[i]);
       uintptr_t offset = reinterpret_cast<uintptr_t>(row->AccessForceNotNull(i)) - reinterpret_cast<uintptr_t>(row);
-      uintptr_t copied_offset = reinterpret_cast<uintptr_t>(copied_row->AccessForceNotNull(i))
-          - reinterpret_cast<uintptr_t>(copied_row);
+      uintptr_t copied_offset =
+          reinterpret_cast<uintptr_t>(copied_row->AccessForceNotNull(i)) - reinterpret_cast<uintptr_t>(copied_row);
       EXPECT_EQ(offset, copied_offset);
     }
     delete[] buffer;
@@ -137,8 +136,7 @@ TEST_F(ProjectedRowTests, Alignment) {
     auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
     storage::ProjectedRow *row = initializer.InitializeRow(buffer);
     for (uint16_t i = 0; i < row->NumColumns(); i++)
-      StorageTestUtil::CheckAlignment(row->AccessForceNotNull(i),
-                                      layout.AttrSize(row->ColumnIds()[i]));
+      StorageTestUtil::CheckAlignment(row->AccessForceNotNull(i), layout.AttrSize(row->ColumnIds()[i]));
     delete[] buffer;
   }
 }

--- a/test/storage/storage_util_test.cpp
+++ b/test/storage/storage_util_test.cpp
@@ -1,13 +1,13 @@
+#include "storage/storage_util.h"
+#include <iostream>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
-#include <iostream>
-#include <unordered_set>
 #include "common/object_pool.h"
 #include "storage/data_table.h"
-#include "storage/storage_util.h"
-#include "util/storage_test_util.h"
 #include "storage/storage_defs.h"
+#include "util/storage_test_util.h"
 #include "util/test_harness.h"
 
 namespace terrier {
@@ -30,7 +30,6 @@ struct StorageUtilTests : public TerrierTest {
     TerrierTest::TearDown();
   }
 };
-
 
 // Write a value to a position, read from the same position and compare results. Repeats for num_iterations.
 // NOLINTNEXTLINE
@@ -68,7 +67,7 @@ TEST_F(StorageUtilTests, CopyToProjectedRow) {
 
     std::bernoulli_distribution null_dist(null_ratio_(generator_));
     for (uint16_t i = 0; i < row->NumColumns(); ++i) {
-      uint8_t attr_size = layout.AttrSize(static_cast<uint16_t >(i + 1));
+      uint8_t attr_size = layout.AttrSize(static_cast<uint16_t>(i + 1));
       byte *from = nullptr;
       bool is_null = null_dist(generator_);
       if (!is_null) {
@@ -89,7 +88,6 @@ TEST_F(StorageUtilTests, CopyToProjectedRow) {
     delete[] row_buffer;
   }
 }
-
 
 // Generate a layout and get a tuple slot, copy a pointer location into the tuple slot, read it back and
 // compare results for each column. Repeats for num_iterations.
@@ -127,7 +125,6 @@ TEST_F(StorageUtilTests, CopyToTupleSlot) {
     }
   }
 }
-
 
 // Generate a random populated projected row (delta), copy the delta into a projected row, and compare them.
 // Repeats for num_iterations.

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -1,14 +1,14 @@
+#include "storage/tuple_access_strategy.h"
 #include <algorithm>
 #include <unordered_map>
-#include <vector>
 #include <utility>
-#include "util/test_thread_pool.h"
-#include "util/storage_test_util.h"
+#include <vector>
 #include "common/typedefs.h"
-#include "storage/storage_util.h"
-#include "storage/tuple_access_strategy.h"
-#include "util/test_harness.h"
 #include "storage/delta_record.h"
+#include "storage/storage_util.h"
+#include "util/storage_test_util.h"
+#include "util/test_harness.h"
+#include "util/test_thread_pool.h"
 
 namespace terrier {
 
@@ -23,7 +23,7 @@ class TupleAccessStrategyTestObject {
   // Using the given random generator, attempts to allocate a slot and write a
   // random tuple into it. The slot and the tuple are logged in the given map.
   // Checks are performed to make sure the insertion is sensible.
-  template<typename Random>
+  template <typename Random>
   std::pair<const storage::TupleSlot, storage::ProjectedRow *> &TryInsertFakeTuple(
       const storage::BlockLayout &layout, const storage::TupleAccessStrategy &tested, storage::RawBlock *block,
       std::unordered_map<storage::TupleSlot, storage::ProjectedRow *> *tuples, Random *generator) {
@@ -53,7 +53,7 @@ class TupleAccessStrategyTestObject {
   std::vector<byte *> loose_pointers_;
 };
 
-struct TupleAccessStrategyTests : public TerrierTest{
+struct TupleAccessStrategyTests : public TerrierTest {
   storage::RawBlock *raw_block_ = nullptr;
   storage::BlockStore block_store_{1};
 
@@ -99,8 +99,7 @@ TEST_F(TupleAccessStrategyTests, Nulls) {
     for (uint16_t col = 0; col < layout.NumCols(); col++) {
       // Either the field is null and the access returns nullptr,
       // or the field is not null and the access ptr is not null
-      EXPECT_TRUE(
-          (tested.AccessWithNullCheck(slot, col) != nullptr) ^ nulls[col]);
+      EXPECT_TRUE((tested.AccessWithNullCheck(slot, col) != nullptr) ^ nulls[col]);
     }
 
     // Flip non-null columns to null should result in returning of nullptr.
@@ -125,23 +124,15 @@ TEST_F(TupleAccessStrategyTests, SimpleInsert) {
     TERRIER_MEMSET(raw_block_, 0, sizeof(storage::RawBlock));
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));
 
-    uint32_t num_inserts =
-        std::uniform_int_distribution<uint32_t>(1, layout.NumSlots())(generator);
+    uint32_t num_inserts = std::uniform_int_distribution<uint32_t>(1, layout.NumSlots())(generator);
 
     std::unordered_map<storage::TupleSlot, storage::ProjectedRow *> tuples;
     for (uint32_t j = 0; j < num_inserts; j++) {
-      test_obj.TryInsertFakeTuple(layout,
-                                  tested,
-                                  raw_block_,
-                                  &tuples,
-                                  &generator);
+      test_obj.TryInsertFakeTuple(layout, tested, raw_block_, &tuples, &generator);
     }
     // Check that all inserted tuples are equal to their expected values
     for (auto &entry : tuples) {
-      StorageTestUtil::CheckTupleEqual(*(entry.second),
-                                       tested,
-                                       layout,
-                                       entry.first);
+      StorageTestUtil::CheckTupleEqual(*(entry.second), tested, layout, entry.first);
     }
   }
 }
@@ -167,28 +158,18 @@ TEST_F(TupleAccessStrategyTests, MemorySafety) {
       // This test should be robust against any future paddings, since
       // we are checking for non-overlapping ranges and not hard-coded
       // boundaries.
-      StorageTestUtil::CheckInBounds(tested.ColumnNullBitmap(raw_block_, col),
-                                     lower_bound,
-                                     upper_bound);
-      lower_bound =
-          StorageTestUtil::IncrementByBytes(tested.ColumnNullBitmap(raw_block_, col),
-                                            common::RawBitmap::SizeInBytes(layout.NumSlots()));
+      StorageTestUtil::CheckInBounds(tested.ColumnNullBitmap(raw_block_, col), lower_bound, upper_bound);
+      lower_bound = StorageTestUtil::IncrementByBytes(tested.ColumnNullBitmap(raw_block_, col),
+                                                      common::RawBitmap::SizeInBytes(layout.NumSlots()));
 
-      StorageTestUtil::CheckInBounds(tested.ColumnStart(raw_block_, col),
-                                     lower_bound,
-                                     upper_bound);
+      StorageTestUtil::CheckInBounds(tested.ColumnStart(raw_block_, col), lower_bound, upper_bound);
 
-      lower_bound =
-          StorageTestUtil::IncrementByBytes(tested.ColumnStart(raw_block_, col),
-                                            layout.NumSlots()
-                                                * layout.AttrSize(col));
+      lower_bound = StorageTestUtil::IncrementByBytes(tested.ColumnStart(raw_block_, col),
+                                                      layout.NumSlots() * layout.AttrSize(col));
     }
     // check that the last column does not go out of the block
-    uint32_t last_column_size =
-        layout.NumSlots() * layout.AttrSize(static_cast<uint16_t>(layout.NumCols() - 1));
-    StorageTestUtil::CheckInBounds(StorageTestUtil::IncrementByBytes(lower_bound,
-                                                                     last_column_size),
-                                   lower_bound,
+    uint32_t last_column_size = layout.NumSlots() * layout.AttrSize(static_cast<uint16_t>(layout.NumCols() - 1));
+    StorageTestUtil::CheckInBounds(StorageTestUtil::IncrementByBytes(lower_bound, last_column_size), lower_bound,
                                    upper_bound);
   }
 }
@@ -233,26 +214,18 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsert) {
     TERRIER_MEMSET(raw_block_, 0, sizeof(storage::RawBlock));
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));
 
-    std::vector<std::unordered_map<storage::TupleSlot, storage::ProjectedRow *>>
-        tuples(num_threads);
+    std::vector<std::unordered_map<storage::TupleSlot, storage::ProjectedRow *>> tuples(num_threads);
 
     auto workload = [&](uint32_t id) {
       std::default_random_engine thread_generator(id);
       for (uint32_t j = 0; j < layout.NumSlots() / num_threads; j++)
-        test_objs[id].TryInsertFakeTuple(layout,
-                                         tested,
-                                         raw_block_,
-                                         &(tuples[id]),
-                                         &thread_generator);
+        test_objs[id].TryInsertFakeTuple(layout, tested, raw_block_, &(tuples[id]), &thread_generator);
     };
 
     thread_pool.RunThreadsUntilFinish(num_threads, workload);
     for (auto &thread_tuples : tuples)
       for (auto &entry : thread_tuples) {
-        StorageTestUtil::CheckTupleEqual(*(entry.second),
-                                         tested,
-                                         layout,
-                                         entry.first);
+        StorageTestUtil::CheckTupleEqual(*(entry.second), tested, layout, entry.first);
       }
   }
 }
@@ -282,17 +255,12 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsertDelete) {
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));
 
     std::vector<std::vector<storage::TupleSlot>> slots(num_threads);
-    std::vector<std::unordered_map<storage::TupleSlot, storage::ProjectedRow *>>
-        tuples(num_threads);
+    std::vector<std::unordered_map<storage::TupleSlot, storage::ProjectedRow *>> tuples(num_threads);
 
     auto workload = [&](uint32_t id) {
       std::default_random_engine thread_generator(id);
       auto insert = [&] {
-        auto &res = test_objs[id].TryInsertFakeTuple(layout,
-                                                     tested,
-                                                     raw_block_,
-                                                     &(tuples[id]),
-                                                     &thread_generator);
+        auto &res = test_objs[id].TryInsertFakeTuple(layout, tested, raw_block_, &(tuples[id]), &thread_generator);
         // log offset so we can pick random deletes
         slots[id].push_back(res.first);
       };
@@ -305,18 +273,13 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsertDelete) {
         slots[id].erase(elem);
       };
 
-      RandomTestUtil::InvokeWorkloadWithDistribution({insert, remove},
-                                                            {0.7, 0.3},
-                                                            &generator,
-                                                            layout.NumSlots() / num_threads);
+      RandomTestUtil::InvokeWorkloadWithDistribution({insert, remove}, {0.7, 0.3}, &generator,
+                                                     layout.NumSlots() / num_threads);
     };
     thread_pool.RunThreadsUntilFinish(num_threads, workload);
     for (auto &thread_tuples : tuples)
       for (auto &entry : thread_tuples) {
-        StorageTestUtil::CheckTupleEqual(*(entry.second),
-                                         tested,
-                                         layout,
-                                         entry.first);
+        StorageTestUtil::CheckTupleEqual(*(entry.second), tested, layout, entry.first);
       }
   }
 }

--- a/test/storage/varlen_pool_test.cpp
+++ b/test/storage/varlen_pool_test.cpp
@@ -1,9 +1,9 @@
-#include <vector>
 #include "storage/varlen_pool.h"
+#include <vector>
+#include "gtest/gtest.h"
 #include "util/random_test_util.h"
 #include "util/storage_test_util.h"
 #include "util/test_thread_pool.h"
-#include "gtest/gtest.h"
 
 namespace terrier {
 
@@ -64,10 +64,7 @@ TEST(VarlenPoolTests, ConcurrentCorrectnessTest) {
         }
       };
 
-      RandomTestUtil::InvokeWorkloadWithDistribution({free, allocate},
-                                               {0.2, 0.8},
-                                               &generator,
-                                               100);
+      RandomTestUtil::InvokeWorkloadWithDistribution({free, allocate}, {0.2, 0.8}, &generator, 100);
     };
 
     thread_pool.RunThreadsUntilFinish(num_threads, workload);
@@ -75,24 +72,20 @@ TEST(VarlenPoolTests, ConcurrentCorrectnessTest) {
     // Concat all the entries we have
     std::vector<storage::VarlenEntry *> all_entries;
     for (auto &thread_entries : entries)
-      for (auto *entry : thread_entries)
-        all_entries.push_back(entry);
+      for (auto *entry : thread_entries) all_entries.push_back(entry);
 
     std::vector<uint32_t> all_sizes;
     for (auto &thread_sizes : sizes)
-      for (auto &size : thread_sizes)
-        all_sizes.push_back(size);
+      for (auto &size : thread_sizes) all_sizes.push_back(size);
 
     // Check size field as expected, and no overlapping memory regions
     for (uint32_t j = 0; j < all_entries.size(); j++) {
       EXPECT_EQ(all_sizes[j], all_entries[j]->size_);
       for (auto *entry : all_entries)
-        if (entry != all_entries[j])
-          CheckNotOverlapping(entry, all_entries[j]);
+        if (entry != all_entries[j]) CheckNotOverlapping(entry, all_entries[j]);
     }
 
-    for (auto *entry : all_entries)
-      pool.Free(entry);
+    for (auto *entry : all_entries) pool.Free(entry);
   }
 }
 

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -1,6 +1,6 @@
 #include <vector>
-#include "util/transaction_test_util.h"
 #include "gtest/gtest.h"
+#include "util/transaction_test_util.h"
 
 namespace terrier {
 class LargeTransactionTests : public TerrierTest {
@@ -24,15 +24,8 @@ TEST_F(LargeTransactionTests, MixedReadWrite) {
   const std::vector<double> update_select_ratio = {0.4, 0.6};
   const uint32_t num_concurrent_txns = 8;
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
-    LargeTransactionTestObject tested(max_columns,
-                                      initial_table_size,
-                                      txn_length,
-                                      update_select_ratio,
-                                      &block_store_,
-                                      &buffer_pool_,
-                                      &generator_,
-                                      false,
-                                      true);
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, false, true);
     auto result = tested.SimulateOltp(num_txns, num_concurrent_txns);
     tested.CheckReadsCorrect(&result.first);
     for (auto w : result.first) delete w;


### PR DESCRIPTION
Part of #105. 

Comments:
1. There is a reference to .cc files in [asan_symbolize.py](https://github.com/cmu-db/terrier/blob/master/build-support/asan_symbolize.py#L27), but I'm not sure if it should be changed.

2. I tried making cpplint Python-3 compatible. It mostly involves removing references to unicode, iteritems, itervalues. But I do not think this is worth doing; most systems will have Python 2 as the default env python. At most a mild inconvenience for people like me who have a Python 3 default.

Whenever we're ready, we can rebase and run make format.