### PR TITLE
Fix typo in the storage and transaction logger macro definitions

### DIFF
--- a/src/include/loggers/storage_logger.h
+++ b/src/include/loggers/storage_logger.h
@@ -16,6 +16,6 @@ void init_storage_logger();
 
 #define STORAGE_LOG_INFO(...) ::terrier::storage::storage_logger->info(__VA_ARGS__);
 
-#define STORAGE_LOG_WARN(...) ::terrier::storage::storage`_logger->warn(__VA_ARGS__);
+#define STORAGE_LOG_WARN(...) ::terrier::storage::storage_logger->warn(__VA_ARGS__);
 
 #define STORAGE_LOG_ERROR(...) ::terrier::storage::storage_logger->error(__VA_ARGS__);

--- a/src/include/loggers/transaction_logger.h
+++ b/src/include/loggers/transaction_logger.h
@@ -16,6 +16,6 @@ void init_transaction_logger();
 
 #define TXN_LOG_INFO(...) ::terrier::transaction::transaction_logger->info(__VA_ARGS__);
 
-#define TXN_LOG_WARN(...) ::terrier::transaction::transaction`_logger->warn(__VA_ARGS__);
+#define TXN_LOG_WARN(...) ::terrier::transaction::transaction_logger->warn(__VA_ARGS__);
 
 #define TXN_LOG_ERROR(...) ::terrier::transaction::transaction_logger->error(__VA_ARGS__);


### PR DESCRIPTION
Specifically for WARN. Storage logger has a typo, and that multiplied to the transaction logger when that file was copy and pasted.