### PR TITLE
Benchmark parameters matching those in #174 for baseline data

### DIFF
--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -51,7 +51,7 @@ class DataTableBenchmark : public benchmark::Fixture {
 
   // Tuple layout
   const uint8_t column_size_ = 8;
-  const storage::BlockLayout layout_{{column_size_, column_size_}};
+  const storage::BlockLayout layout_{{column_size_, column_size_, column_size_, column_size_}};
 
   // Tuple properties
   const storage::ProjectedRowInitializer initializer_{layout_, StorageTestUtil::ProjectionListAllColumns(layout_)};

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -28,7 +28,7 @@ class TupleAccessStrategyBenchmark : public benchmark::Fixture {
 
   // Tuple layout_
   const uint8_t column_size_ = 8;
-  const storage::BlockLayout layout_{{column_size_, column_size_}};
+  const storage::BlockLayout layout_{{column_size_, column_size_, column_size_, column_size_}};
 
   // Tuple properties
   const storage::ProjectedRowInitializer initializer_{layout_, StorageTestUtil::ProjectionListAllColumns(layout_)};


### PR DESCRIPTION
I had to change the benchmark parameters (specifically the number of columns in the BlockLayout) for #174. I want to run a PR through the benchmark suite on Jenkins to verify what I'm seeing locally: that #174's changes don't dramatically alter performance aside from the changes in benchmark parameters.