### PR TITLE
Add small-scale GC tests and optimization for read-only txns

### DIFF
--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -31,7 +31,8 @@ class GarbageCollector {
    * Deallocates transactions that can no longer be referenced by running transactions, and unlinks UndoRecords that
    * are no longer visible to running transactions. This needs to be invoked twice to actually free memory, since the
    * first invocation will unlink a transaction's UndoRecords, while the second time around will allow the GC to free
-   * the transaction if safe to do so.
+   * the transaction if safe to do so. The only exception is read-only transactions, which can be deallocated in a
+   * single GC pass.
    * @return A pair of numbers: the first is the number of transactions deallocated (deleted) on this iteration, while
    * the second is the number of transactions unlinked on this iteration.
    */
@@ -40,13 +41,13 @@ class GarbageCollector {
  private:
   /**
    * Process the deallocate queue
-   * @return number of txns deallocated (not UndoRecords) for debugging/testing
+   * @return number of txns (not UndoRecords) processed for debugging/testing
    */
   uint32_t ProcessDeallocateQueue();
 
   /**
    * Process the unlink queue
-   * @return number of txns unlinked (not UndoRecords) for debugging/testing
+   * @return number of txns (not UndoRecords) processed for debugging/testing
    */
   uint32_t ProcessUnlinkQueue();
 

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -94,7 +94,7 @@ struct GarbageCollectorTests : public ::terrier::TerrierTest {
 };
 
 // NOLINTNEXTLINE
-TEST_F(GarbageCollectorTests, BasicTest) {
+TEST_F(GarbageCollectorTests, SingleInsert) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
     transaction::TransactionManager txn_manager{&buffer_pool_, true};
     GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
@@ -110,8 +110,542 @@ TEST_F(GarbageCollectorTests, BasicTest) {
 
     txn_manager.Commit(txn0);
 
-    EXPECT_EQ(1, gc.PerformGarbageCollection().second);
-    EXPECT_EQ(1, gc.PerformGarbageCollection().first);
+    // Unlink the Insert's UndoRecord, then deallocate it on the next run
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, ReadOnly) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+    txn_manager.Commit(txn0);
+
+    // Unlink the txn and deallocate immediately because it's read-only
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// Corresponds to (MVCCTests, CommitInsert1)
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, CommitInsert1) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+    storage::TupleSlot slot = tested.table_.Insert(txn0, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    // Nothing should be able to be GC'd yet because txn0 has not committed yet
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn1 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Commit(txn0);
+
+    // Nothing should be able to be GC'd yet because txn1 started before txn0's commit
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Commit(txn1);
+
+    // Unlink the two transactions and then deallocate the single non-read-only transaction
+    EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn2 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+    txn_manager.Commit(txn2);
+
+    // Unlink the read-only transaction, and it shouldn't make it to the second invocation because it's read-only
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// Corresponds to (MVCCTests, CommitInsert2)
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, CommitInsert2) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    auto *txn1 = txn_manager.BeginTransaction();
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+    storage::TupleSlot slot = tested.table_.Insert(txn1, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    // Nothing should be able to be GC'd yet because txn0 has not committed yet
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    txn_manager.Commit(txn1);
+
+    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    // Nothing should be able to be GC'd yet because txn0 started before txn1's commit
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    txn_manager.Commit(txn0);
+
+    // Unlink the two transactions and then deallocate the single non-read-only transaction
+    EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn2 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+    txn_manager.Commit(txn2);
+
+    // Unlink the read-only transaction
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // It shouldn't make it to the second invocation because it's read-only
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// Corresponds to (MVCCTests, AbortInsert1)
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, AbortInsert1) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+    storage::TupleSlot slot = tested.table_.Insert(txn0, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    // Nothing should be able to be GC'd yet because txn0 has not committed yet
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn1 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Abort(txn0);
+
+    // Aborted transactions can be removed from the unlink queue immediately
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // But it's not safe to deallocate it yet because txn #1 is still running and may hold a reference to it
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Commit(txn1);
+
+    // Deallocate the aborted txn, and process the read-only transaction
+    EXPECT_EQ(std::make_pair(1u, 1u), gc.PerformGarbageCollection());
+    // Read-only transaction shouldn't have made it to the deallocate queue
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn2 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+    txn_manager.Commit(txn2);
+
+    // Unlink the read-only transaction
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // It shouldn't make it to the second invocation because it's read-only
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// Corresponds to (MVCCTests, AbortInsert2)
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, AbortInsert2) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    auto *txn1 = txn_manager.BeginTransaction();
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+    storage::TupleSlot slot = tested.table_.Insert(txn1, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    // Nothing should be able to be GC'd yet because txn1 has not committed yet
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    txn_manager.Abort(txn1);
+
+    // Aborted transactions can be removed from the unlink queue immediately
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // But it's not safe to deallocate it yet because txn #0 is still running and may hold a reference to it
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Commit(txn0);
+
+    // Deallocate the aborted txn, and process the read-only transaction
+    EXPECT_EQ(std::make_pair(1u, 1u), gc.PerformGarbageCollection());
+    // Read-only transaction shouldn't have made it to the deallocate queue
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn2 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+    txn_manager.Commit(txn2);
+
+    // Unlink the read-only transaction
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // It shouldn't make it to the second invocation because it's read-only
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// Corresponds to (MVCCTests, CommitUpdate1)
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, CommitUpdate1) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+
+    // insert the tuple to be Updated later
+    auto *txn = txn_manager.BeginTransaction();
+    storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
+    txn_manager.Commit(txn);
+
+    // Unlink and reclaim the Insert
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+
+    storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    EXPECT_TRUE(tested.table_.Update(txn0, slot, *update));
+
+    auto *update_tuple = tested.GenerateVersionFromUpdate(*update, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
+
+    // Nothing should be able to be GC'd yet because txn0 has not committed yet
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn1 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Commit(txn0);
+
+    // Nothing should be able to be GC'd yet because txn1 started before txn0's commit
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Commit(txn1);
+
+    // Unlink the update and read-only txns, then deallocate the update txn
+    EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
+    // Read-only transaction shouldn't have made it to the deallocate queue
+    EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn2 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
+    txn_manager.Commit(txn2);
+
+    // Unlink the read-only transaction
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // It shouldn't make it to the second invocation because it's read-only
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// Corresponds to (MVCCTests, CommitUpdate2)
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, CommitUpdate2) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+
+    // insert the tuple to be Updated later
+    auto *txn = txn_manager.BeginTransaction();
+    storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
+    txn_manager.Commit(txn);
+
+    // Unlink and reclaim the Insert
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+
+    storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    auto *txn1 = txn_manager.BeginTransaction();
+
+    EXPECT_TRUE(tested.table_.Update(txn1, slot, *update));
+
+    // Nothing should be able to be GC'd yet because txn1 has not committed yet
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    auto *update_tuple = tested.GenerateVersionFromUpdate(*update, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
+
+    txn_manager.Commit(txn1);
+
+    // Nothing should be able to be GC'd yet because txn0 started before txn1's commit
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Commit(txn0);
+
+    // Unlink the update and read-only txns, then deallocate the update txn
+    EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
+    // Read-only transaction shouldn't have made it to the deallocate queue
+    EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn2 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
+    txn_manager.Commit(txn2);
+
+    // Unlink the read-only transaction
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // It shouldn't make it to the second invocation because it's read-only
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// Corresponds to (MVCCTests, AbortUpdate1)
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, AbortUpdate1) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+
+    // insert the tuple to be Updated later
+    auto *txn = txn_manager.BeginTransaction();
+    storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
+    txn_manager.Commit(txn);
+
+    // Unlink and reclaim the Insert
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+
+    storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    EXPECT_TRUE(tested.table_.Update(txn0, slot, *update));
+
+    auto *update_tuple = tested.GenerateVersionFromUpdate(*update, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
+
+    auto *txn1 = txn_manager.BeginTransaction();
+
+    // Nothing should be able to be GC'd yet because txn0 has not committed yet
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Abort(txn0);
+
+    // Aborted transactions can be removed from the unlink queue immediately
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // But it's not safe to deallocate it yet because txn #1 is still running and may hold a reference to it
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Commit(txn1);
+
+    // Deallocate the aborted txn, and process the read-only transaction
+    EXPECT_EQ(std::make_pair(1u, 1u), gc.PerformGarbageCollection());
+    // Read-only transaction shouldn't have made it to the deallocate queue
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn2 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+    txn_manager.Commit(txn2);
+
+    // Unlink the read-only transaction
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // It shouldn't make it to the second invocation because it's read-only
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// Corresponds to (MVCCTests, AbortUpdate2)
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, AbortUpdate2) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+
+    // insert the tuple to be Updated later
+    auto *txn = txn_manager.BeginTransaction();
+    storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
+    txn_manager.Commit(txn);
+
+    // Unlink and reclaim the Insert
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+
+    storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    auto *txn1 = txn_manager.BeginTransaction();
+
+    EXPECT_TRUE(tested.table_.Update(txn1, slot, *update));
+
+    auto *update_tuple = tested.GenerateVersionFromUpdate(*update, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
+
+    // Nothing should be able to be GC'd yet because txn1 has not committed yet
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    txn_manager.Abort(txn1);
+
+    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    // Aborted transactions can be removed from the unlink queue immediately
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // But it's not safe to deallocate it yet because txn #0 is still running and may hold a reference to it
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    txn_manager.Commit(txn0);
+
+    // Deallocate the aborted txn, and process the read-only transaction
+    EXPECT_EQ(std::make_pair(1u, 1u), gc.PerformGarbageCollection());
+    // Read-only transaction shouldn't have made it to the deallocate queue
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    auto *txn2 = txn_manager.BeginTransaction();
+
+    select_tuple = tested.SelectIntoBuffer(txn2, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+    txn_manager.Commit(txn2);
+
+    // Unlink the read-only transaction
+    EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+    // It shouldn't make it to the second invocation because it's read-only
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
+// Corresponds to (MVCCTests, InsertUpdate1)
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, InsertUpdate1) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    auto *txn1 = txn_manager.BeginTransaction();
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+    storage::TupleSlot slot = tested.table_.Insert(txn1, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn1, slot, tested.all_col_ids_);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    // Nothing should be able to be GC'd yet because txn1 has not committed yet
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    txn_manager.Commit(txn1);
+
+    // Nothing should be able to be GC'd yet because txn0 started before txn1's commit
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
+    EXPECT_FALSE(tested.table_.Update(txn0, slot, *update));
+
+    select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
+    EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
+
+    txn_manager.Abort(txn0);
+
+    // Process the insert and aborted txns. Both should make it to the unlink phase
+    EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(2u, 0u), gc.PerformGarbageCollection());
   }
 }
 

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -628,7 +628,7 @@ TEST_F(MVCCTests, InsertUpdate1) {
     select_tuple = tested.SelectIntoBuffer(txn0, slot, tested.all_col_ids_);
     EXPECT_FALSE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0);
+    txn_manager.Abort(txn0);
   }
 }
 


### PR DESCRIPTION
Adapted the MVCC tests to basic GC tests. Also added an optimization to GC that allows it to deallocate a read-only txn in a single pass.