### PR TITLE
Fix stupid leak in the test harness

### DIFF
--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -15,7 +15,7 @@ RandomWorkloadTransaction::RandomWorkloadTransaction(LargeTransactionTestObject 
 
 RandomWorkloadTransaction::~RandomWorkloadTransaction() {
   if (!test_object_->gc_on_) delete txn_;
-  if (test_object_->bookkeeping_) delete[] buffer_;
+  if (!test_object_->bookkeeping_) delete[] buffer_;
   for (auto &entry : updates_)
     delete[] reinterpret_cast<byte *>(entry.second);
   for (auto &entry : selects_)


### PR DESCRIPTION
I am retarded. I should not write code at 11 p.m. There is no fancy leaks in clang and lambdas. GC was not too slow. The bug was in the performance testing harness. 

 