### PR TITLE
Add thread pool to Google Tests to avoid constant creation and reaping of threads

### DIFF
--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -71,6 +71,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
 // Insert the num_inserts_ of tuples into a DataTable concurrently
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state) {
+  MultiThreadedTestUtil mtt_util;
   // NOLINTNEXTLINE
   for (auto _ : state) {
     storage::DataTable table(&block_store_, layout_);
@@ -80,7 +81,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state
       for (uint32_t i = 0; i < num_inserts_ / num_threads_; i++)
         table.Insert(&txn, *redo_);
     };
-    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads_, workload);
+    mtt_util.RunThreadsUntilFinish(num_threads_, workload);
   }
 
   state.SetItemsProcessed(state.iterations() * num_inserts_);

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -5,7 +5,7 @@
 #include "storage/data_table.h"
 #include "storage/storage_util.h"
 #include "util/storage_test_util.h"
-#include "util/multi_threaded_test_util.h"
+#include "util/test_thread_pool.h"
 #include "util/storage_benchmark_util.h"
 #include "transaction/transaction_context.h"
 #include "transaction/transaction_manager.h"
@@ -71,7 +71,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
 // Insert the num_inserts_ of tuples into a DataTable concurrently
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state) {
-  MultiThreadedTestUtil mtt_util;
+  TestThreadPool thread_pool;
   // NOLINTNEXTLINE
   for (auto _ : state) {
     storage::DataTable table(&block_store_, layout_);
@@ -81,7 +81,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state
       for (uint32_t i = 0; i < num_inserts_ / num_threads_; i++)
         table.Insert(&txn, *redo_);
     };
-    mtt_util.RunThreadsUntilFinish(num_threads_, workload);
+    thread_pool.RunThreadsUntilFinish(num_threads_, workload);
   }
 
   state.SetItemsProcessed(state.iterations() * num_inserts_);

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -5,7 +5,7 @@
 #include "storage/storage_util.h"
 #include "storage/tuple_access_strategy.h"
 #include "util/storage_test_util.h"
-#include "util/multi_threaded_test_util.h"
+#include "util/test_thread_pool.h"
 #include "util/storage_benchmark_util.h"
 
 namespace terrier {
@@ -85,7 +85,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
 // Insert the num_inserts_ of tuples into Blocks concurrently
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::State &state) {
-  MultiThreadedTestUtil mtt_util;
+  TestThreadPool thread_pool;
   storage::TupleAccessStrategy tested(layout_);
 
   // NOLINTNEXTLINE
@@ -108,7 +108,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::St
         }
       };
 
-      mtt_util.RunThreadsUntilFinish(num_threads_, workload);
+      thread_pool.RunThreadsUntilFinish(num_threads_, workload);
     }
     // return all of the used blocks to the BlockStore
     for (uint32_t i = 0; i < num_blocks_; i++) {

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -85,6 +85,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
 // Insert the num_inserts_ of tuples into Blocks concurrently
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::State &state) {
+  MultiThreadedTestUtil mtt_util;
   storage::TupleAccessStrategy tested(layout_);
 
   // NOLINTNEXTLINE
@@ -107,7 +108,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::St
         }
       };
 
-      MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads_, workload);
+      mtt_util.RunThreadsUntilFinish(num_threads_, workload);
     }
     // return all of the used blocks to the BlockStore
     for (uint32_t i = 0; i < num_blocks_; i++) {

--- a/test/common/concurrent_bitmap_test.cpp
+++ b/test/common/concurrent_bitmap_test.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "util/multi_threaded_test_util.h"
+#include "util/test_thread_pool.h"
 #include "common/container/concurrent_bitmap.h"
 #include "util/container_test_util.h"
 
@@ -166,7 +166,7 @@ TEST(ConcurrentBitmapTests, FirstUnsetPosSizeTest) {
 // The test attempts to concurrently flip every bit from 0 to 1 using FirstUnsetPos
 // NOLINTNEXTLINE
 TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
-  MultiThreadedTestUtil mtt_util;
+  TestThreadPool thread_pool;
   std::default_random_engine generator;
   const uint32_t num_iters = 200;
   const uint32_t max_elements = 10000;
@@ -186,7 +186,7 @@ TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
       }
     };
 
-    mtt_util.RunThreadsUntilFinish(num_threads, workload);
+    thread_pool.RunThreadsUntilFinish(num_threads, workload);
 
     // Coalesce the thread-local result vectors into one vector, and
     // then sort the results
