### PR TITLE
Log performance fix

### DIFF
--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -93,19 +93,8 @@ class BufferedLogWriter {
   void Close() { PosixIoWrappers::Close(out_); }
 
   /**
-   * Check if the internal buffer of this BufferedLogWriter has enough space for the specified number of bytes. If the
-   * call returns false, the caller is responsible for either flushing the buffer and handle accordingly or use the
-   * non-buffered version for writes that are too large.
-   *
-   * @param size number of bytes to check for
-   * @return if the internal buffer can hold the given number of bytes.
-   */
-  bool CanBuffer(uint32_t size) { return BUFFER_SIZE - buffer_size_ >= size; }
-
-  /**
    * Write to the log file the given amount of bytes from the given location in memory, but buffer the write so the
-   * update is only written out when the BufferedLogWriter is flushed. It is the caller's responsibility to check
-   * before hand with @see CanBuffer that the write can be buffered into the BufferedLogWriter.
+   * update is only written out when the BufferedLogWriter is persisted.
    * @param data memory location of the bytes to write
    * @param size number of bytes to write
    */
@@ -116,29 +105,26 @@ class BufferedLogWriter {
   }
 
   /**
-   * Write directly to the file, without buffer, the given amount of bytes from the given location in memory. This
-   * method should only be called on objects that are too large to be buffered, as calling this on every small write
-   * would be slow. Additionally, there is no guarantee on the write being persistent on method exist until a call to
-   * Flush().
-   *
-   * @param data memory location of the bytes to write
-   * @param size number of bytes to write
-   */
-  void WriteUnsynced(const void *data, uint32_t size) { PosixIoWrappers::WriteFully(out_, data, size); }
-
-  /**
    * Flush any buffered writes and call fsync to make sure that all writes are consistent.
    */
-  void Flush() {
-    WriteUnsynced(buffer_, buffer_size_);
+  void Persist() {
+    Flush();
     if (fsync(out_) == -1) throw std::runtime_error("fsync failed with errno " + std::to_string(errno));
-    buffer_size_ = 0;
   }
 
  private:
   int out_;  // fd of the output files
   char buffer_[BUFFER_SIZE];
   uint32_t buffer_size_ = 0;
+
+  bool CanBuffer(uint32_t size) { return BUFFER_SIZE - buffer_size_ >= size; }
+
+  void WriteUnsynced(const void *data, uint32_t size) { PosixIoWrappers::WriteFully(out_, data, size); }
+
+  void Flush() {
+    WriteUnsynced(buffer_, buffer_size_);
+    buffer_size_ = 0;
+  }
 };
 
 /**

--- a/src/include/storage/write_ahead_log/log_manager.h
+++ b/src/include/storage/write_ahead_log/log_manager.h
@@ -10,6 +10,7 @@
 #include "storage/record_buffer.h"
 #include "storage/write_ahead_log/log_io.h"
 #include "storage/write_ahead_log/log_record.h"
+#include "transaction/transaction_defs.h"
 
 namespace terrier::storage {
 /**
@@ -51,22 +52,6 @@ class LogManager {
   }
 
   /**
-   * Register a callback for the committed transaction beginning at the given time, such that the callback will be
-   * called as soon as possible by the LogManager when its commit record is out. Behavior is not defined if the provided
-   * transaction is aborted or uncommitted and the callback might never be invoked.
-   *
-   * @param txn_begin begin timestamp of the transaction to observe on
-   * @param callback the callback to invoke when the commit record is persistent; this callback will be invoked on the
-   *                 serializing thread, and should be kept short and fast, performing no expensive computation or waits
-   *                 on resources.
-   */
-  void RegisterTransactionFlushedCallback(timestamp_t txn_begin, const std::function<void()> &callback) {
-    common::SpinLatch::ScopedSpinLatch guard(&callbacks_latch_);
-    auto ret UNUSED_ATTRIBUTE = callbacks_.emplace(txn_begin, callback);
-    TERRIER_ASSERT(ret.second, "Insertion failed, callback is already registered for given transaction");
-  }
-
-  /**
    * Process all the accumulated log records and serialize them out to disk. Flush can happen immediately or later
    * depending on the state of the LogManager, and an explicit call to Flush() is required for any guarantee. (Beware
    * the performance consequences of calling flush too frequently) This method should only be called from a dedicated
@@ -87,14 +72,13 @@ class LogManager {
   RecordBufferSegmentPool *buffer_pool_;
 
   // TODO(Tianyu): Might not be necessary, since commit on txn manager is already protected with a latch
-  common::SpinLatch flush_queue_latch_, callbacks_latch_;
+  common::SpinLatch flush_queue_latch_;
   // TODO(Tianyu): benchmark for if these should be concurrent data structures, and if we should apply the same
   // optimization we applied to the GC queue.
   std::queue<RecordBufferSegment *> flush_queue_;
-  std::unordered_map<timestamp_t, std::function<void()>> callbacks_;
 
   // These do not need to be thread safe since the only thread adding or removing from it is the flushing thread
-  std::vector<timestamp_t> commits_in_buffer_;
+  std::vector<std::pair<transaction::callback_fn, void *>> commits_in_buffer_;
 
   void SerializeRecord(const LogRecord &record);
 

--- a/src/include/transaction/transaction_defs.h
+++ b/src/include/transaction/transaction_defs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <forward_list>
+#include "common/typedefs.h"
 namespace terrier::transaction {
 class TransactionContext;
 // Explicitly define the underlying structure of std::queue as std::list since we believe the default (std::deque) may
@@ -10,4 +11,5 @@ class TransactionContext;
 // background thread (GC). This structure can be replace with something faster if it becomes a measurable performance
 // bottleneck.
 using TransactionQueue = std::forward_list<transaction::TransactionContext *>;
+typedef void (*callback_fn)(void *);
 }  // namespace terrier::transaction

--- a/src/include/transaction/transaction_defs.h
+++ b/src/include/transaction/transaction_defs.h
@@ -11,5 +11,5 @@ class TransactionContext;
 // background thread (GC). This structure can be replace with something faster if it becomes a measurable performance
 // bottleneck.
 using TransactionQueue = std::forward_list<transaction::TransactionContext *>;
-typedef void (*callback_fn)(void *);
+using callback_fn = void (*)(void *);
 }  // namespace terrier::transaction

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -39,12 +39,11 @@ class TransactionManager {
   /**
    * Commits a transaction, making all of its changes visible to others.
    * @param txn the transaction to commit
-   * @param callback callback function that the transaction manager will execute as soon as all log records of the
-   *                 given transaction is flushed out. Needless to say, short callbacks that delegates work
-   *                 to a different thread is preferable.
+   * @param callback function pointer of the callback to invoke when commit is
+   * @param callback_arg a void * argument that can be passed to the callback function when invoked
    * @return commit timestamp of this transaction
    */
-  timestamp_t Commit(TransactionContext *txn, const std::function<void()> &callback);
+  timestamp_t Commit(TransactionContext *txn, transaction::callback_fn callback, void *callback_arg);
 
   /**
    * Aborts a transaction, rolling back its changes (if any).

--- a/test/include/util/transaction_test_util.h
+++ b/test/include/util/transaction_test_util.h
@@ -13,6 +13,11 @@
 #include "util/test_harness.h"
 
 namespace terrier {
+struct TestCallbacks {
+  TestCallbacks() = delete;
+  static void EmptyCallback(void *) {}
+};
+
 class LargeTransactionTestObject;
 class RandomWorkloadTransaction;
 using TupleEntry = std::pair<storage::TupleSlot, storage::ProjectedRow *>;

--- a/test/include/util/transaction_test_util.h
+++ b/test/include/util/transaction_test_util.h
@@ -15,7 +15,7 @@
 namespace terrier {
 struct TestCallbacks {
   TestCallbacks() = delete;
-  static void EmptyCallback(void *) {}
+  static void EmptyCallback(void * /*unused*/) {}
 };
 
 class LargeTransactionTestObject;

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -9,6 +9,7 @@
 #include "transaction/transaction_manager.h"
 #include "util/storage_test_util.h"
 #include "util/test_harness.h"
