### PR TITLE
Pad projected rows to 64-bit align bitmap.

### DIFF
--- a/src/storage/delta_record.cpp
+++ b/src/storage/delta_record.cpp
@@ -31,8 +31,8 @@ ProjectedRowInitializer::ProjectedRowInitializer(const terrier::storage::BlockLa
   size_ = sizeof(ProjectedRow);  // size and num_col size
   // space needed to store col_ids, must be padded up so that the following offsets are aligned
   size_ = StorageUtil::PadUpToSize(sizeof(uint32_t), size_ + static_cast<uint32_t>(col_ids_.size() * sizeof(uint16_t)));
-  // space needed to store value offsets, TODO(Tianyu): I don't think bitmaps need to be padded up to anything?
-  size_ += static_cast<uint32_t>(col_ids_.size() * sizeof(uint32_t));
+  // space needed to store value offsets, we pad up so that bitmaps start 64-bit aligned
+  size_ = StorageUtil::PadUpToSize(sizeof(uint64_t), size_ + static_cast<uint32_t>(col_ids_.size() * sizeof(uint32_t)));
   // space needed to store the bitmap, padded up to the size of the first value in this projected row
   size_ = StorageUtil::PadUpToSize(layout.AttrSize(col_ids_[0]),
                                    size_ + common::RawBitmap::SizeInBytes(static_cast<uint32_t>(col_ids_.size())));


### PR DESCRIPTION
Fix #133.

Profiling with valgrind's massif:
```
	n	time(i)		total(B)	useful-heap(B)	extra-heap(B)	stacks(B)
Before	87	5,582,222,816	4,005,848	2,275,960	1,729,888	0
After	87	5,582,223,305	4,005,848	2,275,960	1,729,888	0
```