### PR TITLE
#141 - New scenarios for large_transaction_test (& w/ GC)

### DIFF
--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -6,10 +6,10 @@
 namespace terrier {
 class LargeGCTests : public TerrierTest {
  public:
-  void StartGC(transaction::TransactionManager *txn_manager, uint32_t gc_period_milli) {
+  void StartGC(transaction::TransactionManager *const txn_manager) {
     gc_ = new storage::GarbageCollector(txn_manager);
     run_gc_ = true;
-    gc_thread_ = std::thread([gc_period_milli, this] { GCThreadLoop(gc_period_milli); });
+    gc_thread_ = std::thread([this] { GCThreadLoop(); });
   }
 
   void EndGC() {
@@ -21,48 +21,72 @@ class LargeGCTests : public TerrierTest {
     delete gc_;
   }
 
-  const uint32_t num_iterations = 100;
+  const uint32_t num_iterations = 10;
   const uint16_t max_columns = 20;
   const uint32_t initial_table_size = 1000;
-  const uint32_t num_txns = 1000;
-  const uint32_t batch_size = 100;
+  const uint32_t num_txns = 10000;
+  const uint32_t batch_size = 1000;
   storage::BlockStore block_store_{1000, 1000};
-  common::ObjectPool<storage::BufferSegment> buffer_pool_{1000, 1000};
+  common::ObjectPool<storage::BufferSegment> buffer_pool_{10000, 10000};
   std::default_random_engine generator_;
   volatile bool run_gc_ = false;
-  volatile bool paused_ = false;
+  volatile bool gc_paused_ = false;
   std::thread gc_thread_;
   storage::GarbageCollector *gc_ = nullptr;
 
  private:
-  void GCThreadLoop(uint32_t gc_period_milli) {
+  const std::chrono::milliseconds gc_period_{10};
+
+  void GCThreadLoop() {
     while (run_gc_) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(gc_period_milli));
-      if (!paused_) gc_->PerformGarbageCollection();
+      std::this_thread::sleep_for(gc_period_);
+      if (!gc_paused_) gc_->PerformGarbageCollection();
     }
   }
 };
 
-// This test case generates random update-selects in concurrent transactions on a pre-populated database.
+// These test cases generates random update-selects in concurrent transactions on a pre-populated database.
 // Each transaction logs their operations locally. At the end of the run, we can reconstruct the snapshot of
 // a database using the updates at every timestamp, and compares the reads with the reconstructed snapshot versions
 // to make sure they are the same.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, MixedReadWriteWithGC) {
   const uint32_t txn_length = 10;
-  const std::vector<double> update_select_ratio = {0.3, 0.7};
+  const std::vector<double> update_select_ratio = {0.4, 0.6};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, true, true);
-    StartGC(tested.GetTxnManager(), 10);
+    StartGC(tested.GetTxnManager());
     for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
-      paused_ = true;
+      gc_paused_ = true;
       tested.CheckReadsCorrect(&result.first);
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
-      paused_ = false;
+      gc_paused_ = false;
+    }
+    EndGC();
+  }
+}
+
+// Double the thread count to force more thread swapping and try to capture unexpected races
+// NOLINTNEXTLINE
+TEST_F(LargeGCTests, MixedReadWriteHighThreadWithGC) {
+  const uint32_t txn_length = 10;
+  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
+  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, true, true);
+    StartGC(tested.GetTxnManager());
+    for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
+      auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
+      gc_paused_ = true;
+      tested.CheckReadsCorrect(&result.first);
+      for (auto w : result.first) delete w;
+      for (auto w : result.second) delete w;
+      gc_paused_ = false;
     }
     EndGC();
   }
@@ -77,14 +101,14 @@ TEST_F(LargeGCTests, LowAbortHighThroughputWithGC) {
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, true, true);
-    StartGC(tested.GetTxnManager(), 10);
+    StartGC(tested.GetTxnManager());
     for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
-      paused_ = true;
+      gc_paused_ = true;
       tested.CheckReadsCorrect(&result.first);
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
-      paused_ = false;
+      gc_paused_ = false;
     }
     EndGC();
   }
@@ -99,14 +123,14 @@ TEST_F(LargeGCTests, LowAbortHighThroughputHighThreadWithGC) {
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, true, true);
-    StartGC(tested.GetTxnManager(), 10);
+    StartGC(tested.GetTxnManager());
     for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
