### PR TITLE
Fix CMP0068 CMake warning on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (TERRIER_VERSION_MAJOR STREQUAL "" OR
     TERRIER_VERSION_MINOR STREQUAL "" OR
     TERRIER_VERSION_PATCH STREQUAL "")
   MESSAGE(FATAL_ERROR "Failed to determine Terrier version from '${TERRIER_VERSION}'")
-endif()
+endif ()
 
 # The SO version is also the ABI version
 # Terrier 0.x.y => SO version is "x", full SO version is "x.y.0"
@@ -50,7 +50,6 @@ set(TERRIER_FULL_SO_VERSION "${TERRIER_SO_VERSION}.${TERRIER_VERSION_PATCH}.0")
 message(STATUS "Terrier version: "
     "${TERRIER_VERSION_MAJOR}.${TERRIER_VERSION_MINOR}.${TERRIER_VERSION_PATCH} "
     "(full: '${TERRIER_VERSION}')")
-
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 
@@ -63,10 +62,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(GNUInstallDirs)
 
 # Compatibility with CMake 3.1
-if(POLICY CMP0054)
+if (POLICY CMP0054)
   # http://www.cmake.org/cmake/help/v3.1/policy/CMP0054.html
   cmake_policy(SET CMP0054 NEW)
-endif()
+endif ()
+
+if (APPLE)
+  cmake_policy(SET CMP0068 NEW)
+endif ()
 
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 
@@ -117,13 +120,13 @@ option(TERRIER_VERBOSE_LINT
     "If off, 'quiet' flags will be passed to linting tools"
     OFF)
 
-if(NOT TERRIER_BUILD_TESTS)
+if (NOT TERRIER_BUILD_TESTS)
   set(NO_TESTS 1)
-endif()
+endif ()
 
-if(NOT TERRIER_BUILD_BENCHMARKS)
+if (NOT TERRIER_BUILD_BENCHMARKS)
   set(NO_BENCHMARKS 1)
-endif()
+endif ()
 
 ###################################################
 # COMPILER TOOLS
@@ -136,7 +139,7 @@ if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
   # with various development tools, such as Vim's YouCompleteMe plugin.
   # See http://clang.llvm.org/docs/JSONCompilationDatabase.html
   set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
-endif()
+endif ()
 
 set(USE_GOLD true CACHE BOOL "Use the GNU Gold linker if available")
 if (USE_GOLD)
@@ -149,7 +152,7 @@ if (USE_GOLD)
     message(STATUS "GNU gold not found")
     set(USE_GOLD OFF)
   endif ()
-endif()
+endif ()
 
 ############################################################
 # Compiler flags
@@ -192,7 +195,7 @@ if (TERRIER_GENERATE_COVERAGE)
 
   if (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
     message(FATAL_ERROR "Coverage can only be generated with a debug build type!")
-  endif()
+  endif ()
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
 
@@ -210,7 +213,7 @@ if (TERRIER_GENERATE_COVERAGE)
       "${COVERAGE_UPLOAD}"
       "${CMAKE_MODULE_PATH}"
   )
-endif()
+endif ()
 
 # CMAKE_CXX_FLAGS now fully assembled
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
@@ -220,7 +223,7 @@ message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 ###########################################################
 if (NOT TERRIER_VERBOSE_LINT)
   set(TERRIER_LINT_QUIET "--quiet")
-endif()
+endif ()
 
 if (UNIX)
 
@@ -246,7 +249,6 @@ if (UNIX)
       --filter=-legal/copyright,-build/header_guard
       )
 endif (UNIX)
-
 
 ###########################################################
 # "make format" and "make check-format" targets
@@ -290,14 +292,14 @@ if (${CLANG_TIDY_FOUND})
       )
   add_dependencies(check-clang-tidy benchmark gtest)                        # clang-tidy needs their headers to exist
 
-endif()
+endif ()
 
 ###########################################################
 # Build properties
 ###########################################################
 
 # set compile output directory
-string (TOLOWER ${CMAKE_BUILD_TYPE} BUILD_SUBDIR_NAME)
+string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_SUBDIR_NAME)
 
 # If build in-source, create the latest symlink. If build out-of-source, which is
 # preferred, simply output the binaries in the build folder
