### PR TITLE
Update LLVM_DIR path for LLVM@6 after LLVM 7's release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         - NAME="Mac [dbg/clang]" CMAKE_BUILD_TYPE=debug TERRIER_USE_ASAN=On
       install:
         - echo 'y' | ./script/installation/packages.sh
-        - export PATH=/usr/local/opt/llvm/bin:$PATH
+        - export LLVM_DIR=/usr/local/Cellar/llvm@6/6.0.1
     - os: linux
       dist: trusty
       env:
@@ -36,7 +36,7 @@ matrix:
         - NAME="Mac [rel/clang]" CMAKE_BUILD_TYPE=release TERRIER_USE_ASAN=Off
       install:
         - echo 'y' | ./script/installation/packages.sh
-        - export PATH=/usr/local/opt/llvm/bin:$PATH
+        - export LLVM_DIR=/usr/local/Cellar/llvm@6/6.0.1
     - os: linux
       dist: trusty
       env:


### PR DESCRIPTION
This (hopefully) fixes the current build issues on Travis with macOS since LLVM 7's release yesterday.