-      paused_ = true;
+      gc_paused_ = true;
       tested.CheckReadsCorrect(&result.first);
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
-      paused_ = false;
+      gc_paused_ = false;
     }
     EndGC();
   }
@@ -122,14 +146,14 @@ TEST_F(LargeGCTests, HighAbortRateWithGC) {
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, true, true);
-    StartGC(tested.GetTxnManager(), 10);
+    StartGC(tested.GetTxnManager());
     for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
-      paused_ = true;
+      gc_paused_ = true;
       tested.CheckReadsCorrect(&result.first);
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
-      paused_ = false;
+      gc_paused_ = false;
     }
     EndGC();
   }
@@ -144,14 +168,14 @@ TEST_F(LargeGCTests, HighAbortRateHighThreadWithGC) {
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, true, true);
-    StartGC(tested.GetTxnManager(), 10);
+    StartGC(tested.GetTxnManager());
     for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
-      paused_ = true;
+      gc_paused_ = true;
       tested.CheckReadsCorrect(&result.first);
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
-      paused_ = false;
+      gc_paused_ = false;
     }
     EndGC();
   }
@@ -166,14 +190,14 @@ TEST_F(LargeGCTests, TPCCWithGC) {
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, true, true);
-    StartGC(tested.GetTxnManager(), 10);
+    StartGC(tested.GetTxnManager());
     for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
-      paused_ = true;
+      gc_paused_ = true;
       tested.CheckReadsCorrect(&result.first);
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
-      paused_ = false;
+      gc_paused_ = false;
     }
     EndGC();
   }
@@ -188,14 +212,14 @@ TEST_F(LargeGCTests, TPCCHighThreadWithGC) {
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, true, true);
-    StartGC(tested.GetTxnManager(), 10);
+    StartGC(tested.GetTxnManager());
     for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
-      paused_ = true;
+      gc_paused_ = true;
       tested.CheckReadsCorrect(&result.first);
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
-      paused_ = false;
+      gc_paused_ = false;
     }
     EndGC();
   }

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -21,7 +21,7 @@ class LargeGCTests : public TerrierTest {
     delete gc_;
   }
 
-  const uint32_t num_iterations = 10;
+  const uint32_t num_iterations = 100;
   const uint16_t max_columns = 20;
   const uint32_t initial_table_size = 1000;
   const uint32_t num_txns = 1000;