@@ -309,12 +311,12 @@ if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
   FILE(MAKE_DIRECTORY ${BUILD_OUTPUT_ROOT_DIRECTORY})
   if (NOT APPLE)
     set(MORE_ARGS "-T")
-  endif()
+  endif ()
   EXECUTE_PROCESS(COMMAND ln ${MORE_ARGS} -sf ${BUILD_OUTPUT_ROOT_DIRECTORY}
       ${CMAKE_CURRENT_BINARY_DIR}/build/latest)
-else()
+else ()
   set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${BUILD_SUBDIR_NAME}/")
-endif()
+endif ()
 
 # where to put generated archives (.a files)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}")

--- a/cmake_modules/SetupCxxFlags.cmake
+++ b/cmake_modules/SetupCxxFlags.cmake
@@ -29,7 +29,7 @@ set(CXX_COMMON_FLAGS "")
 # if no build warning level is specified, default to checkin warning level
 if (NOT BUILD_WARNING_LEVEL)
   set(BUILD_WARNING_LEVEL checkin)
-endif(NOT BUILD_WARNING_LEVEL)
+endif (NOT BUILD_WARNING_LEVEL)
 
 message("Configured for ${BUILD_WARNING_LEVEL} warning level (set with cmake -DBUILD_WARNING_LEVEL={checkin,production,everything})")
 
@@ -47,9 +47,9 @@ if ("${UPPERCASE_BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall \
 -Wconversion -Wno-sign-conversion")
 
-  else()
+  else ()
     message(FATAL_ERROR "Unknown compiler. Version info:\n${COMPILER_VERSION_FULL}")
-  endif()
+  endif ()
 
   # Treat all compiler warnings as errors
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror")
@@ -63,19 +63,19 @@ elseif ("${UPPERCASE_BUILD_WARNING_LEVEL}" STREQUAL "EVERYTHING")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall -Wpedantic -Wextra -Wno-unused-parameter")
     # Treat all compiler warnings as errors
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror")
-  else()
+  else ()
     message(FATAL_ERROR "Unknown compiler. Version info:\n${COMPILER_VERSION_FULL}")
-  endif()
-else()
+  endif ()
+else ()
   # Production builds (warning are not treated as errors)
   if ("${COMPILER_FAMILY}" STREQUAL "clang")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall")
   elseif ("${COMPILER_FAMILY}" STREQUAL "gcc")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall")
-  else()
+  else ()
     message(FATAL_ERROR "Unknown compiler. Version info:\n${COMPILER_VERSION_FULL}")
-  endif()
-endif()
+  endif ()
+endif ()
 
 # Clang options for all builds
 if ("${COMPILER_FAMILY}" STREQUAL "clang")
@@ -88,21 +88,21 @@ if ("${COMPILER_FAMILY}" STREQUAL "clang")
 
   # Avoid clang error when an unknown warning flag is passed
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unknown-warning-option")
-endif()
+endif ()
 
 # if build warning flags is set, add to CXX_COMMON_FLAGS
 if (BUILD_WARNING_FLAGS)
   # Use BUILD_WARNING_FLAGS with BUILD_WARNING_LEVEL=everything to disable
   # warnings (use with Clang's -Weverything flag to find potential errors)
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} ${BUILD_WARNING_FLAGS}")
-endif(BUILD_WARNING_FLAGS)
+endif (BUILD_WARNING_FLAGS)
 
 # color diagnostics
-if("${COMPILER_FAMILY}" STREQUAL "clang")
+if ("${COMPILER_FAMILY}" STREQUAL "clang")
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -fcolor-diagnostics")
-elseif("${COMPILER_FAMILY}" STREQUAL "gcc")
+elseif ("${COMPILER_FAMILY}" STREQUAL "gcc")
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -fdiagnostics-color=auto")
-endif()
+endif ()
 
 # compiler flags for different build types (run 'cmake -DCMAKE_BUILD_TYPE=<type> .')
 # For all builds:
@@ -125,9 +125,9 @@ set(CXX_FLAGS_RELWITHDEBINFO "-ggdb -O2 -DNDEBUG")
 # if no build build type is specified, default to debug builds
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
-endif(NOT CMAKE_BUILD_TYPE)
+endif (NOT CMAKE_BUILD_TYPE)
 
-string (TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
+string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 
 # Set compile flags based on the build type.
 message("Configured for ${CMAKE_BUILD_TYPE} build (set with cmake -DCMAKE_BUILD_TYPE={release,debug,fastdebug,relwithdebinfo})")
@@ -139,10 +139,9 @@ elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_RELEASE}")
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "RELWITHDEBINFO")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS_RELWITHDEBINFO}")
-else()
+else ()
   message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
 endif ()
-
 
 # jemalloc flags
 if (LINUX)
@@ -152,8 +151,8 @@ endif ()
 
 if ("${CMAKE_CXX_FLAGS}" MATCHES "-DNDEBUG")
   set(TERRIER_DEFINITION_FLAGS "-DNDEBUG")
-else()
+else ()
   set(TERRIER_DEFINITION_FLAGS "")
-endif()
+endif ()
 
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -17,7 +17,6 @@
 #
 # Modified from the Apache Arrow project for the Terrier project.
 
-
 # ----------------------------------------------------------------------
 # Thirdparty versions, environment variables, source URLs
 
@@ -26,11 +25,11 @@ set(THIRDPARTY_DIR "${CMAKE_SOURCE_DIR}/third_party")
 if (NOT "$ENV{TERRIER_BUILD_TOOLCHAIN}" STREQUAL "")
   set(JEMALLOC_HOME "$ENV{TERRIER_BUILD_TOOLCHAIN}")
   set(GFLAGS_HOME "$ENV{TERRIER_BUILD_TOOLCHAIN}")
-endif()
+endif ()
 
 if (DEFINED ENV{GFLAGS_HOME})
   set(GFLAGS_HOME "$ENV{GFLAGS_HOME}")
-endif()
+endif ()
 
 # ----------------------------------------------------------------------
 # Versions and URLs for toolchain builds, which also can be used to configure
@@ -38,43 +37,43 @@ endif()
 
 # Read toolchain versions from cpp/thirdparty/versions.txt
 file(STRINGS "${THIRDPARTY_DIR}/versions.txt" TOOLCHAIN_VERSIONS_TXT)
-foreach(_VERSION_ENTRY ${TOOLCHAIN_VERSIONS_TXT})
+foreach (_VERSION_ENTRY ${TOOLCHAIN_VERSIONS_TXT})
   # Exclude comments
-  if(_VERSION_ENTRY MATCHES "#.*")
+  if (_VERSION_ENTRY MATCHES "#.*")
     continue()
-  endif()
+  endif ()
 
   string(REGEX MATCH "^[^=]*" _LIB_NAME ${_VERSION_ENTRY})
   string(REPLACE "${_LIB_NAME}=" "" _LIB_VERSION ${_VERSION_ENTRY})
 
   # Skip blank or malformed lines
-  if(${_LIB_VERSION} STREQUAL "")
+  if (${_LIB_VERSION} STREQUAL "")
     continue()
-  endif()
+  endif ()
 
   # For debugging
   message(STATUS "${_LIB_NAME}: ${_LIB_VERSION}")
 
   set(${_LIB_NAME} "${_LIB_VERSION}")
-endforeach()
+endforeach ()
 
 if (DEFINED ENV{TERRIER_GTEST_URL})
   set(GTEST_SOURCE_URL "$ENV{TERRIER_GTEST_URL}")
-else()
+else ()
   set(GTEST_SOURCE_URL "https://github.com/google/googletest/archive/release-${GTEST_VERSION}.tar.gz")
-endif()
+endif ()
 
 if (DEFINED ENV{TERRIER_GFLAGS_URL})
   set(GFLAGS_SOURCE_URL "$ENV{TERRIER_GFLAGS_URL}")
-else()
+else ()
   set(GFLAGS_SOURCE_URL "https://github.com/gflags/gflags/archive/v${GFLAGS_VERSION}.tar.gz")
