### PR TITLE
Revert to arrow behavior in run-test.sh

### DIFF
--- a/build-support/run-test.sh
+++ b/build-support/run-test.sh
@@ -32,7 +32,7 @@ ROOT=$(cd $(dirname $BASH_SOURCE)/..; pwd)
 TEST_LOGDIR=$OUTPUT_ROOT/build/$1-logs
 mkdir -p $TEST_LOGDIR
 
-RUN_TYPE=$2
+RUN_TYPE=$1
 shift
 TEST_DEBUGDIR=$OUTPUT_ROOT/build/$RUN_TYPE-debug
 mkdir -p $TEST_DEBUGDIR


### PR DESCRIPTION
Per https://github.com/apache/arrow/pull/2443 , note the usage of shift.

I thought it might have disabled ASAN in tests, but it looks like everything was still running properly. We should probably still fix it though.