### PR TITLE
 Switch TransactionQueue from a std::queue to a std::forward_list. 

### DIFF
--- a/src/include/transaction/transaction_defs.h
+++ b/src/include/transaction/transaction_defs.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <list>
-#include <queue>
+#include <forward_list>
 namespace terrier::transaction {
 class TransactionContext;
 // Explicitly define the underlying structure of std::queue as std::list since we believe the default (std::deque) may
@@ -10,5 +9,5 @@ class TransactionContext;
 // automatically (it's a linked list). We can afford std::list's pointer-chasing because it's only processed in a
 // background thread (GC). This structure can be replace with something faster if it becomes a measurable performance
 // bottleneck.
-using TransactionQueue = std::queue<transaction::TransactionContext *, std::list<transaction::TransactionContext *>>;
+using TransactionQueue = std::forward_list<transaction::TransactionContext *>;
 }  // namespace terrier::transaction

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -55,7 +55,6 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
     // Append to our local unlink queue
     txns_to_unlink_.splice_after(txns_to_unlink_.cbefore_begin(), std::move(completed_txns));
   }
-  TERRIER_ASSERT(completed_txns.empty(), "Queue from TransactionManager should now be empty.");
 
   uint32_t txns_processed = 0;
   transaction::TransactionQueue requeue;

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -73,7 +73,7 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
       txns_to_deallocate_.push_front(txn);
       txns_processed++;
     } else if (transaction::TransactionUtil::NewerThan(oldest_txn, txn->TxnId().load())) {
-      // this is a committed txn that is no visible to any running txns. Proceed with unlinking its UndoRecords
+      // this is a committed txn that is not visible to any running txns. Proceed with unlinking its UndoRecords
       UndoBuffer &undos = txn->GetUndoBuffer();
       for (auto &undo_record : undos) {
         UnlinkUndoRecord(txn, undo_record);

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -28,9 +28,9 @@ timestamp_t TransactionManager::Commit(TransactionContext *const txn) {
   table_latch_.Lock();
   const timestamp_t start_time = txn->StartTime();
   size_t result UNUSED_ATTRIBUTE = curr_running_txns_.erase(start_time);
-  TERRIER_ASSERT(result == 1, "committed transaction did not exist in global transactions table");
+  TERRIER_ASSERT(result == 1, "Committed transaction did not exist in global transactions table");
   txn->TxnId().store(commit_time);
-  if (gc_enabled_) completed_txns_.push(txn);
+  if (gc_enabled_) completed_txns_.push_front(txn);
   table_latch_.Unlock();
   return commit_time;
 }
@@ -43,8 +43,8 @@ void TransactionManager::Abort(TransactionContext *const txn) {
   table_latch_.Lock();
   const timestamp_t start_time = txn->StartTime();
   size_t ret UNUSED_ATTRIBUTE = curr_running_txns_.erase(start_time);
-  TERRIER_ASSERT(ret == 1, "aborted transaction did not exist in global transactions table");
-  if (gc_enabled_) completed_txns_.push(txn);
+  TERRIER_ASSERT(ret == 1, "Aborted transaction did not exist in global transactions table");
+  if (gc_enabled_) completed_txns_.push_front(txn);
   table_latch_.Unlock();
 }
 

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -1,4 +1,3 @@
-#include <chrono>
 #include <vector>
 #include "gtest/gtest.h"
 #include "storage/garbage_collector.h"
@@ -45,37 +44,27 @@ class LargeGCTests : public TerrierTest {
 // to make sure they are the same.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, MixedReadWriteWithGC) {
-  const uint32_t num_iterations = 5;
+  const uint32_t num_iterations = 10;
   const uint16_t max_columns = 2;
-  const uint32_t initial_table_size = 1000000;
+  const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 10;
-  const uint32_t num_txns = 1000000;
-  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const uint32_t num_txns = 1000;
+  const uint32_t batch_size = 100;
+  const std::vector<double> update_select_ratio = {0.3, 0.7};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
-  double unlink_time = 0.0;
-  double deallocation_time = 0.0;
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
-                                      &buffer_pool_, &generator_, true, false);
-    tested.SimulateOltp(num_txns, num_concurrent_txns);
-
-    gc_ = new storage::GarbageCollector(tested.GetTxnManager());
-    auto start = std::chrono::high_resolution_clock::now();
-    auto gc_result = gc_->PerformGarbageCollection();
-    auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    std::cout << gc_result.second << " txns unlinked in " << elapsed_seconds.count() << " seconds" << std::endl;
-    unlink_time += elapsed_seconds.count();
-
-    start = std::chrono::high_resolution_clock::now();
-    gc_result = gc_->PerformGarbageCollection();
-    end = std::chrono::high_resolution_clock::now();
-    elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
-    std::cout << gc_result.first << " txns deallocated in " << elapsed_seconds.count() << " seconds" << std::endl;
-    deallocation_time += elapsed_seconds.count();
+                                      &buffer_pool_, &generator_, true, true);
+    StartGC(tested.GetTxnManager(), 10);
+    for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
+      auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
+      paused_ = true;
+      tested.CheckReadsCorrect(&result.first);
+      for (auto w : result.first) delete w;
+      for (auto w : result.second) delete w;
+      paused_ = false;
+    }
+    EndGC();
   }
