### PR TITLE
SqlTable

### DIFF
--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -97,7 +97,7 @@ class Schema {
    * @return description of the schema for a specific column
    */
   Column GetColumn(const col_id_t col_id) const {
-    TERRIER_ASSERT(!col_id < columns_.size(), "column id is out of bounds for this Schema");
+    TERRIER_ASSERT((!col_id) < columns_.size(), "column id is out of bounds for this Schema");
     return columns_[static_cast<uint16_t>(col_id)];
   }
   /**

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -72,10 +72,6 @@ class Schema {
      * @return internal unique identifier for this column
      */
     col_oid_t GetOid() const { return oid_; }
-    /**
-     * @return id used at the storage layer for identifying this column in a layout
-     */
-    col_id_t GetId() const { return id_; }
 
    private:
     const std::string name_;
@@ -84,7 +80,6 @@ class Schema {
     const bool nullable_;
     bool inlined_;
     const col_oid_t oid_;
-    col_id_t id_;
     // TODO(Matt): default value would go here
     // Value default_;
   };

--- a/src/include/storage/block_layout.h
+++ b/src/include/storage/block_layout.h
@@ -47,13 +47,16 @@ struct BlockLayout {
 
  private:
   std::vector<uint8_t> attr_sizes_;
+  // These fields below should be declared const but then that deletes the assignment operator for BlockLayout. With
+  // const-only accessors we should be safe from making changes to a BlockLayout that would break stuff.
+
   // Cached values so that we don't have to iterate through attr_sizes_ every time.
-  const uint32_t tuple_size_;
+  uint32_t tuple_size_;
   // static_header_size is everything in the header that is not the bitmap (dependent in the number of slots)
-  const uint32_t static_header_size_;
-  const uint32_t num_slots_;
+  uint32_t static_header_size_;
+  uint32_t num_slots_;
   // header is everything up to the first column
-  const uint32_t header_size_;
+  uint32_t header_size_;
 
  private:
   uint32_t ComputeTupleSize() const;

--- a/src/include/storage/block_layout.h
+++ b/src/include/storage/block_layout.h
@@ -10,6 +10,8 @@ namespace terrier::storage {
  * Stores metadata about the layout of a block.
  */
 struct BlockLayout {
+  BlockLayout() = default;
+
   /**
    * Constructs a new block layout.
    * @warning The resulting column ids WILL be reordered and are not the same as the indexes given in the
@@ -51,12 +53,12 @@ struct BlockLayout {
   // const-only accessors we should be safe from making changes to a BlockLayout that would break stuff.
 
   // Cached values so that we don't have to iterate through attr_sizes_ every time.
-  const uint32_t tuple_size_;
+  uint32_t tuple_size_;
   // static_header_size is everything in the header that is not the bitmap (dependent in the number of slots)
-  const uint32_t static_header_size_;
-  const uint32_t num_slots_;
+  uint32_t static_header_size_;
+  uint32_t num_slots_;
   // header is everything up to the first column
-  const uint32_t header_size_;
+  uint32_t header_size_;
 
  private:
   uint32_t ComputeTupleSize() const;

--- a/src/include/storage/block_layout.h
+++ b/src/include/storage/block_layout.h
@@ -51,12 +51,12 @@ struct BlockLayout {
   // const-only accessors we should be safe from making changes to a BlockLayout that would break stuff.
 
   // Cached values so that we don't have to iterate through attr_sizes_ every time.
-  uint32_t tuple_size_;
+  const uint32_t tuple_size_;
   // static_header_size is everything in the header that is not the bitmap (dependent in the number of slots)
-  uint32_t static_header_size_;
-  uint32_t num_slots_;
+  const uint32_t static_header_size_;
+  const uint32_t num_slots_;
   // header is everything up to the first column
-  uint32_t header_size_;
+  const uint32_t header_size_;
 
  private:
   uint32_t ComputeTupleSize() const;

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -57,7 +57,7 @@ class DataTable {
   table_oid_t TableOid() const { return table_oid_t{0}; }
 
   /**
-   * Materializes a single tuple from the given slot, as visible at the timestamp.
+   * Materializes a single tuple from the given slot, as visible at the timestamp of the calling txn.
    *
    * @param txn the calling transaction
    * @param slot the tuple slot to read

--- a/src/include/storage/projected_columns.h
+++ b/src/include/storage/projected_columns.h
@@ -229,6 +229,7 @@ class ProjectedColumnsInitializer {
    * @param layout BlockLayout of the RawBlock to be accessed
    * @param col_ids projection list of column ids to map, should have all unique values (no repeats)
    * @param max_tuples max number of tuples the ProjectedColumns should hold
+   * @warning col_ods must be a set (no repeats)
    */
   ProjectedColumnsInitializer(const BlockLayout &layout, std::vector<col_id_t> col_ids, uint32_t max_tuples);
 

--- a/src/include/storage/projected_columns.h
+++ b/src/include/storage/projected_columns.h
@@ -156,11 +156,13 @@ class PACKED ProjectedColumns {
   uint16_t NumColumns() const { return num_cols_; }
 
   /**
+   * @warning don't use these above the storage layer, they have no meaning
    * @return pointer to the start of the array of column ids
    */
   col_id_t *ColumnIds() { return reinterpret_cast<col_id_t *>(varlen_contents_); }
 
   /**
+   * @warning don't use these above the storage layer, they have no meaning
    * @return pointer to the start of the array of column ids
    */
   const col_id_t *ColumnIds() const { return reinterpret_cast<const col_id_t *>(varlen_contents_); }

--- a/src/include/storage/projected_columns.h
+++ b/src/include/storage/projected_columns.h
@@ -227,7 +227,7 @@ class ProjectedColumnsInitializer {
    *  values, bitmaps, and potential padding, and the offsets to jump to for each value. This information is cached for
    *  repeated initialization. The semantics is analogous to @see ProjectedRowInitializer.
    * @param layout BlockLayout of the RawBlock to be accessed
-   * @param col_ids projection list of column ids to map
+   * @param col_ids projection list of column ids to map, should have all unique values (no repeats)
    * @param max_tuples max number of tuples the ProjectedColumns should hold
    */
   ProjectedColumnsInitializer(const BlockLayout &layout, std::vector<col_id_t> col_ids, uint32_t max_tuples);

--- a/src/include/storage/projected_columns.h
+++ b/src/include/storage/projected_columns.h
@@ -205,7 +205,6 @@ class PACKED ProjectedColumns {
  private:
   friend class ProjectedColumnsInitializer;
   uint32_t size_;
-  // TODO(Tianyu): Do I need to store this or will the caller always have access to the initializer?
   uint32_t max_tuples_;
   uint32_t num_tuples_;
   uint16_t num_cols_;
@@ -215,15 +214,12 @@ class PACKED ProjectedColumns {
   const uint32_t *AttrValueOffsets() const { return StorageUtil::AlignedPtr<const uint32_t>(ColumnIds() + num_cols_); }
 };
 
-// TODO(Tianyu): The argument for separate initializer/container class is less strong here than for
-// ProjectedRow. We are putting this here anyway for now for the sake of consistency.
 /**
  * A ProjectedColumnsInitializer calculates and stores information on how to initialize ProjectedColumns
  * for a specific layout. The interface is analogous to @see ProjectedRowInitializer
  */
 class ProjectedColumnsInitializer {
  public:
-  // TODO(Tianyu): num tuples or size in bytes?
   /**
    *  Constructs a ProjectedColumnsInitializer. Calculates the size of this ProjectedColumns, including all members,
    *  values, bitmaps, and potential padding, and the offsets to jump to for each value. This information is cached for

--- a/src/include/storage/projected_row.h
+++ b/src/include/storage/projected_row.h
@@ -168,6 +168,7 @@ class ProjectedRowInitializer {
    * @warning The ProjectedRowInitializer WILL reorder the given col_ids in its representation for better memory
    * utilization and performance. Make no assumption about the ordering of these elements and always consult either
    * the initializer or the populated ProjectedRow for the true ordering.
+   * @warning col_ids must be a set (no repeats)
    *
    * @param layout BlockLayout of the RawBlock to be accessed
    * @param col_ids projection list of column ids to map, should have all unique values (no repeats)

--- a/src/include/storage/projected_row.h
+++ b/src/include/storage/projected_row.h
@@ -57,11 +57,13 @@ class PACKED ProjectedRow {
   uint16_t NumColumns() const { return num_cols_; }
 
   /**
+   * @warning don't use these above the storage layer, they have no meaning
    * @return pointer to the start of the array of column ids
    */
   col_id_t *ColumnIds() { return reinterpret_cast<col_id_t *>(varlen_contents_); }
 
   /**
+   * @warning don't use these above the storage layer, they have no meaning
    * @return pointer to the start of the array of column ids
    */
   const col_id_t *ColumnIds() const { return reinterpret_cast<const col_id_t *>(varlen_contents_); }

--- a/src/include/storage/projected_row.h
+++ b/src/include/storage/projected_row.h
@@ -170,7 +170,7 @@ class ProjectedRowInitializer {
    * the initializer or the populated ProjectedRow for the true ordering.
    *
    * @param layout BlockLayout of the RawBlock to be accessed
-   * @param col_ids projection list of column ids to map
+   * @param col_ids projection list of column ids to map, should have all unique values (no repeats)
    */
   ProjectedRowInitializer(const BlockLayout &layout, std::vector<col_id_t> col_ids);
 

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -1,8 +1,11 @@
 #pragma once
+#include <list>
 #include <utility>
 #include <vector>
 #include "catalog/schema.h"
 #include "storage/data_table.h"
+#include "storage/projected_columns.h"
+#include "storage/projected_row.h"
 #include "storage/storage_defs.h"
 
 namespace terrier::storage {
@@ -10,9 +13,22 @@ namespace terrier::storage {
 /**
  * A SqlTable is a thin layer above DataTable that replaces storage layer concepts like BlockLayout with SQL layer
  * concepts like Schema. This layer will also handle index maintenance, and possibly constraint checking (confirm when
- * we bring in execution layer).
+ * we bring in execution layer). The goal is to hide concepts like col_id_t and BlockLayout above the SqlTable level.
+ * The SqlTable API should only refer to storage concepts via things like Schema and col_oid_t, and then perform the
+ * translation to BlockLayout and col_id_t to talk to the DataTable and other areas of the storage layer.
  */
 class SqlTable {
+  /**
+   * Contains all of the metadata the SqlTable needs to reference a DataTable. We shouldn't ever have to expose these
+   * concepts to anyone above the SqlTable level. If you find yourself wanting to return BlockLayout or col_id_t above
+   * this layer, consider alternatives.
+   */
+  struct DataTableVersion {
+    DataTable *const data_table;
+    const BlockLayout layout;
+    const ColumnMap column_map;
+  };
+
  public:
   /**
    * Constructs a new SqlTable with the given Schema, using the given BlockStore as the source
@@ -22,17 +38,19 @@ class SqlTable {
    * @param schema the initial Schema of this SqlTable
    * @param oid unique identifier for this SqlTable
    */
-  SqlTable(BlockStore *const store, catalog::Schema schema, const table_oid_t oid)
-      : block_store_(store), schema_(std::move(schema)), oid_(oid) {
-    auto layout = StorageUtil::BlockLayoutFromSchema(schema_);
-    table_ = new DataTable(block_store_, layout.first, layout_version_t(0));
-    column_map_ = layout.second;
+  SqlTable(BlockStore *const store, const catalog::Schema &schema, const table_oid_t oid)
+      : block_store_(store), oid_(oid) {
+    auto layout = StorageUtil::BlockLayoutFromSchema(schema);
+    tables_.push_back({new DataTable(block_store_, layout.first, layout_version_t(0)), layout.first, layout.second});
   }
 
   /**
    * Destructs a SqlTable, frees all its members.
    */
-  ~SqlTable() { delete table_; }
+  ~SqlTable() {
+    TERRIER_ASSERT(tables_.size() == 1, "We don't support concurrent schema, so this should have size 1 right now.");
+    delete tables_.front().data_table;
+  }
 
   /**
    * Materializes a single tuple from the given slot, as visible at the timestamp of the calling txn.
@@ -43,7 +61,7 @@ class SqlTable {
    * @return true if tuple is visible to this txn and ProjectedRow has been populated, false otherwise
    */
   bool Select(transaction::TransactionContext *const txn, const TupleSlot slot, ProjectedRow *const out_buffer) const {
-    return table_->Select(txn, slot, out_buffer);
+    return tables_.front().data_table->Select(txn, slot, out_buffer);
   }
 
   /**
@@ -55,9 +73,9 @@ class SqlTable {
    * @return true if successful, false otherwise
    */
   bool Update(transaction::TransactionContext *const txn, const TupleSlot slot, const ProjectedRow &redo) const {
-    // check constraints?
-    // update indexes?
-    return table_->Update(txn, slot, redo);
+    // TODO(Matt): check constraints? Discuss if that happens in execution layer or not
+    // TODO(Matt): update indexes
+    return tables_.front().data_table->Update(txn, slot, redo);
   }
 
   /**
@@ -69,9 +87,9 @@ class SqlTable {
    * such.
    */
   TupleSlot Insert(transaction::TransactionContext *const txn, const ProjectedRow &redo) const {
-    // check constraints?
-    // update indexes?
-    return table_->Insert(txn, redo);
+    // TODO(Matt): check constraints? Discuss if that happens in execution layer or not
+    // TODO(Matt): update indexes
+    return tables_.front().data_table->Insert(txn, redo);
   }
 
   /**
@@ -81,28 +99,54 @@ class SqlTable {
    * @return true if successful, false otherwise
    */
   bool Delete(transaction::TransactionContext *const txn, const TupleSlot slot) {
-    // check constraints?
-    // update indexes?
-    return table_->Delete(txn, slot);
+    // TODO(Matt): check constraints? Discuss if that happens in execution layer or not
+    // TODO(Matt): update indexes
+    return tables_.front().data_table->Delete(txn, slot);
   }
-
-  /**
-   * @return mapping between unique col oids and col ids in the storage layer
-   */
-  const ColumnMap &ColumnMap() const { return column_map_; }
 
   /**
    * @return table's unique identifier
    */
   table_oid_t Oid() const { return oid_; }
 
+  /**
+   * Generates an ProjectedColumnsInitializer for the execution layer to use. This performs the translation from col_oid
+   * to col_id for the Initializer's constructor so that the execution layer doesn't need to know anything about col_id.
+   * @param col_oids
+   * @param max_tuples
+   * @return
+   */
+  std::pair<ProjectedColumnsInitializer, ProjectionMap> ProjectionInitializer(const std::vector<col_oid_t> &col_oids,
+                                                                              const uint32_t max_tuples) const {
+    auto col_ids = ColIdsForOids(col_oids);
+    ProjectedColumnsInitializer initializer(tables_.front().layout, col_ids, max_tuples);
+    auto projection_map = ProjectionMapForInitializer<ProjectedColumnsInitializer>(initializer);
+    return {initializer, projection_map};
+  }
+
+  /**
+   *
+   * @param col_oids
+   * @return
+   */
+  std::pair<ProjectedRowInitializer, ProjectionMap> ProjectionInitializer(
+      const std::vector<col_oid_t> &col_oids) const {
+    auto col_ids = ColIdsForOids(col_oids);
+    ProjectedRowInitializer initializer(tables_.front().layout, col_ids);
+    auto projection_map = ProjectionMapForInitializer<ProjectedRowInitializer>(initializer);
+    return {initializer, projection_map};
+  }
+
  private:
   BlockStore *const block_store_;
-  const catalog::Schema schema_;
   const table_oid_t oid_;
-  DataTable *table_;
 
-  // Replace this with catalog calls in the future
-  ColumnMap column_map_;
+  // Eventually we'll support adding more tables when schema changes. For now we'll always access the first DataTable.
+  std::list<DataTableVersion> tables_;
+
+  std::vector<col_id_t> ColIdsForOids(const std::vector<col_oid_t> &col_oids) const;
+
+  template <class ProjectionInitializerType>
+  ProjectionMap ProjectionMapForInitializer(const ProjectionInitializerType &initializer) const;
 };
 }  // namespace terrier::storage

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -117,9 +117,12 @@ class SqlTable {
    * @param max_tuples the maximum number of tuples to store in the ProjectedColumn
    * @return pair of: initializer to create ProjectedColumns, and a mapping between col_oid and the offset within the
    * ProjectedColumn
+   * @warning col_oids must be a set (no repeats)
    */
-  std::pair<ProjectedColumnsInitializer, ProjectionMap> ProjectionInitializer(const std::set<col_oid_t> &col_oids,
+  std::pair<ProjectedColumnsInitializer, ProjectionMap> ProjectionInitializer(const std::vector<col_oid_t> &col_oids,
                                                                               const uint32_t max_tuples) const {
+    TERRIER_ASSERT((std::set<col_oid_t>(col_oids.cbegin(), col_oids.cend())).size() == col_oids.size(),
+                   "There should not be any duplicated in the col_ids!");
     auto col_ids = ColIdsForOids(col_oids);
     TERRIER_ASSERT(col_ids.size() == col_oids.size(),
                    "Projection should be the same number of columns as requested col_oids.");
@@ -135,9 +138,14 @@ class SqlTable {
    * col_id for the Initializer's constructor so that the execution layer doesn't need to know anything about col_id.
    * @param col_oids set of col_oids to be projected
    * @return pair of: initializer to create ProjectedRow, and a mapping between col_oid and the offset within the
-   * ProjectedRow
+   * ProjectedRow to create ProjectedColumns, and a mapping between col_oid and the offset within the
+   * ProjectedColumn
+   * @warning col_oids must be a set (no repeats)
    */
-  std::pair<ProjectedRowInitializer, ProjectionMap> ProjectionInitializer(const std::set<col_oid_t> &col_oids) const {
+  std::pair<ProjectedRowInitializer, ProjectionMap> ProjectionInitializer(
+      const std::vector<col_oid_t> &col_oids) const {
+    TERRIER_ASSERT((std::set<col_oid_t>(col_oids.cbegin(), col_oids.cend())).size() == col_oids.size(),
+                   "There should not be any duplicated in the col_ids!");
     auto col_ids = ColIdsForOids(col_oids);
     TERRIER_ASSERT(col_ids.size() == col_oids.size(),
                    "Projection should be the same number of columns as requested col_oids.");
@@ -160,7 +168,7 @@ class SqlTable {
    * @param col_oids set of col_oids, they must be in the table's ColumnMap
    * @return vector of col_ids for these col_oids
    */
-  std::vector<col_id_t> ColIdsForOids(const std::set<col_oid_t> &col_oids) const;
+  std::vector<col_id_t> ColIdsForOids(const std::vector<col_oid_t> &col_oids) const;
 
   /**
    * Given a ProjectionInitializer, returns a map between col_oid and the offset within the projection to access that

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -121,8 +121,12 @@ class SqlTable {
   std::pair<ProjectedColumnsInitializer, ProjectionMap> ProjectionInitializer(const std::set<col_oid_t> &col_oids,
                                                                               const uint32_t max_tuples) const {
     auto col_ids = ColIdsForOids(col_oids);
+    TERRIER_ASSERT(col_ids.size() == col_oids.size(),
+                   "Projection should be the same number of columns as requested col_oids.");
     ProjectedColumnsInitializer initializer(tables_.front().layout, col_ids, max_tuples);
     auto projection_map = ProjectionMapForInitializer<ProjectedColumnsInitializer>(initializer);
+    TERRIER_ASSERT(projection_map.size() == col_oids.size(),
+                   "ProjectionMap be the same number of columns as requested col_oids.");
     return {initializer, projection_map};
   }
 
@@ -135,8 +139,12 @@ class SqlTable {
    */
   std::pair<ProjectedRowInitializer, ProjectionMap> ProjectionInitializer(const std::set<col_oid_t> &col_oids) const {
     auto col_ids = ColIdsForOids(col_oids);
+    TERRIER_ASSERT(col_ids.size() == col_oids.size(),
+                   "Projection should be the same number of columns as requested col_oids.");
     ProjectedRowInitializer initializer(tables_.front().layout, col_ids);
     auto projection_map = ProjectionMapForInitializer<ProjectedRowInitializer>(initializer);
+    TERRIER_ASSERT(projection_map.size() == col_oids.size(),
+                   "ProjectionMap be the same number of columns as requested col_oids.");
     return {initializer, projection_map};
   }
 
@@ -147,8 +155,20 @@ class SqlTable {
   // Eventually we'll support adding more tables when schema changes. For now we'll always access the first DataTable.
   std::list<DataTableVersion> tables_;
 
+  /**
+   * Given a set of col_oids, return a vector of corresponding col_ids to use for ProjectionInitialization
+   * @param col_oids set of col_oids, they must be in the table's ColumnMap
+   * @return vector of col_ids for these col_oids
+   */
   std::vector<col_id_t> ColIdsForOids(const std::set<col_oid_t> &col_oids) const;
 
+  /**
+   * Given a ProjectionInitializer, returns a map between col_oid and the offset within the projection to access that
+   * column
+   * @tparam ProjectionInitializerType ProjectedRowInitializer or ProjectedColumnsInitializer
+   * @param initializer the initializer to generate a map for
+   * @return the projection map for this initializer
+   */
   template <class ProjectionInitializerType>
   ProjectionMap ProjectionMapForInitializer(const ProjectionInitializerType &initializer) const;
 };

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <list>
+#include <set>
 #include <utility>
 #include <vector>
 #include "catalog/schema.h"
@@ -112,11 +113,12 @@ class SqlTable {
   /**
    * Generates an ProjectedColumnsInitializer for the execution layer to use. This performs the translation from col_oid
    * to col_id for the Initializer's constructor so that the execution layer doesn't need to know anything about col_id.
-   * @param col_oids
-   * @param max_tuples
-   * @return
+   * @param col_oids set of col_oids to be projected
+   * @param max_tuples the maximum number of tuples to store in the ProjectedColumn
+   * @return pair of: initializer to create ProjectedColumns, and a mapping between col_oid and the offset within the
+   * ProjectedColumn
    */
-  std::pair<ProjectedColumnsInitializer, ProjectionMap> ProjectionInitializer(const std::vector<col_oid_t> &col_oids,
+  std::pair<ProjectedColumnsInitializer, ProjectionMap> ProjectionInitializer(const std::set<col_oid_t> &col_oids,
                                                                               const uint32_t max_tuples) const {
     auto col_ids = ColIdsForOids(col_oids);
     ProjectedColumnsInitializer initializer(tables_.front().layout, col_ids, max_tuples);
@@ -125,12 +127,13 @@ class SqlTable {
   }
 
   /**
-   *
-   * @param col_oids
-   * @return
+   * Generates an ProjectedRowInitializer for the execution layer to use. This performs the translation from col_oid to
+   * col_id for the Initializer's constructor so that the execution layer doesn't need to know anything about col_id.
+   * @param col_oids set of col_oids to be projected
+   * @return pair of: initializer to create ProjectedRow, and a mapping between col_oid and the offset within the
+   * ProjectedRow
    */
-  std::pair<ProjectedRowInitializer, ProjectionMap> ProjectionInitializer(
-      const std::vector<col_oid_t> &col_oids) const {
+  std::pair<ProjectedRowInitializer, ProjectionMap> ProjectionInitializer(const std::set<col_oid_t> &col_oids) const {
     auto col_ids = ColIdsForOids(col_oids);
     ProjectedRowInitializer initializer(tables_.front().layout, col_ids);
     auto projection_map = ProjectionMapForInitializer<ProjectedRowInitializer>(initializer);
@@ -144,7 +147,7 @@ class SqlTable {
   // Eventually we'll support adding more tables when schema changes. For now we'll always access the first DataTable.
   std::list<DataTableVersion> tables_;
 
-  std::vector<col_id_t> ColIdsForOids(const std::vector<col_oid_t> &col_oids) const;
+  std::vector<col_id_t> ColIdsForOids(const std::set<col_oid_t> &col_oids) const;
 
   template <class ProjectionInitializerType>
   ProjectionMap ProjectionMapForInitializer(const ProjectionInitializerType &initializer) const;

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <utility>
+#include <vector>
+#include "catalog/schema.h"
+#include "storage/data_table.h"
+#include "storage/storage_defs.h"
+
+namespace terrier::storage {
+class SqlTable {
+ public:
+  SqlTable(BlockStore *const store, catalog::Schema schema) : block_store_(store), schema_(std::move(schema)) {
+    auto layout = StorageUtil::BlockLayoutFromSchema(schema_);
+    table_ = new DataTable(block_store_, layout.first, layout_version_t(0));
+    column_map_ = layout.second;
+  }
+  ~SqlTable() { delete table_; }
+  bool Select(transaction::TransactionContext *const txn, const TupleSlot slot, ProjectedRow *const out_buffer) const {
+    return table_->Select(txn, slot, out_buffer);
+  }
+  bool Update(transaction::TransactionContext *const txn, const TupleSlot slot, const ProjectedRow &redo) const {
+    // check constraints?
+    // update indexes
+    return table_->Update(txn, slot, redo);
+  }
+  TupleSlot Insert(transaction::TransactionContext *const txn, const ProjectedRow &redo) const {
+    // check constraints?
+    // update indexes
+    return table_->Insert(txn, redo);
+  }
+  bool Delete(transaction::TransactionContext *const txn, const TupleSlot slot) {
+    // check constraints?
+    // update indexes
+    return table_->Delete(txn, slot);
+  }
+
+ private:
+  BlockStore *const block_store_;
+  const catalog::Schema schema_;
+  DataTable *table_;
+
+  // Replace this with catalog calls in the future
+  ColumnMap column_map_;
+};
+}  // namespace terrier::storage

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -6,36 +6,100 @@
 #include "storage/storage_defs.h"
 
 namespace terrier::storage {
+
+/**
+ * A SqlTable is a thin layer above DataTable that replaces storage layer concepts like BlockLayout with SQL layer
+ * concepts like Schema. This layer will also handle index maintenance, and possibly constraint checking (confirm when
+ * we bring in execution layer).
+ */
 class SqlTable {
  public:
-  SqlTable(BlockStore *const store, catalog::Schema schema) : block_store_(store), schema_(std::move(schema)) {
+  /**
+   * Constructs a new SqlTable with the given Schema, using the given BlockStore as the source
+   * of its storage blocks.
+   *
+   * @param store the Block store to use.
+   * @param schema the initial Schema of this SqlTable
+   * @param oid unique identifier for this SqlTable
+   */
+  SqlTable(BlockStore *const store, catalog::Schema schema, const table_oid_t oid)
+      : block_store_(store), schema_(std::move(schema)), oid_(oid) {
     auto layout = StorageUtil::BlockLayoutFromSchema(schema_);
     table_ = new DataTable(block_store_, layout.first, layout_version_t(0));
     column_map_ = layout.second;
   }
+
+  /**
+   * Destructs a SqlTable, frees all its members.
+   */
   ~SqlTable() { delete table_; }
+
+  /**
+   * Materializes a single tuple from the given slot, as visible at the timestamp of the calling txn.
+   *
+   * @param txn the calling transaction
+   * @param slot the tuple slot to read
+   * @param out_buffer output buffer. The object should already contain projection list information. @see ProjectedRow.
+   * @return true if tuple is visible to this txn and ProjectedRow has been populated, false otherwise
+   */
   bool Select(transaction::TransactionContext *const txn, const TupleSlot slot, ProjectedRow *const out_buffer) const {
     return table_->Select(txn, slot, out_buffer);
   }
+
+  /**
+   * Update the tuple according to the redo buffer given.
+   *
+   * @param txn the calling transaction
+   * @param slot the slot of the tuple to update.
+   * @param redo the desired change to be applied. This should be the after-image of the attributes of interest.
+   * @return true if successful, false otherwise
+   */
   bool Update(transaction::TransactionContext *const txn, const TupleSlot slot, const ProjectedRow &redo) const {
     // check constraints?
-    // update indexes
+    // update indexes?
     return table_->Update(txn, slot, redo);
   }
+
+  /**
+   * Inserts a tuple, as given in the redo, and return the slot allocated for the tuple.
+   *
+   * @param txn the calling transaction
+   * @param redo after-image of the inserted tuple.
+   * @return the TupleSlot allocated for this insert, used to identify this tuple's physical location for indexes and
+   * such.
+   */
   TupleSlot Insert(transaction::TransactionContext *const txn, const ProjectedRow &redo) const {
     // check constraints?
-    // update indexes
+    // update indexes?
     return table_->Insert(txn, redo);
   }
+
+  /**
+   * Deletes the given TupleSlot, this will call StageWrite on the provided txn to generate the RedoRecord for delete.
+   * @param txn the calling transaction
+   * @param slot the slot of the tuple to delete
+   * @return true if successful, false otherwise
+   */
   bool Delete(transaction::TransactionContext *const txn, const TupleSlot slot) {
     // check constraints?
-    // update indexes
+    // update indexes?
     return table_->Delete(txn, slot);
   }
+
+  /**
+   * @return mapping between unique col oids and col ids in the storage layer
+   */
+  const ColumnMap &ColumnMap() const { return column_map_; }
+
+  /**
+   * @return table's unique identifier
+   */
+  table_oid_t Oid() const { return oid_; }
 
  private:
   BlockStore *const block_store_;
   const catalog::Schema schema_;
+  const table_oid_t oid_;
   DataTable *table_;
 
   // Replace this with catalog calls in the future

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -106,9 +106,36 @@ class SqlTable {
   }
 
   /**
+   * Sequentially scans the table starting from the given iterator(inclusive) and materializes as many tuples as would
+   * fit into the given buffer, as visible to the transaction given, according to the format described by the given
+   * output buffer. The tuples materialized are guaranteed to be visible and valid, and the function makes best effort
+   * to fill the buffer, unless there are no more tuples. The given iterator is mutated to point to one slot passed the
+   * last slot scanned in the invocation.
+   *
+   * @param txn the calling transaction
+   * @param start_pos iterator to the starting location for the sequential scan
+   * @param out_buffer output buffer. The object should already contain projection list information. This buffer is
+   *                   always cleared of old values.
+   */
+  void Scan(transaction::TransactionContext *const txn, DataTable::SlotIterator *const start_pos,
+            ProjectedColumns *const out_buffer) const {
+    return tables_.front().data_table->Scan(txn, start_pos, out_buffer);
+  }
+
+  /**
    * @return table's unique identifier
    */
   table_oid_t Oid() const { return oid_; }
+
+  /**
+   * @return the first tuple slot contained in the underlying DataTable
+   */
+  DataTable::SlotIterator begin() const { return tables_.front().data_table->begin(); }
+
+  /**
+   * @return one past the last tuple slot contained in the underlying DataTable
+   */
+  DataTable::SlotIterator end() const { return tables_.front().data_table->end(); }
 
   /**
    * Generates an ProjectedColumnsInitializer for the execution layer to use. This performs the translation from col_oid

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -142,6 +142,7 @@ class BlockAllocator {
 using BlockStore = common::ObjectPool<RawBlock, BlockAllocator>;
 
 using ColumnMap = std::unordered_map<col_oid_t, col_id_t>;
+using ProjectionMap = std::unordered_map<col_oid_t, uint16_t>;
 
 /**
  * Denote whether a record modifies the logical delete column, used when DataTable inspects deltas

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -19,7 +19,7 @@ namespace terrier::storage {
 // All tuples potentially visible to txns should have a non-null attribute of version vector.
 // This is not to be confused with a non-null version vector that has value nullptr (0).
 #define VERSION_POINTER_COLUMN_ID col_id_t(0)
-#define NUM_RESERVED_COLUMNS 1
+#define NUM_RESERVED_COLUMNS 1u
 /**
  * A block is a chunk of memory used for storage. It does not have any meaning
  * unless interpreted by a @see TupleAccessStrategy

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <functional>
 #include <ostream>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 #include "common/constants.h"
@@ -227,6 +228,8 @@ class BlockAllocator {
  * malloc.
  */
 using BlockStore = common::ObjectPool<RawBlock, BlockAllocator>;
+
+using ColumnMap = std::unordered_map<col_oid_t, col_id_t>;
 
 /**
  * Denote whether a record modifies the logical delete column, used when DataTable inspects deltas

--- a/src/include/storage/storage_util.h
+++ b/src/include/storage/storage_util.h
@@ -1,8 +1,12 @@
 #pragma once
-#include <unordered_map>
+#include <utility>
 #include "common/macros.h"
 #include "common/typedefs.h"
 #include "storage/storage_defs.h"
+
+namespace terrier::catalog {
+class Schema;
+}
 
 namespace terrier::storage {
 class ProjectedRow;
@@ -129,5 +133,13 @@ class StorageUtil {
    * otherwise
    */
   static DeltaRecordType CheckUndoRecordType(const UndoRecord &undo);
+
+  /**
+   * Given a schema, returns both a BlockLayout for the storage layer, and a mapping between each column's oid and the
+   * corresponding column id in the storage layer/BlockLayout
+   * @param schema Schema to generate a BlockLayout from. Columns should all have unique oids
+   * @return pair of BlockLayout and a map between col_oid_t and col_id
+   */
+  static std::pair<BlockLayout, ColumnMap> BlockLayoutFromSchema(const catalog::Schema &schema);
 };
 }  // namespace terrier::storage

--- a/src/include/storage/storage_util.h
+++ b/src/include/storage/storage_util.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <utility>
 #include <unordered_map>
+#include <utility>
 #include "common/macros.h"
 #include "common/typedefs.h"
 #include "storage/block_layout.h"

--- a/src/include/type/type_id.h
+++ b/src/include/type/type_id.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common/typedefs.h"
+
 namespace terrier::type {
 /**
  * All of our possible SQL types

--- a/src/include/type/type_util.h
+++ b/src/include/type/type_util.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "common/typedefs.h"
+#include "type/type_id.h"
+
 namespace terrier::type {
 
 /**

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -20,7 +20,7 @@ bool DataTable::Select(terrier::transaction::TransactionContext *txn, terrier::s
   return SelectIntoBuffer(txn, slot, out_buffer);
 }
 
-void DataTable::Scan(transaction::TransactionContext *const txn, SlotIterator *start_pos,
+void DataTable::Scan(transaction::TransactionContext *const txn, SlotIterator *const start_pos,
                      ProjectedColumns *const out_buffer) const {
   // TODO(Tianyu): So far this is not that much better than tuple-at-a-time access,
   // but can be improved if block is read-only, or if we implement version synopsis, to just use memcpy when it's safe

--- a/src/storage/projected_columns.cpp
+++ b/src/storage/projected_columns.cpp
@@ -35,7 +35,7 @@ ProjectedColumnsInitializer::ProjectedColumnsInitializer(const terrier::storage:
   }
 }
 
-ProjectedColumns *ProjectedColumnsInitializer::Initialize(void *head) const {
+ProjectedColumns *ProjectedColumnsInitializer::Initialize(void *const head) const {
   TERRIER_ASSERT(reinterpret_cast<uintptr_t>(head) % sizeof(uint64_t) == 0,
                  "start of ProjectedRow needs to be aligned to 8 bytes to"
                  "ensure correctness of alignment of its members");

--- a/src/storage/projected_columns.cpp
+++ b/src/storage/projected_columns.cpp
@@ -1,15 +1,18 @@
 #include "storage/projected_columns.h"
 #include <algorithm>
 #include <functional>
+#include <set>
 #include <utility>
 #include <vector>
 namespace terrier::storage {
-ProjectedColumnsInitializer::ProjectedColumnsInitializer(const terrier::storage::BlockLayout &layout,
-                                                         std::vector<terrier::col_id_t> col_ids, uint32_t max_tuples)
+ProjectedColumnsInitializer::ProjectedColumnsInitializer(const BlockLayout &layout, std::vector<col_id_t> col_ids,
+                                                         const uint32_t max_tuples)
     : max_tuples_(max_tuples), col_ids_(std::move(col_ids)), offsets_(col_ids_.size()) {
   TERRIER_ASSERT(!col_ids_.empty(), "cannot initialize an empty ProjectedColumns");
   TERRIER_ASSERT(col_ids_.size() < layout.NumColumns(),
                  "ProjectedColumns should have fewer columns than the table (can't read version vector)");
+  TERRIER_ASSERT((std::set<col_id_t>(col_ids_.cbegin(), col_ids_.cend())).size() == col_ids_.size(),
+                 "There should not be any duplicated in the col_ids!");
   // TODO(Tianyu): We should really assert that it has a subset of columns, but that is a bit more complicated.
 
   // Sort the projection list for optimal space utilization and delta application performance

--- a/src/storage/projected_row.cpp
+++ b/src/storage/projected_row.cpp
@@ -1,6 +1,7 @@
 #include "storage/projected_row.h"
 #include <algorithm>
 #include <functional>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -20,6 +21,8 @@ ProjectedRowInitializer::ProjectedRowInitializer(const terrier::storage::BlockLa
   TERRIER_ASSERT(!col_ids_.empty(), "cannot initialize an empty ProjectedRow");
   TERRIER_ASSERT(col_ids_.size() < layout.NumColumns(),
                  "ProjectedRow should have fewer columns than the table (can't read version vector)");
+  TERRIER_ASSERT((std::set<col_id_t>(col_ids_.cbegin(), col_ids_.cend())).size() == col_ids_.size(),
+                 "There should not be any duplicated in the col_ids!");
   // TODO(Tianyu): We should really assert that it has a subset of columns, but that is a bit more complicated.
 
   // Sort the projection list for optimal space utilization and delta application performance

--- a/src/storage/projected_row.cpp
+++ b/src/storage/projected_row.cpp
@@ -43,7 +43,7 @@ ProjectedRowInitializer::ProjectedRowInitializer(const terrier::storage::BlockLa
   }
 }
 
-ProjectedRow *ProjectedRowInitializer::InitializeRow(void *head) const {
+ProjectedRow *ProjectedRowInitializer::InitializeRow(void *const head) const {
   TERRIER_ASSERT(reinterpret_cast<uintptr_t>(head) % sizeof(uint64_t) == 0,
                  "start of ProjectedRow needs to be aligned to 8 bytes to"
                  "ensure correctness of alignment of its members");

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -1,4 +1,5 @@
 #include "storage/sql_table.h"
+#include <set>
 #include <vector>
 #include "common/macros.h"
 

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -1,0 +1,44 @@
+#include "storage/sql_table.h"
+#include <vector>
+#include "common/macros.h"
+
+namespace terrier::storage {
+
+std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<terrier::col_oid_t> &col_oids) const {
+  TERRIER_ASSERT(!col_oids.empty(), "Should be used to access at least one column.");
+  std::vector<col_id_t> col_ids;
+
+  // Build the input to the initializer constructor
+  for (const col_oid_t col_oid : col_oids) {
+    TERRIER_ASSERT(tables_.front().column_map.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
+    const col_id_t col_id = tables_.front().column_map.at(col_oid);
+    col_ids.push_back(col_id);
+  }
+
+  return col_ids;
+}
+
+template <class ProjectionInitializerType>
+ProjectionMap SqlTable::ProjectionMapForInitializer(const ProjectionInitializerType &initializer) const {
+  ProjectionMap projection_map;
+  // for every attribute in the initializer
+  for (uint16_t i = 0; i < initializer.NumColumns(); i++) {
+    // extract the underlying col_id it refers to
+    const col_id_t col_id_at_offset = initializer.ColId(i);
+    // find the key (col_oid) in the table's map corresponding to the value (col_id)
+    const auto oid_to_id =
+        std::find_if(tables_.front().column_map.cbegin(), tables_.front().column_map.cend(),
+                     [&](const auto &oid_to_id) -> bool { return oid_to_id.second == col_id_at_offset; });
+    // insert the mapping from col_oid to projection offset
+    projection_map[oid_to_id->first] = i;
+  }
+
+  return projection_map;
+}
+
+template ProjectionMap SqlTable::ProjectionMapForInitializer<ProjectedColumnsInitializer>(
+    const ProjectedColumnsInitializer &initializer) const;
+template ProjectionMap SqlTable::ProjectionMapForInitializer<ProjectedRowInitializer>(
+    const ProjectedRowInitializer &initializer) const;
+
+}  // namespace terrier::storage

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -4,7 +4,7 @@
 
 namespace terrier::storage {
 
-std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<terrier::col_oid_t> &col_oids) const {
+std::vector<col_id_t> SqlTable::ColIdsForOids(const std::set<col_oid_t> &col_oids) const {
   TERRIER_ASSERT(!col_oids.empty(), "Should be used to access at least one column.");
   std::vector<col_id_t> col_ids;
 

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -5,7 +5,7 @@
 
 namespace terrier::storage {
 
-std::vector<col_id_t> SqlTable::ColIdsForOids(const std::set<col_oid_t> &col_oids) const {
+std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<col_oid_t> &col_oids) const {
   TERRIER_ASSERT(!col_oids.empty(), "Should be used to access at least one column.");
   std::vector<col_id_t> col_ids;
 

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -11,8 +11,8 @@ std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<col_oid_t> &col_
 
   // Build the input to the initializer constructor
   for (const col_oid_t col_oid : col_oids) {
-    TERRIER_ASSERT(tables_.front().column_map.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
-    const col_id_t col_id = tables_.front().column_map.at(col_oid);
+    TERRIER_ASSERT(table_.column_map.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
+    const col_id_t col_id = table_.column_map.at(col_oid);
     col_ids.push_back(col_id);
   }
 
@@ -28,7 +28,7 @@ ProjectionMap SqlTable::ProjectionMapForInitializer(const ProjectionInitializerT
     const col_id_t col_id_at_offset = initializer.ColId(i);
     // find the key (col_oid) in the table's map corresponding to the value (col_id)
     const auto oid_to_id =
-        std::find_if(tables_.front().column_map.cbegin(), tables_.front().column_map.cend(),
+        std::find_if(table_.column_map.cbegin(), table_.column_map.cend(),
                      [&](const auto &oid_to_id) -> bool { return oid_to_id.second == col_id_at_offset; });
     // insert the mapping from col_oid to projection offset
     projection_map[oid_to_id->first] = i;

--- a/src/storage/storage_util.cpp
+++ b/src/storage/storage_util.cpp
@@ -1,9 +1,9 @@
 #include "storage/storage_util.h"
 #include <unordered_map>
-#include "storage/projected_columns.h"
 #include <utility>
 #include <vector>
 #include "catalog/schema.h"
+#include "storage/projected_columns.h"
 #include "storage/tuple_access_strategy.h"
 #include "storage/undo_record.h"
 
@@ -138,7 +138,9 @@ std::pair<BlockLayout, ColumnMap> StorageUtil::BlockLayoutFromSchema(const catal
   uint16_t num_1_byte_attrs = 0;
 
   // Begin with the NUM_RESERVED_COLUMNS in the attr_sizes
-  std::vector<uint8_t> attr_sizes({8, 8});
+  std::vector<uint8_t> attr_sizes({8});
+  TERRIER_ASSERT(attr_sizes.size() == NUM_RESERVED_COLUMNS,
+                 "attr_sizes should be initialized with NUM_RESERVED_COLUMNS elements.");
 
   // First pass through to accumulate the counts of each attr_size
   for (const auto &column : schema.GetColumns()) {

--- a/src/storage/storage_util.cpp
+++ b/src/storage/storage_util.cpp
@@ -148,14 +148,15 @@ std::pair<BlockLayout, ColumnMap> StorageUtil::BlockLayoutFromSchema(const catal
     }
   }
 
-  TERRIER_ASSERT(attr_sizes.size() == num_8_byte_attrs + num_4_byte_attrs + num_2_byte_attrs + num_1_byte_attrs,
+  TERRIER_ASSERT(static_cast<uint16_t>(attr_sizes.size()) ==
+                     num_8_byte_attrs + num_4_byte_attrs + num_2_byte_attrs + num_1_byte_attrs,
                  "Number of attr_sizes does not match the sum of attr counts.");
 
   // Initialize the offsets for each attr_size
   uint16_t offset_8_byte_attrs = NUM_RESERVED_COLUMNS;
   uint16_t offset_4_byte_attrs = num_8_byte_attrs;
-  uint16_t offset_2_byte_attrs = offset_4_byte_attrs + num_4_byte_attrs;
-  uint16_t offset_1_byte_attrs = offset_2_byte_attrs + num_2_byte_attrs;
+  auto offset_2_byte_attrs = static_cast<uint16_t>(offset_4_byte_attrs + num_4_byte_attrs);
+  auto offset_1_byte_attrs = static_cast<uint16_t>(offset_2_byte_attrs + num_2_byte_attrs);
 
   ColumnMap col_oid_to_id;
   // Build the map from Schema columns to underlying columns

--- a/src/storage/storage_util.cpp
+++ b/src/storage/storage_util.cpp
@@ -1,5 +1,7 @@
 #include "storage/storage_util.h"
-#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "catalog/schema.h"
 #include "storage/tuple_access_strategy.h"
 #include "storage/undo_record.h"
 
@@ -115,4 +117,68 @@ uint32_t StorageUtil::PadUpToSize(const uint8_t word_size, const uint32_t offset
   const uint32_t remainder = offset % word_size;
   return remainder == 0 ? offset : offset + word_size - remainder;
 }
+
+std::pair<BlockLayout, ColumnMap> StorageUtil::BlockLayoutFromSchema(const catalog::Schema &schema) {
+  uint16_t num_8_byte_attrs = NUM_RESERVED_COLUMNS;
+  uint16_t num_4_byte_attrs = 0;
+  uint16_t num_2_byte_attrs = 0;
+  uint16_t num_1_byte_attrs = 0;
+
+  // Begin with the NUM_RESERVED_COLUMNS in the attr_sizes
+  std::vector<uint8_t> attr_sizes({8, 8});
+
+  // First pass through to accumulate the counts of each attr_size
+  for (const auto &column : schema.GetColumns()) {
+    attr_sizes.push_back(column.GetAttrSize());
+    switch (column.GetAttrSize()) {
+      case 8:
+        num_8_byte_attrs++;
+        break;
+      case 4:
+        num_4_byte_attrs++;
+        break;
+      case 2:
+        num_2_byte_attrs++;
+        break;
+      case 1:
+        num_1_byte_attrs++;
+        break;
+      default:
+        break;
+    }
+  }
+
+  TERRIER_ASSERT(attr_sizes.size() == num_8_byte_attrs + num_4_byte_attrs + num_2_byte_attrs + num_1_byte_attrs,
+                 "Number of attr_sizes does not match the sum of attr counts.");
+
+  // Initialize the offsets for each attr_size
+  uint16_t offset_8_byte_attrs = NUM_RESERVED_COLUMNS;
+  uint16_t offset_4_byte_attrs = num_8_byte_attrs;
+  uint16_t offset_2_byte_attrs = offset_4_byte_attrs + num_4_byte_attrs;
+  uint16_t offset_1_byte_attrs = offset_2_byte_attrs + num_2_byte_attrs;
+
+  ColumnMap col_oid_to_id;
+  // Build the map from Schema columns to underlying columns
+  for (const auto &column : schema.GetColumns()) {
+    switch (column.GetAttrSize()) {
+      case 8:
+        col_oid_to_id[column.GetOid()] = col_id_t(offset_8_byte_attrs++);
+        break;
+      case 4:
+        col_oid_to_id[column.GetOid()] = col_id_t(offset_4_byte_attrs++);
+        break;
+      case 2:
+        col_oid_to_id[column.GetOid()] = col_id_t(offset_2_byte_attrs++);
+        break;
+      case 1:
+        col_oid_to_id[column.GetOid()] = col_id_t(offset_1_byte_attrs++);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return {storage::BlockLayout(attr_sizes), col_oid_to_id};
+}
+
 }  // namespace terrier::storage

--- a/test/include/util/catalog_test_util.h
+++ b/test/include/util/catalog_test_util.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <random>
+#include <vector>
+#include "catalog/schema.h"
+#include "common/typedefs.h"
+#include "type/type_id.h"
+#include "util/random_test_util.h"
+#include "util/storage_test_util.h"
+#include "util/test_thread_pool.h"
+
+namespace terrier {
+struct CatalogTestUtil {
+  // Returns a random Schema that is guaranteed to be valid for a single test instance. Multiple Schemas instantiated
+  // with this function may have non-unique oids, but within a Schema, Column oids are unique.
+  template <typename Random>
+  static catalog::Schema RandomSchema(const uint16_t max_cols, Random *const generator) {
+    TERRIER_ASSERT(max_cols > 0, "There should be at least 1 columm.");
+    col_oid_t col_oid(0);
+    const uint16_t num_attrs = std::uniform_int_distribution<uint16_t>(1, max_cols)(*generator);
+    std::vector<type::TypeId> possible_attr_types{
+        type::TypeId::BOOLEAN, type::TypeId::TINYINT,   type::TypeId::SMALLINT,  type::TypeId::INTEGER,
+        type::TypeId::BIGINT,  type::TypeId::DECIMAL,   type::TypeId::TIMESTAMP, type::TypeId::DATE,
+        type::TypeId::VARCHAR, type::TypeId::VARBINARY, type::TypeId::ARRAY};
+    std::vector<bool> possible_attr_nullable{true, false};
+    std::vector<catalog::Schema::Column> columns;
+    for (uint16_t i = 0; i < num_attrs; i++) {
+      type::TypeId attr_type = *RandomTestUtil::UniformRandomElement(&possible_attr_types, generator);
+      bool attr_nullable = *RandomTestUtil::UniformRandomElement(&possible_attr_nullable, generator);
+      columns.emplace_back("col_name", attr_type, attr_nullable, col_oid++);
+    }
+    return catalog::Schema(columns);
+  }
+};
+}  // namespace terrier

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -80,27 +80,6 @@ struct StorageTestUtil {
     return storage::BlockLayout(attr_sizes);
   }
 
-  // Returns a random Schema that is guaranteed to be valid for a single test instance. Multiple Schemas instantiated
-  // with this function may have non-unique oids, but within a Schema, Column oids are unique.
-  template <typename Random>
-  static catalog::Schema RandomSchema(const uint16_t max_cols, Random *const generator) {
-    TERRIER_ASSERT(max_cols > 0, "There should be at least 1 columm.");
-    col_oid_t col_oid(0);
-    const uint16_t num_attrs = std::uniform_int_distribution<uint16_t>(1, max_cols)(*generator);
-    std::vector<type::TypeId> possible_attr_types{
-        type::TypeId::BOOLEAN, type::TypeId::TINYINT,   type::TypeId::SMALLINT,  type::TypeId::INTEGER,
-        type::TypeId::BIGINT,  type::TypeId::DECIMAL,   type::TypeId::TIMESTAMP, type::TypeId::DATE,
-        type::TypeId::VARCHAR, type::TypeId::VARBINARY, type::TypeId::ARRAY};
-    std::vector<bool> possible_attr_nullable{true, false};
-    std::vector<catalog::Schema::Column> columns;
-    for (uint16_t i = 0; i < num_attrs; i++) {
-      type::TypeId attr_type = *RandomTestUtil::UniformRandomElement(&possible_attr_types, generator);
-      bool attr_nullable = *RandomTestUtil::UniformRandomElement(&possible_attr_nullable, generator);
-      columns.emplace_back("col_name", attr_type, attr_nullable, col_oid++);
-    }
-    return catalog::Schema(columns);
-  }
-
   // Fill the given location with the specified amount of random bytes, using the
   // given generator as a source of randomness.
   template <typename Random>

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -5,12 +5,14 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include "catalog/schema.h"
 #include "common/typedefs.h"
 #include "gtest/gtest.h"
 #include "storage/storage_defs.h"
 #include "storage/storage_util.h"
 #include "storage/tuple_access_strategy.h"
 #include "storage/undo_record.h"
+#include "type/type_id.h"
 #include "util/random_test_util.h"
 #include "util/test_thread_pool.h"
 
@@ -77,6 +79,27 @@ struct StorageTestUtil {
     for (uint16_t i = NUM_RESERVED_COLUMNS; i < num_attrs; i++)
       attr_sizes[i] = *RandomTestUtil::UniformRandomElement(&possible_attr_sizes, generator);
     return storage::BlockLayout(attr_sizes);
+  }
+
+  // Returns a random Schema that is guaranteed to be valid for a single test instance. Multiple Schemas instantiated
+  // with this function may have non-unique oids, but within a Schema, Column oids are unique.
+  template <typename Random>
+  static catalog::Schema RandomSchema(const uint16_t max_cols, Random *const generator) {
+    TERRIER_ASSERT(max_cols > 0, "There should be at least 1 columm.");
+    col_oid_t col_oid(0);
+    const uint16_t num_attrs = std::uniform_int_distribution<uint16_t>(1, max_cols)(*generator);
+    std::vector<type::TypeId> possible_attr_types{
+        type::TypeId::BOOLEAN, type::TypeId::TINYINT,   type::TypeId::SMALLINT,  type::TypeId::INTEGER,
+        type::TypeId::BIGINT,  type::TypeId::DECIMAL,   type::TypeId::TIMESTAMP, type::TypeId::DATE,
+        type::TypeId::VARCHAR, type::TypeId::VARBINARY, type::TypeId::ARRAY};
+    std::vector<bool> possible_attr_nullable{true, false};
+    std::vector<catalog::Schema::Column> columns;
+    for (uint16_t i = 0; i < num_attrs; i++) {
+      type::TypeId attr_type = *RandomTestUtil::UniformRandomElement(&possible_attr_types, generator);
+      bool attr_nullable = *RandomTestUtil::UniformRandomElement(&possible_attr_nullable, generator);
+      columns.emplace_back("col_name", attr_type, attr_nullable, col_oid++);
+    }
+    return catalog::Schema(columns);
   }
 
   // Fill the given location with the specified amount of random bytes, using the

--- a/test/storage/storage_util_test.cpp
+++ b/test/storage/storage_util_test.cpp
@@ -8,6 +8,7 @@
 #include "common/object_pool.h"
 #include "storage/data_table.h"
 #include "storage/storage_defs.h"
+#include "util/catalog_test_util.h"
 #include "util/storage_test_util.h"
 #include "util/test_harness.h"
 
@@ -204,7 +205,7 @@ TEST_F(StorageUtilTests, BlockLayoutFromSchema) {
   for (uint32_t iteration = 0; iteration < num_iterations_; iteration++) {
     uint16_t max_columns = 1000;
     const catalog::Schema schema =
-        StorageTestUtil::RandomSchema(static_cast<uint16_t>(max_columns - NUM_RESERVED_COLUMNS), &generator_);
+        CatalogTestUtil::RandomSchema(static_cast<uint16_t>(max_columns - NUM_RESERVED_COLUMNS), &generator_);
     const auto layout_and_col_map = storage::StorageUtil::BlockLayoutFromSchema(schema);
     const storage::BlockLayout layout = layout_and_col_map.first;
     const std::unordered_map<col_oid_t, col_id_t> column_map = layout_and_col_map.second;

--- a/test/storage/storage_util_test.cpp
+++ b/test/storage/storage_util_test.cpp
@@ -203,7 +203,8 @@ TEST_F(StorageUtilTests, ApplyDelta) {
 TEST_F(StorageUtilTests, BlockLayoutFromSchema) {
   for (uint32_t iteration = 0; iteration < num_iterations_; iteration++) {
     uint16_t max_columns = 1000;
-    const catalog::Schema schema = StorageTestUtil::RandomSchema(max_columns - NUM_RESERVED_COLUMNS, &generator_);
+    const catalog::Schema schema =
+        StorageTestUtil::RandomSchema(static_cast<uint16_t>(max_columns - NUM_RESERVED_COLUMNS), &generator_);
     const auto layout_and_col_map = storage::StorageUtil::BlockLayoutFromSchema(schema);
     const storage::BlockLayout layout = layout_and_col_map.first;
     const std::unordered_map<col_oid_t, col_id_t> column_map = layout_and_col_map.second;
@@ -217,7 +218,7 @@ TEST_F(StorageUtilTests, BlockLayoutFromSchema) {
 
     // Verify that the BlockLayout's columns are sorted by attribute size in descending order
     for (uint16_t i = 0; i < layout.NumColumns() - 1; i++) {
-      EXPECT_GE(layout.AttrSize(col_id_t(i)), layout.AttrSize(col_id_t(i + 1)));
+      EXPECT_GE(layout.AttrSize(col_id_t(i)), layout.AttrSize(col_id_t(static_cast<uint16_t>(i + 1))));
     }
 
     // Verify the contents of the column_map

--- a/test/storage/storage_util_test.cpp
+++ b/test/storage/storage_util_test.cpp
@@ -228,7 +228,6 @@ TEST_F(StorageUtilTests, BlockLayoutFromSchema) {
 
       // Column id should not map to either of the reserved columns
       EXPECT_NE(col_id, col_id_t(0));
-      EXPECT_NE(col_id, col_id_t(1));
       // Find the Column in the Schema corresponding to the current oid
       auto schema_column =
           std::find_if(schema.GetColumns().cbegin(), schema.GetColumns().cend(),


### PR DESCRIPTION
Fix #140.

It's mostly a wrapper of DataTable except that SqlTable is instantiated from a Schema, which then generates a BlockLayout to instantiate a DataTable from, generating a map from Column col_oids to BlockLayout col_ids for use in the binding phase.

I also added ProjectedRowInitializer and ProjectedColumnInitializers that can be called with just col_oids. We want to keep col_id as a purely storage abstraction. I also added constraints that columns must be distinct in a projection. If there are repeats in the original query, handle that early in the execution pipeline and only materialize once.

It's not clear how much testing I should have at this layer right now. We'd really just be exercising the DataTable. I added testing for the Schema -> BlockLayout and corresponding ColumnMap.

Once indexes and such are in, the logic will get more complicated at this layer.