### PR TITLE
Define TransactionQueue to be backed by std::list, add TRACE logging to GC

### DIFF
--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -3,6 +3,7 @@
 #include <queue>
 #include <utility>
 #include "transaction/transaction_context.h"
+#include "transaction/transaction_defs.h"
 #include "transaction/transaction_manager.h"
 
 namespace terrier::storage {
@@ -61,9 +62,9 @@ class GarbageCollector {
   // timestamp of the last time GC unlinked anything. We need this to know when unlinked versions are safe to deallocate
   timestamp_t last_unlinked_;
   // queue of txns that have been unlinked, and should possible be deleted on next GC run
-  std::queue<transaction::TransactionContext *> txns_to_deallocate_;
+  transaction::TransactionQueue txns_to_deallocate_;
   // queue of txns that need to be unlinked
-  std::queue<transaction::TransactionContext *> txns_to_unlink_;
+  transaction::TransactionQueue txns_to_unlink_;
 };
 
 }  // namespace terrier::storage

--- a/src/include/transaction/transaction_defs.h
+++ b/src/include/transaction/transaction_defs.h
@@ -4,5 +4,11 @@
 #include <queue>
 namespace terrier::transaction {
 class TransactionContext;
+// Explicitly define the underlying structure of std::queue as std::list since we believe the default (std::deque) may
+// be too memory inefficient and we don't need the fast random access that it provides. It's also impossible to call
+// std::deque's shrink_to_fit() from the std::queue wrapper, while std::list should reduce its memory footprint
+// automatically (it's a linked list). We can afford std::list's pointer-chasing because it's only processed in a
+// background thread (GC). This structure can be replace with something faster if it becomes a measurable performance
+// bottleneck.
 using TransactionQueue = std::queue<transaction::TransactionContext *, std::list<transaction::TransactionContext *>>;
 }  // namespace terrier::transaction

--- a/src/include/transaction/transaction_defs.h
+++ b/src/include/transaction/transaction_defs.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <list>
+#include <queue>
+namespace terrier::transaction {
+class TransactionContext;
+using TransactionQueue = std::queue<transaction::TransactionContext *, std::list<transaction::TransactionContext *>>;
+}  // namespace terrier::transaction

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <map>
-#include <queue>
 #include <utility>
 #include "common/rw_latch.h"
 #include "common/spin_latch.h"
@@ -9,6 +8,7 @@
 #include "storage/delta_record.h"
 #include "storage/record_buffer.h"
 #include "transaction/transaction_context.h"
+#include "transaction/transaction_defs.h"
 
 namespace terrier::transaction {
 /**
@@ -68,7 +68,7 @@ class TransactionManager {
    * Return a copy of the completed txns queue and empty the local version
    * @return copy of the completed txns for the GC to process
    */
-  std::queue<transaction::TransactionContext *> CompletedTransactionsForGC();
+  TransactionQueue CompletedTransactionsForGC();
 
  private:
   common::ObjectPool<storage::BufferSegment> *buffer_pool_;
@@ -84,7 +84,7 @@ class TransactionManager {
   std::map<timestamp_t, TransactionContext *> curr_running_txns_;
 
   bool gc_enabled_ = false;
-  std::queue<transaction::TransactionContext *> completed_txns_;
+  TransactionQueue completed_txns_;
 
   void Rollback(timestamp_t txn_id, const storage::UndoRecord &record);
 };

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -125,7 +125,7 @@ void GarbageCollector::UnlinkUndoRecord(transaction::TransactionContext *const t
       curr = next;
       next = curr->Next();
     }
-    // we're in position with next being the UndiRecord to be unlinked
+    // we're in position with next being the UndoRecord to be unlinked
     if (next != nullptr && next->Timestamp().load() == txn->TxnId().load()) {
       curr->Next().store(next->Next().load());
       break;

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -1,4 +1,3 @@
-#include <queue>
 #include <utility>
 #include "common/container/concurrent_queue.h"
 #include "common/macros.h"
@@ -6,6 +5,7 @@
 #include "storage/data_table.h"
 #include "storage/garbage_collector.h"
 #include "transaction/transaction_context.h"
+#include "transaction/transaction_defs.h"
 #include "transaction/transaction_manager.h"
 #include "transaction/transaction_util.h"
 
@@ -19,10 +19,12 @@ std::pair<uint32_t, uint32_t> GarbageCollector::PerformGarbageCollection() {
     // safe to deallocate the transactions in our queue.
     last_unlinked_ = txn_manager_->GetTimestamp();
   }
-  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): last_unlinked_: {}", static_cast<uint64_t>(last_unlinked_));
+  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): last_unlinked_: {}",
+                    static_cast<uint64_t>(last_unlinked_));
   STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_deallocated: {}", txns_deallocated);
   STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_unlinked: {}", txns_unlinked);
