### PR TITLE
Reorganize strong typedefs to have namespaces

### DIFF
--- a/benchmark/include/util/transaction_benchmark_util.h
+++ b/benchmark/include/util/transaction_benchmark_util.h
@@ -68,10 +68,10 @@ class RandomWorkloadTransaction {
    */
   void Finish();
 
-  timestamp_t BeginTimestamp() const { return start_time_; }
+  transaction::timestamp_t BeginTimestamp() const { return start_time_; }
 
-  timestamp_t CommitTimestamp() const {
-    if (aborted_) return timestamp_t(static_cast<uint64_t>(-1));
+  transaction::timestamp_t CommitTimestamp() const {
+    if (aborted_) return transaction::timestamp_t(static_cast<uint64_t>(-1));
     return commit_time_;
   }
 
@@ -83,7 +83,7 @@ class RandomWorkloadTransaction {
   transaction::TransactionContext *txn_;
   // extra bookkeeping for correctness checks
   bool aborted_;
-  timestamp_t start_time_, commit_time_;
+  transaction::timestamp_t start_time_, commit_time_;
   std::unordered_map<storage::TupleSlot, storage::ProjectedRow *> updates_;
   byte *buffer_;
 };

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 #include "benchmark/benchmark.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/data_table.h"
 #include "storage/storage_util.h"
 #include "transaction/transaction_context.h"
@@ -84,9 +84,10 @@ class DataTableBenchmark : public benchmark::Fixture {
 BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    storage::DataTable table(&block_store_, layout_, layout_version_t(0));
+    storage::DataTable table(&block_store_, layout_, storage::layout_version_t(0));
     // We can use dummy timestamps here since we're not invoking concurrency control
-    transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool_, LOGGING_DISABLED);
+    transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
+                                        LOGGING_DISABLED);
     for (uint32_t i = 0; i < num_inserts_; ++i) {
       table.Insert(&txn, *redo_);
     }
@@ -101,10 +102,11 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state
   TestThreadPool thread_pool;
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    storage::DataTable table(&block_store_, layout_, layout_version_t(0));
+    storage::DataTable table(&block_store_, layout_, storage::layout_version_t(0));
     auto workload = [&](uint32_t id) {
       // We can use dummy timestamps here since we're not invoking concurrency control
-      transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool_, LOGGING_DISABLED);
+      transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
+                                          LOGGING_DISABLED);
       for (uint32_t i = 0; i < num_inserts_ / num_threads_; i++) table.Insert(&txn, *redo_);
     };
     thread_pool.RunThreadsUntilFinish(num_threads_, workload);