-endif()
+endif ()
 
 if (DEFINED ENV{TERRIER_GBENCHMARK_URL})
   set(GBENCHMARK_SOURCE_URL "$ENV{TERRIER_GBENCHMARK_URL}")
-else()
+else ()
   set(GBENCHMARK_SOURCE_URL "https://github.com/google/benchmark/archive/v${GBENCHMARK_VERSION}.tar.gz")
-endif()
+endif ()
 
 # ----------------------------------------------------------------------
 # ExternalProject options
@@ -86,13 +85,13 @@ set(EP_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}}")
 
 if (NOT TERRIER_VERBOSE_THIRDPARTY_BUILD)
   set(EP_LOG_OPTIONS
-    LOG_CONFIGURE 1
-    LOG_BUILD 1
-    LOG_INSTALL 1
-    LOG_DOWNLOAD 1)
-else()
+      LOG_CONFIGURE 1
+      LOG_BUILD 1
+      LOG_INSTALL 1
+      LOG_DOWNLOAD 1)
+else ()
   set(EP_LOG_OPTIONS)
-endif()
+endif ()
 
 # Set -fPIC on all external projects
 set(EP_CXX_FLAGS "${EP_CXX_FLAGS} -fPIC")
@@ -101,7 +100,7 @@ set(EP_C_FLAGS "${EP_C_FLAGS} -fPIC")
 # Ensure that a default make is set
 if ("${MAKE}" STREQUAL "")
   find_program(MAKE make)
-endif()
+endif ()
 
 # ----------------------------------------------------------------------
 # Find pthreads
@@ -109,54 +108,54 @@ endif()
 find_library(PTHREAD_LIBRARY pthread)
 message(STATUS "Found pthread: ${PTHREAD_LIBRARY}")
 
-if(TERRIER_BUILD_TESTS OR TERRIER_BUILD_BENCHMARKS)
+if (TERRIER_BUILD_TESTS OR TERRIER_BUILD_BENCHMARKS)
   add_custom_target(unittest ctest -L unittest)
 
-  if("$ENV{GTEST_HOME}" STREQUAL "")
-    if(APPLE)
+  if ("$ENV{GTEST_HOME}" STREQUAL "")
+    if (APPLE)
       set(GTEST_CMAKE_CXX_FLAGS "-fPIC -DGTEST_USE_OWN_TR1_TUPLE=1 -Wno-unused-value -Wno-ignored-attributes")
-    else()
+    else ()
       set(GTEST_CMAKE_CXX_FLAGS "-fPIC")