@@ -52,7 +52,7 @@ class LargeGCTests : public TerrierTest {
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, MixedReadWriteWithGC) {
   const uint32_t txn_length = 10;
-  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const std::vector<double> update_select_ratio = {0.5, 0.5};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
@@ -74,7 +74,7 @@ TEST_F(LargeGCTests, MixedReadWriteWithGC) {
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, MixedReadWriteHighThreadWithGC) {
   const uint32_t txn_length = 10;
-  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const std::vector<double> update_select_ratio = {0.5, 0.5};
   const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
@@ -141,7 +141,7 @@ TEST_F(LargeGCTests, LowAbortHighThroughputHighThreadWithGC) {
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, HighAbortRateWithGC) {
   const uint32_t txn_length = 40;
-  const std::vector<double> update_select_ratio = {0.7, 0.3};
+  const std::vector<double> update_select_ratio = {0.8, 0.2};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
@@ -163,7 +163,7 @@ TEST_F(LargeGCTests, HighAbortRateWithGC) {
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, HighAbortRateHighThreadWithGC) {
   const uint32_t txn_length = 40;
-  const std::vector<double> update_select_ratio = {0.7, 0.3};
+  const std::vector<double> update_select_ratio = {0.8, 0.2};
   const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -21,6 +21,11 @@ class LargeGCTests : public TerrierTest {
     delete gc_;
   }
 
+  const uint32_t num_iterations = 100;
+  const uint16_t max_columns = 20;
+  const uint32_t initial_table_size = 1000;
+  const uint32_t num_txns = 100;
+  const uint32_t batch_size = 100;
   storage::BlockStore block_store_{1000, 1000};
   common::ObjectPool<storage::BufferSegment> buffer_pool_{1000, 1000};
   std::default_random_engine generator_;
@@ -44,12 +49,7 @@ class LargeGCTests : public TerrierTest {
 // to make sure they are the same.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, MixedReadWriteWithGC) {
-  const uint32_t num_iterations = 10;
-  const uint16_t max_columns = 2;
-  const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 10;
-  const uint32_t num_txns = 1000;
-  const uint32_t batch_size = 100;
   const std::vector<double> update_select_ratio = {0.3, 0.7};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
@@ -72,12 +72,7 @@ TEST_F(LargeGCTests, MixedReadWriteWithGC) {
 // and longer transactions leading to more aborts.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, HighAbortRateWithGC) {
-  const uint32_t num_iterations = 10;
-  const uint16_t max_columns = 2;
-  const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 40;
-  const uint32_t num_txns = 1000;
-  const uint32_t batch_size = 200;
   const std::vector<double> update_select_ratio = {0.7, 0.3};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
@@ -99,12 +94,7 @@ TEST_F(LargeGCTests, HighAbortRateWithGC) {
 // This test duplicates the previous one with a higher number of thread swapouts.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, HighAbortRateHighThreadWithGC) {
-  const uint32_t num_iterations = 10;
-  const uint16_t max_columns = 2;
-  const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 40;
-  const uint32_t num_txns = 1000;
-  const uint32_t batch_size = 200;
   const std::vector<double> update_select_ratio = {0.7, 0.3};
   const uint32_t num_concurrent_txns = 2*TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
@@ -126,12 +116,7 @@ TEST_F(LargeGCTests, HighAbortRateHighThreadWithGC) {
 // This test attempts simulate a TPC-C-like scenario.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, TPCCWithGC) {
-  const uint32_t num_iterations = 10;
-  const uint16_t max_columns = 2;
-  const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 5;
-  const uint32_t num_txns = 1000;
-  const uint32_t batch_size = 100;
   const std::vector<double> update_select_ratio = {0.4, 0.6};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
@@ -153,12 +138,7 @@ TEST_F(LargeGCTests, TPCCWithGC) {
 // This test duplicates the previous one with a higher number of thread swapouts.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, TPCCHighThreadWithGC) {
-  const uint32_t num_iterations = 10;
-  const uint16_t max_columns = 2;
-  const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 5;
-  const uint32_t num_txns = 1000;
-  const uint32_t batch_size = 100;
   const std::vector<double> update_select_ratio = {0.4, 0.6};
   const uint32_t num_concurrent_txns = 2*TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -24,8 +24,8 @@ class LargeGCTests : public TerrierTest {
   const uint32_t num_iterations = 10;
   const uint16_t max_columns = 20;
   const uint32_t initial_table_size = 1000;
-  const uint32_t num_txns = 10000;
-  const uint32_t batch_size = 1000;
+  const uint32_t num_txns = 1000;
+  const uint32_t batch_size = 100;
   storage::BlockStore block_store_{1000, 1000};
   common::ObjectPool<storage::BufferSegment> buffer_pool_{10000, 10000};
   std::default_random_engine generator_;

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -70,6 +70,7 @@ TEST_F(LargeGCTests, MixedReadWriteWithGC) {
 
 // This test is similar to the previous one, but with a higher ration of updates
 // and longer transactions leading to more aborts.
+// NOLINTNEXTLINE
 TEST_F(LargeGCTests, HighAbortRateWithGC) {
   const uint32_t num_iterations = 10;
   const uint16_t max_columns = 2;
@@ -87,6 +88,89 @@ TEST_F(LargeGCTests, HighAbortRateWithGC) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
       paused_ = true;
       tested.CheckReadsCorrect(&result.first);
+      for (auto w : result.first) delete w;
+      for (auto w : result.second) delete w;
+      paused_ = false;
+    }
+    EndGC();
+  }
+}
+
+// This test duplicates the previous one with a higher number of thread swapouts.
+// NOLINTNEXTLINE
+TEST_F(LargeGCTests, HighAbortRateHighThreadWithGC) {
+  const uint32_t num_iterations = 10;
+  const uint16_t max_columns = 2;
+  const uint32_t initial_table_size = 1000;
+  const uint32_t txn_length = 40;
+  const uint32_t num_txns = 1000;
+  const uint32_t batch_size = 200;
+  const std::vector<double> update_select_ratio = {0.7, 0.3};
+  const uint32_t num_concurrent_txns = 2*TestThreadPool::HardwareConcurrency();
+  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, true, true);
+    StartGC(tested.GetTxnManager(), 10);
+    for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
+      auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
+      paused_ = true;
+      tested.CheckReadsCorrect(&result.first);
+      for (auto w : result.first) delete w;
+      for (auto w : result.second) delete w;
+      paused_ = false;
+    }
+    EndGC();
+  }
+}
+
+// This test attempts simulate a TPC-C-like scenario.
+// NOLINTNEXTLINE
+TEST_F(LargeGCTests, TPCCWithGC) {
+  const uint32_t num_iterations = 10;
+  const uint16_t max_columns = 2;
+  const uint32_t initial_table_size = 1000;
+  const uint32_t txn_length = 5;
+  const uint32_t num_txns = 1000;
+  const uint32_t batch_size = 100;
+  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
+  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, true, true);
+    StartGC(tested.GetTxnManager(), 10);
+    for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
+      auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
+      paused_ = true;
+      tested.CheckReadsCorrect(&result.first);
+      using namespace std;
+      for (auto w : result.first) delete w;
+      for (auto w : result.second) delete w;
+      paused_ = false;
+    }
+    EndGC();
+  }
+}
+
+// This test duplicates the previous one with a higher number of thread swapouts.
+// NOLINTNEXTLINE
+TEST_F(LargeGCTests, TPCCHighThreadWithGC) {
+  const uint32_t num_iterations = 10;
+  const uint16_t max_columns = 2;
+  const uint32_t initial_table_size = 1000;
+  const uint32_t txn_length = 5;
+  const uint32_t num_txns = 1000;
+  const uint32_t batch_size = 100;
+  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const uint32_t num_concurrent_txns = 2*TestThreadPool::HardwareConcurrency();
+  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, true, true);
+    StartGC(tested.GetTxnManager(), 10);
+    for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
+      auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
+      paused_ = true;
+      tested.CheckReadsCorrect(&result.first);
+      using namespace std;
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
       paused_ = false;

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -21,7 +21,7 @@ class LargeGCTests : public TerrierTest {
     delete gc_;
   }
 
-  const uint32_t num_iterations = 100;
+  const uint32_t num_iterations = 10;
   const uint16_t max_columns = 20;
   const uint32_t initial_table_size = 1000;
   const uint32_t num_txns = 1000;

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -68,7 +68,7 @@ TEST_F(LargeGCTests, MixedReadWriteWithGC) {
   }
 }
 
-// This test is similar to the previous one, but with a higher ration of updates
+// This test is similar to the previous one, but with a higher ratio of updates
 // and longer transactions leading to more aborts.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, HighAbortRateWithGC) {
@@ -96,7 +96,7 @@ TEST_F(LargeGCTests, HighAbortRateWithGC) {
 TEST_F(LargeGCTests, HighAbortRateHighThreadWithGC) {
   const uint32_t txn_length = 40;
   const std::vector<double> update_select_ratio = {0.7, 0.3};
-  const uint32_t num_concurrent_txns = 2*TestThreadPool::HardwareConcurrency();
+  const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, true, true);
@@ -113,7 +113,7 @@ TEST_F(LargeGCTests, HighAbortRateHighThreadWithGC) {
   }
 }
 
-// This test attempts simulate a TPC-C-like scenario.
+// This test attempts to simulate a TPC-C-like scenario.
 // NOLINTNEXTLINE
 TEST_F(LargeGCTests, TPCCWithGC) {
   const uint32_t txn_length = 5;
@@ -140,7 +140,7 @@ TEST_F(LargeGCTests, TPCCWithGC) {
 TEST_F(LargeGCTests, TPCCHighThreadWithGC) {
   const uint32_t txn_length = 5;
   const std::vector<double> update_select_ratio = {0.4, 0.6};
-  const uint32_t num_concurrent_txns = 2*TestThreadPool::HardwareConcurrency();
+  const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, true, true);

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -142,7 +142,6 @@ TEST_F(LargeGCTests, TPCCWithGC) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
       paused_ = true;
       tested.CheckReadsCorrect(&result.first);
-      using namespace std;
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
       paused_ = false;
@@ -170,7 +169,6 @@ TEST_F(LargeGCTests, TPCCHighThreadWithGC) {
       auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
       paused_ = true;
       tested.CheckReadsCorrect(&result.first);
-      using namespace std;
       for (auto w : result.first) delete w;
       for (auto w : result.second) delete w;
       paused_ = false;

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -67,4 +67,31 @@ TEST_F(LargeGCTests, MixedReadWriteWithGC) {
     EndGC();
   }
 }
+
+// This test is similar to the previous one, but with a higher ration of updates
+// and longer transactions leading to more aborts.
+TEST_F(LargeGCTests, HighAbortRateWithGC) {
+  const uint32_t num_iterations = 10;
+  const uint16_t max_columns = 2;
+  const uint32_t initial_table_size = 1000;
+  const uint32_t txn_length = 40;
+  const uint32_t num_txns = 1000;
+  const uint32_t batch_size = 200;
+  const std::vector<double> update_select_ratio = {0.7, 0.3};
+  const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
+  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, true, true);
+    StartGC(tested.GetTxnManager(), 10);
+    for (uint32_t batch = 0; batch * batch_size < num_txns; batch++) {
+      auto result = tested.SimulateOltp(batch_size, num_concurrent_txns);
+      paused_ = true;
+      tested.CheckReadsCorrect(&result.first);
+      for (auto w : result.first) delete w;
+      for (auto w : result.second) delete w;
+      paused_ = false;
+    }
+    EndGC();
+  }
+}
 }  // namespace terrier

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -55,7 +55,7 @@ TEST_F(LargeTransactionTests, HighAbortRate) {
 TEST_F(LargeTransactionTests, HighAbortRateHighThread) {
   const uint32_t txn_length = 40;
   const std::vector<double> update_select_ratio = {0.7, 0.3};
-  const uint32_t num_concurrent_txns = 2*TestThreadPool::HardwareConcurrency();
+  const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, false, true);

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -8,7 +8,7 @@ class LargeTransactionTests : public TerrierTest {
   const uint32_t num_iterations = 10;
   const uint16_t max_columns = 20;
   const uint32_t initial_table_size = 1000;
-  const uint32_t num_txns = 10000;
+  const uint32_t num_txns = 1000;
   storage::BlockStore block_store_{1000, 1000};
   common::ObjectPool<storage::BufferSegment> buffer_pool_{10000, 10000};
   std::default_random_engine generator_;

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -21,7 +21,7 @@ class LargeTransactionTests : public TerrierTest {
 // NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, MixedReadWrite) {
   const uint32_t txn_length = 10;
-  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const std::vector<double> update_select_ratio = {0.5, 0.5};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
@@ -37,7 +37,7 @@ TEST_F(LargeTransactionTests, MixedReadWrite) {
 // NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, MixedReadWriteHighThread) {
   const uint32_t txn_length = 10;
-  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const std::vector<double> update_select_ratio = {0.5, 0.5};
   const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
@@ -86,7 +86,7 @@ TEST_F(LargeTransactionTests, LowAbortHighThroughputHighThread) {
 // NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, HighAbortRate) {
   const uint32_t txn_length = 40;
-  const std::vector<double> update_select_ratio = {0.7, 0.3};
+  const std::vector<double> update_select_ratio = {0.8, 0.2};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
@@ -102,7 +102,7 @@ TEST_F(LargeTransactionTests, HighAbortRate) {
 // NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, HighAbortRateHighThread) {
   const uint32_t txn_length = 40;
-  const std::vector<double> update_select_ratio = {0.7, 0.3};
+  const std::vector<double> update_select_ratio = {0.8, 0.2};
   const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -5,24 +5,40 @@
 namespace terrier {
 class LargeTransactionTests : public TerrierTest {
  public:
-  const uint32_t num_iterations = 100;
+  const uint32_t num_iterations = 10;
   const uint16_t max_columns = 20;
   const uint32_t initial_table_size = 1000;
-  const uint32_t num_txns = 100;
+  const uint32_t num_txns = 10000;
   storage::BlockStore block_store_{1000, 1000};
-  common::ObjectPool<storage::BufferSegment> buffer_pool_{1000, 1000};
+  common::ObjectPool<storage::BufferSegment> buffer_pool_{10000, 10000};
   std::default_random_engine generator_;
 };
 
-// This test case generates random update-selects in concurrent transactions on a pre-populated database.
+// These test cases generates random update-selects in concurrent transactions on a pre-populated database.
 // Each transaction logs their operations locally. At the end of the run, we can reconstruct the snapshot of
 // a database using the updates at every timestamp, and compares the reads with the reconstructed snapshot versions
 // to make sure they are the same.
 // NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, MixedReadWrite) {
-  const uint32_t txn_length = 20;
+  const uint32_t txn_length = 10;
   const std::vector<double> update_select_ratio = {0.4, 0.6};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
+  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, false, true);
+    auto result = tested.SimulateOltp(num_txns, num_concurrent_txns);
+    tested.CheckReadsCorrect(&result.first);
+    for (auto w : result.first) delete w;
+    for (auto w : result.second) delete w;
+  }
+}
+
+// Double the thread count to force more thread swapping and try to capture unexpected races
+// NOLINTNEXTLINE
+TEST_F(LargeTransactionTests, MixedReadWriteHighThread) {
+  const uint32_t txn_length = 10;
+  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, false, true);
@@ -65,22 +81,6 @@ TEST_F(LargeTransactionTests, LowAbortHighThroughputHighThread) {
   }
 }
 
-// This test aims to behave like a TPC-C benchmark
-// NOLINTNEXTLINE
-TEST_F(LargeTransactionTests, TPCC) {
-  const uint32_t txn_length = 5;
-  const std::vector<double> update_select_ratio = {0.4, 0.6};
-  const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
-  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
-    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
-                                      &buffer_pool_, &generator_, false, true);
-    auto result = tested.SimulateOltp(num_txns, num_concurrent_txns);
-    tested.CheckReadsCorrect(&result.first);
-    for (auto w : result.first) delete w;
-    for (auto w : result.second) delete w;
-  }
-}
-
 // This test is similar to the previous one, but with a higher ratio of updates
 // and longer transactions leading to more aborts.
 // NOLINTNEXTLINE
@@ -104,6 +104,22 @@ TEST_F(LargeTransactionTests, HighAbortRateHighThread) {
   const uint32_t txn_length = 40;
   const std::vector<double> update_select_ratio = {0.7, 0.3};
   const uint32_t num_concurrent_txns = 2 * TestThreadPool::HardwareConcurrency();
+  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, false, true);
+    auto result = tested.SimulateOltp(num_txns, num_concurrent_txns);
+    tested.CheckReadsCorrect(&result.first);
+    for (auto w : result.first) delete w;
+    for (auto w : result.second) delete w;
+  }
+}
+
+// This test aims to behave like a TPC-C benchmark
+// NOLINTNEXTLINE
+TEST_F(LargeTransactionTests, TPCC) {
+  const uint32_t txn_length = 5;
+  const std::vector<double> update_select_ratio = {0.4, 0.6};
+  const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, false, true);

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -5,6 +5,10 @@
 namespace terrier {
 class LargeTransactionTests : public TerrierTest {
  public:
+  const uint32_t num_iterations = 100;
+  const uint16_t max_columns = 20;
+  const uint32_t initial_table_size = 1000;
+  const uint32_t num_txns = 100;
   storage::BlockStore block_store_{1000, 1000};
   common::ObjectPool<storage::BufferSegment> buffer_pool_{1000, 1000};
   std::default_random_engine generator_;
@@ -16,11 +20,7 @@ class LargeTransactionTests : public TerrierTest {
 // to make sure they are the same.
 // NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, MixedReadWrite) {
-  const uint32_t num_iterations = 100;
-  const uint16_t max_columns = 20;
-  const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 20;
-  const uint32_t num_txns = 100;
   const std::vector<double> update_select_ratio = {0.4, 0.6};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
@@ -33,15 +33,11 @@ TEST_F(LargeTransactionTests, MixedReadWrite) {
   }
 }
 
-// This test is similar to the previous one, but with a higher ration of updates
+// This test is similar to the previous one, but with a higher ratio of updates
 // and longer transactions leading to more aborts.
 // NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, HighAbortRate) {
-  const uint32_t num_iterations = 100;
-  const uint16_t max_columns = 20;
-  const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 40;
-  const uint32_t num_txns = 200;
   const std::vector<double> update_select_ratio = {0.7, 0.3};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
@@ -57,11 +53,7 @@ TEST_F(LargeTransactionTests, HighAbortRate) {
 // This test duplicates the previous one with a higher number of thread swapouts.
 // NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, HighAbortRateHighThread) {
-  const uint32_t num_iterations = 100;
-  const uint16_t max_columns = 20;
-  const uint32_t initial_table_size = 1000;
   const uint32_t txn_length = 40;
-  const uint32_t num_txns = 200;
   const std::vector<double> update_select_ratio = {0.7, 0.3};
   const uint32_t num_concurrent_txns = 2*TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -32,4 +32,24 @@ TEST_F(LargeTransactionTests, MixedReadWrite) {
     for (auto w : result.second) delete w;
   }
 }
+
+// This test is similar to the previous one, but with a higher ration of updates
+// and longer transactions leading to more aborts.
+TEST_F(LargeTransactionTests, HighAbortRate) {
+  const uint32_t num_iterations = 100;
+  const uint16_t max_columns = 20;
+  const uint32_t initial_table_size = 1000;
+  const uint32_t txn_length = 40;
+  const uint32_t num_txns = 200;
+  const std::vector<double> update_select_ratio = {0.7, 0.3};
+  const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
+  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, false, true);
+    auto result = tested.SimulateOltp(num_txns, num_concurrent_txns);
+    tested.CheckReadsCorrect(&result.first);
+    for (auto w : result.first) delete w;
+    for (auto w : result.second) delete w;
+  }
+}
 }  // namespace terrier