@@ -213,7 +213,7 @@ TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
 // This is equivalent to grabbing a free slot if used in an allocator
 // NOLINTNEXTLINE
 TEST(ConcurrentBitmapTests, ConcurrentCorrectnessTest) {
-  MultiThreadedTestUtil mtt_util;
+  TestThreadPool thread_pool;
   std::default_random_engine generator;
   const uint32_t num_iters = 200;
   const uint32_t max_elements = 450000;
@@ -229,7 +229,7 @@ TEST(ConcurrentBitmapTests, ConcurrentCorrectnessTest) {
         if (bitmap->Flip(i, false)) elements[thread_id].push_back(i);
     };
 
-    mtt_util.RunThreadsUntilFinish(num_threads, workload);
+    thread_pool.RunThreadsUntilFinish(num_threads, workload);
 
     // Coalesce the thread-local result vectors into one vector, and
     // then sort the results

--- a/test/common/concurrent_bitmap_test.cpp
+++ b/test/common/concurrent_bitmap_test.cpp
@@ -166,6 +166,7 @@ TEST(ConcurrentBitmapTests, FirstUnsetPosSizeTest) {
 // The test attempts to concurrently flip every bit from 0 to 1 using FirstUnsetPos
 // NOLINTNEXTLINE
 TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
+  MultiThreadedTestUtil mtt_util;
   std::default_random_engine generator;
   const uint32_t num_iters = 200;
   const uint32_t max_elements = 10000;
@@ -185,7 +186,7 @@ TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
       }
     };
 
-    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+    mtt_util.RunThreadsUntilFinish(num_threads, workload);
 
     // Coalesce the thread-local result vectors into one vector, and
     // then sort the results
