### PR TITLE
ScopedTimer

### DIFF
--- a/src/include/common/scoped_timer.h
+++ b/src/include/common/scoped_timer.h
@@ -13,11 +13,13 @@ namespace terrier::common {
 /**
  * The ScopedTimer provided an easy way to collect the elapsed time for a block of code. It stores the current time when
  * it is instantiated, and then when it is destructed it updates the elapsed milliseconds time in the value pointed to
- * by the constructor argument.
+ * by the constructor argument. This is meant for debugging the performance impact of components that don't have
+ * dedicate benchmarks, and possibly for use with performance counters in the future. Its output shouldn't be used as
+ * pass/fail criteria in any Google Benchmarks (use the framework for that) or Google Tests (performance is variable
+ * from machine to machine).
  */
 class ScopedTimer {
  public:
-  ScopedTimer() = delete;
   /**
    * Constucts a ScopedTimer. This marks the beginning of the timer's elapsed time.
    * @param elapsed_ms pointer to write the elapsed time (milliseconds) on destruction

--- a/src/include/common/scoped_timer.h
+++ b/src/include/common/scoped_timer.h
@@ -5,12 +5,30 @@
 
 namespace terrier::common {
 
+// TODO(Matt): we could templatize this for different resolutions (milliseconds, nanoseconds, etc.) but then the caller
+// needs to include the <chrono> library to pass in the correct template arguments, which this is trying to be a wrapper
+// for. However, I'm not opposed to the idea of templatizing it for this purpose if we decide milliseconds is not always
+// suitable.
+
+/**
+ * The ScopedTimer provided an easy way to collect the elapsed time for a block of code. It stores the current time when
+ * it is instantiated, and then when it is destructed it updates the elapsed milliseconds time in the value pointed to
+ * by the constructor argument.
+ */
 class ScopedTimer {
  public:
   ScopedTimer() = delete;
+  /**
+   * Constucts a ScopedTimer. This marks the beginning of the timer's elapsed time.
+   * @param elapsed_ms pointer to write the elapsed time (milliseconds) on destruction
+   */
   explicit ScopedTimer(uint64_t *const elapsed_ms)
       : start_(std::chrono::high_resolution_clock::now()), elapsed_ms_(elapsed_ms) {}
 
+  /**
+   * This marks the end of the timer's elapsed time. The ScopedTimer will update the original constructor argument's
+   * value on destruction.
+   */
   ~ScopedTimer() {
     auto end = std::chrono::high_resolution_clock::now();
     *elapsed_ms_ = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(end - start_).count());

--- a/src/include/common/scoped_timer.h
+++ b/src/include/common/scoped_timer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <chrono>  // NOLINT
+#include "common/macros.h"
+
+namespace terrier::common {
+
+class ScopedTimer {
+ public:
+  ScopedTimer() = delete;
+  explicit ScopedTimer(uint64_t *const elapsed_ms)
+      : start_(std::chrono::high_resolution_clock::now()), elapsed_ms_(elapsed_ms) {}
+
+  ~ScopedTimer() {
+    auto end = std::chrono::high_resolution_clock::now();
+    *elapsed_ms_ = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(end - start_).count());
+  }
+  DISALLOW_COPY_AND_MOVE(ScopedTimer)
+ private:
+  const std::chrono::high_resolution_clock::time_point start_;
+  uint64_t *const elapsed_ms_;
+};
+}  // namespace terrier::common


### PR DESCRIPTION
This is more of a debugging tool at the moment, but eventually we might want to use this performance profiling of various components at runtime in the complete system. I decided to throw this together while trying to time each stage of the garbage collection process. We should prefer to use Google Benchmarks when actually characterizing performance, and also avoid using this as some sort of Google Test pass/fail metric. I just think it's useful for debugging and comparing performance changes for aspects of the system that don't have full benchmarks. I'm happy to not merge it in if others don't think it'll prove useful though.
```
#include <iostream>
#include <thread>  // NOLINT
#include "common/scoped_timer.h"

int main() {
  uint64_t elapsed_ms = 0;
  {
    terrier::common::ScopedTimer timer(&elapsed_ms);
    // do some stuff
    std::this_thread::sleep_for(std::chrono::seconds(5));
  }

  std::cout << "that took " << elapsed_ms << " milliseconds" << std::endl;
}
```
The output is:
`that took 5000 milliseconds`