### PR TITLE
Resolve CMake warning in lib_pgquery

### DIFF
--- a/third_party/libpg_query/CMakeLists.txt
+++ b/third_party/libpg_query/CMakeLists.txt
@@ -1,6 +1,3 @@
-cmake_minimum_required(VERSION 2.8.7)
-
-# ---[ Peloton project
 project(pg_query CXX C)
 
 # this code imitates the Makefile in /third_party/libpg_query/


### PR DESCRIPTION
Fix #235.

The cmake_minimum_required() call changes the sort of warnings we're shown, I believe. Since the main CMake project requires a greater version anyway, we can safely remove it.