### PR TITLE
tweak test numbers

### DIFF
--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -17,7 +17,7 @@ TEST(BitmapTests, ByteMultipleCorrectnessTest) {
   // Maximum bitmap size multiplier.
   const uint32_t max_size_multiplier = 100;
   // Number of times to randomly permute bitmap
-  const uint32_t num_iterations = 1000;
+  const uint32_t num_iterations = 100;
 
   for (uint32_t iter = 0; iter < num_bitmap_sizes; ++iter) {
     // Test a byte-multiple sized bitmap
@@ -54,7 +54,7 @@ TEST(BitmapTests, NonByteMultipleCorrectnessTest) {
   // Maximum bitmap size multiplier.
   const uint32_t max_size_multiplier = 100;
   // Number of times to randomly permute bitmap
-  const uint32_t num_iterations = 1000;
+  const uint32_t num_iterations = 100;
 
   for (uint32_t iter = 0; iter < num_bitmap_sizes; ++iter) {
     // Test a non-byte-multiple sized bitmap
@@ -92,7 +92,7 @@ TEST(BitmapTests, WordUnalignedCorrectnessTest) {
   // Maximum bitmap size multiplier.
   const uint32_t max_size_multiplier = 100;
   // Number of times to randomly permute bitmap
-  const uint32_t num_iterations = 1000;
+  const uint32_t num_iterations = 100;
 
   for (uint32_t iter = 0; iter < num_bitmap_sizes; ++iter) {
     // Test a byte-multiple sized bitmap

--- a/test/common/concurrent_bitmap_test.cpp
+++ b/test/common/concurrent_bitmap_test.cpp
@@ -17,7 +17,7 @@ namespace terrier {
 TEST(ConcurrentBitmapTests, SimpleCorrectnessTest) {
   std::default_random_engine generator;
   // Number of bitmap sizes to test.
-  const uint32_t num_bitmap_sizes = 1000;
+  const uint32_t num_bitmap_sizes = 50;
   // Maximum bitmap size.
   const uint32_t max_bitmap_size = 1000;
 
@@ -53,7 +53,7 @@ TEST(ConcurrentBitmapTests, SimpleCorrectnessTest) {
 TEST(ConcurrentBitmapTests, FirstUnsetPosTest) {
   std::default_random_engine generator;
   // Number of bitmap sizes to test.
-  const uint32_t num_bitmap_sizes = 1000;
+  const uint32_t num_bitmap_sizes = 50;
   // Maximum bitmap size.
   const uint32_t max_bitmap_size = 1000;
   uint32_t pos;
@@ -166,7 +166,7 @@ TEST(ConcurrentBitmapTests, FirstUnsetPosSizeTest) {
 TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
   TestThreadPool thread_pool;
   std::default_random_engine generator;
-  const uint32_t num_iters = 200;
+  const uint32_t num_iters = 100;
   const uint32_t max_elements = 10000;
   const uint32_t num_threads = 8;
 
@@ -211,8 +211,8 @@ TEST(ConcurrentBitmapTests, ConcurrentFirstUnsetPosTest) {
 TEST(ConcurrentBitmapTests, ConcurrentCorrectnessTest) {
   TestThreadPool thread_pool;
   std::default_random_engine generator;
-  const uint32_t num_iters = 200;
-  const uint32_t max_elements = 450000;
+  const uint32_t num_iters = 100;
+  const uint32_t max_elements = 100000;
   const uint32_t num_threads = 8;
 
   for (uint32_t iter = 0; iter < num_iters; ++iter) {

--- a/test/storage/data_table_concurrent_test.cpp
+++ b/test/storage/data_table_concurrent_test.cpp
@@ -83,7 +83,7 @@ struct DataTableConcurrentTests : public TerrierTest {
 // NOLINTNEXTLINE
 TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
   TestThreadPool thread_pool;
-  const uint32_t num_iterations = 10;
+  const uint32_t num_iterations = 50;
   const uint32_t num_inserts = 10000;
   const uint16_t max_columns = 20;
   const uint32_t num_threads = 8;
@@ -120,7 +120,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
 // NOLINTNEXTLINE
 TEST_F(DataTableConcurrentTests, ConcurrentUpdateOneWriterWins) {
   TestThreadPool thread_pool;
-  const uint32_t num_iterations = 1000;
+  const uint32_t num_iterations = 100;
   const uint16_t max_columns = 20;
   const uint32_t num_threads = 8;
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -137,7 +137,7 @@ struct DataTableTests : public TerrierTest {
 // random tuple. Repeats for num_iterations.
 // NOLINTNEXTLINE
 TEST_F(DataTableTests, SimpleInsertSelect) {
-  const uint32_t num_iterations = 10;
+  const uint32_t num_iterations = 50;
   const uint32_t num_inserts = 1000;
   const uint16_t max_columns = 100;
   for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
@@ -162,7 +162,7 @@ TEST_F(DataTableTests, SimpleInsertSelect) {
 // delta chain produces the correct tuple. Repeats for num_iterations.
 // NOLINTNEXTLINE
 TEST_F(DataTableTests, SimpleVersionChain) {
-  const uint32_t num_iterations = 100;
+  const uint32_t num_iterations = 50;
   const uint32_t num_updates = 10;
   const uint16_t max_columns = 100;
 
@@ -196,7 +196,7 @@ TEST_F(DataTableTests, SimpleVersionChain) {
 // correct tuple. Repeats for num_iterations.
 // NOLINTNEXTLINE
 TEST_F(DataTableTests, WriteWriteConflictUpdateFails) {
-  const uint32_t num_iterations = 1000;
+  const uint32_t num_iterations = 50;
   const uint16_t max_columns = 100;
 
   for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {

--- a/test/storage/delta_record_test.cpp
+++ b/test/storage/delta_record_test.cpp
@@ -34,7 +34,7 @@ struct DeltaRecordTests : public TerrierTest {
 // NOLINTNEXTLINE
 TEST_F(DeltaRecordTests, UndoChainAccess) {
   uint32_t num_iterations = 10;
-  uint32_t max_chain_size = 100;
+  uint32_t max_chain_size = 20;
   for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
     std::vector<storage::UndoRecord *> record_list;
     std::uniform_int_distribution<> size_dist(1, max_chain_size);
@@ -75,7 +75,7 @@ TEST_F(DeltaRecordTests, UndoChainAccess) {
 // ProjectedRows back. Repeat for num_iterations.
 // NOLINTNEXTLINE
 TEST_F(DeltaRecordTests, UndoGetProjectedRow) {
-  uint32_t num_iterations = 500;
+  uint32_t num_iterations = 50;
   for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
     // get a random table layout
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -44,7 +44,7 @@ class LargeGCTests : public TerrierTest {
 // to make sure they are the same.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, MixedReadWriteWithGC) {
-  const uint32_t num_iterations = 1;
+  const uint32_t num_iterations = 10;
   const uint16_t max_columns = 2;
   const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 10;

--- a/test/storage/projected_row_test.cpp
+++ b/test/storage/projected_row_test.cpp
@@ -64,7 +64,7 @@ TEST_F(ProjectedRowTests, Nulls) {
 // This tests checks that the copy function works as intended
 // NOLINTNEXTLINE
 TEST_F(ProjectedRowTests, CopyProjectedRowLayout) {
-  const uint32_t num_iterations = 500;
+  const uint32_t num_iterations = 50;
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     // get a random table layout
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
@@ -96,7 +96,7 @@ TEST_F(ProjectedRowTests, CopyProjectedRowLayout) {
 // go out of page boundary. (In other words, memory safe.)
 // NOLINTNEXTLINE
 TEST_F(ProjectedRowTests, MemorySafety) {
-  const uint32_t num_iterations = 500;
+  const uint32_t num_iterations = 50;
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     // get a random table layout
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
@@ -125,7 +125,7 @@ TEST_F(ProjectedRowTests, MemorySafety) {
 // This test checks that all the fields within projected row is aligned
 // NOLINTNEXTLINE
 TEST_F(ProjectedRowTests, Alignment) {
-  const uint32_t num_iterations = 500;
+  const uint32_t num_iterations = 50;
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     // get a random table layout
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);

--- a/test/storage/storage_util_test.cpp
+++ b/test/storage/storage_util_test.cpp
@@ -34,7 +34,7 @@ struct StorageUtilTests : public TerrierTest {
 // Write a value to a position, read from the same position and compare results. Repeats for num_iterations.
 // NOLINTNEXTLINE
 TEST_F(StorageUtilTests, ReadWriteBytes) {
-  uint32_t num_iterations = 500;
+  uint32_t num_iterations = 50;
   for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
     // generate a random val
     std::vector<uint8_t> valid_sizes{1, 2, 4, 8};
@@ -54,7 +54,7 @@ TEST_F(StorageUtilTests, ReadWriteBytes) {
 // row and compare results for each column. Repeats for num_iterations.
 // NOLINTNEXTLINE
 TEST_F(StorageUtilTests, CopyToProjectedRow) {
-  uint32_t num_iterations = 500;
+  uint32_t num_iterations = 50;
   for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
     // get a random table layout
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
@@ -93,7 +93,7 @@ TEST_F(StorageUtilTests, CopyToProjectedRow) {
 // compare results for each column. Repeats for num_iterations.
 // NOLINTNEXTLINE
 TEST_F(StorageUtilTests, CopyToTupleSlot) {
-  uint32_t num_iterations = 500;
+  uint32_t num_iterations = 50;
   for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
     storage::TupleAccessStrategy tested(layout);
@@ -130,7 +130,7 @@ TEST_F(StorageUtilTests, CopyToTupleSlot) {
 // Repeats for num_iterations.
 // NOLINTNEXTLINE
 TEST_F(StorageUtilTests, ApplyDelta) {
-  uint32_t num_iterations = 500;
+  uint32_t num_iterations = 50;
   for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
     // get a random table layout
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);

--- a/test/storage/tuple_access_strategy_test.cpp
+++ b/test/storage/tuple_access_strategy_test.cpp
@@ -73,7 +73,7 @@ struct TupleAccessStrategyTests : public TerrierTest {
 // NOLINTNEXTLINE
 TEST_F(TupleAccessStrategyTests, Nulls) {
   std::default_random_engine generator;
-  const uint32_t repeat = 100;
+  const uint32_t repeat = 10;
   for (uint32_t i = 0; i < repeat; i++) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator);
     storage::TupleAccessStrategy tested(layout);
@@ -113,7 +113,7 @@ TEST_F(TupleAccessStrategyTests, Nulls) {
 // Tests that we can allocate a tuple slot, write things into the slot and get them out.
 // NOLINTNEXTLINE
 TEST_F(TupleAccessStrategyTests, SimpleInsert) {
-  const uint32_t repeat = 100;
+  const uint32_t repeat = 50;
   const uint32_t max_cols = 100;
   std::default_random_engine generator;
   for (uint32_t i = 0; i < repeat; i++) {
@@ -142,7 +142,7 @@ TEST_F(TupleAccessStrategyTests, SimpleInsert) {
 // go out of page boundary. (In other words, memory safe.)
 // NOLINTNEXTLINE
 TEST_F(TupleAccessStrategyTests, MemorySafety) {
-  const uint32_t repeat = 500;
+  const uint32_t repeat = 100;
   std::default_random_engine generator;
   for (uint32_t i = 0; i < repeat; i++) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator);
@@ -179,7 +179,7 @@ TEST_F(TupleAccessStrategyTests, MemorySafety) {
 // These properties are necessary to ensure high performance by accessing aligned fields.
 // NOLINTNEXTLINE
 TEST_F(TupleAccessStrategyTests, Alignment) {
-  const uint32_t repeat = 500;
+  const uint32_t repeat = 100;
   std::default_random_engine generator;
   StorageTestUtil::CheckAlignment(raw_block_, common::Constants::BLOCK_SIZE);
   for (uint32_t i = 0; i < repeat; i++) {
@@ -201,7 +201,7 @@ TEST_F(TupleAccessStrategyTests, Alignment) {
 // NOLINTNEXTLINE
 TEST_F(TupleAccessStrategyTests, ConcurrentInsert) {
   TestThreadPool thread_pool;
-  const uint32_t repeat = 200;
+  const uint32_t repeat = 100;
   std::default_random_engine generator;
   for (uint32_t i = 0; i < repeat; i++) {
     // We want to test relatively common cases with large numbers of slots
@@ -241,7 +241,7 @@ TEST_F(TupleAccessStrategyTests, ConcurrentInsert) {
 // NOLINTNEXTLINE
 TEST_F(TupleAccessStrategyTests, ConcurrentInsertDelete) {
   TestThreadPool thread_pool;
-  const uint32_t repeat = 200;
+  const uint32_t repeat = 100;
   std::default_random_engine generator;
   for (uint32_t i = 0; i < repeat; i++) {
     // We want to test relatively common cases with large numbers of slots

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -16,7 +16,7 @@ class LargeTransactionTests : public TerrierTest {
 // to make sure they are the same.
 // NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, MixedReadWrite) {
-  const uint32_t num_iterations = 10;
+  const uint32_t num_iterations = 100;
   const uint16_t max_columns = 20;
   const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 20;


### PR DESCRIPTION
... so that test runtime makes more sense. Reduction is applied overboard for CI tests (we can run longer tests overnight), especially on easier things like bitmaps. Large tests run time is slightly increased.