-    endif()
+    endif ()
     string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_BUILD_TYPE)
     set(GTEST_CMAKE_CXX_FLAGS "${EP_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}} ${GTEST_CMAKE_CXX_FLAGS}")
 
     set(GTEST_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/googletest_ep-prefix/src/googletest_ep")
     set(GTEST_INCLUDE_DIR "${GTEST_PREFIX}/include")
     set(GTEST_STATIC_LIB
-      "${GTEST_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        "${GTEST_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(GTEST_MAIN_STATIC_LIB
-      "${GTEST_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        "${GTEST_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(GTEST_VENDORED 1)
     set(GTEST_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                         -DCMAKE_INSTALL_PREFIX=${GTEST_PREFIX}
-                         -DCMAKE_CXX_FLAGS=${GTEST_CMAKE_CXX_FLAGS})
+        -DCMAKE_INSTALL_PREFIX=${GTEST_PREFIX}
+        -DCMAKE_CXX_FLAGS=${GTEST_CMAKE_CXX_FLAGS})
 
     ExternalProject_Add(googletest_ep
-      URL ${GTEST_SOURCE_URL}
-      BUILD_BYPRODUCTS ${GTEST_STATIC_LIB} ${GTEST_MAIN_STATIC_LIB}
-      CMAKE_ARGS ${GTEST_CMAKE_ARGS}
-      ${EP_LOG_OPTIONS})
-  else()
+        URL ${GTEST_SOURCE_URL}
+        BUILD_BYPRODUCTS ${GTEST_STATIC_LIB} ${GTEST_MAIN_STATIC_LIB}
+        CMAKE_ARGS ${GTEST_CMAKE_ARGS}
+        ${EP_LOG_OPTIONS})
+  else ()
     find_package(GTest REQUIRED)
     set(GTEST_VENDORED 0)
-  endif()
+  endif ()
 
   message(STATUS "GTest include dir: ${GTEST_INCLUDE_DIR}")
   message(STATUS "GTest static library: ${GTEST_STATIC_LIB}")
   include_directories(SYSTEM ${GTEST_INCLUDE_DIR})
   ADD_THIRDPARTY_LIB(gtest
-    STATIC_LIB ${GTEST_STATIC_LIB})
+      STATIC_LIB ${GTEST_STATIC_LIB})
   ADD_THIRDPARTY_LIB(gtest_main
-    STATIC_LIB ${GTEST_MAIN_STATIC_LIB})
+      STATIC_LIB ${GTEST_MAIN_STATIC_LIB})
 
-  if(GTEST_VENDORED)
+  if (GTEST_VENDORED)
     add_dependencies(gtest googletest_ep)
     add_dependencies(gtest_main googletest_ep)
-  endif()
+  endif ()
 
   # gflags (formerly Googleflags) command line parsing
-  if("${GFLAGS_HOME}" STREQUAL "")
+  if ("${GFLAGS_HOME}" STREQUAL "")
     set(GFLAGS_CMAKE_CXX_FLAGS ${EP_CXX_FLAGS})
 
     set(GFLAGS_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/gflags_ep-prefix/src/gflags_ep")
@@ -165,82 +164,82 @@ if(TERRIER_BUILD_TESTS OR TERRIER_BUILD_BENCHMARKS)
     set(GFLAGS_STATIC_LIB "${GFLAGS_PREFIX}/lib/libgflags.a")
     set(GFLAGS_VENDORED 1)
     set(GFLAGS_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                          -DCMAKE_INSTALL_PREFIX=${GFLAGS_PREFIX}
-                          -DBUILD_SHARED_LIBS=OFF
-                          -DBUILD_STATIC_LIBS=ON
-                          -DBUILD_PACKAGING=OFF
-                          -DBUILD_TESTING=OFF
-                          -BUILD_CONFIG_TESTS=OFF
-                          -DINSTALL_HEADERS=ON
-                          -DCMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}=${EP_CXX_FLAGS}
-                          -DCMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}=${EP_C_FLAGS}
-                          -DCMAKE_CXX_FLAGS=${GFLAGS_CMAKE_CXX_FLAGS})
+        -DCMAKE_INSTALL_PREFIX=${GFLAGS_PREFIX}
+        -DBUILD_SHARED_LIBS=OFF
+        -DBUILD_STATIC_LIBS=ON
+        -DBUILD_PACKAGING=OFF
+        -DBUILD_TESTING=OFF
+        -BUILD_CONFIG_TESTS=OFF
+        -DINSTALL_HEADERS=ON
+        -DCMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}=${EP_CXX_FLAGS}
+        -DCMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}=${EP_C_FLAGS}
+        -DCMAKE_CXX_FLAGS=${GFLAGS_CMAKE_CXX_FLAGS})
 
     ExternalProject_Add(gflags_ep
-      URL ${GFLAGS_SOURCE_URL}
-      ${EP_LOG_OPTIONS}
-      BUILD_IN_SOURCE 1
-      BUILD_BYPRODUCTS "${GFLAGS_STATIC_LIB}"
-      CMAKE_ARGS ${GFLAGS_CMAKE_ARGS})
-  else()
+        URL ${GFLAGS_SOURCE_URL}
+        ${EP_LOG_OPTIONS}
+        BUILD_IN_SOURCE 1
+        BUILD_BYPRODUCTS "${GFLAGS_STATIC_LIB}"
+        CMAKE_ARGS ${GFLAGS_CMAKE_ARGS})
+  else ()
     set(GFLAGS_VENDORED 0)
     find_package(GFlags REQUIRED)