@@ -212,6 +213,7 @@ TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
 // This is equivalent to grabbing a free slot if used in an allocator
 // NOLINTNEXTLINE
 TEST(ConcurrentBitmapTests, ConcurrentCorrectnessTest) {
+  MultiThreadedTestUtil mtt_util;
   std::default_random_engine generator;
   const uint32_t num_iters = 200;
   const uint32_t max_elements = 450000;
@@ -227,7 +229,7 @@ TEST(ConcurrentBitmapTests, ConcurrentCorrectnessTest) {
         if (bitmap->Flip(i, false)) elements[thread_id].push_back(i);
     };
 
-    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+    mtt_util.RunThreadsUntilFinish(num_threads, workload);
 
     // Coalesce the thread-local result vectors into one vector, and
     // then sort the results

--- a/test/common/object_pool_test.cpp
+++ b/test/common/object_pool_test.cpp
@@ -49,6 +49,7 @@ class ObjectPoolTestType {
 // the same pointer to two threads at the same time.
 // NOLINTNEXTLINE
 TEST(ObjectPoolTests, ConcurrentCorrectnessTest) {
+  MultiThreadedTestUtil mtt_util;
   // This should have no bearing on the correctness of test
   const uint64_t reuse_limit = 100;
   common::ObjectPool<ObjectPoolTestType> tested(reuse_limit);
@@ -75,6 +76,6 @@ TEST(ObjectPoolTests, ConcurrentCorrectnessTest) {
       tested.Release(ptr->Release(tid));
   };
 
-  MultiThreadedTestUtil::RunThreadsUntilFinish(8, workload, 100);
+  mtt_util.RunThreadsUntilFinish(8, workload, 100);
 }
 }  // namespace terrier

--- a/test/common/object_pool_test.cpp
+++ b/test/common/object_pool_test.cpp
@@ -4,7 +4,8 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "util/multi_threaded_test_util.h"
+#include "util/random_test_util.h"
+#include "util/test_thread_pool.h"
 #include "common/object_pool.h"
 
 namespace terrier {
@@ -49,7 +50,7 @@ class ObjectPoolTestType {
 // the same pointer to two threads at the same time.
 // NOLINTNEXTLINE
 TEST(ObjectPoolTests, ConcurrentCorrectnessTest) {
-  MultiThreadedTestUtil mtt_util;
+  TestThreadPool thread_pool;
   // This should have no bearing on the correctness of test
   const uint64_t reuse_limit = 100;
   common::ObjectPool<ObjectPoolTestType> tested(reuse_limit);
@@ -63,12 +64,12 @@ TEST(ObjectPoolTests, ConcurrentCorrectnessTest) {
     };
     auto free = [&] {
       if (!ptrs.empty()) {
-        auto pos = MultiThreadedTestUtil::UniformRandomElement(&ptrs, &generator);
+        auto pos = RandomTestUtil::UniformRandomElement(&ptrs, &generator);
         tested.Release((*pos)->Release(tid));
         ptrs.erase(pos);
       }
     };
-    MultiThreadedTestUtil::InvokeWorkloadWithDistribution({free, allocate},
+    TestThreadPool::InvokeWorkloadWithDistribution({free, allocate},
                                              {0.5, 0.5},
                                              &generator,
                                              100);
@@ -76,6 +77,6 @@ TEST(ObjectPoolTests, ConcurrentCorrectnessTest) {
       tested.Release(ptr->Release(tid));
   };
 
-  mtt_util.RunThreadsUntilFinish(8, workload, 100);
+  thread_pool.RunThreadsUntilFinish(8, workload, 100);
 }
 }  // namespace terrier

--- a/test/common/object_pool_test.cpp
+++ b/test/common/object_pool_test.cpp
@@ -69,7 +69,7 @@ TEST(ObjectPoolTests, ConcurrentCorrectnessTest) {
         ptrs.erase(pos);
       }
     };
-    TestThreadPool::InvokeWorkloadWithDistribution({free, allocate},
+    RandomTestUtil::InvokeWorkloadWithDistribution({free, allocate},
                                              {0.5, 0.5},
                                              &generator,
                                              100);

--- a/test/include/util/multi_threaded_test_util.h
+++ b/test/include/util/multi_threaded_test_util.h
@@ -1,20 +1,68 @@
 #pragma once
+#include <condition_variable>  // NOLINT
 #include <functional>
+#include <mutex>  // NOLINT
+#include <queue>
 #include <random>
 #include <thread>  // NOLINT
+#include <utility>
 #include <vector>
 #include "common/container/concurrent_vector.h"
 #include "common/object_pool.h"
 #include "gtest/gtest.h"
-#include "tbb/task_scheduler_init.h"
 #include "tbb/task_group.h"
+#include "tbb/task_scheduler_init.h"
 
 namespace terrier {
 /**
  * Static utility class for common code for multi-threaded tests.
  */
 struct MultiThreadedTestUtil {
-  MultiThreadedTestUtil() = delete;
+ private:
+  std::vector<std::thread> thread_pool_;
+  std::queue<std::function<void()>> work_pool_;
+  std::mutex work_lock_;
+  std::condition_variable work_cv_;
+  std::condition_variable finished_cv_;
+  uint32_t busy_threads_ = 0;
+  bool shutdown_ = false;
+
+  void AddThread() {
+    thread_pool_.emplace_back([this] {
+      // keep the thread alive
+      while (true) {
+        // grab the lock
+        std::unique_lock<std::mutex> lock(work_lock_);
+        // try to get work
+        work_cv_.wait(lock, [this] { return shutdown_ || !work_pool_.empty(); });
+        // woke up! time to work or time to die?
+        if (shutdown_) {
+          break;
+        }
+        // grab the work
+        ++busy_threads_;
+        auto work = std::move(work_pool_.front());
+        work_pool_.pop();
+        // release the lock while we work
+        lock.unlock();
+        work();
+        // we lock again to notify that we're done
+        lock.lock();
+        --busy_threads_;
+        finished_cv_.notify_one();
+      }
+    });
+  }
+
+ public:
+  ~MultiThreadedTestUtil() {
+    std::unique_lock<std::mutex> lock(work_lock_);    // grab the lock
+    shutdown_ = true;                                 // signal all the threads to shutdown
+    work_cv_.notify_all();                            // wake up all the threads
+    lock.unlock();                                    // free the lock
+    for (auto &thread : thread_pool_) thread.join();  // wait for all the threads to terminate
+  }
+
   /**
    * Selects an element from the supplied vector uniformly at random, using the
    * given random generator.
@@ -46,27 +94,27 @@ struct MultiThreadedTestUtil {
   }
 
   /**
-   * Spawn up the specified number of threads with the workload and join them before
-   * returning. This can be done repeatedly if desired.
+   * Execute the workload with the specified number of threads and wait for them to finish before
+   * returning. This can be done repeatedly if desired. Threads will be reused.
    *
-   * @param num_threads number of threads to spawn up
+   * @param num_threads number of threads to use for execution
    * @param workload the task the thread should run
    * @param repeat the number of times this should be done.
    */
-  static void RunThreadsUntilFinish(uint32_t num_threads, const std::function<void(uint32_t)> &workload,
-                                    uint32_t repeat = 1) {
-    // requires that calling thread does not use any of TBB's task scheduling
-    // alternatively, we can spawn up a new thread
-    // but we are not guaranteed these run in parallel..
-    tbb::task_scheduler_init scheduler(num_threads);
+  void RunThreadsUntilFinish(uint32_t num_threads, const std::function<void(uint32_t)> &workload, uint32_t repeat = 1) {
+    // ensure our thread pool has enough threads
+    while (thread_pool_.size() < num_threads) AddThread();
+
     for (uint32_t i = 0; i < repeat; i++) {
-      tbb::task_group group;
+      std::unique_lock<std::mutex> lock(work_lock_);  // grab the lock
+      // add the jobs to the queue
       for (uint32_t j = 0; j < num_threads; j++) {
-        group.run(tbb::make_task([j, &workload] { workload(j); }));
+        work_pool_.emplace([j, &workload] { workload(j); });
+        work_cv_.notify_one();
       }
-      group.wait();
+      // wait for all the threads to finish
+      finished_cv_.wait(lock, [this] { return busy_threads_ == 0 && work_pool_.empty(); });
     }
-    scheduler.terminate();
   }
 
   /**

--- a/test/include/util/random_test_util.h
+++ b/test/include/util/random_test_util.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <random>
+#include <vector>
+
+namespace terrier {
+/**
+ * Utility class for random element selection
+ */
+class RandomTestUtil {
+ public:
+  /**
+   * Selects an element from the supplied vector uniformly at random, using the
+   * given random generator.
+   *
+   * @tparam T type of elements in the vector
+   * @tparam Random type of random generator to use
+   * @param elems vector of elements to draw from
+   * @param generator source of randomness to use
+   * @return iterator to a randomly selected element
+   */
+  template <typename T, typename Random>
+  static typename std::vector<T>::iterator UniformRandomElement(std::vector<T> *elems, Random *const generator) {
+    return elems->begin() + std::uniform_int_distribution(0, static_cast<int>(elems->size() - 1))(*generator);
+  }
+
+  /**
+   * Selects an element from the supplied constant vector uniformly at random, using the
+   * given random generator.
+   *
+   * @tparam T type of elements in the vector
+   * @tparam Random type of random generator to use
+   * @param elems vector of elements to draw from
+   * @param generator source of randomness to use
+   * @return const iterator to a randomly selected element
+   */
+  template <class T, class Random>
+  static typename std::vector<T>::const_iterator UniformRandomElement(const std::vector<T> &elems,
+                                                                      Random *const generator) {
+    return elems.cbegin() + std::uniform_int_distribution(0, static_cast<int>(elems.size() - 1))(*generator);
+  }
+};
+
+}  // namespace terrier

--- a/test/include/util/random_test_util.h
+++ b/test/include/util/random_test_util.h
@@ -2,6 +2,7 @@
 
 #include <random>
 #include <vector>
+#include "common/macros.h"
 
 namespace terrier {
 /**
@@ -38,6 +39,28 @@ class RandomTestUtil {
   static typename std::vector<T>::const_iterator UniformRandomElement(const std::vector<T> &elems,
                                                                       Random *const generator) {
     return elems.cbegin() + std::uniform_int_distribution(0, static_cast<int>(elems.size() - 1))(*generator);
+  }
+
+  /**
+   * Given a list of workloads and probabilities (must be of the same size), select
+   * a random workload according to the probability to be run. This can be done
+   * repeatedly if desired.
+   *
+   * @tparam Random type of random generator to use
+   * @param workloads list of workloads to draw from
+   * @param probabilities list of probabilities for each workload to be selected
+   *    (if they don't sum up to one, they would be treated as weights
+   *     i.e. suppose we have {w1, w2, ...} pr_n = w_n / sum(ws))
+   * @param generator source of randomness to use
+   * @param repeat the number of times this should be done.
+   */
+  template <typename Random>
+  static void InvokeWorkloadWithDistribution(std::vector<std::function<void()>> workloads,
+                                             std::vector<double> probabilities, Random *generator,
+                                             uint32_t repeat = 1) {
+    PELOTON_ASSERT(probabilities.size() == workloads.size(), "Probabilities and workloads must have the same size.");
+    std::discrete_distribution dist(probabilities.begin(), probabilities.end());
+    for (uint32_t i = 0; i < repeat; i++) workloads[dist(*generator)]();
   }
 };
 

--- a/test/include/util/random_test_util.h
+++ b/test/include/util/random_test_util.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <random>
 #include <vector>
 #include "common/macros.h"

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -9,7 +9,8 @@
 #include "gtest/gtest.h"
 #include "storage/storage_defs.h"
 #include "storage/storage_util.h"
-#include "util/multi_threaded_test_util.h"
+#include "util/random_test_util.h"
+#include "util/test_thread_pool.h"
 
 namespace terrier {
 struct StorageTestUtil {
@@ -70,7 +71,7 @@ struct StorageTestUtil {
     std::vector<uint8_t> possible_attr_sizes{1, 2, 4, 8}, attr_sizes(num_attrs);
     attr_sizes[0] = 8;
     for (uint16_t i = 1; i < num_attrs; i++)
-      attr_sizes[i] = *MultiThreadedTestUtil::UniformRandomElement(&possible_attr_sizes, generator);
+      attr_sizes[i] = *RandomTestUtil::UniformRandomElement(&possible_attr_sizes, generator);
     return {num_attrs, attr_sizes};
   }
 

--- a/test/include/util/test_thread_pool.h
+++ b/test/include/util/test_thread_pool.h
@@ -49,28 +49,6 @@ class TestThreadPool {
     }
   }
 
-  /**
-   * Given a list of workloads and probabilities (must be of the same size), select
-   * a random workload according to the probability to be run. This can be done
-   * repeatedly if desired.
-   *
-   * @tparam Random type of random generator to use
-   * @param workloads list of workloads to draw from
-   * @param probabilities list of probabilities for each workload to be selected
-   *    (if they don't sum up to one, they would be treated as weights
-   *     i.e. suppose we have {w1, w2, ...} pr_n = w_n / sum(ws))
-   * @param generator source of randomness to use
-   * @param repeat the number of times this should be done.
-   */
-  template <typename Random>
-  static void InvokeWorkloadWithDistribution(std::vector<std::function<void()>> workloads,
-                                             std::vector<double> probabilities, Random *generator,
-                                             uint32_t repeat = 1) {
-    PELOTON_ASSERT(probabilities.size() == workloads.size(), "Probabilities and workloads must have the same size.");
-    std::discrete_distribution dist(probabilities.begin(), probabilities.end());
-    for (uint32_t i = 0; i < repeat; i++) workloads[dist(*generator)]();
-  }
-
  private:
   std::vector<std::thread> thread_pool_;
   std::queue<std::function<void()>> work_pool_;

--- a/test/include/util/test_thread_pool.h
+++ b/test/include/util/test_thread_pool.h
@@ -10,51 +10,19 @@
 #include "common/container/concurrent_vector.h"
 #include "common/object_pool.h"
 #include "gtest/gtest.h"
-#include "tbb/task_group.h"
-#include "tbb/task_scheduler_init.h"
 
 namespace terrier {
 /**
- * Static utility class for common code for multi-threaded tests.
+ * Thread pool for use in tests to avoid creating and destroying a ton of threads when running multiple iterations
  */
-class MultiThreadedTestUtil {
+class TestThreadPool {
  public:
-  ~MultiThreadedTestUtil() {
+  ~TestThreadPool() {
     std::unique_lock<std::mutex> lock(work_lock_);    // grab the lock
     shutdown_ = true;                                 // signal all the threads to shutdown
     work_cv_.notify_all();                            // wake up all the threads
     lock.unlock();                                    // free the lock
     for (auto &thread : thread_pool_) thread.join();  // wait for all the threads to terminate
-  }
-
-  /**
-   * Selects an element from the supplied vector uniformly at random, using the
-   * given random generator.
-   *
-   * @tparam T type of elements in the vector
-   * @tparam Random type of random generator to use
-   * @param elems vector of elements to draw from
-   * @param generator source of randomness to use
-   * @return iterator to a randomly selected element
-   */
-  template <typename T, typename Random>
-  static typename std::vector<T>::iterator UniformRandomElement(std::vector<T> *elems, Random *generator) {
-    return elems->begin() + std::uniform_int_distribution(0, static_cast<int>(elems->size() - 1))(*generator);
-  }
-
-  /**
-   * Selects an element from the supplied constant vector uniformly at random, using the
-   * given random generator.
-   *
-   * @tparam T type of elements in the vector
-   * @tparam Random type of random generator to use
-   * @param elems vector of elements to draw from
-   * @param generator source of randomness to use
-   * @return const iterator to a randomly selected element
-   */
-  template <class T, class Random>
-  static typename std::vector<T>::const_iterator UniformRandomElement(const std::vector<T> &elems, Random *generator) {
-    return elems.cbegin() + std::uniform_int_distribution(0, static_cast<int>(elems.size() - 1))(*generator);
   }
 
   /**

--- a/test/storage/data_table_concurrent_test.cpp
+++ b/test/storage/data_table_concurrent_test.cpp
@@ -88,6 +88,7 @@ struct DataTableConcurrentTests : public TerrierTest {
 // Therefore all transactions should successfully insert their tuples, which is what we test for.
 // NOLINTNEXTLINE
 TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
+  MultiThreadedTestUtil mtt_util;
   const uint32_t num_iterations = 10;
   const uint32_t num_inserts = 10000;
   const uint16_t max_columns = 20;
@@ -105,7 +106,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
         fake_txns[id].InsertRandomTuple(&thread_generator);
     };
 
-    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+    mtt_util.RunThreadsUntilFinish(num_threads, workload);
     std::vector<uint16_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     auto *select_buffer = new byte[storage::ProjectedRow::Size(layout, all_col_ids)];
     for (auto &fake_txn : fake_txns) {
@@ -125,6 +126,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
 // Therefore only one transaction should win, which is what we test for.
 // NOLINTNEXTLINE
 TEST_F(DataTableConcurrentTests, ConcurrentUpdateOneWriterWins) {
+  MultiThreadedTestUtil mtt_util;
   const uint32_t num_iterations = 1000;
   const uint16_t max_columns = 20;
   const uint32_t num_threads = 8;
@@ -154,7 +156,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentUpdateOneWriterWins) {
         fail++;
     };
 
-    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+    mtt_util.RunThreadsUntilFinish(num_threads, workload);
     EXPECT_EQ(1, success);
     EXPECT_EQ(num_threads - 1, fail);
   }

--- a/test/storage/data_table_concurrent_test.cpp
+++ b/test/storage/data_table_concurrent_test.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 #include "storage/data_table.h"
 #include "util/storage_test_util.h"
-#include "util/multi_threaded_test_util.h"
+#include "util/test_thread_pool.h"
 #include "transaction/transaction_context.h"
 #include "util/test_harness.h"
 
@@ -88,7 +88,7 @@ struct DataTableConcurrentTests : public TerrierTest {
 // Therefore all transactions should successfully insert their tuples, which is what we test for.
 // NOLINTNEXTLINE
 TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
-  MultiThreadedTestUtil mtt_util;
+  TestThreadPool thread_pool;
   const uint32_t num_iterations = 10;
   const uint32_t num_inserts = 10000;
   const uint16_t max_columns = 20;
@@ -106,7 +106,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
         fake_txns[id].InsertRandomTuple(&thread_generator);
     };
 
-    mtt_util.RunThreadsUntilFinish(num_threads, workload);
+    thread_pool.RunThreadsUntilFinish(num_threads, workload);
     std::vector<uint16_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     auto *select_buffer = new byte[storage::ProjectedRow::Size(layout, all_col_ids)];
     for (auto &fake_txn : fake_txns) {
@@ -126,7 +126,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
 // Therefore only one transaction should win, which is what we test for.
 // NOLINTNEXTLINE
 TEST_F(DataTableConcurrentTests, ConcurrentUpdateOneWriterWins) {
-  MultiThreadedTestUtil mtt_util;
+  TestThreadPool thread_pool;
   const uint32_t num_iterations = 1000;
   const uint16_t max_columns = 20;
   const uint32_t num_threads = 8;
@@ -156,7 +156,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentUpdateOneWriterWins) {
         fail++;
     };
 
-    mtt_util.RunThreadsUntilFinish(num_threads, workload);
+    thread_pool.RunThreadsUntilFinish(num_threads, workload);
     EXPECT_EQ(1, success);
     EXPECT_EQ(num_threads - 1, fail);
   }

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -219,6 +219,7 @@ TEST_F(TupleAccessStrategyTests, Alignment) {
 // and verifies that all tuples are written into unique slots correctly.
 // NOLINTNEXTLINE
 TEST_F(TupleAccessStrategyTests, ConcurrentInsert) {
+  MultiThreadedTestUtil mtt_util;
   const uint32_t repeat = 200;
   std::default_random_engine generator;
   for (uint32_t i = 0; i < repeat; i++) {
@@ -245,7 +246,7 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsert) {
                                          &thread_generator);
     };
 
-    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+    mtt_util.RunThreadsUntilFinish(num_threads, workload);
     for (auto &thread_tuples : tuples)
       for (auto &entry : thread_tuples) {
         StorageTestUtil::CheckTupleEqual(*(entry.second),
@@ -266,6 +267,7 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsert) {
 // responsibility of concurrency control and GC, not storage.
 // NOLINTNEXTLINE
 TEST_F(TupleAccessStrategyTests, ConcurrentInsertDelete) {
+  MultiThreadedTestUtil mtt_util;
   const uint32_t repeat = 200;
   std::default_random_engine generator;
   for (uint32_t i = 0; i < repeat; i++) {
@@ -308,7 +310,7 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsertDelete) {
                                                             &generator,
                                                             layout.num_slots_ / num_threads);
     };
-    MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+    mtt_util.RunThreadsUntilFinish(num_threads, workload);
     for (auto &thread_tuples : tuples)
       for (auto &entry : thread_tuples) {
         StorageTestUtil::CheckTupleEqual(*(entry.second),

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -305,7 +305,7 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsertDelete) {
         slots[id].erase(elem);
       };
 
-      TestThreadPool::InvokeWorkloadWithDistribution({insert, remove},
+      RandomTestUtil::InvokeWorkloadWithDistribution({insert, remove},
                                                             {0.7, 0.3},
                                                             &generator,
                                                             layout.num_slots_ / num_threads);

--- a/test/storage/varlen_pool_test.cpp
+++ b/test/storage/varlen_pool_test.cpp
@@ -34,6 +34,7 @@ void CheckNotOverlapping(storage::VarlenEntry *a, storage::VarlenEntry *b) {
 // expected value, and no overlapping)
 // NOLINTNEXTLINE
 TEST(VarlenPoolTests, ConcurrentCorrectnessTest) {
+  MultiThreadedTestUtil mtt_util;
   const uint32_t repeat = 100, num_threads = 8;
   for (uint32_t i = 0; i < repeat; i++) {
     storage::VarlenPool pool;
@@ -68,7 +69,7 @@ TEST(VarlenPoolTests, ConcurrentCorrectnessTest) {
                                                100);
     };
 
-     MultiThreadedTestUtil::RunThreadsUntilFinish(num_threads, workload);
+     mtt_util.RunThreadsUntilFinish(num_threads, workload);
 
     // Concat all the entries we have
     std::vector<storage::VarlenEntry *> all_entries;

--- a/test/storage/varlen_pool_test.cpp
+++ b/test/storage/varlen_pool_test.cpp
@@ -64,7 +64,7 @@ TEST(VarlenPoolTests, ConcurrentCorrectnessTest) {
         }
       };
 
-      TestThreadPool::InvokeWorkloadWithDistribution({free, allocate},
+      RandomTestUtil::InvokeWorkloadWithDistribution({free, allocate},
                                                {0.2, 0.8},
                                                &generator,
                                                100);

--- a/test/storage/varlen_pool_test.cpp
+++ b/test/storage/varlen_pool_test.cpp
@@ -1,7 +1,8 @@
 #include <vector>
 #include "storage/varlen_pool.h"
-#include "util/multi_threaded_test_util.h"
+#include "util/random_test_util.h"
 #include "util/storage_test_util.h"
+#include "util/test_thread_pool.h"
 #include "gtest/gtest.h"
 
 namespace terrier {
@@ -34,7 +35,7 @@ void CheckNotOverlapping(storage::VarlenEntry *a, storage::VarlenEntry *b) {
 // expected value, and no overlapping)
 // NOLINTNEXTLINE
 TEST(VarlenPoolTests, ConcurrentCorrectnessTest) {
-  MultiThreadedTestUtil mtt_util;
+  TestThreadPool thread_pool;
   const uint32_t repeat = 100, num_threads = 8;
   for (uint32_t i = 0; i < repeat; i++) {
     storage::VarlenPool pool;
@@ -53,7 +54,7 @@ TEST(VarlenPoolTests, ConcurrentCorrectnessTest) {
 
       auto free = [&] {
         if (!entries[thread_id].empty()) {
-          auto pos = MultiThreadedTestUtil::UniformRandomElement(&(entries[thread_id]), &generator);
+          auto pos = RandomTestUtil::UniformRandomElement(&(entries[thread_id]), &generator);
           // Check size field as expected
           EXPECT_EQ(sizes[thread_id][pos - entries[thread_id].begin()], (*pos)->size_);
           // clean up
@@ -63,13 +64,13 @@ TEST(VarlenPoolTests, ConcurrentCorrectnessTest) {
         }
       };
 
-      MultiThreadedTestUtil::InvokeWorkloadWithDistribution({free, allocate},
+      TestThreadPool::InvokeWorkloadWithDistribution({free, allocate},
                                                {0.2, 0.8},
                                                &generator,
                                                100);
     };
 
-     mtt_util.RunThreadsUntilFinish(num_threads, workload);
+    thread_pool.RunThreadsUntilFinish(num_threads, workload);
 
     // Concat all the entries we have
     std::vector<storage::VarlenEntry *> all_entries;

--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -24,7 +24,7 @@ template<class Random>
 void RandomWorkloadTransaction::RandomUpdate(Random *generator) {
   if (aborted_) return;
   storage::TupleSlot
-      updated = MultiThreadedTestUtil::UniformRandomElement(test_object_->last_checked_version_, generator)->first;
+      updated = RandomTestUtil::UniformRandomElement(test_object_->last_checked_version_, generator)->first;
   std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(test_object_->layout_, generator);
   auto *update_buffer =
       test_object_->bookkeeping_ ? new byte[storage::ProjectedRow::Size(test_object_->layout_, update_col_ids)]
@@ -50,7 +50,7 @@ template<class Random>
 void RandomWorkloadTransaction::RandomSelect(Random *generator) {
   if (aborted_) return;
   storage::TupleSlot
-      selected = MultiThreadedTestUtil::UniformRandomElement(test_object_->last_checked_version_, generator)->first;
+      selected = RandomTestUtil::UniformRandomElement(test_object_->last_checked_version_, generator)->first;
   auto *select_buffer = test_object_->bookkeeping_ ? new byte[test_object_->row_size_] : buffer_;
   storage::ProjectedRow *select =
       storage::ProjectedRow::InitializeProjectedRow(select_buffer, test_object_->all_cols_, test_object_->layout_);
@@ -103,7 +103,7 @@ LargeTransactionTestObject::~LargeTransactionTestObject() {
 
 // Caller is responsible for freeing the returned results if bookkeeping is on.
 SimulationResult LargeTransactionTestObject::SimulateOltp(uint32_t num_transactions, uint32_t num_concurrent_txns) {
-  MultiThreadedTestUtil mtt_util;
+  TestThreadPool thread_pool;
   std::vector<RandomWorkloadTransaction *> txns;
   std::function<void(uint32_t)> workload;
   std::atomic<uint32_t> txns_run = 0;
@@ -129,7 +129,7 @@ SimulationResult LargeTransactionTestObject::SimulateOltp(uint32_t num_transacti
     };
   }
 
-  mtt_util.RunThreadsUntilFinish(num_concurrent_txns, workload);
+  thread_pool.RunThreadsUntilFinish(num_concurrent_txns, workload);
 
   if (!bookkeeping_) {
     // We only need to deallocate, and return, if gc is on, this loop is a no-op
@@ -174,7 +174,7 @@ void LargeTransactionTestObject::SimulateOneTransaction(terrier::RandomWorkloadT
 
   auto update = [&] { txn->RandomUpdate(&thread_generator); };
   auto select = [&] { txn->RandomSelect(&thread_generator); };
-  MultiThreadedTestUtil::InvokeWorkloadWithDistribution({update, select},
+  TestThreadPool::InvokeWorkloadWithDistribution({update, select},
                                                         update_select_ratio_,
                                                         &thread_generator,
                                                         txn_length_);

--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -103,6 +103,7 @@ LargeTransactionTestObject::~LargeTransactionTestObject() {
 
 // Caller is responsible for freeing the returned results if bookkeeping is on.
 SimulationResult LargeTransactionTestObject::SimulateOltp(uint32_t num_transactions, uint32_t num_concurrent_txns) {
+  MultiThreadedTestUtil mtt_util;
   std::vector<RandomWorkloadTransaction *> txns;
   std::function<void(uint32_t)> workload;
   std::atomic<uint32_t> txns_run = 0;
@@ -128,7 +129,7 @@ SimulationResult LargeTransactionTestObject::SimulateOltp(uint32_t num_transacti
     };
   }
 
-  MultiThreadedTestUtil::RunThreadsUntilFinish(num_concurrent_txns, workload);
+  mtt_util.RunThreadsUntilFinish(num_concurrent_txns, workload);
 
   if (!bookkeeping_) {
     // We only need to deallocate, and return, if gc is on, this loop is a no-op

--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -174,7 +174,7 @@ void LargeTransactionTestObject::SimulateOneTransaction(terrier::RandomWorkloadT
 
   auto update = [&] { txn->RandomUpdate(&thread_generator); };
   auto select = [&] { txn->RandomSelect(&thread_generator); };
-  TestThreadPool::InvokeWorkloadWithDistribution({update, select},
+  RandomTestUtil::InvokeWorkloadWithDistribution({update, select},
                                                         update_select_ratio_,
                                                         &thread_generator,
                                                         txn_length_);


### PR DESCRIPTION
Fix #102.

To use RunUntilThreadsFinish, we now need to construct an instance of MultiThreadedTestUtil. The tests have been fixed up accordingly. All other functionality remains the same.

Not implemented: shutting down a subset of threads. Would we want this?