@@ -116,10 +118,11 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state
 // Read the num_reads_ of tuples in a sequential order from a DataTable in a single thread
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(DataTableBenchmark, SequentialRead)(benchmark::State &state) {
-  storage::DataTable read_table(&block_store_, layout_, layout_version_t(0));
+  storage::DataTable read_table(&block_store_, layout_, storage::layout_version_t(0));
   // Populate read_table by inserting tuples
   // We can use dummy timestamps here since we're not invoking concurrency control
-  transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool_, LOGGING_DISABLED);
+  transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
+                                      LOGGING_DISABLED);
   std::vector<storage::TupleSlot> read_order;
   for (uint32_t i = 0; i < num_reads_; ++i) {
     read_order.emplace_back(read_table.Insert(&txn, *redo_));
@@ -137,10 +140,11 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SequentialRead)(benchmark::State &state) 
 // Read the num_reads_ of tuples in a random order from a DataTable in a single thread
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(DataTableBenchmark, RandomRead)(benchmark::State &state) {
-  storage::DataTable read_table(&block_store_, layout_, layout_version_t(0));
+  storage::DataTable read_table(&block_store_, layout_, storage::layout_version_t(0));
   // Populate read_table_ by inserting tuples
   // We can use dummy timestamps here since we're not invoking concurrency control
-  transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool_, LOGGING_DISABLED);
+  transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
+                                      LOGGING_DISABLED);
   std::vector<storage::TupleSlot> read_order;
   for (uint32_t i = 0; i < num_reads_; ++i) {
     read_order.emplace_back(read_table.Insert(&txn, *redo_));
@@ -161,10 +165,11 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, RandomRead)(benchmark::State &state) {
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentRandomRead)(benchmark::State &state) {
   TestThreadPool thread_pool;
-  storage::DataTable read_table(&block_store_, layout_, layout_version_t(0));
+  storage::DataTable read_table(&block_store_, layout_, storage::layout_version_t(0));
   // populate read_table_ by inserting tuples
   // We can use dummy timestamps here since we're not invoking concurrency control
-  transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool_, LOGGING_DISABLED);
+  transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
+                                      LOGGING_DISABLED);
   std::vector<storage::TupleSlot> read_order;
   for (uint32_t i = 0; i < num_reads_; ++i) {
     read_order.emplace_back(read_table.Insert(&txn, *redo_));
@@ -181,7 +186,8 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentRandomRead)(benchmark::State &s
   for (auto _ : state) {
     auto workload = [&](uint32_t id) {
       // We can use dummy timestamps here since we're not invoking concurrency control
-      transaction::TransactionContext txn(timestamp_t(0), timestamp_t(0), &buffer_pool_, LOGGING_DISABLED);
+      transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
+                                          LOGGING_DISABLED);
       for (uint32_t i = 0; i < num_reads_ / num_threads_; i++)
         read_table.Select(&txn, read_order[(rand_read_offsets[id] + i) % read_order.size()], reads_[id]);
     };

--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -1,7 +1,7 @@
 #include <vector>
 
 #include "benchmark/benchmark.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/storage_util.h"
 #include "storage/tuple_access_strategy.h"
 #include "util/storage_test_util.h"
@@ -60,7 +60,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
       storage::RawBlock *raw_block = block_store_.Get();
       raw_blocks_.emplace_back(raw_block);
       TERRIER_MEMSET(raw_block, 0, sizeof(storage::RawBlock));
-      tested.InitializeRawBlock(raw_block, layout_version_t(0));
+      tested.InitializeRawBlock(raw_block, storage::layout_version_t(0));
       for (uint32_t j = 0; j < layout_.NumSlots(); j++) {
         storage::TupleSlot slot;
         tested.Allocate(raw_block, &slot);
@@ -89,7 +89,7 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, ConcurrentInsert)(benchmark::St
       storage::RawBlock *raw_block = block_store_.Get();
       raw_blocks_.emplace_back(raw_block);
       TERRIER_MEMSET(raw_block, 0, sizeof(storage::RawBlock));
-      tested.InitializeRawBlock(raw_block, layout_version_t(0));
+      tested.InitializeRawBlock(raw_block, storage::layout_version_t(0));
 
       auto workload = [&](uint32_t id) {
         for (uint32_t j = 0; j < layout_.NumSlots() / num_threads_; j++) {

--- a/benchmark/util/transaction_benchmark_util.cpp
+++ b/benchmark/util/transaction_benchmark_util.cpp
@@ -25,7 +25,8 @@ void RandomWorkloadTransaction::RandomUpdate(Random *generator) {
   if (aborted_) return;
   storage::TupleSlot updated =
       RandomTestUtil::UniformRandomElement(test_object_->last_checked_version_, generator)->first;
-  std::vector<col_id_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(test_object_->layout_, generator);
+  std::vector<storage::col_id_t> update_col_ids =
+      StorageTestUtil::ProjectionListRandomColumns(test_object_->layout_, generator);
   storage::ProjectedRowInitializer initializer(test_object_->layout_, update_col_ids);
   auto *update_buffer = buffer_;
   storage::ProjectedRow *update = initializer.InitializeRow(update_buffer);
@@ -43,7 +44,7 @@ void RandomWorkloadTransaction::RandomUpdate(Random *generator) {
 template <class Random>
 void RandomWorkloadTransaction::RandomInsert(Random *generator) {
   if (aborted_) return;
-  std::vector<col_id_t> insert_col_ids = StorageTestUtil::ProjectionListAllColumns(test_object_->layout_);
+  std::vector<storage::col_id_t> insert_col_ids = StorageTestUtil::ProjectionListAllColumns(test_object_->layout_);
   storage::ProjectedRowInitializer initializer(test_object_->layout_, insert_col_ids);
   auto *insert_buffer = buffer_;
   storage::ProjectedRow *insert = initializer.InitializeRow(insert_buffer);
@@ -85,7 +86,7 @@ LargeTransactionBenchmarkObject::LargeTransactionBenchmarkObject(const std::vect
       operation_ratio_(std::move(operation_ratio)),
       generator_(generator),
       layout_({attr_sizes}),
-      table_(block_store, layout_, layout_version_t(0)),
+      table_(block_store, layout_, storage::layout_version_t(0)),
       txn_manager_(buffer_pool, gc_on, log_manager),
       gc_on_(gc_on),
       wal_on_(log_manager != LOGGING_DISABLED),

--- a/src/include/catalog/catalog_defs.h
+++ b/src/include/catalog/catalog_defs.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "common/strong_typedef.h"
+
+namespace terrier::catalog {
+STRONG_TYPEDEF(col_oid_t, uint32_t);
+STRONG_TYPEDEF(table_oid_t, uint32_t);
+}  // namespace terrier::catalog

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include "common/constants.h"
 #include "common/macros.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/storage_defs.h"
 #include "type/type_id.h"
 #include "type/type_util.h"
@@ -96,9 +96,9 @@ class Schema {
    * @param col_id offset into the schema specifying which Column to access
    * @return description of the schema for a specific column
    */
-  Column GetColumn(const col_id_t col_id) const {
+  Column GetColumn(const storage::col_id_t col_id) const {
     TERRIER_ASSERT((!col_id) < columns_.size(), "column id is out of bounds for this Schema");
-    return columns_[static_cast<uint16_t>(col_id)];
+    return columns_[!col_id];
   }
   /**
    * @return description of this SQL table's schema as a collection of Columns

--- a/src/include/common/allocator.h
+++ b/src/include/common/allocator.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cerrno>
 #include <cstdlib>
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 namespace terrier::common {
 
 /**

--- a/src/include/common/container/bitmap.h
+++ b/src/include/common/container/bitmap.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 
 #ifndef BYTE_SIZE
 #define BYTE_SIZE 8u

--- a/src/include/common/container/concurrent_bitmap.h
+++ b/src/include/common/container/concurrent_bitmap.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include "common/allocator.h"
 #include "common/container/bitmap.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 
 // This code should not compile if these assumptions are not true.
 static_assert(sizeof(std::atomic<uint8_t>) == sizeof(uint8_t), "unexpected std::atomic size for 8-bit ints");

--- a/src/include/common/container/concurrent_map.h
+++ b/src/include/common/container/concurrent_map.h
@@ -4,7 +4,7 @@
 #include <functional>
 #include <utility>
 #include "common/macros.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 
 namespace terrier::common {
 #define TEMPLATE_ARGS K, V, Hasher, Equality, Alloc

--- a/src/include/common/hash_util.h
+++ b/src/include/common/hash_util.h
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <string>
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 namespace terrier::common {
 
 using hash_t = uint64_t;

--- a/src/include/common/object_pool.h
+++ b/src/include/common/object_pool.h
@@ -6,7 +6,7 @@
 #include "common/allocator.h"
 #include "common/container/concurrent_queue.h"
 #include "common/spin_latch.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 
 namespace terrier::common {
 // TODO(Yangjun): this class should be moved somewhere else.

--- a/src/include/common/strong_typedef.h
+++ b/src/include/common/strong_typedef.h
@@ -46,13 +46,11 @@ namespace terrier::common {
  *
  * This works with all types of ints.
  */
-#define STRONG_TYPEDEF(name, underlying_type)                                      \
-  namespace terrier {                                                              \
-  namespace tags {                                                                 \
-  struct name##_typedef_tag {};                                                    \
-  }                                                                                \
-  using name = common::StrongTypeAlias<tags::name##_typedef_tag, underlying_type>; \
-  }
+#define STRONG_TYPEDEF(name, underlying_type) \
+  namespace tags {                            \
+  struct name##_typedef_tag {};               \
+  }                                           \
+  using name = ::terrier::common::StrongTypeAlias<tags::name##_typedef_tag, underlying_type>;
 
 /**
  * A StrongTypeAlias is the underlying implementation of STRONG_TYPEDEF.
@@ -211,13 +209,9 @@ namespace terrier {
 using byte = std::byte;
 }
 
-// TODO(Matt): consider namespacing strong typedefs so we have storage::col_id_t and catalog::col_oid_t
-STRONG_TYPEDEF(col_id_t, uint16_t);
 STRONG_TYPEDEF(col_oid_t, uint32_t);
 STRONG_TYPEDEF(date_t, uint32_t);
-STRONG_TYPEDEF(layout_version_t, uint32_t);
 STRONG_TYPEDEF(table_oid_t, uint32_t);
-STRONG_TYPEDEF(timestamp_t, uint64_t);
 
 namespace std {
 // TODO(Tianyu): Expand this specialization if needed.

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -65,7 +65,7 @@ class GarbageCollector {
 
   transaction::TransactionManager *const txn_manager_;
   // timestamp of the last time GC unlinked anything. We need this to know when unlinked versions are safe to deallocate
-  timestamp_t last_unlinked_;
+  transaction::timestamp_t last_unlinked_;
   // queue of txns that have been unlinked, and should possible be deleted on next GC run
   transaction::TransactionQueue txns_to_deallocate_;
   // queue of txns that need to be unlinked

--- a/src/include/storage/projected_columns.h
+++ b/src/include/storage/projected_columns.h
@@ -2,7 +2,7 @@
 #include <vector>
 #include "common/container/bitmap.h"
 #include "common/macros.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/storage_util.h"
 
 namespace terrier::storage {

--- a/src/include/storage/projected_row.h
+++ b/src/include/storage/projected_row.h
@@ -2,7 +2,7 @@
 #include <vector>
 #include "common/container/bitmap.h"
 #include "common/macros.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/storage_util.h"
 
 namespace terrier::storage {

--- a/src/include/storage/record_buffer.h
+++ b/src/include/storage/record_buffer.h
@@ -2,7 +2,7 @@
 #include <vector>
 #include "common/constants.h"
 #include "common/object_pool.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/undo_record.h"
 
 namespace terrier::storage {

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -10,7 +10,7 @@
 #include "common/container/bitmap.h"
 #include "common/macros.h"
 #include "common/object_pool.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 
 namespace terrier::storage {
 // Write Ahead Logging:
@@ -18,8 +18,14 @@ namespace terrier::storage {
 
 // All tuples potentially visible to txns should have a non-null attribute of version vector.
 // This is not to be confused with a non-null version vector that has value nullptr (0).
-#define VERSION_POINTER_COLUMN_ID col_id_t(0)
+#define VERSION_POINTER_COLUMN_ID ::terrier::storage::col_id_t(0)
 #define NUM_RESERVED_COLUMNS 1u
+
+// Use byte for raw byte storage instead of char so string functions are explicitly disabled for those.
+using byte = std::byte;
+STRONG_TYPEDEF(col_id_t, uint16_t);
+STRONG_TYPEDEF(layout_version_t, uint32_t);
+
 /**
  * A block is a chunk of memory used for storage. It does not have any meaning
  * unless interpreted by a @see TupleAccessStrategy

--- a/src/include/storage/storage_util.h
+++ b/src/include/storage/storage_util.h
@@ -2,7 +2,7 @@
 #include <unordered_map>
 #include <utility>
 #include "common/macros.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/block_layout.h"
 #include "storage/storage_defs.h"
 

--- a/src/include/storage/undo_record.h
+++ b/src/include/storage/undo_record.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include "storage/projected_row.h"
+#include "transaction/transaction_defs.h"
 
 namespace terrier::storage {
 class DataTable;
@@ -27,12 +28,12 @@ class UndoRecord {
   /**
    * @return Timestamp up to which the old projected row was visible.
    */
-  std::atomic<timestamp_t> &Timestamp() { return timestamp_; }
+  std::atomic<transaction::timestamp_t> &Timestamp() { return timestamp_; }
 
   /**
    * @return Timestamp up to which the old projected row was visible.
    */
-  const std::atomic<timestamp_t> &Timestamp() const { return timestamp_; }
+  const std::atomic<transaction::timestamp_t> &Timestamp() const { return timestamp_; }
 
   /**
    * @return the type of this undo record
@@ -100,7 +101,7 @@ class UndoRecord {
    * @param table the DataTable this UndoRecord points to
    * @return pointer to the initialized UndoRecord
    */
-  static UndoRecord *InitializeInsert(byte *const head, const timestamp_t timestamp, const TupleSlot slot,
+  static UndoRecord *InitializeInsert(byte *const head, const transaction::timestamp_t timestamp, const TupleSlot slot,
                                       DataTable *const table) {
     auto *result = reinterpret_cast<UndoRecord *>(head);
     result->type_ = DeltaRecordType::INSERT;
@@ -120,7 +121,7 @@ class UndoRecord {
    * @param table the DataTable this UndoRecord points to
    * @return pointer to the initialized UndoRecord
    */
-  static UndoRecord *InitializeDelete(byte *const head, const timestamp_t timestamp, const TupleSlot slot,
+  static UndoRecord *InitializeDelete(byte *const head, const transaction::timestamp_t timestamp, const TupleSlot slot,
                                       DataTable *const table) {
     auto *result = reinterpret_cast<UndoRecord *>(head);
     result->type_ = DeltaRecordType::DELETE;
@@ -141,7 +142,7 @@ class UndoRecord {
    * @param initializer the initializer to use for the embedded ProjectedRow
    * @return pointer to the initialized UndoRecord
    */
-  static UndoRecord *InitializeUpdate(byte *const head, const timestamp_t timestamp, const TupleSlot slot,
+  static UndoRecord *InitializeUpdate(byte *const head, const transaction::timestamp_t timestamp, const TupleSlot slot,
                                       DataTable *const table, const ProjectedRowInitializer &initializer) {
     auto *result = reinterpret_cast<UndoRecord *>(head);
 
@@ -167,7 +168,7 @@ class UndoRecord {
    * @param redo the redo changes to be applied
    * @return pointer to the initialized UndoRecord
    */
-  static UndoRecord *InitializeUpdate(byte *const head, const timestamp_t timestamp, const TupleSlot slot,
+  static UndoRecord *InitializeUpdate(byte *const head, const transaction::timestamp_t timestamp, const TupleSlot slot,
                                       DataTable *const table, const storage::ProjectedRow &redo) {
     auto *result = reinterpret_cast<UndoRecord *>(head);
 
@@ -185,7 +186,7 @@ class UndoRecord {
  private:
   DeltaRecordType type_;
   std::atomic<UndoRecord *> next_;
-  std::atomic<timestamp_t> timestamp_;
+  std::atomic<transaction::timestamp_t> timestamp_;
   DataTable *table_;
   TupleSlot slot_;
   // This needs to be aligned to 8 bytes to ensure the real size of UndoRecord (plus actual ProjectedRow) is also

--- a/src/include/storage/varlen_pool.h
+++ b/src/include/storage/varlen_pool.h
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <unordered_set>
 #include "common/spin_latch.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 
 namespace terrier::storage {
 

--- a/src/include/storage/write_ahead_log/log_manager.h
+++ b/src/include/storage/write_ahead_log/log_manager.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 #include "common/spin_latch.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/record_buffer.h"
 #include "storage/write_ahead_log/log_io.h"
 #include "storage/write_ahead_log/log_record.h"

--- a/src/include/storage/write_ahead_log/log_record.h
+++ b/src/include/storage/write_ahead_log/log_record.h
@@ -24,7 +24,7 @@ class LogRecord {
   /**
    * @return begin timestamp of the transaction that generated this log record
    */
-  timestamp_t TxnBegin() const { return txn_begin_; }
+  transaction::timestamp_t TxnBegin() const { return txn_begin_; }
 
   /**
    * Get the underlying record body as a certain type, determined from RecordType().
@@ -59,7 +59,7 @@ class LogRecord {
    * @return pointer to the start of the initialized record header
    */
   static LogRecord *InitializeHeader(byte *const head, const LogRecordType type, const uint32_t size,
-                                     const timestamp_t txn_begin) {
+                                     const transaction::timestamp_t txn_begin) {
     auto *result = reinterpret_cast<LogRecord *>(head);
     result->type_ = type;
     result->size_ = size;
@@ -71,7 +71,7 @@ class LogRecord {
   /* Header common to all log records */
   LogRecordType type_;
   uint32_t size_;
-  timestamp_t txn_begin_;
+  transaction::timestamp_t txn_begin_;
   // This needs to be aligned to 8 bytes to ensure the real size of RedoRecord (plus actual ProjectedRow) is also
   // a multiple of 8.
   uint64_t varlen_contents_[0];
@@ -132,7 +132,7 @@ class RedoRecord {
    * @param initializer the initializer to use for the underlying
    * @return pointer to the initialized log record, always equal in value to the given head
    */
-  static LogRecord *Initialize(byte *const head, const timestamp_t txn_begin, DataTable *const table,
+  static LogRecord *Initialize(byte *const head, const transaction::timestamp_t txn_begin, DataTable *const table,
                                const TupleSlot tuple_slot, const ProjectedRowInitializer &initializer) {
     LogRecord *result = LogRecord::InitializeHeader(head, LogRecordType::REDO, Size(initializer), txn_begin);
     auto *body = result->GetUnderlyingRecordBodyAs<RedoRecord>();
@@ -154,7 +154,7 @@ class RedoRecord {
    * @param tuple_slot
    * @return
    */
-  static LogRecord *PartialInitialize(byte *const head, const uint32_t size, const timestamp_t txn_begin,
+  static LogRecord *PartialInitialize(byte *const head, const uint32_t size, const transaction::timestamp_t txn_begin,
                                       DataTable *const table, TupleSlot tuple_slot) {
     LogRecord *result = LogRecord::InitializeHeader(head, LogRecordType::REDO, size, txn_begin);
     auto *body = result->GetUnderlyingRecordBodyAs<RedoRecord>();
@@ -205,7 +205,8 @@ class DeleteRecord {
    * @param slot the tuple slot this delete applies to
    * @return pointer to the initialized log record, always equal in value to the given head
    */
-  static LogRecord *Initialize(byte *const head, const timestamp_t txn_begin, DataTable *const table, TupleSlot slot) {
+  static LogRecord *Initialize(byte *const head, const transaction::timestamp_t txn_begin, DataTable *const table,
+                               TupleSlot slot) {
     auto *result = LogRecord::InitializeHeader(head, LogRecordType::DELETE, Size(), txn_begin);
     auto *body = result->GetUnderlyingRecordBodyAs<DeleteRecord>();
     body->table_ = table;
@@ -259,8 +260,9 @@ class CommitRecord {
    * @param is_read_only indicates whether the transaction generating this log record is read-only or not
    * @return pointer to the initialized log record, always equal in value to the given head
    */
-  static LogRecord *Initialize(byte *const head, const timestamp_t txn_begin, const timestamp_t txn_commit,
-                               transaction::callback_fn callback, void *callback_arg, bool is_read_only) {
+  static LogRecord *Initialize(byte *const head, const transaction::timestamp_t txn_begin,
+                               const transaction::timestamp_t txn_commit, transaction::callback_fn callback,
+                               void *callback_arg, bool is_read_only) {
     auto *result = LogRecord::InitializeHeader(head, LogRecordType::COMMIT, Size(), txn_begin);
     auto *body = result->GetUnderlyingRecordBodyAs<CommitRecord>();
     body->txn_commit_ = txn_commit;
@@ -273,7 +275,7 @@ class CommitRecord {
   /**
    * @return the commit time of the transaction that generated this log record
    */
-  timestamp_t CommitTime() const { return txn_commit_; }
+  transaction::timestamp_t CommitTime() const { return txn_commit_; }
 
   /**
    * @return function pointer of the transaction callback
@@ -291,7 +293,7 @@ class CommitRecord {
   bool IsReadOnly() const { return is_read_only_; }
 
  private:
-  timestamp_t txn_commit_;
+  transaction::timestamp_t txn_commit_;
   transaction::callback_fn callback_;
   void *callback_arg_;
   bool is_read_only_;

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <vector>
 #include "common/object_pool.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/data_table.h"
 #include "storage/record_buffer.h"
 #include "storage/storage_defs.h"

--- a/src/include/transaction/transaction_defs.h
+++ b/src/include/transaction/transaction_defs.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <forward_list>
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 namespace terrier::transaction {
+STRONG_TYPEDEF(timestamp_t, uint64_t);
+
 class TransactionContext;
 // Explicitly define the underlying structure of std::queue as std::list since we believe the default (std::deque) may
 // be too memory inefficient and we don't need the fast random access that it provides. It's also impossible to call

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -3,7 +3,7 @@
 #include <utility>
 #include "common/shared_latch.h"
 #include "common/spin_latch.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/data_table.h"
 #include "storage/record_buffer.h"
 #include "storage/undo_record.h"

--- a/src/include/transaction/transaction_util.h
+++ b/src/include/transaction/transaction_util.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 
 namespace terrier::transaction {
 

--- a/src/include/type/type_id.h
+++ b/src/include/type/type_id.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 
 namespace terrier::type {
+STRONG_TYPEDEF(date_t, uint32_t);
+STRONG_TYPEDEF(timestamp_t, uint64_t);
+
 /**
  * All of our possible SQL types
  */
@@ -22,5 +25,4 @@ enum class TypeId : uint8_t {
   ARRAY,
   UDT
 };
-
 }  // namespace terrier::type

--- a/src/include/type/type_util.h
+++ b/src/include/type/type_util.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "type/type_id.h"
 
 namespace terrier::type {

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string>
 #include "common/hash_util.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "storage/varlen_pool.h"
 #include "type/type_id.h"
 

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <string>
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "type/type_id.h"
 #include "type/value.h"
 

--- a/src/main/terrier.cpp
+++ b/src/main/terrier.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include "common/allocator.h"
 #include "common/stat_registry.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "loggers/main_logger.h"
 #include "loggers/storage_logger.h"
 #include "loggers/transaction_logger.h"
@@ -36,9 +36,10 @@ int main() {
   terrier::storage::RecordBufferSegmentPool buffer_pool_{100000, 10000};
   terrier::storage::BlockStore block_store_{1000, 100};
   terrier::storage::BlockLayout block_layout_({4, 8});
-  const std::vector<terrier::col_id_t> col_ids = {terrier::col_id_t{0}, terrier::col_id_t{1}};
-  terrier::storage::DataTable data_table_(&block_store_, block_layout_, terrier::layout_version_t{0});
-  terrier::timestamp_t timestamp(0);
+  const std::vector<terrier::storage::col_id_t> col_ids = {terrier::storage::col_id_t{0},
+                                                           terrier::storage::col_id_t{1}};
+  terrier::storage::DataTable data_table_(&block_store_, block_layout_, terrier::storage::layout_version_t{0});
+  terrier::transaction::timestamp_t timestamp(0);
   auto *txn = new terrier::transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED);
   auto init = terrier::storage::ProjectedRowInitializer(block_layout_, col_ids);
   auto *redo_buffer_ = terrier::common::AllocationUtil::AllocateAligned(init.ProjectedRowSize());

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -235,9 +235,9 @@ bool DataTable::Visible(const TupleSlot slot, const TupleAccessStrategy &accesso
 
 bool DataTable::HasConflict(UndoRecord *const version_ptr, const transaction::TransactionContext *const txn) const {
   if (version_ptr == nullptr) return false;  // Nobody owns this tuple's write lock, no older version visible
-  const timestamp_t version_timestamp = version_ptr->Timestamp().load();
-  const timestamp_t txn_id = txn->TxnId().load();
-  const timestamp_t start_time = txn->StartTime();
+  const transaction::timestamp_t version_timestamp = version_ptr->Timestamp().load();
+  const transaction::timestamp_t txn_id = txn->TxnId().load();
+  const transaction::timestamp_t start_time = txn->StartTime();
   const bool owned_by_other_txn =
       (!transaction::TransactionUtil::Committed(version_timestamp) && version_timestamp != txn_id);
   const bool newer_committed_version = transaction::TransactionUtil::Committed(version_timestamp) &&

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -27,7 +27,7 @@ std::pair<uint32_t, uint32_t> GarbageCollector::PerformGarbageCollection() {
 }
 
 uint32_t GarbageCollector::ProcessDeallocateQueue() {
-  const timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
+  const transaction::timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
   uint32_t txns_processed = 0;
   transaction::TransactionContext *txn = nullptr;
 
@@ -46,7 +46,7 @@ uint32_t GarbageCollector::ProcessDeallocateQueue() {
 }
 
 uint32_t GarbageCollector::ProcessUnlinkQueue() {
-  const timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
+  const transaction::timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
   transaction::TransactionContext *txn = nullptr;
 
   // Get the completed transactions from the TransactionManager

--- a/test/include/util/catalog_test_util.h
+++ b/test/include/util/catalog_test_util.h
@@ -2,7 +2,7 @@
 #include <random>
 #include <vector>
 #include "catalog/schema.h"
-#include "common/typedefs.h"
+#include "common/strong_typedef.h"
 #include "type/type_id.h"
 #include "util/random_test_util.h"
 #include "util/storage_test_util.h"

--- a/test/include/util/transaction_test_util.h
+++ b/test/include/util/transaction_test_util.h
@@ -22,7 +22,7 @@ class LargeTransactionTestObject;
 class RandomWorkloadTransaction;
 using TupleEntry = std::pair<storage::TupleSlot, storage::ProjectedRow *>;
 using TableSnapshot = std::unordered_map<storage::TupleSlot, storage::ProjectedRow *>;
-using VersionedSnapshots = std::map<timestamp_t, TableSnapshot>;
+using VersionedSnapshots = std::map<transaction::timestamp_t, TableSnapshot>;
 // {committed, aborted}
 using SimulationResult = std::pair<std::vector<RandomWorkloadTransaction *>, std::vector<RandomWorkloadTransaction *>>;
 
@@ -76,10 +76,10 @@ class RandomWorkloadTransaction {
    */
   void Finish();
 
-  timestamp_t BeginTimestamp() const { return start_time_; }
+  transaction::timestamp_t BeginTimestamp() const { return start_time_; }
 
-  timestamp_t CommitTimestamp() const {
-    if (aborted_) return timestamp_t(static_cast<uint64_t>(-1));
+  transaction::timestamp_t CommitTimestamp() const {
+    if (aborted_) return transaction::timestamp_t(static_cast<uint64_t>(-1));
     return commit_time_;
   }
 
@@ -91,7 +91,7 @@ class RandomWorkloadTransaction {
   transaction::TransactionContext *txn_;
   // extra bookkeeping for correctness checks
   bool aborted_;
-  timestamp_t start_time_, commit_time_;
+  transaction::timestamp_t start_time_, commit_time_;
   std::vector<TupleEntry> selects_;
   std::unordered_map<storage::TupleSlot, storage::ProjectedRow *> updates_;
   byte *buffer_;

--- a/test/parser/expression_test.cpp
+++ b/test/parser/expression_test.cpp
@@ -102,9 +102,9 @@ TEST(ExpressionTests, BasicTest) {
   delete expr_d_3;
 
   // constant timestamp
-  auto expr_ts_1 = new ConstantValueExpression(type::ValueFactory::GetTimeStampValue(timestamp_t(1)));
-  auto expr_ts_2 = new ConstantValueExpression(type::ValueFactory::GetTimeStampValue(timestamp_t(1)));
-  auto expr_ts_3 = new ConstantValueExpression(type::ValueFactory::GetTimeStampValue(timestamp_t(32768)));
+  auto expr_ts_1 = new ConstantValueExpression(type::ValueFactory::GetTimeStampValue(type::timestamp_t(1)));
+  auto expr_ts_2 = new ConstantValueExpression(type::ValueFactory::GetTimeStampValue(type::timestamp_t(1)));
+  auto expr_ts_3 = new ConstantValueExpression(type::ValueFactory::GetTimeStampValue(type::timestamp_t(32768)));
 
   EXPECT_TRUE(*expr_ts_1 == *expr_ts_2);
   EXPECT_FALSE(*expr_ts_1 == *expr_ts_3);
@@ -114,9 +114,9 @@ TEST(ExpressionTests, BasicTest) {
   delete expr_ts_3;
 
   // constant date
-  auto expr_date_1 = new ConstantValueExpression(type::ValueFactory::GetDateValue(date_t(1)));
-  auto expr_date_2 = new ConstantValueExpression(type::ValueFactory::GetDateValue(date_t(1)));
-  auto expr_date_3 = new ConstantValueExpression(type::ValueFactory::GetDateValue(date_t(32768)));
+  auto expr_date_1 = new ConstantValueExpression(type::ValueFactory::GetDateValue(type::date_t(1)));
+  auto expr_date_2 = new ConstantValueExpression(type::ValueFactory::GetDateValue(type::date_t(1)));
+  auto expr_date_3 = new ConstantValueExpression(type::ValueFactory::GetDateValue(type::date_t(32768)));
 
   EXPECT_TRUE(*expr_date_1 == *expr_date_2);
   EXPECT_FALSE(*expr_date_1 == *expr_date_3);

--- a/test/storage/delta_record_test.cpp
+++ b/test/storage/delta_record_test.cpp
@@ -44,19 +44,19 @@ TEST_F(DeltaRecordTests, UndoChainAccess) {
       storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
       storage::TupleAccessStrategy tested(layout);
       TERRIER_MEMSET(raw_block_, 0, sizeof(storage::RawBlock));
-      tested.InitializeRawBlock(raw_block_, layout_version_t(0));
+      tested.InitializeRawBlock(raw_block_, storage::layout_version_t(0));
 
       // get data table
-      storage::DataTable data_table(&block_store_, layout, layout_version_t(0));
+      storage::DataTable data_table(&block_store_, layout, storage::layout_version_t(0));
 
       // get tuple slot
       storage::TupleSlot slot;
       EXPECT_TRUE(tested.Allocate(raw_block_, &slot));
 
       // compute the size of the buffer
-      const std::vector<col_id_t> col_ids = StorageTestUtil::ProjectionListRandomColumns(layout, &generator_);
+      const std::vector<storage::col_id_t> col_ids = StorageTestUtil::ProjectionListRandomColumns(layout, &generator_);
       storage::ProjectedRowInitializer initializer(layout, col_ids);
-      timestamp_t time = static_cast<timestamp_t>(timestamp_dist_(generator_));
+      transaction::timestamp_t time = static_cast<transaction::timestamp_t>(timestamp_dist_(generator_));
       auto *record_buffer = common::AllocationUtil::AllocateAligned(storage::UndoRecord::Size(initializer));
       storage::UndoRecord *record =
           storage::UndoRecord::InitializeUpdate(record_buffer, time, slot, &data_table, initializer);
@@ -81,10 +81,10 @@ TEST_F(DeltaRecordTests, UndoGetProjectedRow) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
     storage::TupleAccessStrategy tested(layout);
     TERRIER_MEMSET(raw_block_, 0, sizeof(storage::RawBlock));
-    tested.InitializeRawBlock(raw_block_, layout_version_t(0));
+    tested.InitializeRawBlock(raw_block_, storage::layout_version_t(0));
 
     // generate a random projectedRow
-    std::vector<col_id_t> update_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
+    std::vector<storage::col_id_t> update_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, update_col_ids);
     auto *redo_buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
     storage::ProjectedRow *redo = initializer.InitializeRow(redo_buffer);
@@ -92,7 +92,7 @@ TEST_F(DeltaRecordTests, UndoGetProjectedRow) {
     // projected row
 
     // get data table
-    storage::DataTable data_table(&block_store_, layout, layout_version_t(0));
+    storage::DataTable data_table(&block_store_, layout, storage::layout_version_t(0));
 
     // get tuple slot
     storage::TupleSlot slot;
@@ -100,7 +100,7 @@ TEST_F(DeltaRecordTests, UndoGetProjectedRow) {
 
     // compute the size of the buffer
     uint32_t size = storage::UndoRecord::Size(*redo);
-    timestamp_t time = static_cast<timestamp_t>(timestamp_dist_(generator_));
+    transaction::timestamp_t time = static_cast<transaction::timestamp_t>(timestamp_dist_(generator_));
     auto *record_buffer = common::AllocationUtil::AllocateAligned(size);
     storage::UndoRecord *record = storage::UndoRecord::InitializeUpdate(record_buffer, time, slot, &data_table, *redo);
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(layout, record->Delta(), redo));

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -17,7 +17,8 @@ class GarbageCollectorDataTableTestObject {
  public:
   template <class Random>
   GarbageCollectorDataTableTestObject(storage::BlockStore *block_store, const uint16_t max_col, Random *generator)
-      : layout_(StorageTestUtil::RandomLayout(max_col, generator)), table_(block_store, layout_, layout_version_t(0)) {}
+      : layout_(StorageTestUtil::RandomLayout(max_col, generator)),
+        table_(block_store, layout_, storage::layout_version_t(0)) {}
 
   ~GarbageCollectorDataTableTestObject() {
     for (auto ptr : loose_pointers_) delete[] ptr;
@@ -37,7 +38,7 @@ class GarbageCollectorDataTableTestObject {
 
   template <class Random>
   storage::ProjectedRow *GenerateRandomUpdate(Random *generator) {
-    std::vector<col_id_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
+    std::vector<storage::col_id_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
     storage::ProjectedRowInitializer update_initializer(layout_, update_col_ids);
     auto *buffer = common::AllocationUtil::AllocateAligned(update_initializer.ProjectedRowSize());
     loose_pointers_.push_back(buffer);

--- a/test/storage/projected_row_test.cpp
+++ b/test/storage/projected_row_test.cpp
@@ -27,7 +27,7 @@ TEST_F(ProjectedRowTests, Nulls) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
 
     // generate a random projectedRow
-    std::vector<col_id_t> update_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
+    std::vector<storage::col_id_t> update_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, update_col_ids);
     auto *update_buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
     storage::ProjectedRow *update = initializer.InitializeRow(update_buffer);
@@ -35,9 +35,9 @@ TEST_F(ProjectedRowTests, Nulls) {
 
     // generator a binary vector and set nulls according to binary vector. For null attributes, we set value to be 0.
     std::bernoulli_distribution coin(null_ratio_(generator_));
-    std::unordered_map<col_id_t, bool> null_cols;
+    std::unordered_map<storage::col_id_t, bool> null_cols;
     for (uint16_t i = 0; i < update->NumColumns(); i++) {
-      col_id_t col_id(i);
+      storage::col_id_t col_id(i);
       null_cols[col_id] = coin(generator_);
       if (null_cols[col_id]) {
         byte *val_ptr = update->AccessForceNotNull(i);
@@ -49,7 +49,7 @@ TEST_F(ProjectedRowTests, Nulls) {
     }
     // check correctness
     for (uint16_t i = 0; i < update->NumColumns(); i++) {
-      col_id_t col_id(i);
+      storage::col_id_t col_id(i);
       byte *addr = update->AccessWithNullCheck(i);
       if (null_cols[col_id]) {
         EXPECT_EQ(addr, nullptr);
@@ -72,7 +72,7 @@ TEST_F(ProjectedRowTests, CopyProjectedRowLayout) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
 
     // generate a random projectedRow
-    std::vector<col_id_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
+    std::vector<storage::col_id_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, all_col_ids);
     auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
     storage::ProjectedRow *row = initializer.InitializeRow(buffer);
@@ -104,7 +104,7 @@ TEST_F(ProjectedRowTests, MemorySafety) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
 
     // generate a random projectedRow
-    std::vector<col_id_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
+    std::vector<storage::col_id_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, all_col_ids);
     auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
     storage::ProjectedRow *row = initializer.InitializeRow(buffer);
@@ -133,7 +133,7 @@ TEST_F(ProjectedRowTests, Alignment) {
     storage::BlockLayout layout = StorageTestUtil::RandomLayout(common::Constants::MAX_COL, &generator_);
 
     // generate a random projectedRow
-    std::vector<col_id_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
+    std::vector<storage::col_id_t> all_col_ids = StorageTestUtil::ProjectionListAllColumns(layout);
     storage::ProjectedRowInitializer initializer(layout, all_col_ids);
     auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
     storage::ProjectedRow *row = initializer.InitializeRow(buffer);

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -16,7 +16,8 @@ class MVCCDataTableTestObject {
  public:
   template <class Random>
   MVCCDataTableTestObject(storage::BlockStore *block_store, const uint16_t max_col, Random *generator)
-      : layout_(StorageTestUtil::RandomLayout(max_col, generator)), table_(block_store, layout_, layout_version_t(0)) {}
+      : layout_(StorageTestUtil::RandomLayout(max_col, generator)),
+        table_(block_store, layout_, storage::layout_version_t(0)) {}
 
   ~MVCCDataTableTestObject() {
     for (auto ptr : loose_pointers_) delete[] ptr;
@@ -37,7 +38,7 @@ class MVCCDataTableTestObject {
 
   template <class Random>
   storage::ProjectedRow *GenerateRandomUpdate(Random *generator) {
-    std::vector<col_id_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
+    std::vector<storage::col_id_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(layout_, generator);
     storage::ProjectedRowInitializer update_initializer(layout_, update_col_ids);
     auto *buffer = common::AllocationUtil::AllocateAligned(update_initializer.ProjectedRowSize());
     loose_pointers_.push_back(buffer);

--- a/test/type/value_type_test.cpp
+++ b/test/type/value_type_test.cpp
@@ -22,7 +22,7 @@ TEST(valueTests, BasicTest) {
   // bigint
   // double
   // timestamp
-  timestamp_t timestamp_value = static_cast<timestamp_t>(0);
+  type::timestamp_t timestamp_value = static_cast<type::timestamp_t>(0);
   Value pv_timestamp = ValueFactory::GetTimeStampValue(timestamp_value);
   EXPECT_TRUE(pv_timestamp.GetTimestampValue() == timestamp_value);
   // date

--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -28,7 +28,8 @@ void RandomWorkloadTransaction::RandomUpdate(Random *generator) {
   if (aborted_) return;
   storage::TupleSlot updated =
       RandomTestUtil::UniformRandomElement(test_object_->last_checked_version_, generator)->first;
-  std::vector<col_id_t> update_col_ids = StorageTestUtil::ProjectionListRandomColumns(test_object_->layout_, generator);
+  std::vector<storage::col_id_t> update_col_ids =
+      StorageTestUtil::ProjectionListRandomColumns(test_object_->layout_, generator);
   storage::ProjectedRowInitializer initializer(test_object_->layout_, update_col_ids);
   auto *update_buffer =
       test_object_->bookkeeping_ ? common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize()) : buffer_;
@@ -91,7 +92,7 @@ LargeTransactionTestObject::LargeTransactionTestObject(uint16_t max_columns, uin
       update_select_ratio_(std::move(update_select_ratio)),
       generator_(generator),
       layout_(StorageTestUtil::RandomLayout(max_columns, generator_)),
-      table_(block_store, layout_, layout_version_t(0)),
+      table_(block_store, layout_, storage::layout_version_t(0)),
       txn_manager_(buffer_pool, gc_on, log_manager),
       gc_on_(gc_on),
       wal_on_(log_manager != LOGGING_DISABLED),
@@ -158,7 +159,7 @@ void LargeTransactionTestObject::CheckReadsCorrect(std::vector<RandomWorkloadTra
   TERRIER_ASSERT(bookkeeping_, "Cannot check for correctness with bookkeeping off");
   VersionedSnapshots snapshots = ReconstructVersionedTable(commits);
   // make sure table_version is updated
-  timestamp_t latest_version = commits->at(commits->size() - 1)->commit_time_;
+  transaction::timestamp_t latest_version = commits->at(commits->size() - 1)->commit_time_;
   // Only need to check that reads make sense?
   for (RandomWorkloadTransaction *txn : *commits) CheckTransactionReadCorrect(txn, snapshots);
 
@@ -231,7 +232,7 @@ VersionedSnapshots LargeTransactionTestObject::ReconstructVersionedTable(
     std::vector<RandomWorkloadTransaction *> *txns) {
   VersionedSnapshots result;
   // empty starting version
-  TableSnapshot *prev = &(result.emplace(timestamp_t(0), TableSnapshot()).first->second);
+  TableSnapshot *prev = &(result.emplace(transaction::timestamp_t(0), TableSnapshot()).first->second);
   // populate with initial image of the table
   for (auto &entry : last_checked_version_) (*prev)[entry.first] = CopyTuple(entry.second);
 
@@ -245,12 +246,12 @@ VersionedSnapshots LargeTransactionTestObject::ReconstructVersionedTable(
 
 void LargeTransactionTestObject::CheckTransactionReadCorrect(RandomWorkloadTransaction *txn,
                                                              const VersionedSnapshots &snapshots) {
-  timestamp_t start_time = txn->start_time_;
+  transaction::timestamp_t start_time = txn->start_time_;
   // this version is the most recent future update
   auto ret = snapshots.upper_bound(start_time);
   // Go to the version visible to this txn
   --ret;
-  timestamp_t version_timestamp = ret->first;
+  transaction::timestamp_t version_timestamp = ret->first;
   const TableSnapshot &before_snapshot = ret->second;
   EXPECT_TRUE(transaction::TransactionUtil::NewerThan(start_time, version_timestamp));
   for (auto &entry : txn->selects_) {


### PR DESCRIPTION
I realized that we were mixing SQL timestamp with transactional timestamps in the values thing. Seems like a good time to introduce namespaces for all these to avoid these happening in the future as it is a fairly major refactor (lots of search and replace)