-  endif()
+  endif ()
 
   message(STATUS "GFlags include dir: ${GFLAGS_INCLUDE_DIR}")
   message(STATUS "GFlags static library: ${GFLAGS_STATIC_LIB}")
   include_directories(SYSTEM ${GFLAGS_INCLUDE_DIR})
   ADD_THIRDPARTY_LIB(gflags
-    STATIC_LIB ${GFLAGS_STATIC_LIB})
+      STATIC_LIB ${GFLAGS_STATIC_LIB})
 
-  if(GFLAGS_VENDORED)
+  if (GFLAGS_VENDORED)
     add_dependencies(gflags gflags_ep)
-  endif()
-endif()
+  endif ()
+endif ()
 
-if(TERRIER_BUILD_BENCHMARKS)
+if (TERRIER_BUILD_BENCHMARKS)
   add_custom_target(runbenchmark ctest -L benchmark)
 
-  if("$ENV{GBENCHMARK_HOME}" STREQUAL "")
+  if ("$ENV{GBENCHMARK_HOME}" STREQUAL "")
     set(GBENCHMARK_CMAKE_CXX_FLAGS "-fPIC -std=c++17 ${EP_CXX_FLAGS}")
 
-    if(APPLE)
+    if (APPLE)
       set(GBENCHMARK_CMAKE_CXX_FLAGS "${GBENCHMARK_CMAKE_CXX_FLAGS} -stdlib=libc++")
-    endif()
+    endif ()
 
     set(GBENCHMARK_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/gbenchmark_ep/src/gbenchmark_ep-install")
     set(GBENCHMARK_INCLUDE_DIR "${GBENCHMARK_PREFIX}/include")
     set(GBENCHMARK_STATIC_LIB "${GBENCHMARK_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}benchmark${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(GBENCHMARK_VENDORED 1)
     set(GBENCHMARK_CMAKE_ARGS
-          "-DCMAKE_BUILD_TYPE=Release"
-          "-DCMAKE_INSTALL_PREFIX:PATH=${GBENCHMARK_PREFIX}"
-          "-DBENCHMARK_ENABLE_TESTING=OFF"
-          "-DCMAKE_CXX_FLAGS=${GBENCHMARK_CMAKE_CXX_FLAGS}")
+        "-DCMAKE_BUILD_TYPE=Release"
+        "-DCMAKE_INSTALL_PREFIX:PATH=${GBENCHMARK_PREFIX}"
+        "-DBENCHMARK_ENABLE_TESTING=OFF"
+        "-DCMAKE_CXX_FLAGS=${GBENCHMARK_CMAKE_CXX_FLAGS}")
     if (APPLE)
       set(GBENCHMARK_CMAKE_ARGS ${GBENCHMARK_CMAKE_ARGS} "-DBENCHMARK_USE_LIBCXX=ON")
-    endif()
+    endif ()
 
     ExternalProject_Add(gbenchmark_ep
-      URL ${GBENCHMARK_SOURCE_URL}
-      BUILD_BYPRODUCTS "${GBENCHMARK_STATIC_LIB}"
-      CMAKE_ARGS ${GBENCHMARK_CMAKE_ARGS}
-      ${EP_LOG_OPTIONS})
-  else()
+        URL ${GBENCHMARK_SOURCE_URL}
+        BUILD_BYPRODUCTS "${GBENCHMARK_STATIC_LIB}"
+        CMAKE_ARGS ${GBENCHMARK_CMAKE_ARGS}
+        ${EP_LOG_OPTIONS})
+  else ()
     find_package(GBenchmark REQUIRED)
     set(GBENCHMARK_VENDORED 0)
-  endif()
+  endif ()
 
   message(STATUS "GBenchmark include dir: ${GBENCHMARK_INCLUDE_DIR}")
   message(STATUS "GBenchmark static library: ${GBENCHMARK_STATIC_LIB}")
   include_directories(SYSTEM ${GBENCHMARK_INCLUDE_DIR})
   ADD_THIRDPARTY_LIB(benchmark
-    STATIC_LIB ${GBENCHMARK_STATIC_LIB})
+      STATIC_LIB ${GBENCHMARK_STATIC_LIB})
 
-  if(GBENCHMARK_VENDORED)
+  if (GBENCHMARK_VENDORED)
     add_dependencies(benchmark gbenchmark_ep)