-
-  std::cout << "mean unlink time: " << unlink_time / num_iterations << " seconds" << std::endl;
-  std::cout << "mean deallocation time: " << deallocation_time / num_iterations << " seconds" << std::endl;
 }
 }  // namespace terrier


### PR DESCRIPTION
### Summary
This is a performance change and should reduce the time needed to move elements between TransactionQueues. I modified the large_garbage_collector__test to behave as a benchmark (not kept in this PR, but we should probably add a scenario like this as a dedicated benchmark in the future) by creating a large table, running a bunch of update transactions, and then seeing how long the GC takes to clean up all the garbage.
### Test
```
#include <chrono>
#include <vector>
#include "gtest/gtest.h"
#include "storage/garbage_collector.h"
#include "util/transaction_test_util.h"

namespace terrier {
class LargeGCTests : public TerrierTest {
 public:

  storage::BlockStore block_store_{1000};
  common::ObjectPool<storage::BufferSegment> buffer_pool_{1000};
  std::default_random_engine generator_;
  storage::GarbageCollector *gc_ = nullptr;
};

// NOLINTNEXTLINE
TEST_F(LargeGCTests, MixedReadWriteWithGC) {
  const uint32_t num_iterations = 5;
  const uint16_t max_columns = 2;
  const uint32_t initial_table_size = 1000000;
  const uint32_t txn_length = 10;
  const uint32_t num_txns = 1000000;
  const std::vector<double> update_select_ratio = {0.4, 0.6};
  const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
  double unlink_time = 0.0;
  double deallocation_time = 0.0;
  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                      &buffer_pool_, &generator_, true, false);
    // run txns
    tested.SimulateOltp(num_txns, num_concurrent_txns);

    gc_ = new storage::GarbageCollector(tested.GetTxnManager());

    // first round of GC unlinks everything (and deallocates any read-only txns)
    auto start = std::chrono::high_resolution_clock::now();
    auto gc_result = gc_->PerformGarbageCollection();
    auto end = std::chrono::high_resolution_clock::now();
    auto elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
    std::cout << gc_result.second << " txns unlinked in " << elapsed_seconds.count() << " seconds" << std::endl;
    unlink_time += elapsed_seconds.count();

    // second round of GC deallocates the previously unlinked txns
    start = std::chrono::high_resolution_clock::now();
    gc_result = gc_->PerformGarbageCollection();
    end = std::chrono::high_resolution_clock::now();
    elapsed_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
    std::cout << gc_result.first << " txns deallocated in " << elapsed_seconds.count() << " seconds" << std::endl;
    deallocation_time += elapsed_seconds.count();
  }

  std::cout << "mean unlink time: " << unlink_time / num_iterations << " seconds" << std::endl;
  std::cout << "mean deallocation time: " << deallocation_time / num_iterations << " seconds" << std::endl;
}
}  // namespace terrier
```
### Results
**Master:**
```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from LargeGCTests
[ RUN      ] LargeGCTests.MixedReadWriteWithGC
1000001 txns unlinked in 3.14369 seconds
993881 txns deallocated in 0.481728 seconds
1000001 txns unlinked in 3.03849 seconds
993881 txns deallocated in 0.44668 seconds
1000001 txns unlinked in 3.05728 seconds
993881 txns deallocated in 0.450835 seconds
1000001 txns unlinked in 3.12717 seconds
993881 txns deallocated in 0.454488 seconds
1000001 txns unlinked in 3.00857 seconds
993881 txns deallocated in 0.44538 seconds
mean unlink time: 3.07504 seconds
mean deallocation time: 0.455822 seconds
[       OK ] LargeGCTests.MixedReadWriteWithGC (27636 ms)
[----------] 1 test from LargeGCTests (27636 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (27636 ms total)
[  PASSED  ] 1 test.
```
**PR:**
```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from LargeGCTests
[ RUN      ] LargeGCTests.MixedReadWriteWithGC
1000001 txns unlinked in 0.749671 seconds
993881 txns deallocated in 0.472261 seconds
1000001 txns unlinked in 0.751856 seconds
993881 txns deallocated in 0.462672 seconds
1000001 txns unlinked in 0.738099 seconds
993881 txns deallocated in 0.462966 seconds
1000001 txns unlinked in 0.709454 seconds
993881 txns deallocated in 0.445883 seconds
1000001 txns unlinked in 0.707433 seconds
993881 txns deallocated in 0.445711 seconds
mean unlink time: 0.731303 seconds
mean deallocation time: 0.457899 seconds
[       OK ] LargeGCTests.MixedReadWriteWithGC (15588 ms)
[----------] 1 test from LargeGCTests (15588 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (15588 ms total)
[  PASSED  ] 1 test.
```
### Results summary
Master unlink time: 3.075 seconds
PR unlink time: 0.731 seconds