--- a/test/transaction/large_transaction_test.cpp
+++ b/test/transaction/large_transaction_test.cpp
@@ -35,6 +35,7 @@ TEST_F(LargeTransactionTests, MixedReadWrite) {
 
 // This test is similar to the previous one, but with a higher ration of updates
 // and longer transactions leading to more aborts.
+// NOLINTNEXTLINE
 TEST_F(LargeTransactionTests, HighAbortRate) {
   const uint32_t num_iterations = 100;
   const uint16_t max_columns = 20;
@@ -43,6 +44,26 @@ TEST_F(LargeTransactionTests, HighAbortRate) {
   const uint32_t num_txns = 200;
   const std::vector<double> update_select_ratio = {0.7, 0.3};
   const uint32_t num_concurrent_txns = TestThreadPool::HardwareConcurrency();
+  for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
+    LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
+                                      &buffer_pool_, &generator_, false, true);
+    auto result = tested.SimulateOltp(num_txns, num_concurrent_txns);
+    tested.CheckReadsCorrect(&result.first);
+    for (auto w : result.first) delete w;
+    for (auto w : result.second) delete w;
+  }
+}
+
+// This test duplicates the previous one with a higher number of thread swapouts.
+// NOLINTNEXTLINE
+TEST_F(LargeTransactionTests, HighAbortRateHighThread) {
+  const uint32_t num_iterations = 100;
+  const uint16_t max_columns = 20;
+  const uint32_t initial_table_size = 1000;
+  const uint32_t txn_length = 40;
+  const uint32_t num_txns = 200;
+  const std::vector<double> update_select_ratio = {0.7, 0.3};
+  const uint32_t num_concurrent_txns = 2*TestThreadPool::HardwareConcurrency();
   for (uint32_t iteration = 0; iteration < num_iterations; iteration++) {
     LargeTransactionTestObject tested(max_columns, initial_table_size, txn_length, update_select_ratio, &block_store_,
                                       &buffer_pool_, &generator_, false, true);


### PR DESCRIPTION
I noticed a failure while running the tests. Here is the corresponding log:

> Running main() from gtest_main.cc
[==========] Running 5 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 5 tests from LargeGCTests
[ RUN      ] LargeGCTests.MixedReadWriteWithGC
[       OK ] LargeGCTests.MixedReadWriteWithGC (12383 ms)
[ RUN      ] LargeGCTests.HighAbortRateWithGC
/home/amlatyr/Code/terrier/test/util/transaction_test_util.cpp:246: Failure
Value of: StorageTestUtil::ProjectionListEqual(layout_, entry.second, it->second)
  Actual: false
Expected: true
[  FAILED  ] LargeGCTests.HighAbortRateWithGC (7657 ms)
[ RUN      ] LargeGCTests.HighAbortRateHighThreadWithGC
[       OK ] LargeGCTests.HighAbortRateHighThreadWithGC (7041 ms)
[ RUN      ] LargeGCTests.TPCCWithGC
[       OK ] LargeGCTests.TPCCWithGC (16982 ms)
[ RUN      ] LargeGCTests.TPCCHighThreadWithGC
[       OK ] LargeGCTests.TPCCHighThreadWithGC (18133 ms)
[----------] 5 tests from LargeGCTests (62196 ms total)
[----------] Global test environment tear-down
[==========] 5 tests from 1 test case ran. (62196 ms total)
[  PASSED  ] 4 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] LargeGCTests.HighAbortRateWithGC
 1 FAILED TEST

I am unable to reproduce it.