### PR TITLE
Alignment of ProjectedRow & Layout optimization

### DIFF
--- a/benchmark/include/util/storage_benchmark_util.h
+++ b/benchmark/include/util/storage_benchmark_util.h
@@ -19,14 +19,14 @@ struct TupleAccessStrategyBenchmarkUtil {
   static void InsertTuple(const storage::ProjectedRow &tuple, const storage::TupleAccessStrategy *tested,
                           const storage::BlockLayout &layout, const storage::TupleSlot slot) {
     // Skip the version vector for tuples
-    for (uint16_t col = 1; col < layout.num_cols_; col++) {
+    for (uint16_t col = 1; col < layout.NumCols(); col++) {
       const byte *val_ptr = tuple.AccessWithNullCheck(static_cast<uint16_t>(col - 1));
       if (val_ptr == nullptr) {
         tested->SetNull(slot, col);
       } else {
         // Read the value
-        uint64_t val = storage::StorageUtil::ReadBytes(layout.attr_sizes_[col], val_ptr);
-        storage::StorageUtil::WriteBytes(layout.attr_sizes_[col], val, tested->AccessForceNotNull(slot, col));
+        uint64_t val = storage::StorageUtil::ReadBytes(layout.AttrSize(col), val_ptr);
+        storage::StorageUtil::WriteBytes(layout.AttrSize(col), val, tested->AccessForceNotNull(slot, col));
       }
     }
   }

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -21,8 +21,8 @@ class DataTableBenchmark : public benchmark::Fixture {
  public:
   void SetUp(const benchmark::State &state) final {
     // generate a random redo ProjectedRow to Insert
-    redo_buffer_ = new byte[redo_size_];
-    redo_ = storage::ProjectedRow::InitializeProjectedRow(redo_buffer_, all_col_ids_, layout_);
+    redo_buffer_ = StorageTestUtil::AllocateAligned(initializer_.ProjectedRowSize());
+    redo_ = initializer_.InitializeProjectedRow(redo_buffer_);
     StorageTestUtil::PopulateRandomRow(redo_, layout_, 0, &generator_);
   }
   void TearDown(const benchmark::State &state) final {
@@ -35,8 +35,7 @@ class DataTableBenchmark : public benchmark::Fixture {
   const storage::BlockLayout layout_{num_columns_, {column_size_, column_size_}};
 
   // Tuple properties
-  const std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout_)};
-  const uint32_t redo_size_ = storage::ProjectedRow::Size(layout_, all_col_ids_);
+  const storage::ProjectedRowInitializer initializer_{layout_, StorageTestUtil::ProjectionListAllColumns(layout_)};
 
   // Workload
   const uint32_t num_inserts_ = 10000000;

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -21,8 +21,8 @@ class DataTableBenchmark : public benchmark::Fixture {
  public:
   void SetUp(const benchmark::State &state) final {
     // generate a random redo ProjectedRow to Insert
-    redo_buffer_ = StorageTestUtil::AllocateAligned(initializer_.ProjectedRowSize());
-    redo_ = initializer_.InitializeProjectedRow(redo_buffer_);
+    redo_buffer_ = common::AllocationUtil::AllocateAligned(initializer_.ProjectedRowSize());
+    redo_ = initializer_.InitializeRow(redo_buffer_);
     StorageTestUtil::PopulateRandomRow(redo_, layout_, 0, &generator_);
   }
   void TearDown(const benchmark::State &state) final {

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -38,7 +38,7 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
   // Workload
   const uint32_t num_inserts_ = 10000000;
   const uint32_t num_threads_ = 8;
-  const uint32_t num_blocks_ = num_inserts_ / layout_.num_slots_;
+  const uint32_t num_blocks_ = num_inserts_ / layout_.NumSlots();
 
   // Test infrastructure
   std::default_random_engine generator_;
@@ -63,7 +63,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
       raw_blocks_.emplace_back(raw_block);
       TERRIER_MEMSET(raw_block, 0, sizeof(storage::RawBlock));
       tested.InitializeRawBlock(raw_block, layout_version_t(0));
-      for (uint32_t j = 0; j < layout_.num_slots_; j++) {
+      for (uint32_t j = 0; j < layout_.NumSlots(); j++) {
         storage::TupleSlot slot;
         tested.Allocate(raw_block, &slot);
         TupleAccessStrategyBenchmarkUtil::InsertTuple(*redo_,
@@ -78,7 +78,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
     }
   }
 
-  state.SetItemsProcessed(state.iterations() * layout_.num_slots_ * num_blocks_);
+  state.SetItemsProcessed(state.iterations() * layout_.NumSlots() * num_blocks_);
 }
 
 // Insert the num_inserts_ of tuples into Blocks concurrently
@@ -97,7 +97,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::St
       tested.InitializeRawBlock(raw_block, layout_version_t(0));
 
       auto workload = [&](uint32_t id) {
-        for (uint32_t j = 0; j < layout_.num_slots_ / num_threads_; j++) {
+        for (uint32_t j = 0; j < layout_.NumSlots() / num_threads_; j++) {
           storage::TupleSlot slot;
           tested.Allocate(raw_block, &slot);
           TupleAccessStrategyBenchmarkUtil::InsertTuple(*redo_,
@@ -115,7 +115,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::St
     }
   }
 
-  state.SetItemsProcessed(state.iterations() * layout_.num_slots_ * num_blocks_);
+  state.SetItemsProcessed(state.iterations() * layout_.NumSlots() * num_blocks_);
 }
 
 BENCHMARK_REGISTER_F(TupleAccessStrategyBenchmark, SimpleInsert)

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -19,8 +19,8 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
  public:
   void SetUp(const benchmark::State &state) final {
     // generate a random redo ProjectedRow to Insert
-    redo_buffer_ = new byte[redo_size_];
-    redo_ = storage::ProjectedRow::InitializeProjectedRow(redo_buffer_, all_col_ids_, layout_);
+    redo_buffer_ = StorageTestUtil::AllocateAligned(initializer_.ProjectedRowSize());
+    redo_ = initializer_.InitializeProjectedRow(redo_buffer_);
     StorageTestUtil::PopulateRandomRow(redo_, layout_, 0, &generator_);
   }
   void TearDown(const benchmark::State &state) final {
@@ -33,8 +33,7 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
   const storage::BlockLayout layout_{num_columns_, {column_size_, column_size_}};
 
   // Tuple properties
-  const std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout_)};
-  const uint32_t redo_size_ = storage::ProjectedRow::Size(layout_, all_col_ids_);
+  const storage::ProjectedRowInitializer initializer_{layout_, StorageTestUtil::ProjectionListAllColumns(layout_)};
 
   // Workload
   const uint32_t num_inserts_ = 10000000;

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -19,10 +19,11 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
  public:
   void SetUp(const benchmark::State &state) final {
     // generate a random redo ProjectedRow to Insert
-    redo_buffer_ = StorageTestUtil::AllocateAligned(initializer_.ProjectedRowSize());
-    redo_ = initializer_.InitializeProjectedRow(redo_buffer_);
+    redo_buffer_ = common::AllocationUtil::AllocateAligned(initializer_.ProjectedRowSize());
+    redo_ = initializer_.InitializeRow(redo_buffer_);
     StorageTestUtil::PopulateRandomRow(redo_, layout_, 0, &generator_);
   }
+
   void TearDown(const benchmark::State &state) final {
     delete[] redo_buffer_;
   }

--- a/src/include/common/allocator.h
+++ b/src/include/common/allocator.h
@@ -1,0 +1,59 @@
+#pragma once
+#include <cstdlib>
+#include "common/typedefs.h"
+namespace terrier::common {
+
+/**
+ * Static utility class for more advanced memory allocation behavior
+ */
+struct AllocationUtil {
+  AllocationUtil() = delete;
+
+  /**
+   * Allocates a chunk of memory whose start address is aligned to the given word size (which is
+   * 8 bytes by default) If you ever use an argument that is not 8 bytes, you should really know
+   * what you are doing.
+   * @param byte_size size of the memory chunk to allocate, in bytes
+   * @param alignment the word size to align up to, 8 bytes by default
+   * @return allocated memory pointer
+   */
+  static byte *AllocateAligned(uint64_t byte_size, uint64_t alignment = sizeof(uint64_t)) {
+    void *result;
+    posix_memalign(&result, alignment, byte_size);
+    return reinterpret_cast<byte *>(result);
+  }
+};
+
+/**
+ * Allocator that allocates and destroys a byte array. Memory location returned by this default allocator is
+ * not zeroed-out. The address returned is guaranteed to be aligned to 8 bytes.
+ * @tparam T object whose size determines the byte array size.
+ */
+template <typename T>
+class ByteAlignedAllocator {
+ public:
+  /**
+   * Allocates a new byte array sized to hold a T.
+   * @return a pointer to the byte array allocated.
+   */
+  T *New() {
+    auto *result = reinterpret_cast<T *>(AllocationUtil::AllocateAligned(sizeof(T)));
+    Reuse(result);
+    return result;
+  }
+
+  /**
+   * Reuse a reused chunk of memory to be handed out again
+   * @param reused memory location, possibly filled with junk bytes
+   */
+  void Reuse(T *const reused) {}
+
+  /**
+   * Deletes the byte array.
+   * @param ptr pointer to the byte array to be deleted.
+   */
+  void Delete(T *const ptr) { delete[] ptr; }  // NOLINT
+  // clang-tidy believes we are trying to free released memory.
+  // We believe otherwise, hence we're telling it to shut up.
+};
+}  // namespace terrier::common

--- a/src/include/common/allocator.h
+++ b/src/include/common/allocator.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cerrno>
 #include <cstdlib>
 #include "common/typedefs.h"
 namespace terrier::common {
@@ -12,14 +13,16 @@ struct AllocationUtil {
   /**
    * Allocates a chunk of memory whose start address is aligned to the given word size (which is
    * 8 bytes by default) If you ever use an argument that is not 8 bytes, you should really know
-   * what you are doing.
+   * what you are doing. Alignment must be both a power of two and a multiple of sizeof(void *)
    * @param byte_size size of the memory chunk to allocate, in bytes
    * @param alignment the word size to align up to, 8 bytes by default
    * @return allocated memory pointer
    */
-  static byte *AllocateAligned(uint64_t byte_size, uint64_t alignment = sizeof(uint64_t)) {
+  static byte *AllocateAligned(uint64_t byte_size, uint64_t alignment = sizeof(void *)) {
     void *result = nullptr;
-    posix_memalign(&result, alignment, byte_size);
+    int32_t ret UNUSED_ATTRIBUTE = posix_memalign(&result, alignment, byte_size);
+    TERRIER_ASSERT(ret != EINVAL,
+                   "Invalid alignment given to posix_memalign, should be a power of 2 and multiple pf sizeof(void *)");
     return reinterpret_cast<byte *>(result);
   }
 };

--- a/src/include/common/allocator.h
+++ b/src/include/common/allocator.h
@@ -18,7 +18,7 @@ struct AllocationUtil {
    * @return allocated memory pointer
    */
   static byte *AllocateAligned(uint64_t byte_size, uint64_t alignment = sizeof(uint64_t)) {
-    void *result;
+    void *result = nullptr;
     posix_memalign(&result, alignment, byte_size);
     return reinterpret_cast<byte *>(result);
   }

--- a/src/include/common/container/bitmap.h
+++ b/src/include/common/container/bitmap.h
@@ -25,14 +25,8 @@ namespace terrier::common {
  * Therefore, you should never construct an instance of a RawBitmap. Reinterpret an existing block of memory that you
  * know will be a valid bitmap.
  *
-<<<<<<< HEAD
- * Use @see SizeInBytes to get the correct size for a bitmap of n
- * elements. Beware that because the size information is lost at compile time,
- * there is ABSOLUTELY no bounds check and you have to rely on programming
-=======
  * Use @see common::BitmapSize to get the correct size for a bitmap of n elements. Beware that because the size
  * information is lost at compile time, there is ABSOLUTELY no bounds check and you have to rely on programming
->>>>>>> master
  * discipline to ensure safe access.
  *
  * For easy initialization in tests and such, use the static Allocate and Deallocate methods
@@ -44,6 +38,10 @@ class RawBitmap {
   ~RawBitmap() = delete;
   DISALLOW_COPY_AND_MOVE(RawBitmap)
 
+  /**
+   * @param n number of elements in the bitmap
+   * @return the size of the bitmap holding the given number of elements, in bytes.
+   */
   static constexpr uint32_t SizeInBytes(uint32_t n) { return n % BYTE_SIZE == 0 ? n / BYTE_SIZE : n / BYTE_SIZE + 1; }
 
   /**

--- a/src/include/common/container/bitmap.h
+++ b/src/include/common/container/bitmap.h
@@ -19,7 +19,6 @@ static_assert(BYTE_SIZE == 8u, "BYTE_SIZE should be set to 8!");
 #define ONE_COLD_MASK(n) (0xFF - ONE_HOT_MASK(n))
 
 namespace terrier::common {
-constexpr uint32_t BitmapSize(uint32_t n) { return n % BYTE_SIZE == 0 ? n / BYTE_SIZE : n / BYTE_SIZE + 1; }
 
 /**
  * A RawBitmap is a bitmap that does not have the compile-time
@@ -29,7 +28,7 @@ constexpr uint32_t BitmapSize(uint32_t n) { return n % BYTE_SIZE == 0 ? n / BYTE
  * Therefore, you should never construct an instance of a RawBitmap.
  * Reinterpret an existing block of memory that you know will be a valid bitmap.
  *
- * Use @see terrier::BitmapSize to get the correct size for a bitmap of n
+ * Use @see SizeInBytes to get the correct size for a bitmap of n
  * elements. Beware that because the size information is lost at compile time,
  * there is ABSOLUTELY no bounds check and you have to rely on programming
  * discipline to ensure safe access.
@@ -44,6 +43,8 @@ class RawBitmap {
   ~RawBitmap() = delete;
   DISALLOW_COPY_AND_MOVE(RawBitmap)
 
+  static constexpr uint32_t SizeInBytes(uint32_t n) { return n % BYTE_SIZE == 0 ? n / BYTE_SIZE : n / BYTE_SIZE + 1; }
+
   /**
    * Allocates a new RawBitmap of size num_bits.
    * Up to the caller to call Deallocate on its return value.
@@ -51,7 +52,7 @@ class RawBitmap {
    * @return ptr to new RawBitmap.
    */
   static RawBitmap *Allocate(uint32_t num_bits) {
-    auto size = BitmapSize(num_bits);
+    auto size = SizeInBytes(num_bits);
     auto *result = new uint8_t[size];
     PELOTON_MEMSET(result, 0, size);
     return reinterpret_cast<RawBitmap *>(result);
@@ -106,7 +107,7 @@ class RawBitmap {
    * @param num_bits number of bits to clear.
    */
   void Clear(uint32_t num_bits) {
-    auto size = BitmapSize(num_bits);
+    auto size = SizeInBytes(num_bits);
     PELOTON_MEMSET(bits_, 0, size);
   }
 

--- a/src/include/common/container/concurrent_bitmap.h
+++ b/src/include/common/container/concurrent_bitmap.h
@@ -40,7 +40,7 @@ class RawConcurrentBitmap {
    * @return ptr to new RawConcurrentBitmap
    */
   static RawConcurrentBitmap *Allocate(uint32_t num_bits) {
-    uint32_t num_bytes = BitmapSize(num_bits);
+    uint32_t num_bytes = RawBitmap::SizeInBytes(num_bits);
     auto *result = new uint8_t[num_bytes];
     PELOTON_MEMSET(result, 0, num_bytes);
     return reinterpret_cast<RawConcurrentBitmap *>(result);
@@ -104,7 +104,7 @@ class RawConcurrentBitmap {
       return false;
     }
 
-    uint32_t num_bytes = BitmapSize(bitmap_num_bits);  // maximum number of bytes in the bitmap
+    uint32_t num_bytes = RawBitmap::SizeInBytes(bitmap_num_bits);  // maximum number of bytes in the bitmap
     uint32_t byte_pos = start_pos / BYTE_SIZE;         // current byte position
     uint32_t bits_left = bitmap_num_bits - start_pos;  // number of bits remaining
     bool found_unset_bit = false;                      // whether we found an unset bit previously
@@ -174,7 +174,7 @@ class RawConcurrentBitmap {
    * @warning this is not thread safe!
    */
   void UnsafeClear(uint32_t num_bits) {
-    auto size = BitmapSize(num_bits);
+    auto size = RawBitmap::SizeInBytes(num_bits);
     PELOTON_MEMSET(bits_, 0, size);
   }
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -90,6 +90,7 @@ class DataTable {
   // TODO(Matt): remove this single TAS when using concurrent schema
   const TupleAccessStrategy accessor_;
   // for performance in generating initializer for inserts
+  // TODO(Tianyu): I suppose we can use this for deletes too?
   const storage::ProjectedRowInitializer insert_record_initializer_{accessor_.GetBlockLayout(),
                                                                     {PRIMARY_KEY_COLUMN_ID}};
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -90,7 +90,8 @@ class DataTable {
   // TODO(Matt): remove this single TAS when using concurrent schema
   const TupleAccessStrategy accessor_;
   // for performance in generating initializer for inserts
-  const storage::ProjectedRowInitializer insert_record_initializer_{accessor_.GetBlockLayout(), {PRIMARY_KEY_COLUMN_ID}};
+  const storage::ProjectedRowInitializer insert_record_initializer_{accessor_.GetBlockLayout(),
+                                                                    {PRIMARY_KEY_COLUMN_ID}};
 
   common::ConcurrentVector<RawBlock *> blocks_;
   std::atomic<RawBlock *> insertion_head_ = nullptr;

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -89,6 +89,8 @@ class DataTable {
 
   // TODO(Matt): remove this single TAS when using concurrent schema
   const TupleAccessStrategy accessor_;
+  // for performance in generating initializer for inserts
+  const storage::ProjectedRowInitializer insert_record_initializer_{accessor_.GetBlockLayout(), {PRIMARY_KEY_COLUMN_ID}};
 
   common::ConcurrentVector<RawBlock *> blocks_;
   std::atomic<RawBlock *> insertion_head_ = nullptr;

--- a/src/include/storage/delta_record.h
+++ b/src/include/storage/delta_record.h
@@ -140,6 +140,12 @@ class PACKED ProjectedRow {
 /**
  * A ProjectedRowInitializer calculates and stores information on how to initialize ProjectedRows
  * for a specific layout.
+ *
+ * More specifically, ProjectedRowInitializer will calculate an optimal layout for the given col_ids and layout,
+ * treating the vector as an unordered set of ids to include, and stores the information locally so it can be copied
+ * into new ProjectedRows. It works almost like compilation, in that the initialization process is slightly more
+ * expensive on the first invocation but cheaper on sequential ones. The correct way to use this is to get an
+ * initializer and use it multiple times. Avoid throwing these away every time you are done.
  */
 class ProjectedRowInitializer {
  public:
@@ -162,7 +168,7 @@ class ProjectedRowInitializer {
    * @param head pointer to the byte buffer to initialize as a ProjectedRow
    * @return pointer to the initialized ProjectedRow
    */
-  ProjectedRow *InitializeProjectedRow(void *head) const;
+  ProjectedRow *InitializeRow(void *head) const;
 
   /**
    * @return size of the ProjectedRow in memory, in bytes, that this initializer constructs.
@@ -271,8 +277,8 @@ class UndoRecord {
    * @param initializer the initializer to use for the embedded ProjectedRow
    * @return pointer to the initialized UndoRecord
    */
-  static UndoRecord *InitializeRecord(void *head, timestamp_t timestamp, TupleSlot slot, DataTable *table,
-                                      const ProjectedRowInitializer &initializer);
+  static UndoRecord *Initialize(void *head, timestamp_t timestamp, TupleSlot slot, DataTable *table,
+                                const ProjectedRowInitializer &initializer);
 
   /**
    * Populates the UndoRecord's members based on next pointer, timestamp, projection list, and the redo changes that

--- a/src/include/storage/delta_record.h
+++ b/src/include/storage/delta_record.h
@@ -173,7 +173,7 @@ class DataTable;
  * pointer to the next record, timestamp of the transaction that created this record, pointer to the data table, and the
  * tuple slot.
  */
-class PACKED UndoRecord {  // See comment in ProjectedRow about why this is packed
+class UndoRecord {  // See comment in ProjectedRow about why this is packed
  public:
   UndoRecord() = delete;
   DISALLOW_COPY_AND_MOVE(UndoRecord)

--- a/src/include/storage/delta_record.h
+++ b/src/include/storage/delta_record.h
@@ -173,7 +173,7 @@ class DataTable;
  * pointer to the next record, timestamp of the transaction that created this record, pointer to the data table, and the
  * tuple slot.
  */
-class UndoRecord {  // See comment in ProjectedRow about why this is packed
+class UndoRecord {
  public:
   UndoRecord() = delete;
   DISALLOW_COPY_AND_MOVE(UndoRecord)

--- a/src/include/storage/delta_record.h
+++ b/src/include/storage/delta_record.h
@@ -137,6 +137,10 @@ class PACKED ProjectedRow {
   }
 };
 
+/**
+ * A ProjectedRowInitializer calculates and stores information on how to initialize ProjectedRows
+ * for a specific layout.
+ */
 class ProjectedRowInitializer {
  public:
   /**

--- a/src/include/storage/storage_util.h
+++ b/src/include/storage/storage_util.h
@@ -81,25 +81,6 @@ class StorageUtil {
    * Specifically, columns present in the delta will have their value (or lack of value, in the case of null) copied
    * into the same column in the buffer. It is expected that the buffer's columns is a super set of the delta. If not,
    * behavior is not defined.
-   * @param layout layout used for the projected row
-   * @param delta delta to apply
-   * @param buffer buffer to apply delta into
-   * @param col_to_index a mapping between column id and projection list index for the buffer to apply delta to. This
-   *                     speeds up operation if multiple deltas are expected to be applied to the same buffer.
-   */
-  static void ApplyDelta(const BlockLayout &layout, const ProjectedRow &delta, ProjectedRow *buffer,
-                         const std::unordered_map<uint16_t, uint16_t> &col_to_index);
-
-  /**
-   * Applies delta into the given buffer.
-   *
-   * Specifically, columns present in the delta will have their value (or lack of value, in the case of null) copied
-   * into the same column in the buffer. It is expected that the buffer's columns is a super set of the delta. If not,
-   * behavior is not defined.
-   *
-   * @warning This version of the function is slow if you expect to apply multiple deltas into the same buffer, because
-   * every call will construct their own maps from column id to projection list index. If that is your use case, call
-   * the other version of this function that takes in a map that can be reused across different calls.
    *
    * @param layout layout used for the projected row
    * @param delta delta to apply

--- a/src/include/storage/storage_util.h
+++ b/src/include/storage/storage_util.h
@@ -106,6 +106,7 @@ class StorageUtil {
    * @param buffer buffer to apply delta into
    */
   static void ApplyDelta(const BlockLayout &layout, const ProjectedRow &delta, ProjectedRow *buffer);
+
   /**
    * Given an address offset, aligns it to the word_size
    * @param word_size size in bytes to align offset to
@@ -113,5 +114,32 @@ class StorageUtil {
    * @return modified version of address padded to align to word_size
    */
   static uint32_t PadUpToSize(uint8_t word_size, uint32_t offset);
+
+  /**
+   * Given a pointer, pad the pointer so that the pointer aligns to the given size.
+   * @param size the size to pad up to
+   * @param ptr the pointer to pad
+   * @return padded pointer
+   */
+  // This const qualifier on ptr lies. Use this really only for pointer arithmetic.
+  static byte *AlignedPtr(const uint8_t size, const void *ptr) {
+    auto ptr_value = reinterpret_cast<uintptr_t>(ptr);
+    uint64_t remainder = ptr_value % size;
+    return remainder == 0
+           ? reinterpret_cast<byte *>(ptr_value)
+           : reinterpret_cast<byte *>(ptr_value + size - remainder);
+  }
+
+  /**
+   * Given a pointer, pad the pointer so that the pointer aligns to the size of A.
+   * @tparam A type of value to pad up to
+   * @param ptr the pointer to pad
+   * @return padded pointer
+   */
+  template<class A>
+  static A *AlignedPtr(const void *ptr) {
+    return reinterpret_cast<A *>(AlignedPtr(sizeof(A), ptr));
+  }
+
 };
 }  // namespace terrier::storage

--- a/src/include/storage/tuple_access_strategy.h
+++ b/src/include/storage/tuple_access_strategy.h
@@ -39,8 +39,8 @@ class TupleAccessStrategy {
      * @return a pointer to the start of the column. (use as an array)
      */
     byte *ColumnStart(const BlockLayout &layout, const uint16_t col) {
-      return varlen_contents_ +
-             StorageUtil::PadUpToSize(layout.attr_sizes_[col], common::BitmapSize(layout.num_slots_));
+      return StorageUtil::AlignedPtr(layout.attr_sizes_[col],
+                                     varlen_contents_ + common::RawBitmap::SizeInBytes(layout.num_slots_));
     }
 
     /**

--- a/src/include/storage/tuple_access_strategy.h
+++ b/src/include/storage/tuple_access_strategy.h
@@ -39,8 +39,8 @@ class TupleAccessStrategy {
      * @return a pointer to the start of the column. (use as an array)
      */
     byte *ColumnStart(const BlockLayout &layout, const uint16_t col) {
-      return StorageUtil::AlignedPtr(layout.attr_sizes_[col],
-                                     varlen_contents_ + common::RawBitmap::SizeInBytes(layout.num_slots_));
+      return StorageUtil::AlignedPtr(layout.AttrSize(col),
+                                     varlen_contents_ + common::RawBitmap::SizeInBytes(layout.NumSlots()));
     }
 
     /**
@@ -105,7 +105,7 @@ class TupleAccessStrategy {
      * @return reference to num_attrs. Use as a member.
      */
     uint16_t &NumAttrs(const BlockLayout &layout) {
-      return *reinterpret_cast<uint16_t *>(AttrOffets() + layout.num_cols_);
+      return *reinterpret_cast<uint16_t *>(AttrOffets() + layout.NumCols());
     }
 
     /**
@@ -161,7 +161,7 @@ class TupleAccessStrategy {
    */
   byte *AccessWithNullCheck(const TupleSlot slot, const uint16_t col) const {
     if (!ColumnNullBitmap(slot.GetBlock(), col)->Test(slot.GetOffset())) return nullptr;
-    return ColumnStart(slot.GetBlock(), col) + layout_.attr_sizes_[col] * slot.GetOffset();
+    return ColumnStart(slot.GetBlock(), col) + layout_.AttrSize(col) * slot.GetOffset();
   }
 
   /**
@@ -173,7 +173,7 @@ class TupleAccessStrategy {
   byte *AccessWithoutNullCheck(const TupleSlot slot, const uint16_t col) const {
     TERRIER_ASSERT(col == PRESENCE_COLUMN_ID,
                    "Currently this should only be called on the presence column by the DataTable.");
-    return ColumnStart(slot.GetBlock(), col) + layout_.attr_sizes_[col] * slot.GetOffset();
+    return ColumnStart(slot.GetBlock(), col) + layout_.AttrSize(col) * slot.GetOffset();
   }
 
   /**
@@ -186,7 +186,7 @@ class TupleAccessStrategy {
   byte *AccessForceNotNull(const TupleSlot slot, const uint16_t col) const {
     common::RawConcurrentBitmap *bitmap = ColumnNullBitmap(slot.GetBlock(), col);
     if (!bitmap->Test(slot.GetOffset())) bitmap->Flip(slot.GetOffset(), false);
-    return ColumnStart(slot.GetBlock(), col) + layout_.attr_sizes_[col] * slot.GetOffset();
+    return ColumnStart(slot.GetBlock(), col) + layout_.AttrSize(col) * slot.GetOffset();
   }
 
   /**

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -65,11 +65,11 @@ class TransactionContext {
    * @param slot the TupleSlot being updated
    * @return a persistent pointer to the head of a memory chunk large enough to hold the undo record
    */
-  storage::UndoRecord *UndoRecordForInsert(storage::DataTable *const table, const storage::BlockLayout &layout,
-                                           const storage::TupleSlot slot) {
-    const storage::ProjectedRowInitializer initializer(layout, {PRIMARY_KEY_COLUMN_ID});
-    storage::UndoRecord *result = undo_buffer_.NewEntry(storage::UndoRecord::Size(initializer));
-    return storage::UndoRecord::InitializeRecord(result, txn_id_.load(), slot, table, initializer);
+  storage::UndoRecord *UndoRecordForInsert(storage::DataTable *const table,
+                                           const storage::TupleSlot slot,
+                                           const storage::ProjectedRowInitializer &insert_record_initializer) {
+    storage::UndoRecord *result = undo_buffer_.NewEntry(storage::UndoRecord::Size(insert_record_initializer));
+    return storage::UndoRecord::InitializeRecord(result, txn_id_.load(), slot, table, insert_record_initializer);
   }
 
  private:

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -61,8 +61,8 @@ class TransactionContext {
   /**
    * Reserve space on this transaction's undo buffer for a record to log the insert given
    * @param table pointer to the updated DataTable object
-   * @param layout the layout of the insert target
    * @param slot the TupleSlot being updated
+   * @param insert_record_initializer ProjectedRowInitializer used to initialize an insert undo record
    * @return a persistent pointer to the head of a memory chunk large enough to hold the undo record
    */
   storage::UndoRecord *UndoRecordForInsert(storage::DataTable *const table, const storage::TupleSlot slot,

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -67,9 +67,9 @@ class TransactionContext {
    */
   storage::UndoRecord *UndoRecordForInsert(storage::DataTable *const table, const storage::BlockLayout &layout,
                                            const storage::TupleSlot slot) {
-    uint32_t size = storage::UndoRecord::Size(layout, {PRIMARY_KEY_COLUMN_ID});
-    storage::UndoRecord *result = undo_buffer_.NewEntry(size);
-    return storage::UndoRecord::InitializeRecord(result, txn_id_.load(), slot, table, layout, {PRIMARY_KEY_COLUMN_ID});
+    storage::ProjectedRowInitializer initializer(layout, {PRIMARY_KEY_COLUMN_ID});
+    storage::UndoRecord *result = undo_buffer_.NewEntry(storage::UndoRecord::Size(initializer));
+    return storage::UndoRecord::InitializeRecord(result, txn_id_.load(), slot, table, initializer);
   }
 
  private:

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -68,7 +68,7 @@ class TransactionContext {
   storage::UndoRecord *UndoRecordForInsert(storage::DataTable *const table, const storage::TupleSlot slot,
                                            const storage::ProjectedRowInitializer &insert_record_initializer) {
     storage::UndoRecord *result = undo_buffer_.NewEntry(storage::UndoRecord::Size(insert_record_initializer));
-    return storage::UndoRecord::InitializeRecord(result, txn_id_.load(), slot, table, insert_record_initializer);
+    return storage::UndoRecord::Initialize(result, txn_id_.load(), slot, table, insert_record_initializer);
   }
 
  private:

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -65,8 +65,7 @@ class TransactionContext {
    * @param slot the TupleSlot being updated
    * @return a persistent pointer to the head of a memory chunk large enough to hold the undo record
    */
-  storage::UndoRecord *UndoRecordForInsert(storage::DataTable *const table,
-                                           const storage::TupleSlot slot,
+  storage::UndoRecord *UndoRecordForInsert(storage::DataTable *const table, const storage::TupleSlot slot,
                                            const storage::ProjectedRowInitializer &insert_record_initializer) {
     storage::UndoRecord *result = undo_buffer_.NewEntry(storage::UndoRecord::Size(insert_record_initializer));
     return storage::UndoRecord::InitializeRecord(result, txn_id_.load(), slot, table, insert_record_initializer);

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -86,6 +86,6 @@ class TransactionManager {
   bool gc_enabled_ = false;
   TransactionQueue completed_txns_;
 
-  void Rollback(timestamp_t txn_id, const storage::UndoRecord &record);
+  void Rollback(timestamp_t txn_id, const storage::UndoRecord &record) const;
 };
 }  // namespace terrier::transaction

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -6,8 +6,8 @@
 
 namespace terrier::storage {
 DataTable::DataTable(BlockStore *const store, const BlockLayout &layout) : block_store_(store), accessor_(layout) {
-  TERRIER_ASSERT(layout.attr_sizes_[0] == 8, "First column must have size 8 for the version chain.");
-  TERRIER_ASSERT(layout.num_cols_ > 1, "First column is reserved for version info.");
+  TERRIER_ASSERT(layout.AttrSize(0) == 8, "First column must have size 8 for the version chain.");
+  TERRIER_ASSERT(layout.NumCols() > 1, "First column is reserved for version info.");
   NewBlock(nullptr);
   TERRIER_ASSERT(insertion_head_ != nullptr, "Insertion head should not be null after creating new block.");
 }
@@ -15,7 +15,7 @@ DataTable::DataTable(BlockStore *const store, const BlockLayout &layout) : block
 void DataTable::Select(transaction::TransactionContext *const txn,
                        const TupleSlot slot,
                        ProjectedRow *const out_buffer) const {
-  TERRIER_ASSERT(out_buffer->NumColumns() < accessor_.GetBlockLayout().num_cols_,
+  TERRIER_ASSERT(out_buffer->NumColumns() < accessor_.GetBlockLayout().NumCols(),
                  "The output buffer never returns the version pointer, so it should have fewer attributes.");
   TERRIER_ASSERT(out_buffer->NumColumns() > 0, "The output buffer should return at least one attribute.");
 
@@ -36,13 +36,6 @@ void DataTable::Select(transaction::TransactionContext *const txn,
   // Alternatively, if the current transaction holds the write lock, it should be able to read its own updates.
   if (version_ptr == nullptr || version_ptr->Timestamp().load() == txn->TxnId().load()) return;
 
-  // Creates a mapping from col offset to project list index. This allows us to efficiently
-  // access columns since deltas can concern a different set of columns when chasing the
-  // version chain
-  std::unordered_map<uint16_t, uint16_t> col_to_projection_list_index;
-  for (uint16_t i = 0; i < out_buffer->NumColumns(); i++)
-    col_to_projection_list_index.emplace(out_buffer->ColumnIds()[i], i);
-
   // Apply deltas until we reconstruct a version safe for us to read
   // If the version chain becomes null, this tuple does not exist for this version, and the last delta
   // record would be an undo for insert that sets the primary key to null, which is intended behavior.
@@ -50,8 +43,7 @@ void DataTable::Select(transaction::TransactionContext *const txn,
       && transaction::TransactionUtil::NewerThan(version_ptr->Timestamp().load(), txn->StartTime())) {
     StorageUtil::ApplyDelta(accessor_.GetBlockLayout(),
                             *(version_ptr->Delta()),
-                            out_buffer,
-                            col_to_projection_list_index);
+                            out_buffer);
     version_ptr = version_ptr->Next();
   }
 }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -96,7 +96,7 @@ TupleSlot DataTable::Insert(transaction::TransactionContext *const txn,
   }
   // At this point, sequential scan down the block can still see this, except it thinks it is logically deleted if we 0
   // the primary key column
-  UndoRecord *undo = txn->UndoRecordForInsert(this, accessor_.GetBlockLayout(), result);
+  UndoRecord *undo = txn->UndoRecordForInsert(this, result, insert_record_initializer_);
 
   // Populate undo record with the before image of presence column
   undo->Delta()->SetNull(0);

--- a/src/storage/delta_record.cpp
+++ b/src/storage/delta_record.cpp
@@ -1,10 +1,11 @@
 #include <vector>
 #include <utility>
+#include <functional>
+#include <algorithm>
 #include "storage/delta_record.h"
 #include "storage/storage_util.h"
 
 namespace terrier::storage {
-
 ProjectedRow *ProjectedRow::CopyProjectedRowLayout(void *head, const ProjectedRow &other) {
   auto *result = reinterpret_cast<ProjectedRow *>(head);
   auto header_size = reinterpret_cast<uintptr_t>(&other.Bitmap()) - reinterpret_cast<uintptr_t>(&other);
@@ -19,21 +20,25 @@ ProjectedRowInitializer::ProjectedRowInitializer(const terrier::storage::BlockLa
     : col_ids_(std::move(col_ids)),
       offsets_(col_ids_.size()) {
   TERRIER_ASSERT(!col_ids_.empty(), "cannot initialize an empty ProjectedRow");
+  // Sort the projection list for optimal space utilization and delta application performance
+  // If the col ids are valid ones laid out by BlockLayout, ascending order of id guarantees
+  // descending order in attribute size.
+  std::sort(col_ids_.begin(), col_ids_.end(), std::less<>());
   size_ = sizeof(ProjectedRow);  // size and num_col size
   // space needed to store col_ids, must be padded up so that the following offsets are aligned
   size_ = StorageUtil::PadUpToSize(sizeof(uint32_t), size_ + static_cast<uint32_t>(col_ids_.size() * sizeof(uint16_t)));
   // space needed to store value offsets, TODO(Tianyu): I don't think bitmaps need to be padded up to anything?
   size_ += static_cast<uint32_t>(col_ids_.size() * sizeof(uint32_t));
   // space needed to store the bitmap, padded up to the size of the first value in this projected row
-  size_ = StorageUtil::PadUpToSize(layout.attr_sizes_[col_ids_[0]],
+  size_ = StorageUtil::PadUpToSize(layout.AttrSize(col_ids_[0]),
                                    size_ + common::RawBitmap::SizeInBytes(static_cast<uint32_t>(col_ids_.size())));
   for (uint32_t i = 0; i < col_ids_.size(); i++) {
     offsets_[i] = size_;
     // Pad up to either the next value's size, or 8 bytes at the end of the ProjectedRow.
     auto next_size = static_cast<uint8_t>(i == col_ids_.size() - 1
                                           ? sizeof(uint64_t)
-                                          : layout.attr_sizes_[col_ids_[i + 1]]);
-    size_ = StorageUtil::PadUpToSize(next_size, size_ + layout.attr_sizes_[col_ids_[i]]);
+                                          : layout.AttrSize(col_ids_[i + 1]));
+    size_ = StorageUtil::PadUpToSize(next_size, size_ + layout.AttrSize(col_ids_[i]));
   }
 }
 

--- a/src/storage/delta_record.cpp
+++ b/src/storage/delta_record.cpp
@@ -17,13 +17,13 @@ ProjectedRow *ProjectedRow::CopyProjectedRowLayout(void *head, const ProjectedRo
 ProjectedRowInitializer::ProjectedRowInitializer(const terrier::storage::BlockLayout &layout,
                                                  std::vector<uint16_t> col_ids)
     : col_ids_(std::move(col_ids)),
-      offsets_(col_ids.size()) {
+      offsets_(col_ids_.size()) {
   TERRIER_ASSERT(!col_ids_.empty(), "cannot initialize an empty ProjectedRow");
   size_ = sizeof(ProjectedRow);  // size and num_col size
   // space needed to store col_ids, must be padded up so that the following offsets are aligned
   size_ = StorageUtil::PadUpToSize(sizeof(uint32_t), size_ + static_cast<uint32_t>(col_ids_.size() * sizeof(uint16_t)));
   // space needed to store value offsets, TODO(Tianyu): I don't think bitmaps need to be padded up to anything?
-  size_ += static_cast<uint32_t>(col_ids.size() * sizeof(uint32_t));
+  size_ += static_cast<uint32_t>(col_ids_.size() * sizeof(uint32_t));
   // space needed to store the bitmap, padded up to the size of the first value in this projected row
   size_ = StorageUtil::PadUpToSize(layout.attr_sizes_[col_ids_[0]],
                                    size_ + common::RawBitmap::SizeInBytes(static_cast<uint32_t>(col_ids_.size())));

--- a/src/storage/tuple_access_strategy.cpp
+++ b/src/storage/tuple_access_strategy.cpp
@@ -13,7 +13,7 @@ TupleAccessStrategy::TupleAccessStrategy(BlockLayout layout)
     column_offsets_[i] = acc_offset;
     uint32_t column_size = layout_.attr_sizes_[i] * layout_.num_slots_  // content
         + StorageUtil::PadUpToSize(layout_.attr_sizes_[i],
-                                   common::BitmapSize(layout_.num_slots_));  // padded-bitmap size
+                                   common::RawBitmap::SizeInBytes(layout_.num_slots_));  // padded-bitmap size
     acc_offset += StorageUtil::PadUpToSize(sizeof(uint64_t), column_size);
   }
 }

--- a/src/storage/tuple_access_strategy.cpp
+++ b/src/storage/tuple_access_strategy.cpp
@@ -5,15 +5,15 @@
 namespace terrier::storage {
 
 TupleAccessStrategy::TupleAccessStrategy(BlockLayout layout)
-    : layout_(std::move(layout)), column_offsets_(layout.num_cols_) {
+    : layout_(std::move(layout)), column_offsets_(layout_.NumCols()) {
   // Calculate the start position of each column
   // we use 64-bit vectorized scans on bitmaps.
-  uint32_t acc_offset = StorageUtil::PadUpToSize(sizeof(uint64_t), layout_.header_size_);
-  for (uint16_t i = 0; i < layout_.num_cols_; i++) {
+  uint32_t acc_offset = StorageUtil::PadUpToSize(sizeof(uint64_t), layout_.HeaderSize());
+  for (uint16_t i = 0; i < layout_.NumCols(); i++) {
     column_offsets_[i] = acc_offset;
-    uint32_t column_size = layout_.attr_sizes_[i] * layout_.num_slots_  // content
-        + StorageUtil::PadUpToSize(layout_.attr_sizes_[i],
-                                   common::RawBitmap::SizeInBytes(layout_.num_slots_));  // padded-bitmap size
+    uint32_t column_size = layout_.AttrSize(i) * layout_.NumSlots()  // content
+        + StorageUtil::PadUpToSize(layout_.AttrSize(i),
+                                   common::RawBitmap::SizeInBytes(layout_.NumSlots()));  // padded-bitmap size
     acc_offset += StorageUtil::PadUpToSize(sizeof(uint64_t), column_size);
   }
 }
@@ -24,28 +24,28 @@ void TupleAccessStrategy::InitializeRawBlock(RawBlock *const raw,
   raw->layout_version_ = layout_version;
   raw->num_records_ = 0;
   auto *result = reinterpret_cast<TupleAccessStrategy::Block *>(raw);
-  result->NumSlots() = layout_.num_slots_;
+  result->NumSlots() = layout_.NumSlots();
 
-  for (uint16_t i = 0; i < layout_.num_cols_; i++)
+  for (uint16_t i = 0; i < layout_.NumCols(); i++)
     result->AttrOffets()[i] = column_offsets_[i];
 
-  result->NumAttrs(layout_) = layout_.num_cols_;
+  result->NumAttrs(layout_) = layout_.NumCols();
 
-  for (uint16_t i = 0; i < layout_.num_cols_; i++)
-    result->AttrSizes(layout_)[i] = layout_.attr_sizes_[i];
+  for (uint16_t i = 0; i < layout_.NumCols(); i++)
+    result->AttrSizes(layout_)[i] = layout_.AttrSize(i);
 
-  result->Column(PRESENCE_COLUMN_ID)->PresenceBitmap()->UnsafeClear(layout_.num_slots_);
+  result->Column(PRESENCE_COLUMN_ID)->PresenceBitmap()->UnsafeClear(layout_.NumSlots());
 }
 
 bool TupleAccessStrategy::Allocate(RawBlock *const block, TupleSlot *const slot) const {
   common::RawConcurrentBitmap *bitmap = ColumnNullBitmap(block, PRESENCE_COLUMN_ID);
   const uint32_t start = block->num_records_;
 
-  if (start == layout_.num_slots_) return false;
+  if (start == layout_.NumSlots()) return false;
 
   uint32_t pos = start;
 
-  while (bitmap->FirstUnsetPos(layout_.num_slots_, pos, &pos)) {
+  while (bitmap->FirstUnsetPos(layout_.NumSlots(), pos, &pos)) {
     if (bitmap->Flip(pos, false)) {
       *slot = TupleSlot(block, pos);
       block->num_records_++;

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -24,7 +24,8 @@ timestamp_t TransactionManager::Commit(TransactionContext *const txn) {
   const timestamp_t commit_time = time_++;
   // Flip all timestamps to be committed
   storage::UndoBuffer &undos = txn->GetUndoBuffer();
-  for (auto &it : undos) it.Timestamp().store(commit_time);
+  for (auto &it : undos)
+    it.Timestamp().store(commit_time);
   table_latch_.Lock();
   const timestamp_t start_time = txn->StartTime();
   size_t result UNUSED_ATTRIBUTE = curr_running_txns_.erase(start_time);

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -64,11 +64,11 @@ TransactionQueue TransactionManager::CompletedTransactionsForGC() {
   return hand_to_gc;
 }
 
-void TransactionManager::Rollback(timestamp_t txn_id, const storage::UndoRecord &record) {
-  storage::DataTable *table = record.Table();
-  storage::TupleSlot slot = record.Slot();
+void TransactionManager::Rollback(const timestamp_t txn_id, const storage::UndoRecord &record) const {
+  storage::DataTable *const table = record.Table();
+  const storage::TupleSlot slot = record.Slot();
   storage::UndoRecord
-      *version_ptr = table->AtomicallyReadVersionPtr(slot, table->accessor_);
+      *const version_ptr = table->AtomicallyReadVersionPtr(slot, table->accessor_);
   // We do not hold the lock. Should just return
   if (version_ptr == nullptr || version_ptr->Timestamp().load() != txn_id) return;
   // Re-apply the before image

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -20,6 +20,7 @@ TransactionContext *TransactionManager::BeginTransaction() {
 
 timestamp_t TransactionManager::Commit(TransactionContext *const txn) {
   common::ReaderWriterLatch::ScopedWriterLatch guard(&commit_latch_);
+  // TODO(Tianyu): Potentially don't need to get a commit time for read-only txns
   const timestamp_t commit_time = time_++;
   // Flip all timestamps to be committed
   storage::UndoBuffer &undos = txn->GetUndoBuffer();

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -4,13 +4,13 @@
 namespace terrier::transaction {
 TransactionContext *TransactionManager::BeginTransaction() {
   common::ReaderWriterLatch::ScopedReaderLatch guard(&commit_latch_);
-  timestamp_t id = time_++;
+  timestamp_t start_time = time_++;
   // TODO(Tianyu):
   // Maybe embed this into the data structure, or use an object pool?
   // Doing this with std::map or other data structure is risky though, as they may not
   // guarantee that the iterator or underlying pointer is stable across operations.
   // (That is, they may change as concurrent inserts and deletes happen)
-  auto *result = new TransactionContext(id, id + INT64_MIN, buffer_pool_);
+  auto *result = new TransactionContext(start_time, start_time + INT64_MIN, buffer_pool_);
   table_latch_.Lock();
   auto ret UNUSED_ATTRIBUTE = curr_running_txns_.emplace(result->StartTime(), result);
   TERRIER_ASSERT(ret.second, "commit start time should be globally unique");

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -102,7 +102,7 @@ TEST(BitmapTests, WordUnalignedCorrectnessTest) {
     const uint32_t num_elements = 16 * multiplier;
 
     // provision enough space for the bitmap elements, plus padding because we're going to make it unaligned to wordsize
-    auto size = common::BitmapSize(num_elements) + sizeof(uint64_t);
+    auto size = common::RawBitmap::SizeInBytes(num_elements) + sizeof(uint64_t);
     auto allocated_buffer = new uint8_t[size];
     PELOTON_MEMSET(allocated_buffer, 0, size);
 

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -64,11 +64,6 @@ struct StorageTestUtil {
     return reinterpret_cast<A *>(reinterpret_cast<byte *>(ptr) + bytes);
   }
 
-  // Align some bytes that is aligned to 8 bytes
-  static byte *AllocateAligned(uint32_t byte_size) {
-    return reinterpret_cast<byte *>(new uint64_t[storage::StorageUtil::PadUpToSize(sizeof(uint64_t), byte_size)]);
-  }
-
   // Returns a random layout that is guaranteed to be valid.
   template <typename Random>
   static storage::BlockLayout RandomLayout(const uint16_t max_cols, Random *const generator) {

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -64,6 +64,11 @@ struct StorageTestUtil {
     return reinterpret_cast<A *>(reinterpret_cast<byte *>(ptr) + bytes);
   }
 
+  // Align some bytes that is aligned to 8 bytes
+  static byte *AllocateAligned(uint32_t byte_size) {
+    return reinterpret_cast<byte *>(new uint64_t[storage::StorageUtil::PadUpToSize(sizeof(uint64_t), byte_size)]);
+  }
+
   // Returns a random layout that is guaranteed to be valid.
   template <typename Random>
   static storage::BlockLayout RandomLayout(const uint16_t max_cols, Random *const generator) {

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -99,17 +99,17 @@ struct StorageTestUtil {
       std::bernoulli_distribution coin(1 - null_bias);
 
       if (coin(*generator))
-        FillWithRandomBytes(layout.attr_sizes_[col], row->AccessForceNotNull(projection_list_idx), generator);
+        FillWithRandomBytes(layout.AttrSize(col), row->AccessForceNotNull(projection_list_idx), generator);
       else
         row->SetNull(projection_list_idx);
     }
   }
 
   static std::vector<uint16_t> ProjectionListAllColumns(const storage::BlockLayout &layout) {
-    std::vector<uint16_t> col_ids(layout.num_cols_ - 1u);
+    std::vector<uint16_t> col_ids(layout.NumCols() - 1u);
     // Add all of the column ids from the layout to the projection list
     // 0 is version vector so we skip it
-    for (uint16_t col = 1; col < layout.num_cols_; col++) {
+    for (uint16_t col = 1; col < layout.NumCols(); col++) {
       col_ids[col - 1] = col;
     }
     return col_ids;
@@ -121,12 +121,12 @@ struct StorageTestUtil {
     // randomly select a number of columns for this delta to contain. Must be at least 1, but shouldn't be num_cols
     // since we exclude the version vector column
     uint16_t num_cols =
-        std::uniform_int_distribution<uint16_t>(1, static_cast<uint16_t>(layout.num_cols_ - 1))(*generator);
+        std::uniform_int_distribution<uint16_t>(1, static_cast<uint16_t>(layout.NumCols() - 1))(*generator);
 
     std::vector<uint16_t> col_ids;
     // Add all of the column ids from the layout to the projection list
     // 0 is version vector so we skip it
-    for (uint16_t col = 1; col < layout.num_cols_; col++) {
+    for (uint16_t col = 1; col < layout.NumCols(); col++) {
       col_ids.push_back(col);
     }
 
@@ -147,7 +147,7 @@ struct StorageTestUtil {
     }
 
     for (uint16_t projection_list_index = 0; projection_list_index < one->NumColumns(); projection_list_index++) {
-      uint8_t attr_size = layout.attr_sizes_[one->ColumnIds()[projection_list_index]];
+      uint8_t attr_size = layout.AttrSize(one->ColumnIds()[projection_list_index]);
       const byte *one_content = one->AccessWithNullCheck(projection_list_index);
       const byte *other_content = other->AccessWithNullCheck(projection_list_index);
 
@@ -170,8 +170,7 @@ struct StorageTestUtil {
       uint16_t col_id = row.ColumnIds()[i];
       const byte *attr = row.AccessWithNullCheck(i);
       if (attr != nullptr) {
-        printf("col_id: %u is %" PRIx64 "\n", col_id,
-               storage::StorageUtil::ReadBytes(layout.attr_sizes_[col_id], attr));
+        printf("col_id: %u is %" PRIx64 "\n", col_id, storage::StorageUtil::ReadBytes(layout.AttrSize(col_id), attr));
       } else {
         printf("col_id: %u is NULL\n", col_id);
       }
@@ -183,14 +182,14 @@ struct StorageTestUtil {
   static void InsertTuple(const storage::ProjectedRow &tuple, const storage::TupleAccessStrategy &tested,
                           const storage::BlockLayout &layout, const storage::TupleSlot slot) {
     // Skip the version vector for tuples
-    for (uint16_t col = 1; col < layout.num_cols_; col++) {
+    for (uint16_t col = 1; col < layout.NumCols(); col++) {
       const byte *val_ptr = tuple.AccessWithNullCheck(static_cast<uint16_t>(col - 1));
       if (val_ptr == nullptr) {
         tested.SetNull(slot, col);
       } else {
         // Read the value
-        uint64_t val = storage::StorageUtil::ReadBytes(layout.attr_sizes_[col], val_ptr);
-        storage::StorageUtil::WriteBytes(layout.attr_sizes_[col], val, tested.AccessForceNotNull(slot, col));
+        uint64_t val = storage::StorageUtil::ReadBytes(layout.AttrSize(col), val_ptr);
+        storage::StorageUtil::WriteBytes(layout.AttrSize(col), val, tested.AccessForceNotNull(slot, col));
       }
     }
   }
@@ -198,14 +197,14 @@ struct StorageTestUtil {
   // Check that the written tuple is the same as the expected one
   static void CheckTupleEqual(const storage::ProjectedRow &expected, const storage::TupleAccessStrategy &tested,
                               const storage::BlockLayout &layout, const storage::TupleSlot slot) {
-    for (uint16_t col = 1; col < layout.num_cols_; col++) {
+    for (uint16_t col = 1; col < layout.NumCols(); col++) {
       const byte *val_ptr = expected.AccessWithNullCheck(static_cast<uint16_t>(col - 1));
       byte *col_slot = tested.AccessWithNullCheck(slot, col);
       if (val_ptr != nullptr) {
         // Read the value
-        uint64_t val = storage::StorageUtil::ReadBytes(layout.attr_sizes_[col], val_ptr);
+        uint64_t val = storage::StorageUtil::ReadBytes(layout.AttrSize(col), val_ptr);
         EXPECT_TRUE(col_slot != nullptr);
-        EXPECT_EQ(val, storage::StorageUtil::ReadBytes(layout.attr_sizes_[col], col_slot));
+        EXPECT_EQ(val, storage::StorageUtil::ReadBytes(layout.AttrSize(col), col_slot));
       } else {
         EXPECT_TRUE(col_slot == nullptr);
       }

--- a/test/include/util/transaction_test_util.h
+++ b/test/include/util/transaction_test_util.h
@@ -172,7 +172,6 @@ class LargeTransactionTestObject {
   std::vector<TupleEntry> last_checked_version_;
 
   // so we don't have to calculate these over and over again
-  std::vector<uint16_t> all_cols_{StorageTestUtil::ProjectionListAllColumns(layout_)};
-  uint32_t row_size_ = storage::ProjectedRow::Size(layout_, all_cols_);
+  storage::ProjectedRowInitializer row_initializer_{layout_, StorageTestUtil::ProjectionListAllColumns(layout_)};
 };
 }  // namespace terrier

--- a/test/storage/data_table_concurrent_test.cpp
+++ b/test/storage/data_table_concurrent_test.cpp
@@ -26,9 +26,9 @@ class FakeTransaction {
   template<class Random>
   storage::TupleSlot InsertRandomTuple(Random *generator) {
     // generate a random redo ProjectedRow to Insert
-    auto *redo_buffer = new byte[redo_size_];
+    auto *redo_buffer = StorageTestUtil::AllocateAligned(redo_initializer_.ProjectedRowSize());
     loose_pointers_.push_back(redo_buffer);
-    storage::ProjectedRow *redo = storage::ProjectedRow::InitializeProjectedRow(redo_buffer, all_col_ids_, layout_);
+    storage::ProjectedRow *redo = redo_initializer_.InitializeProjectedRow(redo_buffer);
     StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
 
     storage::TupleSlot slot = table_->Insert(&txn_, *redo);
@@ -41,9 +41,9 @@ class FakeTransaction {
   bool RandomlyUpdateTuple(const storage::TupleSlot slot, Random *generator) {
     // generate random update
     std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
-    auto *update_buffer = new byte[storage::ProjectedRow::Size(layout_, update_col_ids)];
-    storage::ProjectedRow *update =
-        storage::ProjectedRow::InitializeProjectedRow(update_buffer, update_col_ids, layout_);
+    storage::ProjectedRowInitializer update_initializer(layout_, update_col_ids);
+    auto *update_buffer = StorageTestUtil::AllocateAligned(update_initializer.ProjectedRowSize());
+    storage::ProjectedRow *update = update_initializer.InitializeProjectedRow(update_buffer);
     StorageTestUtil::PopulateRandomRow(update, layout_, null_bias_, generator);
 
     bool result = table_->Update(&txn_, slot, *update);
@@ -67,8 +67,7 @@ class FakeTransaction {
   const storage::BlockLayout &layout_;
   storage::DataTable *table_;
   double null_bias_;
-  std::vector<uint16_t> all_col_ids_{StorageTestUtil::ProjectionListAllColumns(layout_)};
-  uint32_t redo_size_ = storage::ProjectedRow::Size(layout_, all_col_ids_);
+  storage::ProjectedRowInitializer redo_initializer_{layout_, StorageTestUtil::ProjectionListAllColumns(layout_)};
   // All data structures here are only accessed thread-locally so no need
   // for concurrent versions
   std::vector<storage::TupleSlot> inserted_slots_;
@@ -113,12 +112,12 @@ TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
     };
 
     thread_pool.RunThreadsUntilFinish(num_threads, workload);
-    std::vector<uint16_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
-    auto *select_buffer = new byte[storage::ProjectedRow::Size(layout, all_col_ids)];
+    storage::ProjectedRowInitializer select_initializer(layout, StorageTestUtil::ProjectionListAllColumns(layout));
+    auto *select_buffer = StorageTestUtil::AllocateAligned(select_initializer.ProjectedRowSize());
     for (auto &fake_txn : fake_txns) {
       for (auto slot : fake_txn->InsertedTuples()) {
         storage::ProjectedRow
-            *select_row = storage::ProjectedRow::InitializeProjectedRow(select_buffer, all_col_ids, layout);
+            *select_row = select_initializer.InitializeProjectedRow(select_buffer);
         tested.Select(fake_txn->GetTxn(), slot, select_row);
         EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(layout, fake_txn->GetReferenceTuple(slot), select_row));
       }

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -81,10 +81,7 @@ class RandomDataTableTestObject {
       TERRIER_MEMCPY(version_buffer, tuple_versions_[slot].back().second, redo_initializer_.ProjectedRowSize());
       auto *version = reinterpret_cast<storage::ProjectedRow *>(version_buffer);
       // apply delta
-      std::unordered_map<uint16_t, uint16_t> col_to_projection_list_index;
-      for (uint16_t i = 0; i < version->NumColumns(); i++)
-        col_to_projection_list_index.emplace(version->ColumnIds()[i], i);
-      storage::StorageUtil::ApplyDelta(layout_, *update, version, col_to_projection_list_index);
+      storage::StorageUtil::ApplyDelta(layout_, *update, version);
       tuple_versions_[slot].emplace_back(timestamp, version);
     }
 

--- a/test/storage/delta_record_test.cpp
+++ b/test/storage/delta_record_test.cpp
@@ -68,7 +68,7 @@ TEST_F(DeltaRecordTests, UndoChainAccess) {
     for (uint32_t i = 0; i < record_list.size() - 1; i++)
       EXPECT_EQ(record_list[i]->Next(), record_list[i + 1]);
 
-    for(auto record : record_list) delete[] reinterpret_cast<byte *>(record);
+    for (auto record : record_list) delete[] reinterpret_cast<byte *>(record);
   }
 }
 

--- a/test/storage/delta_record_test.cpp
+++ b/test/storage/delta_record_test.cpp
@@ -58,7 +58,7 @@ TEST_F(DeltaRecordTests, UndoChainAccess) {
       const std::vector<uint16_t> col_ids = StorageTestUtil::ProjectionListRandomColumns(layout, &generator_);
       storage::ProjectedRowInitializer initializer(layout, col_ids);
       timestamp_t time = static_cast<timestamp_t >(timestamp_dist_(generator_));
-      auto *record_buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+      auto *record_buffer = common::AllocationUtil::AllocateAligned(storage::UndoRecord::Size(initializer));
       storage::UndoRecord *record = storage::UndoRecord::Initialize(record_buffer,
                                                                     time,
                                                                     slot,

--- a/test/storage/delta_record_test.cpp
+++ b/test/storage/delta_record_test.cpp
@@ -60,16 +60,15 @@ TEST_F(DeltaRecordTests, UndoChainAccess) {
 
       // compute the size of the buffer
       const std::vector<uint16_t> col_ids = StorageTestUtil::ProjectionListRandomColumns(layout, &generator_);
-      uint32_t size = storage::UndoRecord::Size(layout, col_ids);
+      storage::ProjectedRowInitializer initializer(layout, col_ids);
       timestamp_t time = static_cast<timestamp_t >(timestamp_dist_(generator_));
-      auto *record_buffer = new byte[size];
+      auto *record_buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
       loose_pointers_.push_back(record_buffer);
       storage::UndoRecord *record = storage::UndoRecord::InitializeRecord(record_buffer,
                                                                           time,
                                                                           slot,
                                                                           &data_table,
-                                                                          layout,
-                                                                          col_ids);
+                                                                          initializer);
       // Chain the records
       if (i != 0)
         record_list.back()->Next() = record;
@@ -77,7 +76,7 @@ TEST_F(DeltaRecordTests, UndoChainAccess) {
     }
 
     for (uint32_t i = 0; i < record_list.size() - 1; i++)
-      EXPECT_EQ(record_list[i]->Next(), record_list[i+1]);
+      EXPECT_EQ(record_list[i]->Next(), record_list[i + 1]);
   }
 }
 
@@ -85,7 +84,7 @@ TEST_F(DeltaRecordTests, UndoChainAccess) {
 // Generate UndoRecords using ProjectedRows and get ProjectedRows back from UndoRecords to see if you get the same
 // ProjectedRows back. Repeat for num_iterations.
 // NOLINTNEXTLINE
-TEST_F(DeltaRecordTests, UndoGetProjectedRow){
+TEST_F(DeltaRecordTests, UndoGetProjectedRow) {
   uint32_t num_iterations = 500;
   for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
     // get a random table layout
@@ -96,9 +95,9 @@ TEST_F(DeltaRecordTests, UndoGetProjectedRow){
 
     // generate a random projectedRow
     std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
-    auto *redo_buffer = new byte[storage::ProjectedRow::Size(layout, update_col_ids)];
-    storage::ProjectedRow *redo =
-        storage::ProjectedRow::InitializeProjectedRow(redo_buffer, update_col_ids, layout);
+    storage::ProjectedRowInitializer initializer(layout, update_col_ids);
+    auto *redo_buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
+    storage::ProjectedRow *redo = initializer.InitializeProjectedRow(redo_buffer);
     // we don't need to populate projected row since we only copying the layout when we create a UndoRecord using
     // projected row
     loose_pointers_.push_back(redo_buffer);
@@ -113,7 +112,7 @@ TEST_F(DeltaRecordTests, UndoGetProjectedRow){
     // compute the size of the buffer
     uint32_t size = storage::UndoRecord::Size(*redo);
     timestamp_t time = static_cast<timestamp_t >(timestamp_dist_(generator_));
-    auto *record_buffer = new byte[size];
+    auto *record_buffer = StorageTestUtil::AllocateAligned(size);
     loose_pointers_.push_back(record_buffer);
     storage::UndoRecord *record = storage::UndoRecord::InitializeRecord(record_buffer,
                                                                         time,

--- a/test/storage/delta_record_test.cpp
+++ b/test/storage/delta_record_test.cpp
@@ -22,6 +22,11 @@ struct DeltaRecordTests : public TerrierTest {
     TerrierTest::SetUp();
     raw_block_ = block_store_.Get();
   }
+
+  void TearDown() override {
+    block_store_.Release(raw_block_);
+    TerrierTest::TearDown();
+  }
 };
 
 

--- a/test/storage/delta_record_test.cpp
+++ b/test/storage/delta_record_test.cpp
@@ -58,12 +58,12 @@ TEST_F(DeltaRecordTests, UndoChainAccess) {
       const std::vector<uint16_t> col_ids = StorageTestUtil::ProjectionListRandomColumns(layout, &generator_);
       storage::ProjectedRowInitializer initializer(layout, col_ids);
       timestamp_t time = static_cast<timestamp_t >(timestamp_dist_(generator_));
-      auto *record_buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
-      storage::UndoRecord *record = storage::UndoRecord::InitializeRecord(record_buffer,
-                                                                          time,
-                                                                          slot,
-                                                                          &data_table,
-                                                                          initializer);
+      auto *record_buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+      storage::UndoRecord *record = storage::UndoRecord::Initialize(record_buffer,
+                                                                    time,
+                                                                    slot,
+                                                                    &data_table,
+                                                                    initializer);
       // Chain the records
       if (i != 0)
         record_list.back()->Next() = record;
@@ -93,8 +93,8 @@ TEST_F(DeltaRecordTests, UndoGetProjectedRow) {
     // generate a random projectedRow
     std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, update_col_ids);
-    auto *redo_buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
-    storage::ProjectedRow *redo = initializer.InitializeProjectedRow(redo_buffer);
+    auto *redo_buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+    storage::ProjectedRow *redo = initializer.InitializeRow(redo_buffer);
     // we don't need to populate projected row since we only copying the layout when we create a UndoRecord using
     // projected row
 
@@ -108,7 +108,7 @@ TEST_F(DeltaRecordTests, UndoGetProjectedRow) {
     // compute the size of the buffer
     uint32_t size = storage::UndoRecord::Size(*redo);
     timestamp_t time = static_cast<timestamp_t >(timestamp_dist_(generator_));
-    auto *record_buffer = StorageTestUtil::AllocateAligned(size);
+    auto *record_buffer = common::AllocationUtil::AllocateAligned(size);
     storage::UndoRecord *record = storage::UndoRecord::InitializeRecord(record_buffer,
                                                                         time,
                                                                         slot,

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -56,10 +56,7 @@ class GarbageCollectorDataTableTestObject {
     // Copy previous version
     TERRIER_MEMCPY(buffer, &previous, initializer_.ProjectedRowSize());
     auto *version = reinterpret_cast<storage::ProjectedRow *>(buffer);
-    std::unordered_map<uint16_t, uint16_t> col_to_projection_list_index;
-    for (uint16_t i = 0; i < version->NumColumns(); i++)
-      col_to_projection_list_index.emplace(version->ColumnIds()[i], i);
-    storage::StorageUtil::ApplyDelta(layout_, delta, version, col_to_projection_list_index);
+    storage::StorageUtil::ApplyDelta(layout_, delta, version);
     return version;
   }
 

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -31,9 +31,9 @@ class GarbageCollectorDataTableTestObject {
 
   template<class Random>
   storage::ProjectedRow *GenerateRandomTuple(Random *generator) {
-    auto *buffer = StorageTestUtil::AllocateAligned(initializer_.ProjectedRowSize());
+    auto *buffer = common::AllocationUtil::AllocateAligned(initializer_.ProjectedRowSize());
     loose_pointers_.push_back(buffer);
-    storage::ProjectedRow *redo = initializer_.InitializeProjectedRow(buffer);
+    storage::ProjectedRow *redo = initializer_.InitializeRow(buffer);
     StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
     return redo;
   }
@@ -42,16 +42,16 @@ class GarbageCollectorDataTableTestObject {
   storage::ProjectedRow *GenerateRandomUpdate(Random *generator) {
     std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
     storage::ProjectedRowInitializer update_initializer(layout_, update_col_ids);
-    auto *buffer = StorageTestUtil::AllocateAligned(update_initializer.ProjectedRowSize());
+    auto *buffer = common::AllocationUtil::AllocateAligned(update_initializer.ProjectedRowSize());
     loose_pointers_.push_back(buffer);
-    storage::ProjectedRow *update = update_initializer.InitializeProjectedRow(buffer);
+    storage::ProjectedRow *update = update_initializer.InitializeRow(buffer);
     StorageTestUtil::PopulateRandomRow(update, layout_, null_bias_, generator);
     return update;
   }
 
   storage::ProjectedRow *GenerateVersionFromUpdate(const storage::ProjectedRow &delta,
                                                    const storage::ProjectedRow &previous) {
-    auto *buffer = StorageTestUtil::AllocateAligned(initializer_.ProjectedRowSize());
+    auto *buffer = common::AllocationUtil::AllocateAligned(initializer_.ProjectedRowSize());
     loose_pointers_.push_back(buffer);
     // Copy previous version
     TERRIER_MEMCPY(buffer, &previous, initializer_.ProjectedRowSize());
@@ -63,7 +63,7 @@ class GarbageCollectorDataTableTestObject {
   storage::ProjectedRow *SelectIntoBuffer(transaction::TransactionContext *const txn,
                                           const storage::TupleSlot slot) {
     // generate a redo ProjectedRow for Select
-    storage::ProjectedRow *select_row = initializer_.InitializeProjectedRow(select_buffer_);
+    storage::ProjectedRow *select_row = initializer_.InitializeRow(select_buffer_);
     table_.Select(txn, slot, select_row);
     return select_row;
   }
@@ -75,7 +75,7 @@ class GarbageCollectorDataTableTestObject {
   const double null_bias_ = 0;
   std::vector<byte *> loose_pointers_;
   storage::ProjectedRowInitializer initializer_{layout_, StorageTestUtil::ProjectionListAllColumns(layout_)};
-  byte *select_buffer_ = StorageTestUtil::AllocateAligned(initializer_.ProjectedRowSize());
+  byte *select_buffer_ = common::AllocationUtil::AllocateAligned(initializer_.ProjectedRowSize());
 };
 
 struct GarbageCollectorTests : public ::terrier::TerrierTest {

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -143,7 +143,7 @@ TEST_F(GarbageCollectorTests, CommitInsert1) {
     auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
     storage::TupleSlot slot = tested.table_.Insert(txn0, *insert_tuple);
 
-    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     // Nothing should be able to be GC'd yet because txn0 has not committed yet
@@ -151,7 +151,7 @@ TEST_F(GarbageCollectorTests, CommitInsert1) {
 
     auto *txn1 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Commit(txn0);
@@ -159,7 +159,7 @@ TEST_F(GarbageCollectorTests, CommitInsert1) {
     // Nothing should be able to be GC'd yet because txn1 started before txn0's commit
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Commit(txn1);
@@ -170,7 +170,7 @@ TEST_F(GarbageCollectorTests, CommitInsert1) {
 
     auto *txn2 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
     txn_manager.Commit(txn2);
 
@@ -195,10 +195,10 @@ TEST_F(GarbageCollectorTests, CommitInsert2) {
     auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
     storage::TupleSlot slot = tested.table_.Insert(txn1, *insert_tuple);
 
-    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     // Nothing should be able to be GC'd yet because txn0 has not committed yet
@@ -206,7 +206,7 @@ TEST_F(GarbageCollectorTests, CommitInsert2) {
 
     txn_manager.Commit(txn1);
 
-    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     // Nothing should be able to be GC'd yet because txn0 started before txn1's commit
@@ -220,7 +220,7 @@ TEST_F(GarbageCollectorTests, CommitInsert2) {
 
     auto *txn2 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
     txn_manager.Commit(txn2);
 
@@ -244,7 +244,7 @@ TEST_F(GarbageCollectorTests, AbortInsert1) {
     auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
     storage::TupleSlot slot = tested.table_.Insert(txn0, *insert_tuple);
 
-    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     // Nothing should be able to be GC'd yet because txn0 has not committed yet
@@ -252,7 +252,7 @@ TEST_F(GarbageCollectorTests, AbortInsert1) {
 
     auto *txn1 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Abort(txn0);
@@ -262,7 +262,7 @@ TEST_F(GarbageCollectorTests, AbortInsert1) {
     // But it's not safe to deallocate it yet because txn #1 is still running and may hold a reference to it
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Commit(txn1);
@@ -274,7 +274,7 @@ TEST_F(GarbageCollectorTests, AbortInsert1) {
 
     auto *txn2 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
     txn_manager.Commit(txn2);
 
@@ -300,10 +300,10 @@ TEST_F(GarbageCollectorTests, AbortInsert2) {
     auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
     storage::TupleSlot slot = tested.table_.Insert(txn1, *insert_tuple);
 
-    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     // Nothing should be able to be GC'd yet because txn1 has not committed yet
@@ -316,7 +316,7 @@ TEST_F(GarbageCollectorTests, AbortInsert2) {
     // But it's not safe to deallocate it yet because txn #0 is still running and may hold a reference to it
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Commit(txn0);
@@ -328,7 +328,7 @@ TEST_F(GarbageCollectorTests, AbortInsert2) {
 
     auto *txn2 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
     txn_manager.Commit(txn2);
 
@@ -366,7 +366,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate1) {
 
     auto *update_tuple = tested.GenerateVersionFromUpdate(*update, *insert_tuple);
 
-    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
 
     // Nothing should be able to be GC'd yet because txn0 has not committed yet
@@ -374,7 +374,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate1) {
 
     auto *txn1 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Commit(txn0);
@@ -382,7 +382,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate1) {
     // Nothing should be able to be GC'd yet because txn1 started before txn0's commit
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Commit(txn1);
@@ -394,7 +394,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate1) {
 
     auto *txn2 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
     txn_manager.Commit(txn2);
 
@@ -437,10 +437,10 @@ TEST_F(GarbageCollectorTests, CommitUpdate2) {
 
     auto *update_tuple = tested.GenerateVersionFromUpdate(*update, *insert_tuple);
 
-    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
 
     txn_manager.Commit(txn1);
@@ -448,7 +448,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate2) {
     // Nothing should be able to be GC'd yet because txn0 started before txn1's commit
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Commit(txn0);
@@ -460,7 +460,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate2) {
 
     auto *txn2 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
     txn_manager.Commit(txn2);
 
@@ -498,7 +498,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate1) {
 
     auto *update_tuple = tested.GenerateVersionFromUpdate(*update, *insert_tuple);
 
-    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
 
     auto *txn1 = txn_manager.BeginTransaction();
@@ -506,7 +506,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate1) {
     // Nothing should be able to be GC'd yet because txn0 has not committed yet
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Abort(txn0);
@@ -516,7 +516,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate1) {
     // But it's not safe to deallocate it yet because txn #1 is still running and may hold a reference to it
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Commit(txn1);
@@ -528,7 +528,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate1) {
 
     auto *txn2 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
     txn_manager.Commit(txn2);
 
@@ -568,10 +568,10 @@ TEST_F(GarbageCollectorTests, AbortUpdate2) {
 
     auto *update_tuple = tested.GenerateVersionFromUpdate(*update, *insert_tuple);
 
-    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
 
     // Nothing should be able to be GC'd yet because txn1 has not committed yet
@@ -579,7 +579,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate2) {
 
     txn_manager.Abort(txn1);
 
-    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     // Aborted transactions can be removed from the unlink queue immediately
@@ -596,7 +596,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate2) {
 
     auto *txn2 = txn_manager.BeginTransaction();
 
-    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
     txn_manager.Commit(txn2);
 
@@ -622,7 +622,7 @@ TEST_F(GarbageCollectorTests, InsertUpdate1) {
     auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
     storage::TupleSlot slot = tested.table_.Insert(txn1, *insert_tuple);
 
-    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     // Nothing should be able to be GC'd yet because txn1 has not committed yet
@@ -636,7 +636,7 @@ TEST_F(GarbageCollectorTests, InsertUpdate1) {
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
     EXPECT_FALSE(tested.table_.Update(txn0, slot, *update));
 
-    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
     txn_manager.Abort(txn0);

--- a/test/storage/projected_row_test.cpp
+++ b/test/storage/projected_row_test.cpp
@@ -75,8 +75,8 @@ TEST_F(ProjectedRowTests, Nulls) {
   }
 }
 
-// NOLINTNEXTLINE
 // This tests checks that the copy function works as intended
+// NOLINTNEXTLINE
 TEST_F(ProjectedRowTests, CopyProjectedRowLayout) {
   const uint32_t num_iterations = 500;
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
@@ -135,8 +135,8 @@ TEST_F(ProjectedRowTests, MemorySafety) {
   }
 }
 
-// NOLINTNEXTLINE
 // This test checks that all the fields within projected row is aligned
+// NOLINTNEXTLINE
 TEST_F(ProjectedRowTests, Alignment) {
   const uint32_t num_iterations = 500;
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {

--- a/test/storage/projected_row_test.cpp
+++ b/test/storage/projected_row_test.cpp
@@ -41,7 +41,7 @@ TEST_F(ProjectedRowTests, Nulls) {
       null_cols[i] = coin(generator_);
       if (null_cols[i]) {
         byte *val_ptr = update->AccessForceNotNull(i);
-        storage::StorageUtil::WriteBytes(layout.attr_sizes_[i + 1], 0, val_ptr);
+        storage::StorageUtil::WriteBytes(layout.AttrSize(static_cast<uint16_t>(i + 1)), 0, val_ptr);
         update->SetNull(i);
       } else {
         update->SetNotNull(i);
@@ -53,7 +53,7 @@ TEST_F(ProjectedRowTests, Nulls) {
       if (null_cols[i]) {
         EXPECT_EQ(addr, nullptr);
         byte *val_ptr = update->AccessForceNotNull(i);
-        EXPECT_EQ(0, storage::StorageUtil::ReadBytes(layout.attr_sizes_[i + 1], val_ptr));
+        EXPECT_EQ(0, storage::StorageUtil::ReadBytes(layout.AttrSize(static_cast<uint16_t>(i + 1)), val_ptr));
       } else {
         EXPECT_FALSE(addr == nullptr);
       }
@@ -108,12 +108,12 @@ TEST_F(ProjectedRowTests, MemorySafety) {
     auto *buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
     storage::ProjectedRow *row = initializer.InitializeProjectedRow(buffer);
 
-    EXPECT_EQ(layout.num_cols_ - 1, row->NumColumns());
+    EXPECT_EQ(layout.NumCols() - 1, row->NumColumns());
     void *upper_bound = reinterpret_cast<byte *>(row) + row->Size();
     // check the rest values memory addresses don't overlapping previous addresses.
     for (uint16_t i = 1; i < row->NumColumns(); i++) {
       void *lower_bound = StorageTestUtil::IncrementByBytes(row->AccessForceNotNull(static_cast<uint16_t>(i - 1)),
-                                                            layout.attr_sizes_[row->ColumnIds()[i - 1]]);
+                                                            layout.AttrSize(row->ColumnIds()[i - 1]));
       // Check that the previous address is within allocated bounds
       StorageTestUtil::CheckInBounds(lower_bound, row, upper_bound);
       // check if the value address is in bound
@@ -138,7 +138,7 @@ TEST_F(ProjectedRowTests, Alignment) {
     storage::ProjectedRow *row = initializer.InitializeProjectedRow(buffer);
     for (uint16_t i = 0; i < row->NumColumns(); i++)
       StorageTestUtil::CheckAlignment(row->AccessForceNotNull(i),
-                                      layout.attr_sizes_[row->ColumnIds()[i]]);
+                                      layout.AttrSize(row->ColumnIds()[i]));
     delete[] buffer;
   }
 }

--- a/test/storage/projected_row_test.cpp
+++ b/test/storage/projected_row_test.cpp
@@ -29,8 +29,8 @@ TEST_F(ProjectedRowTests, Nulls) {
     // generate a random projectedRow
     std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, update_col_ids);
-    auto *update_buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
-    storage::ProjectedRow *update = initializer.InitializeProjectedRow(update_buffer);
+    auto *update_buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+    storage::ProjectedRow *update = initializer.InitializeRow(update_buffer);
     StorageTestUtil::PopulateRandomRow(update, layout, null_ratio_(generator_), &generator_);
 
 
@@ -73,10 +73,10 @@ TEST_F(ProjectedRowTests, CopyProjectedRowLayout) {
     // generate a random projectedRow
     std::vector<uint16_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, all_col_ids);
-    auto *buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
-    storage::ProjectedRow *row = initializer.InitializeProjectedRow(buffer);
+    auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+    storage::ProjectedRow *row = initializer.InitializeRow(buffer);
 
-    auto *copy = StorageTestUtil::AllocateAligned(row->Size());
+    auto *copy = common::AllocationUtil::AllocateAligned(row->Size());
     auto *copied_row = storage::ProjectedRow::CopyProjectedRowLayout(copy, *row);
 
     EXPECT_EQ(copied_row->NumColumns(), row->NumColumns());
@@ -105,8 +105,8 @@ TEST_F(ProjectedRowTests, MemorySafety) {
     // generate a random projectedRow
     std::vector<uint16_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, all_col_ids);
-    auto *buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
-    storage::ProjectedRow *row = initializer.InitializeProjectedRow(buffer);
+    auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+    storage::ProjectedRow *row = initializer.InitializeRow(buffer);
 
     EXPECT_EQ(layout.NumCols() - 1, row->NumColumns());
     void *upper_bound = reinterpret_cast<byte *>(row) + row->Size();
@@ -134,8 +134,8 @@ TEST_F(ProjectedRowTests, Alignment) {
     // generate a random projectedRow
     std::vector<uint16_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, all_col_ids);
-    auto *buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
-    storage::ProjectedRow *row = initializer.InitializeProjectedRow(buffer);
+    auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+    storage::ProjectedRow *row = initializer.InitializeRow(buffer);
     for (uint16_t i = 0; i < row->NumColumns(); i++)
       StorageTestUtil::CheckAlignment(row->AccessForceNotNull(i),
                                       layout.AttrSize(row->ColumnIds()[i]));

--- a/test/storage/storage_util_test.cpp
+++ b/test/storage/storage_util_test.cpp
@@ -63,8 +63,8 @@ TEST_F(StorageUtilTests, CopyToProjectedRow) {
     // generate a random projectedRow
     std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer update_initializer(layout, update_col_ids);
-    auto *row_buffer = StorageTestUtil::AllocateAligned(update_initializer.ProjectedRowSize());
-    storage::ProjectedRow *row = update_initializer.InitializeProjectedRow(row_buffer);
+    auto *row_buffer = common::AllocationUtil::AllocateAligned(update_initializer.ProjectedRowSize());
+    storage::ProjectedRow *row = update_initializer.InitializeRow(row_buffer);
 
     std::bernoulli_distribution null_dist(null_ratio_(generator_));
     for (uint16_t i = 0; i < row->NumColumns(); ++i) {
@@ -141,8 +141,8 @@ TEST_F(StorageUtilTests, ApplyDelta) {
     // the old row
     std::vector<uint16_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, all_col_ids);
-    auto *old_buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
-    storage::ProjectedRow *old = initializer.InitializeProjectedRow(old_buffer);
+    auto *old_buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+    storage::ProjectedRow *old = initializer.InitializeRow(old_buffer);
     StorageTestUtil::PopulateRandomRow(old, layout, null_ratio_(generator_), &generator_);
 
     // store the values as a reference
@@ -159,8 +159,8 @@ TEST_F(StorageUtilTests, ApplyDelta) {
     // the delta change to apply
     std::vector<uint16_t> rand_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout, &generator_);
     storage::ProjectedRowInitializer rand_initializer(layout, rand_col_ids);
-    auto *delta_buffer = StorageTestUtil::AllocateAligned(rand_initializer.ProjectedRowSize());
-    storage::ProjectedRow *delta = rand_initializer.InitializeProjectedRow(delta_buffer);
+    auto *delta_buffer = common::AllocationUtil::AllocateAligned(rand_initializer.ProjectedRowSize());
+    storage::ProjectedRow *delta = rand_initializer.InitializeRow(delta_buffer);
     StorageTestUtil::PopulateRandomRow(delta, layout, null_ratio_(generator_), &generator_);
 
     // apply delta

--- a/test/storage/storage_util_test.cpp
+++ b/test/storage/storage_util_test.cpp
@@ -168,7 +168,7 @@ TEST_F(StorageUtilTests, ApplyDelta) {
     // check changes has been applied
     for (uint16_t delta_col_offset = 0; delta_col_offset < rand_initializer.NumCols(); ++delta_col_offset) {
       uint16_t col = rand_initializer.ColId(delta_col_offset);
-      uint16_t old_col_offset = col - 1;  // since all columns were in the old one
+      uint16_t old_col_offset = static_cast<uint16_t>(col - 1);  // since all columns were in the old one
       byte *delta_val_ptr = delta->AccessWithNullCheck(delta_col_offset);
       byte *old_val_ptr = old->AccessWithNullCheck(old_col_offset);
       if (delta_val_ptr == nullptr) {
@@ -187,7 +187,8 @@ TEST_F(StorageUtilTests, ApplyDelta) {
         byte *ptr = old->AccessWithNullCheck(i);
         EXPECT_EQ(ptr, copy[i].first);
         if (ptr != nullptr) {
-          EXPECT_EQ(storage::StorageUtil::ReadBytes(layout.AttrSize(i + 1), ptr), copy[i].second);
+          EXPECT_EQ(storage::StorageUtil::ReadBytes(layout.AttrSize(static_cast<uint16_t>(i + 1)), ptr),
+                    copy[i].second);
         }
       }
     }

--- a/test/storage/storage_util_test.cpp
+++ b/test/storage/storage_util_test.cpp
@@ -85,7 +85,6 @@ TEST_F(StorageUtilTests, CopyToProjectedRow) {
             storage::StorageUtil::ReadBytes(attr_size, row->AccessWithNullCheck(col)));
         delete[] from;
       }
-
     }
     delete[] row_buffer;
   }

--- a/test/storage/storage_util_test.cpp
+++ b/test/storage/storage_util_test.cpp
@@ -168,7 +168,7 @@ TEST_F(StorageUtilTests, ApplyDelta) {
     // check changes has been applied
     for (uint16_t delta_col_offset = 0; delta_col_offset < rand_initializer.NumCols(); ++delta_col_offset) {
       uint16_t col = rand_initializer.ColId(delta_col_offset);
-      uint16_t old_col_offset = static_cast<uint16_t>(col - 1);  // since all columns were in the old one
+      auto old_col_offset = static_cast<uint16_t>(col - 1);  // since all columns were in the old one
       byte *delta_val_ptr = delta->AccessWithNullCheck(delta_col_offset);
       byte *old_val_ptr = old->AccessWithNullCheck(old_col_offset);
       if (delta_val_ptr == nullptr) {

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -34,8 +34,8 @@ class TupleAccessStrategyTestObject {
 
     // Generate a random ProjectedRow to insert
     storage::ProjectedRowInitializer initializer(layout, StorageTestUtil::ProjectionListAllColumns(layout));
-    auto *buffer = StorageTestUtil::AllocateAligned(initializer.ProjectedRowSize());
-    storage::ProjectedRow *row = initializer.InitializeProjectedRow(buffer);
+    auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+    storage::ProjectedRow *row = initializer.InitializeRow(buffer);
     std::default_random_engine real_generator;
     std::uniform_real_distribution<double> distribution{0.0, 1.0};
     StorageTestUtil::PopulateRandomRow(row, layout, distribution(real_generator), generator);

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -73,7 +73,7 @@ struct TupleAccessStrategyTests : public TerrierTest{
 // NOLINTNEXTLINE
 TEST_F(TupleAccessStrategyTests, Nulls) {
   std::default_random_engine generator;
-  const uint32_t repeat = 200;
+  const uint32_t repeat = 100;
   for (uint32_t i = 0; i < repeat; i++) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator);
     storage::TupleAccessStrategy tested(layout);
@@ -82,12 +82,12 @@ TEST_F(TupleAccessStrategyTests, Nulls) {
 
     storage::TupleSlot slot;
     EXPECT_TRUE(tested.Allocate(raw_block_, &slot));
-    std::vector<bool> nulls(layout.num_cols_);
+    std::vector<bool> nulls(layout.NumCols());
     std::bernoulli_distribution coin(0.5);
     // primary key always not null
     nulls[0] = false;
     // Randomly set some columns to be not null
-    for (uint16_t col = 1; col < layout.num_cols_; col++) {
+    for (uint16_t col = 1; col < layout.NumCols(); col++) {
       if (coin(generator)) {
         nulls[col] = true;
       } else {
@@ -96,7 +96,7 @@ TEST_F(TupleAccessStrategyTests, Nulls) {
       }
     }
 
-    for (uint16_t col = 0; col < layout.num_cols_; col++) {
+    for (uint16_t col = 0; col < layout.NumCols(); col++) {
       // Either the field is null and the access returns nullptr,
       // or the field is not null and the access ptr is not null
       EXPECT_TRUE(
@@ -104,7 +104,7 @@ TEST_F(TupleAccessStrategyTests, Nulls) {
     }
 
     // Flip non-null columns to null should result in returning of nullptr.
-    for (uint16_t col = 1; col < layout.num_cols_; col++) {
+    for (uint16_t col = 1; col < layout.NumCols(); col++) {
       if (!nulls[col]) tested.SetNull(slot, col);
       EXPECT_TRUE(tested.AccessWithNullCheck(slot, col) == nullptr);
     }
@@ -126,7 +126,7 @@ TEST_F(TupleAccessStrategyTests, SimpleInsert) {
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));
 
     uint32_t num_inserts =
-        std::uniform_int_distribution<uint32_t>(1, layout.num_slots_)(generator);
+        std::uniform_int_distribution<uint32_t>(1, layout.NumSlots())(generator);
 
     std::unordered_map<storage::TupleSlot, storage::ProjectedRow *> tuples;
     for (uint32_t j = 0; j < num_inserts; j++) {
@@ -163,7 +163,7 @@ TEST_F(TupleAccessStrategyTests, MemorySafety) {
     // Skip header
     void *lower_bound = tested.ColumnNullBitmap(raw_block_, 0);
     void *upper_bound = raw_block_ + sizeof(storage::RawBlock);
-    for (uint16_t col = 0; col < layout.num_cols_; col++) {
+    for (uint16_t col = 0; col < layout.NumCols(); col++) {
       // This test should be robust against any future paddings, since
       // we are checking for non-overlapping ranges and not hard-coded
       // boundaries.
@@ -172,7 +172,7 @@ TEST_F(TupleAccessStrategyTests, MemorySafety) {
                                      upper_bound);
       lower_bound =
           StorageTestUtil::IncrementByBytes(tested.ColumnNullBitmap(raw_block_, col),
-                                            common::RawBitmap::SizeInBytes(layout.num_slots_));
+                                            common::RawBitmap::SizeInBytes(layout.NumSlots()));
 
       StorageTestUtil::CheckInBounds(tested.ColumnStart(raw_block_, col),
                                      lower_bound,
@@ -180,12 +180,12 @@ TEST_F(TupleAccessStrategyTests, MemorySafety) {
 
       lower_bound =
           StorageTestUtil::IncrementByBytes(tested.ColumnStart(raw_block_, col),
-                                            layout.num_slots_
-                                                * layout.attr_sizes_[col]);
+                                            layout.NumSlots()
+                                                * layout.AttrSize(col));
     }
     // check that the last column does not go out of the block
     uint32_t last_column_size =
-        layout.num_slots_ * layout.attr_sizes_[layout.num_cols_ - 1];
+        layout.NumSlots() * layout.AttrSize(static_cast<uint16_t>(layout.NumCols() - 1));
     StorageTestUtil::CheckInBounds(StorageTestUtil::IncrementByBytes(lower_bound,
                                                                      last_column_size),
                                    lower_bound,
@@ -208,8 +208,8 @@ TEST_F(TupleAccessStrategyTests, Alignment) {
     // test layout, not the content.
     tested.InitializeRawBlock(raw_block_, layout_version_t(0));
 
-    for (uint16_t col = 0; col < layout.num_cols_; col++) {
-      StorageTestUtil::CheckAlignment(tested.ColumnStart(raw_block_, col), layout.attr_sizes_[col]);
+    for (uint16_t col = 0; col < layout.NumCols(); col++) {
+      StorageTestUtil::CheckAlignment(tested.ColumnStart(raw_block_, col), layout.AttrSize(col));
       StorageTestUtil::CheckAlignment(tested.ColumnNullBitmap(raw_block_, col), 8);
     }
   }
@@ -238,7 +238,7 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsert) {
 
     auto workload = [&](uint32_t id) {
       std::default_random_engine thread_generator(id);
-      for (uint32_t j = 0; j < layout.num_slots_ / num_threads; j++)
+      for (uint32_t j = 0; j < layout.NumSlots() / num_threads; j++)
         test_objs[id].TryInsertFakeTuple(layout,
                                          tested,
                                          raw_block_,
@@ -308,7 +308,7 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsertDelete) {
       RandomTestUtil::InvokeWorkloadWithDistribution({insert, remove},
                                                             {0.7, 0.3},
                                                             &generator,
-                                                            layout.num_slots_ / num_threads);
+                                                            layout.NumSlots() / num_threads);
     };
     thread_pool.RunThreadsUntilFinish(num_threads, workload);
     for (auto &thread_tuples : tuples)

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -32,9 +32,9 @@ class MVCCDataTableTestObject {
 
   template<class Random>
   storage::ProjectedRow *GenerateRandomTuple(Random *generator) {
-    auto *buffer = StorageTestUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
+    auto *buffer = common::AllocationUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
     loose_pointers_.push_back(buffer);
-    storage::ProjectedRow* redo = redo_initializer.InitializeProjectedRow(buffer);
+    storage::ProjectedRow* redo = redo_initializer.InitializeRow(buffer);
     StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
     return redo;
   }
@@ -43,16 +43,16 @@ class MVCCDataTableTestObject {
   storage::ProjectedRow *GenerateRandomUpdate(Random *generator) {
     std::vector<uint16_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
     storage::ProjectedRowInitializer update_initializer(layout_, update_col_ids);
-    auto *buffer = StorageTestUtil::AllocateAligned(update_initializer.ProjectedRowSize());
+    auto *buffer = common::AllocationUtil::AllocateAligned(update_initializer.ProjectedRowSize());
     loose_pointers_.push_back(buffer);
-    storage::ProjectedRow *update = update_initializer.InitializeProjectedRow(buffer);
+    storage::ProjectedRow *update = update_initializer.InitializeRow(buffer);
     StorageTestUtil::PopulateRandomRow(update, layout_, null_bias_, generator);
     return update;
   }
 
   storage::ProjectedRow *GenerateVersionFromUpdate(const storage::ProjectedRow &delta,
                                                    const storage::ProjectedRow &previous) {
-    auto *buffer = StorageTestUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
+    auto *buffer = common::AllocationUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
     loose_pointers_.push_back(buffer);
     // Copy previous version
     TERRIER_MEMCPY(buffer, &previous, redo_initializer.ProjectedRowSize());
@@ -65,7 +65,7 @@ class MVCCDataTableTestObject {
   storage::ProjectedRow *SelectIntoBuffer(transaction::TransactionContext *const txn,
                                           const storage::TupleSlot slot) {
     // generate a redo ProjectedRow for Select
-    storage::ProjectedRow *select_row = redo_initializer.InitializeProjectedRow(select_buffer_);
+    storage::ProjectedRow *select_row = redo_initializer.InitializeRow(select_buffer_);
     table_.Select(txn, slot, select_row);
     return select_row;
   }
@@ -78,7 +78,7 @@ class MVCCDataTableTestObject {
   std::vector<byte *> loose_pointers_;
   std::vector<transaction::TransactionContext *> loose_txns_;
   storage::ProjectedRowInitializer redo_initializer{layout_, StorageTestUtil::ProjectionListAllColumns(layout_)};
-  byte *select_buffer_ = StorageTestUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
+  byte *select_buffer_ = common::AllocationUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
 };
 
 class MVCCTests : public ::terrier::TerrierTest {

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -58,9 +58,7 @@ class MVCCDataTableTestObject {
     TERRIER_MEMCPY(buffer, &previous, redo_initializer.ProjectedRowSize());
     auto *version = reinterpret_cast<storage::ProjectedRow *>(buffer);
     std::unordered_map<uint16_t, uint16_t> col_to_projection_list_index;
-    for (uint16_t i = 0; i < version->NumColumns(); i++)
-      col_to_projection_list_index.emplace(version->ColumnIds()[i], i);
-    storage::StorageUtil::ApplyDelta(layout_, delta, version, col_to_projection_list_index);
+    storage::StorageUtil::ApplyDelta(layout_, delta, version);
     return version;
   }
 

--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -14,7 +14,7 @@ RandomWorkloadTransaction::RandomWorkloadTransaction(LargeTransactionTestObject 
     // need to over provision, accounting for all the padding that could go in
       buffer_(test_object->bookkeeping_ ? nullptr : StorageTestUtil::AllocateAligned(
           test_object->row_initializer_.ProjectedRowSize()
-              + static_cast<uint32_t>(sizeof(uint64_t) * test_object->layout_.num_cols_))) {}
+              + static_cast<uint32_t>(sizeof(uint64_t) * test_object->layout_.NumCols()))) {}
 
 RandomWorkloadTransaction::~RandomWorkloadTransaction() {
   if (!test_object_->gc_on_) delete txn_;

--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -11,10 +11,9 @@ RandomWorkloadTransaction::RandomWorkloadTransaction(LargeTransactionTestObject 
       aborted_(false),
       start_time_(txn_->StartTime()),
       commit_time_(UINT64_MAX),
-    // need to over provision, accounting for all the padding that could go in
-      buffer_(test_object->bookkeeping_ ? nullptr : StorageTestUtil::AllocateAligned(
-          test_object->row_initializer_.ProjectedRowSize()
-              + static_cast<uint32_t>(sizeof(uint64_t) * test_object->layout_.NumCols()))) {}
+      buffer_(test_object->bookkeeping_ ? nullptr
+                                        : StorageTestUtil::AllocateAligned(test_object->row_initializer_
+                                                                                      .ProjectedRowSize())) {}
 
 RandomWorkloadTransaction::~RandomWorkloadTransaction() {
   if (!test_object_->gc_on_) delete txn_;

--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -14,7 +14,7 @@ RandomWorkloadTransaction::RandomWorkloadTransaction(LargeTransactionTestObject 
     // need to over provision, accounting for all the padding that could go in
       buffer_(test_object->bookkeeping_ ? nullptr : StorageTestUtil::AllocateAligned(
           test_object->row_initializer_.ProjectedRowSize()
-              + sizeof(uint64_t) * test_object->layout_.num_cols_)) {}
+              + static_cast<uint32_t>(sizeof(uint64_t) * test_object->layout_.num_cols_))) {}
 
 RandomWorkloadTransaction::~RandomWorkloadTransaction() {
   if (!test_object_->gc_on_) delete txn_;


### PR DESCRIPTION
this branch vs. master on Single-threaded data table insert on larger tuple (5 cols * 8 bytes), 1 txn and 10M inserts.
```
2018-08-22 16:07:20
Run on (4 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32K (x2)
  L1 Instruction 32K (x2)
  L2 Unified 262K (x2)
  L3 Unified 4194K (x1)
---------------------------------------------------------------------------------
Benchmark                                          Time           CPU Iterations
---------------------------------------------------------------------------------
DataTableBenchmark/SimpleInsert/real_time       1810 ms       1790 ms          1   5.26979M items/s

2018-08-22 16:09:53
Run on (4 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32K (x2)
  L1 Instruction 32K (x2)
  L2 Unified 262K (x2)
  L3 Unified 4194K (x1)
---------------------------------------------------------------------------------
Benchmark                                          Time           CPU Iterations
---------------------------------------------------------------------------------
DataTableBenchmark/SimpleInsert/real_time       3439 ms       3392 ms          1   2.77277M items/s
```
Not adding additional benchmarks because we will take a pass through all of them tomorrow anyways