-  endif()
-endif()
+  endif ()
+endif ()
 
 #----------------------------------------------------------------------
 
@@ -270,8 +269,8 @@ list(APPEND TERRIER_LINK_LIBS ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY
 find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 if (${LLVM_PACKAGE_VERSION} VERSION_LESS "6.0")
-  message( FATAL_ERROR "LLVM 6.0 or newer is required." )
-endif()
+  message(FATAL_ERROR "LLVM 6.0 or newer is required.")
+endif ()
 llvm_map_components_to_libnames(LLVM_LIBRARIES core mcjit nativecodegen native)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 list(APPEND TERRIER_LINK_LIBS ${LLVM_LIBRARIES})

--- a/cmake_modules/san-config.cmake
+++ b/cmake_modules/san-config.cmake
@@ -15,32 +15,31 @@
 # Clang does not support using ASAN and TSAN simultaneously.
 if ("${TERRIER_USE_ASAN}" AND "${TERRIER_USE_TSAN}")
   message(SEND_ERROR "Can only enable one of ASAN or TSAN at a time")
-endif()
+endif ()
 
 # Flag to enable clang address sanitizer
 # This will only build if clang or a recent enough gcc is the chosen compiler
 if (${TERRIER_USE_ASAN})
-  if(NOT (("${COMPILER_FAMILY}" STREQUAL "clang") OR
-          ("${COMPILER_FAMILY}" STREQUAL "gcc" AND "${COMPILER_VERSION}" VERSION_GREATER "4.8")))
+  if (NOT (("${COMPILER_FAMILY}" STREQUAL "clang") OR
+  ("${COMPILER_FAMILY}" STREQUAL "gcc" AND "${COMPILER_VERSION}" VERSION_GREATER "4.8")))
     message(SEND_ERROR "Cannot use ASAN without clang or gcc >= 4.8")
-  endif()
+  endif ()
 
   # If UBSAN is also enabled, and we're on clang < 3.5, ensure static linking is
   # enabled. Otherwise, we run into https://llvm.org/bugs/show_bug.cgi?id=18211
-  if("${TERRIER_USE_UBSAN}" AND
+  if ("${TERRIER_USE_UBSAN}" AND
       "${COMPILER_FAMILY}" STREQUAL "clang" AND
       "${COMPILER_VERSION}" VERSION_LESS "3.5")
-    if("${TERRIER_LINK}" STREQUAL "a")
+    if ("${TERRIER_LINK}" STREQUAL "a")
       message("Using static linking for ASAN+UBSAN build")
       set(TERRIER_LINK "s")
-    elseif("${TERRIER_LINK}" STREQUAL "d")
+    elseif ("${TERRIER_LINK}" STREQUAL "d")
       message(SEND_ERROR "Cannot use dynamic linking when ASAN and UBSAN are both enabled")
-    endif()
-  endif()
+    endif ()
+  endif ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -DADDRESS_SANITIZER")
   message(STATUS "AddressSanitizer enabled.")
-endif()
-
+endif ()
 
 # Flag to enable clang undefined behavior sanitizer
 # We explicitly don't enable all of the sanitizer flags:
@@ -48,20 +47,20 @@ endif()
 # - disable 'alignment' because unaligned access is really OK on Nehalem and we do it
 #   all over the place.
 if (${TERRIER_USE_UBSAN})
-  if(NOT (("${COMPILER_FAMILY}" STREQUAL "clang") OR
-          ("${COMPILER_FAMILY}" STREQUAL "gcc" AND "${COMPILER_VERSION}" VERSION_GREATER "4.9")))
+  if (NOT (("${COMPILER_FAMILY}" STREQUAL "clang") OR
+  ("${COMPILER_FAMILY}" STREQUAL "gcc" AND "${COMPILER_VERSION}" VERSION_GREATER "4.9")))
     message(SEND_ERROR "Cannot use UBSAN without clang or gcc >= 4.9")
-  endif()
+  endif ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fno-sanitize=alignment,vptr -fno-sanitize-recover")
   message("STATUS UndefinedBehaviorSanitizer enabled.")
 endif ()
 
 # Flag to enable thread sanitizer (clang or gcc 4.8)
 if (${TERRIER_USE_TSAN})
-  if(NOT (("${COMPILER_FAMILY}" STREQUAL "clang") OR
-          ("${COMPILER_FAMILY}" STREQUAL "gcc" AND "${COMPILER_VERSION}" VERSION_GREATER "4.8")))
+  if (NOT (("${COMPILER_FAMILY}" STREQUAL "clang") OR
+  ("${COMPILER_FAMILY}" STREQUAL "gcc" AND "${COMPILER_VERSION}" VERSION_GREATER "4.8")))
     message(SEND_ERROR "Cannot use TSAN without clang or gcc >= 4.8")
-  endif()
+  endif ()
 
   add_definitions("-fsanitize=thread")
   message("STATUS ThreadSanitizer enabled.")
@@ -83,38 +82,36 @@ if (${TERRIER_USE_TSAN})
   # require all code to be position independent, and the easiest way to
   # guarantee that is via dynamic linking (not all 3rd party archives are
   # compiled with -fPIC e.g. boost).
-  if("${TERRIER_LINK}" STREQUAL "a")
+  if ("${TERRIER_LINK}" STREQUAL "a")
     message("Using dynamic linking for TSAN")
     set(TERRIER_LINK "d")
-  elseif("${TERRIER_LINK}" STREQUAL "s")
+  elseif ("${TERRIER_LINK}" STREQUAL "s")
     message(SEND_ERROR "Cannot use TSAN with static linking")
-  endif()
-endif()
-
+  endif ()
+endif ()
 
 if (${TERRIER_USE_COVERAGE})
-  if(NOT ("${COMPILER_FAMILY}" STREQUAL "clang"))
+  if (NOT ("${COMPILER_FAMILY}" STREQUAL "clang"))
     message(SEND_ERROR "You can only enable coverage with clang")
-  endif()
+  endif ()
   add_definitions("-fsanitize-coverage=trace-pc-guard")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-coverage=trace-pc-guard")
-endif()
-
+endif ()
 
 if ("${TERRIER_USE_UBSAN}" OR "${TERRIER_USE_ASAN}" OR "${TERRIER_USE_TSAN}")
   # GCC 4.8 and 4.9 (latest as of this writing) don't allow you to specify a
   # sanitizer blacklist.
-  if("${COMPILER_FAMILY}" STREQUAL "clang")
+  if ("${COMPILER_FAMILY}" STREQUAL "clang")
     # Require clang 3.4 or newer; clang 3.3 has issues with TSAN and pthread
     # symbol interception.
-    if("${COMPILER_VERSION}" VERSION_LESS "3.4")
-        message(SEND_ERROR "Must use clang 3.4 or newer to run a sanitizer build."
-        " Detected unsupported version ${COMPILER_VERSION}."
-        " Try using clang from $NATIVE_TOOLCHAIN/.")
-    endif()
+    if ("${COMPILER_VERSION}" VERSION_LESS "3.4")
+      message(SEND_ERROR "Must use clang 3.4 or newer to run a sanitizer build."
+          " Detected unsupported version ${COMPILER_VERSION}."
+          " Try using clang from $NATIVE_TOOLCHAIN/.")
+    endif ()
     add_definitions("-fsanitize-blacklist=${BUILD_SUPPORT_DIR}/sanitize-blacklist.txt")
-  else()
+  else ()
     message(WARNING "GCC does not support specifying a sanitizer blacklist. Known sanitizer check failures will not be suppressed.")
-  endif()
-endif()
+  endif ()
+endif ()


### PR DESCRIPTION
Explicitly setting the policy to NEW to silence the warning about rpath stuff.

It resolves this warning in master:
```
CMake Warning (dev):
  Policy CMP0068 is not set: RPATH settings on macOS do not affect
  install_name.  Run "cmake --help-policy CMP0068" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

  For compatibility with older versions of CMake, the install_name fields for
  the following targets are still affected by RPATH settings:

   terrier_shared

This warning is for project developers.  Use -Wno-dev to suppress it.
```