+#include "util/transaction_test_util.h"
 
 namespace terrier {
 // Not thread-safe
@@ -102,7 +103,7 @@ TEST_F(GarbageCollectorTests, SingleInsert) {
     // Nothing should be able to be GC'd yet because txn0 has not committed yet
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the Insert's UndoRecord, then deallocate it on the next run
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -119,7 +120,7 @@ TEST_F(GarbageCollectorTests, ReadOnly) {
     storage::GarbageCollector gc(&txn_manager);
 
     auto *txn0 = txn_manager.BeginTransaction();
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the txn and deallocate immediately because it's read-only
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -141,7 +142,7 @@ TEST_F(GarbageCollectorTests, WriteWriteConflictRequeue) {
     // insert the tuple to be Updated later
     auto *txn = txn_manager.BeginTransaction();
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -193,7 +194,7 @@ TEST_F(GarbageCollectorTests, CommitInsert1) {
     tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     // Nothing should be able to be GC'd yet because txn1 started before txn0's commit
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
@@ -201,7 +202,7 @@ TEST_F(GarbageCollectorTests, CommitInsert1) {
     tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the two transactions and then deallocate the single non-read-only transaction
     EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
@@ -212,7 +213,7 @@ TEST_F(GarbageCollectorTests, CommitInsert1) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the read-only transaction, and it shouldn't make it to the second invocation because it's read-only
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -245,7 +246,7 @@ TEST_F(GarbageCollectorTests, CommitInsert2) {
     // Nothing should be able to be GC'd yet because txn0 has not committed yet
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     tested.SelectIntoBuffer(txn0, slot);
     EXPECT_FALSE(tested.select_result_);
@@ -253,7 +254,7 @@ TEST_F(GarbageCollectorTests, CommitInsert2) {
     // Nothing should be able to be GC'd yet because txn0 started before txn1's commit
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the two transactions and then deallocate the single non-read-only transaction
     EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
@@ -264,7 +265,7 @@ TEST_F(GarbageCollectorTests, CommitInsert2) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the read-only transaction
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -308,7 +309,7 @@ TEST_F(GarbageCollectorTests, AbortInsert1) {
     tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     // Deallocate the aborted txn, and process the read-only transaction
     EXPECT_EQ(std::make_pair(1u, 1u), gc.PerformGarbageCollection());
@@ -319,7 +320,7 @@ TEST_F(GarbageCollectorTests, AbortInsert1) {
 
     tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(tested.select_result_);
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the read-only transaction
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -363,7 +364,7 @@ TEST_F(GarbageCollectorTests, AbortInsert2) {
     tested.SelectIntoBuffer(txn0, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     // Deallocate the aborted txn, and process the read-only transaction
     EXPECT_EQ(std::make_pair(1u, 1u), gc.PerformGarbageCollection());
@@ -374,7 +375,7 @@ TEST_F(GarbageCollectorTests, AbortInsert2) {
 
     tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(tested.select_result_);
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the read-only transaction
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -396,7 +397,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate1) {
     // insert the tuple to be Updated later
     auto *txn = txn_manager.BeginTransaction();
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink and reclaim the Insert
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -423,7 +424,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate1) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     // Nothing should be able to be GC'd yet because txn1 started before txn0's commit
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
@@ -432,7 +433,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate1) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the update and read-only txns, then deallocate the update txn
     EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
@@ -444,7 +445,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate1) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the read-only transaction
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -466,7 +467,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate2) {
     // insert the tuple to be Updated later
     auto *txn = txn_manager.BeginTransaction();
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink and reclaim the Insert
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -493,7 +494,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate2) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     // Nothing should be able to be GC'd yet because txn0 started before txn1's commit
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
@@ -502,7 +503,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate2) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the update and read-only txns, then deallocate the update txn
     EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
@@ -514,7 +515,7 @@ TEST_F(GarbageCollectorTests, CommitUpdate2) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the read-only transaction
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -536,7 +537,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate1) {
     // insert the tuple to be Updated later
     auto *txn = txn_manager.BeginTransaction();
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink and reclaim the Insert
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -574,7 +575,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate1) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     // Deallocate the aborted txn, and process the read-only transaction
     EXPECT_EQ(std::make_pair(1u, 1u), gc.PerformGarbageCollection());
@@ -586,7 +587,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate1) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the read-only transaction
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -608,7 +609,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate2) {
     // insert the tuple to be Updated later
     auto *txn = txn_manager.BeginTransaction();
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink and reclaim the Insert
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -646,7 +647,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate2) {
     // But it's not safe to deallocate it yet because txn #0 is still running and may hold a reference to it
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     // Deallocate the aborted txn, and process the read-only transaction
     EXPECT_EQ(std::make_pair(1u, 1u), gc.PerformGarbageCollection());
@@ -658,7 +659,7 @@ TEST_F(GarbageCollectorTests, AbortUpdate2) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
 
     // Unlink the read-only transaction
     EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
@@ -689,7 +690,7 @@ TEST_F(GarbageCollectorTests, InsertUpdate1) {
     // Nothing should be able to be GC'd yet because txn1 has not committed yet
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     // Nothing should be able to be GC'd yet because txn0 started before txn1's commit
     EXPECT_EQ(std::make_pair(0u, 0u), gc.PerformGarbageCollection());

--- a/test/storage/log_test.cpp
+++ b/test/storage/log_test.cpp
@@ -98,7 +98,7 @@ TEST_F(WriteAheadLoggingTests, LargeLogTest) {
   LargeTransactionTestObject tested(5, 1, 5, {0.0, 1.0}, &block_store_, &pool_, &generator_, true, true, &log_manager_);
   StartLogging(10);
   StartGC(tested.GetTxnManager(), 10);
-  auto result = tested.SimulateOltp(1, 4);
+  auto result = tested.SimulateOltp(100, 4);
   EndGC();
   EndLogging();
 

--- a/test/storage/log_test.cpp
+++ b/test/storage/log_test.cpp
@@ -47,7 +47,8 @@ class WriteAheadLoggingTests : public TerrierTest {
     auto txn_begin = in->ReadValue<timestamp_t>();
     if (record_type == storage::LogRecordType::COMMIT) {
       auto txn_commit = in->ReadValue<timestamp_t>();
-      return storage::CommitRecord::Initialize(buf, txn_begin, txn_commit);
+      // Okay to fill in null since nobody will invoke the callback
+      return storage::CommitRecord::Initialize(buf, txn_begin, txn_commit, nullptr, nullptr);
     }
     // TODO(Tianyu): Without a lookup mechanism this oid is not exactly meaningful. Implement lookup when possible
     auto table_oid UNUSED_ATTRIBUTE = in->ReadValue<table_oid_t>();

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -8,6 +8,7 @@
 #include "transaction/transaction_manager.h"
 #include "util/storage_test_util.h"
 #include "util/test_harness.h"
+#include "util/transaction_test_util.h"
 
 namespace terrier {
 // Not thread-safe
@@ -126,12 +127,12 @@ TEST_F(MVCCTests, CommitInsert1) {
     tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -139,7 +140,7 @@ TEST_F(MVCCTests, CommitInsert1) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -184,13 +185,13 @@ TEST_F(MVCCTests, CommitInsert2) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     tested.SelectIntoBuffer(txn0, slot);
 
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -198,7 +199,7 @@ TEST_F(MVCCTests, CommitInsert2) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -248,14 +249,14 @@ TEST_F(MVCCTests, AbortInsert1) {
     tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
 
     tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(tested.select_result_);
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -305,14 +306,14 @@ TEST_F(MVCCTests, AbortInsert2) {
     tested.SelectIntoBuffer(txn0, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
 
     tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(tested.select_result_);
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -347,7 +348,7 @@ TEST_F(MVCCTests, CommitUpdate1) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -369,13 +370,13 @@ TEST_F(MVCCTests, CommitUpdate1) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -383,7 +384,7 @@ TEST_F(MVCCTests, CommitUpdate1) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -418,7 +419,7 @@ TEST_F(MVCCTests, CommitUpdate2) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -439,13 +440,13 @@ TEST_F(MVCCTests, CommitUpdate2) {
     select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -453,7 +454,7 @@ TEST_F(MVCCTests, CommitUpdate2) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, update_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -488,7 +489,7 @@ TEST_F(MVCCTests, AbortUpdate1) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -516,7 +517,7 @@ TEST_F(MVCCTests, AbortUpdate1) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -524,7 +525,7 @@ TEST_F(MVCCTests, AbortUpdate1) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -559,7 +560,7 @@ TEST_F(MVCCTests, AbortUpdate2) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -587,7 +588,7 @@ TEST_F(MVCCTests, AbortUpdate2) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -595,7 +596,7 @@ TEST_F(MVCCTests, AbortUpdate2) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -632,7 +633,7 @@ TEST_F(MVCCTests, InsertUpdate1) {
     storage::ProjectedRow *select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
     EXPECT_FALSE(tested.table_.Update(txn0, slot, *update));
@@ -675,7 +676,7 @@ TEST_F(MVCCTests, CommitDelete1) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn0 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn0);
@@ -692,20 +693,20 @@ TEST_F(MVCCTests, CommitDelete1) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
 
     tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(tested.select_result_);
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -740,7 +741,7 @@ TEST_F(MVCCTests, CommitDelete2) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn0 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn0);
@@ -757,20 +758,20 @@ TEST_F(MVCCTests, CommitDelete2) {
     tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
 
     tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(tested.select_result_);
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -805,7 +806,7 @@ TEST_F(MVCCTests, AbortDelete1) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn0 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn0);
@@ -828,7 +829,7 @@ TEST_F(MVCCTests, AbortDelete1) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -836,7 +837,7 @@ TEST_F(MVCCTests, AbortDelete1) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -871,7 +872,7 @@ TEST_F(MVCCTests, AbortDelete2) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn0 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn0);
@@ -894,7 +895,7 @@ TEST_F(MVCCTests, AbortDelete2) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -902,7 +903,7 @@ TEST_F(MVCCTests, AbortDelete2) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -939,7 +940,7 @@ TEST_F(MVCCTests, CommitUpdateDelete1) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -966,20 +967,20 @@ TEST_F(MVCCTests, CommitUpdateDelete1) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
 
     tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(tested.select_result_);
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -1016,7 +1017,7 @@ TEST_F(MVCCTests, CommitUpdateDelete2) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -1042,20 +1043,20 @@ TEST_F(MVCCTests, CommitUpdateDelete2) {
     tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(tested.select_result_);
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     select_tuple = tested.SelectIntoBuffer(txn0, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
 
     tested.SelectIntoBuffer(txn2, slot);
     EXPECT_FALSE(tested.select_result_);
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -1092,7 +1093,7 @@ TEST_F(MVCCTests, AbortUpdateDelete1) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -1125,7 +1126,7 @@ TEST_F(MVCCTests, AbortUpdateDelete1) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -1133,7 +1134,7 @@ TEST_F(MVCCTests, AbortUpdateDelete1) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -1170,7 +1171,7 @@ TEST_F(MVCCTests, AbortUpdateDelete2) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -1203,7 +1204,7 @@ TEST_F(MVCCTests, AbortUpdateDelete2) {
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn2 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn2);
@@ -1211,7 +1212,7 @@ TEST_F(MVCCTests, AbortUpdateDelete2) {
     select_tuple = tested.SelectIntoBuffer(txn2, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn2, [] {});
+    txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -1241,7 +1242,7 @@ TEST_F(MVCCTests, SimpleDelete1) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -1268,14 +1269,14 @@ TEST_F(MVCCTests, SimpleDelete1) {
     update = tested.GenerateRandomUpdate(&generator_);
     EXPECT_FALSE(tested.table_.Update(txn0, slot, *update));
 
-    txn_manager.Commit(txn0, [] {});
+    txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
 
     auto *txn1 = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn1);
 
     tested.SelectIntoBuffer(txn1, slot);
     EXPECT_FALSE(tested.select_result_);
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 
@@ -1305,7 +1306,7 @@ TEST_F(MVCCTests, SimpleDelete2) {
     auto *txn = txn_manager.BeginTransaction();
     tested.loose_txns_.push_back(txn);
     storage::TupleSlot slot = tested.table_.Insert(txn, *insert_tuple);
-    txn_manager.Commit(txn, [] {});
+    txn_manager.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
 
     storage::ProjectedRow *update = tested.GenerateRandomUpdate(&generator_);
 
@@ -1340,7 +1341,7 @@ TEST_F(MVCCTests, SimpleDelete2) {
     select_tuple = tested.SelectIntoBuffer(txn1, slot);
     EXPECT_TRUE(tested.select_result_);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), select_tuple, insert_tuple));
-    txn_manager.Commit(txn1, [] {});
+    txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
   }
 }
 

--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -78,7 +78,7 @@ void RandomWorkloadTransaction::Finish() {
   if (aborted_)
     test_object_->txn_manager_.Abort(txn_);
   else
-    commit_time_ = test_object_->txn_manager_.Commit(txn_, [] {});
+    commit_time_ = test_object_->txn_manager_.Commit(txn_, TestCallbacks::EmptyCallback, nullptr);
 }
 
 LargeTransactionTestObject::LargeTransactionTestObject(uint16_t max_columns, uint32_t initial_table_size,
@@ -206,7 +206,7 @@ void LargeTransactionTestObject::PopulateInitialTable(uint32_t num_tuples, Rando
     }
     last_checked_version_.emplace_back(inserted, bookkeeping_ ? redo : nullptr);
   }
-  txn_manager_.Commit(initial_txn_, [] {});
+  txn_manager_.Commit(initial_txn_, TestCallbacks::EmptyCallback, nullptr);
   // cleanup if not keeping track of all the inserts.
   if (!bookkeeping_) delete[] redo_buffer;
 }


### PR DESCRIPTION
WAL was limiting transaction throughput even when not waiting on disk flush because of contention at a global callback map. It no longer does that as we now embed callback into a commit record. We achieve comparable performance to when logging is turned off on dev 4.  More detailed charts are coming.

Retardedness in the log IO code is also gone.