### PR TITLE
Fix for GC contending with TM's Rollback()

### DIFF
--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -52,8 +52,11 @@ class GarbageCollector {
   uint32_t ProcessUnlinkQueue();
 
   /**
-   * Given a UndoRecord that has been deemed safe to unlink by the GC, removes it from the version chain. This requires
-   * a while loop to handle contention from running transactions (basically restart the process if needed).
+   * Given a UndoRecord that has been deemed safe to unlink by the GC, attempts to remove it from the version chain.
+   * It's possible that this process will fail because the GC is conservative with conflicts. If the UndoRecord in the
+   * version chain to be updated in order to unlink the target UndoRecord is not yet committed, we will fail and
+   * expect this txn to be requeued and we'll try again on the next GC invocation, hopefully after the conflicting txn
+   * is either committed or aborted.
    * @param txn pointer to the transaction that created this UndoRecord
    * @param undo_record UndoRecord to be unlinked
    * @return true if the UndoRecord was either unlinked successfully or already unlinked, false otherwise

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -56,8 +56,9 @@ class GarbageCollector {
    * a while loop to handle contention from running transactions (basically restart the process if needed).
    * @param txn pointer to the transaction that created this UndoRecord
    * @param undo_record UndoRecord to be unlinked
+   * @return true if the UndoRecord was either unlinked successfully or already unlinked, false otherwise
    */
-  void UnlinkUndoRecord(transaction::TransactionContext *txn, const UndoRecord &undo_record) const;
+  bool UnlinkUndoRecord(transaction::TransactionContext *txn, UndoRecord *undo_record) const;
 
   transaction::TransactionManager *const txn_manager_;
   // timestamp of the last time GC unlinked anything. We need this to know when unlinked versions are safe to deallocate

--- a/src/include/storage/undo_record.h
+++ b/src/include/storage/undo_record.h
@@ -36,6 +36,13 @@ class UndoRecord {
 
   /**
    * @return the DataTable this UndoRecord points to
+   * @warning this can be nullptr if it was never installed in a version chain, or unlinked by GC
+   */
+  DataTable *&Table() { return table_; }
+
+  /**
+   * @return the DataTable this UndoRecord points to
+   * @warning this can be nullptr if it was never installed in a version chain, or unlinked by GC
    */
   DataTable *Table() const { return table_; }
 

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -13,7 +13,9 @@ namespace terrier::storage {
 
 std::pair<uint32_t, uint32_t> GarbageCollector::PerformGarbageCollection() {
   uint32_t txns_deallocated = ProcessDeallocateQueue();
+  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_deallocated: {}", txns_deallocated);
   uint32_t txns_unlinked = ProcessUnlinkQueue();
+  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_unlinked: {}", txns_unlinked);
   if (txns_unlinked > 0) {
     // Only update this field if we actually unlinked anything, otherwise we're being too conservative about when it's
     // safe to deallocate the transactions in our queue.
@@ -21,8 +23,6 @@ std::pair<uint32_t, uint32_t> GarbageCollector::PerformGarbageCollection() {
   }
   STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): last_unlinked_: {}",
                     static_cast<uint64_t>(last_unlinked_));
-  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_deallocated: {}", txns_deallocated);
-  STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_unlinked: {}", txns_unlinked);
   return std::make_pair(txns_deallocated, txns_unlinked);
 }
 
@@ -74,11 +74,18 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
       txns_processed++;
     } else if (transaction::TransactionUtil::NewerThan(oldest_txn, txn->TxnId().load())) {
       // this is a committed txn that is not visible to any running txns. Proceed with unlinking its UndoRecords
+
+      bool all_unlinked = true;
       for (auto &undo_record : txn->undo_buffer_) {
-        UnlinkUndoRecord(txn, undo_record);
+        all_unlinked = all_unlinked && UnlinkUndoRecord(txn, &undo_record);
       }
-      txns_to_deallocate_.push_front(txn);
-      txns_processed++;
+      if (all_unlinked) {
+        txns_to_deallocate_.push_front(txn);
+        txns_processed++;
+      } else {
+        // we didn't unlink all of the UndoRecords, requeue for next GC run
+        requeue.push_front(txn);
+      }
     } else {
       // this is a committed txn that is still visible, requeue for next GC run
       requeue.push_front(txn);
@@ -93,42 +100,54 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
   return txns_processed;
 }
 
-void GarbageCollector::UnlinkUndoRecord(transaction::TransactionContext *const txn,
-                                        const UndoRecord &undo_record) const {
-  TERRIER_ASSERT(txn->TxnId().load() == undo_record.Timestamp().load(),
+bool GarbageCollector::UnlinkUndoRecord(transaction::TransactionContext *const txn,
+                                        UndoRecord *const undo_record) const {
+  TERRIER_ASSERT(txn->TxnId().load() == undo_record->Timestamp().load(),
                  "This undo_record does not belong to this txn.");
-  DataTable *const table = undo_record.Table();
-  const TupleSlot slot = undo_record.Slot();
+  DataTable *table = undo_record->Table();
+  if (table == nullptr) {
+    // This UndoRecord has already been unlinked
+    return true;
+  }
+  const TupleSlot slot = undo_record->Slot();
   const TupleAccessStrategy &accessor = table->accessor_;
 
   UndoRecord *version_ptr;
-  do {
+  version_ptr = table->AtomicallyReadVersionPtr(slot, accessor);
+  TERRIER_ASSERT(version_ptr != nullptr, "GC should not be trying to unlink in an empty version chain.");
+
+  if (version_ptr->Timestamp().load() == txn->TxnId().load()) {
+    // Our UndoRecord is the first in the chain, handle contention on the write lock with CAS
+    if (table->CompareAndSwapVersionPtr(slot, accessor, version_ptr, version_ptr->Next())) {
+      undo_record->Table() = nullptr;
+      return true;
+    }
+    // Someone swooped the VersionPointer while we were trying to swap it (aka took the write lock)
     version_ptr = table->AtomicallyReadVersionPtr(slot, accessor);
-    TERRIER_ASSERT(version_ptr != nullptr, "GC should not be trying to unlink in an empty version chain.");
+  }
+  // a version chain is guaranteed to not change when not at the head (assuming single-threaded GC), so we are safe
+  // to traverse and update pointers without CAS
+  UndoRecord *curr = version_ptr;
+  UndoRecord *next;
 
-    if (version_ptr->Timestamp().load() == txn->TxnId().load()) {
-      // Our UndoRecord is the first in the chain, handle contention on the write lock with CAS
-      if (table->CompareAndSwapVersionPtr(slot, accessor, version_ptr, version_ptr->Next())) break;
-      // Someone swooped the VersionPointer while we were trying to swap it (aka took the write lock)
-      version_ptr = table->AtomicallyReadVersionPtr(slot, accessor);
-    }
-    // a version chain is guaranteed to not change when not at the head (assuming single-threaded GC), so we are safe
-    // to traverse and update pointers without CAS
-    UndoRecord *curr = version_ptr;
-    UndoRecord *next = curr->Next();
+  // traverse until we find the UndoRecord that we want to unlink
+  while (true) {
+    next = curr->Next();
+    TERRIER_ASSERT(next != nullptr, "record to unlink is not found");
+    if (next->Timestamp().load() == txn->TxnId().load()) break;
+    curr = next;
+  }
 
-    // traverse until we hit the UndoRecord that we want to unlink
-    while (next != nullptr && next->Timestamp().load() != txn->TxnId().load()) {
-      curr = next;
-      next = curr->Next();
-    }
-    // we're in position with next being the UndoRecord to be unlinked
-    if (next != nullptr && next->Timestamp().load() == txn->TxnId().load()) {
-      curr->Next().store(next->Next().load());
-      break;
-    }
-    // If that process didn't work (interleaved abort) then try again
-  } while (true);
+  // we're in position with next being the UndoRecord to be unlinked
+  if (transaction::TransactionUtil::Committed(curr->Timestamp().load())) {
+    // update the next pointer to unlink the UndoRecord
+    curr->Next().store(next->Next().load());
+    // mark the UndoRecord as unlinked by setting its table pointer to nullptr
+    undo_record->Table() = nullptr;
+    return true;
+  }
+
+  return false;
 }
 
 }  // namespace terrier::storage

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -125,8 +125,9 @@ TEST_F(GarbageCollectorTests, ReadOnly) {
   }
 }
 
-// Insert a tuples and commit. Next transaction tries to update 1 tuple, verify that GC doesn't unlink or free the
-// Insert txn's context until safe to do so NOLINTNEXTLINE
+// Insert a tuple and commit. Next transaction tries to update that tuple (takes write lock), verify that GC doesn't
+// unlink or free the Insert txn's context until safe to do so
+// NOLINTNEXTLINE
 TEST_F(GarbageCollectorTests, WriteWriteConflictRequeue) {
   for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
     transaction::TransactionManager txn_manager{&buffer_pool_, true, LOGGING_DISABLED};

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -125,6 +125,45 @@ TEST_F(GarbageCollectorTests, ReadOnly) {
   }
 }
 
+// Insert a tuples and commit. Next transaction tries to update 1 tuple, verify that GC doesn't unlink or free the
+// Insert txn's context until safe to do so NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, WriteWriteConflictRequeue) {
+  for (uint32_t iteration = 0; iteration < num_iterations_; ++iteration) {
+    transaction::TransactionManager txn_manager{&buffer_pool_, true, LOGGING_DISABLED};
+    GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+    storage::GarbageCollector gc(&txn_manager);
+
+    auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+
+    // insert the tuple to be Updated later
+    auto *txn = txn_manager.BeginTransaction();
+    storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
+    txn_manager.Commit(txn, [] {});
+
+    storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
+
+    auto *txn0 = txn_manager.BeginTransaction();
+
+    EXPECT_TRUE(tested.table_.Update(txn0, slot, *update));
+
+    auto *update_tuple = tested.GenerateVersionFromUpdate(*update, *insert_tuple);
+
+    storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn0, slot);
+    EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
+
+    // Verify that Insert txn doesn't get fully unlinked or reclaimed until txn0 finishes
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+    EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
+
+    txn_manager.Abort(txn0);
+
+    // Aborted transactions can be removed from the unlink queue immediately
+    EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
+    // Safe to deallocate both transactions
+    EXPECT_EQ(std::make_pair(2u, 0u), gc.PerformGarbageCollection());
+  }
+}
+
 // Corresponds to (MVCCTests, CommitInsert1)
 // NOLINTNEXTLINE
 TEST_F(GarbageCollectorTests, CommitInsert1) {


### PR DESCRIPTION
The new GC tests (#167) demonstrated an issue with the GarbageCollector contending with a txn trying to perform an abort on the same slot. This extends our first writer wins semantics to the GC. Basically if the GC needs to update an uncommitted UndoRecord's next pointer in order to unlink the garbage UndoRecord, it will defer and requeue that txn's context for the next GC invocation.

We avoid processing UndoRecords multiple times by applying a new invariant: if an UndoRecord's table pointer in null, that means it is not installed in a version chain. We apply this to write-write conflicts at the DataTable and TransactionManager level, as well as the GarbageCollector.

I added a simple test case for this, but the real proof is once the new GC tests go in after this. I have verified locally that merging this branch into (#167) that all of the new tests pass with this fix.