### PR TITLE
num_iterations adjustment on mvcc and gc tests

### DIFF
--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -77,7 +77,7 @@ struct GarbageCollectorTests : public ::terrier::TerrierTest {
   storage::BlockStore block_store_{100};
   common::ObjectPool<storage::BufferSegment> buffer_pool_{10000};
   std::default_random_engine generator_;
-  const uint32_t num_iterations_ = 5;
+  const uint32_t num_iterations_ = 100;
   const uint16_t max_columns_ = 100;
 };
 

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -80,7 +80,7 @@ class MVCCTests : public ::terrier::TerrierTest {
   storage::BlockStore block_store_{100};
   common::ObjectPool<storage::BufferSegment> buffer_pool_{10000};
   std::default_random_engine generator_;
-  const uint32_t num_iterations_ = 1000;
+  const uint32_t num_iterations_ = 100;
   const uint16_t max_columns_ = 100;
 };
 


### PR DESCRIPTION
Make num_iterations for garbage_collector_test and mvcc_test consistent since they represent the same test sequences.