-  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_to_deallocate_.size(): {}", txns_to_deallocate_.size());
+  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_to_deallocate_.size(): {}",
+                    txns_to_deallocate_.size());
   STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_to_unlink_.size(): {}", txns_to_unlink_.size());
   return std::make_pair(txns_deallocated, txns_unlinked);
 }
@@ -51,7 +53,7 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
   transaction::TransactionContext *txn = nullptr;
 
   // Get the completed transactions from the TransactionManager
-  std::queue<transaction::TransactionContext *> from_txn_manager = txn_manager_->CompletedTransactionsForGC();
+  transaction::TransactionQueue from_txn_manager = txn_manager_->CompletedTransactionsForGC();
   STORAGE_LOG_TRACE("GarbageCollector::ProcessUnlinkQueue(): from_txn_manager.size(): {}", from_txn_manager.size());
   // Append to our local unlink queue
   while (!from_txn_manager.empty()) {
@@ -61,7 +63,7 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
   }
 
   uint32_t txns_unlinked = 0;
-  std::queue<transaction::TransactionContext *> requeue;
+  transaction::TransactionQueue requeue;
   // Process every transaction in the unlink queue
 
   while (!txns_to_unlink_.empty()) {

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -19,6 +19,11 @@ std::pair<uint32_t, uint32_t> GarbageCollector::PerformGarbageCollection() {
     // safe to deallocate the transactions in our queue.
     last_unlinked_ = txn_manager_->GetTimestamp();
   }
+  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): last_unlinked_: {}", static_cast<uint64_t>(last_unlinked_));
+  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_deallocated: {}", txns_deallocated);
+  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_unlinked: {}", txns_unlinked);
+  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_to_deallocate_.size(): {}", txns_to_deallocate_.size());
+  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_to_unlink_.size(): {}", txns_to_unlink_.size());
   return std::make_pair(txns_deallocated, txns_unlinked);
 }
 
@@ -47,6 +52,7 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
 
   // Get the completed transactions from the TransactionManager
   std::queue<transaction::TransactionContext *> from_txn_manager = txn_manager_->CompletedTransactionsForGC();
+  STORAGE_LOG_TRACE("GarbageCollector::ProcessUnlinkQueue(): from_txn_manager.size(): {}", from_txn_manager.size());
   // Append to our local unlink queue
   while (!from_txn_manager.empty()) {
     txn = from_txn_manager.front();
@@ -81,6 +87,7 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
   }
   // requeue any txns that we were still visible to running transactions
   if (!requeue.empty()) {
+    STORAGE_LOG_TRACE("GarbageCollector::ProcessUnlinkQueue(): requeue.size(): {}", requeue.size());
     txns_to_unlink_ = requeue;
   }
 

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -1,4 +1,3 @@
-#include <queue>
 #include <utility>
 #include "transaction/transaction_manager.h"
 
@@ -56,9 +55,9 @@ timestamp_t TransactionManager::OldestTransactionStartTime() const {
   return result;
 }
 
-std::queue<TransactionContext *> TransactionManager::CompletedTransactionsForGC() {
+TransactionQueue TransactionManager::CompletedTransactionsForGC() {
   table_latch_.Lock();
-  std::queue<transaction::TransactionContext *> hand_to_gc(std::move(completed_txns_));
+  TransactionQueue hand_to_gc(std::move(completed_txns_));
   TERRIER_ASSERT(completed_txns_.empty(), "TransactionManager's queue should now be empty.");
   table_latch_.Unlock();
   return hand_to_gc;


### PR DESCRIPTION
By default the std::queues were backed by std::dequeue which I believe to be inefficient for the GC's use case. Also added basic TRACE logging to GC to be able to watch its state.