### PR TITLE
Reclaim slots when deleted in GC

### DIFF
--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -177,6 +177,16 @@ class DataTable {
   }
 
   /**
+   * @warning NOT the number of tuples currently in the data table. Such a value is not well-defined unless referring
+   * to a transactional snapshot.
+   * @return number of slots allocated for this data table.
+   */
+  uint64_t NumSlots() const {
+    common::SpinLatch::ScopedSpinLatch guard(&blocks_latch_);
+    return blocks_.size() * accessor_.GetBlockLayout().NumSlots();
+  }
+
+  /**
    * Update the tuple according to the redo buffer given, and update the version chain to link to an
    * undo record that is allocated in the txn. The undo record is populated with a before-image of the tuple in the
    * process. Update will only happen if there is no write-write conflict and tuple is visible, otherwise, this is

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -53,7 +53,7 @@ class GarbageCollector {
 
   bool ProcessUndoRecord(transaction::TransactionContext *txn, UndoRecord *undo_record) const;
 
-  void ReclaimSlotIfDelete(UndoRecord *undo_record) const;
+  void ReclaimSlotIfDeleted(UndoRecord *undo_record) const;
 
   /**
    * Given a UndoRecord that has been deemed safe to unlink by the GC, attempts to remove it from the version chain.

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -51,6 +51,10 @@ class GarbageCollector {
    */
   uint32_t ProcessUnlinkQueue();
 
+  bool ProcessUndoRecord(transaction::TransactionContext *txn, UndoRecord *undo_record) const;
+
+  void ReclaimSlotIfDelete(UndoRecord *undo_record) const;
+
   /**
    * Given a UndoRecord that has been deemed safe to unlink by the GC, attempts to remove it from the version chain.
    * It's possible that this process will fail because the GC is conservative with conflicts. If the UndoRecord in the

--- a/test/storage/garbage_collector_test.cpp
+++ b/test/storage/garbage_collector_test.cpp
@@ -710,4 +710,41 @@ TEST_F(GarbageCollectorTests, InsertUpdate1) {
   }
 }
 
+// TODO(Tianyu): This test should be fine for now as the reclamation makes little change to the
+// GC logic. We need to incorporate inserts and delets into the larger test framework to test
+// out its interaction with other transactions, however, and that is more involved.
+
+// Checks that GC is correctly reclaiming free slots.
+// NOLINTNEXTLINE
+TEST_F(GarbageCollectorTests, SlotReclamation) {
+  transaction::TransactionManager txn_manager(&buffer_pool_, true, LOGGING_DISABLED);
+  GarbageCollectorDataTableTestObject tested(&block_store_, max_columns_, &generator_);
+  storage::GarbageCollector gc(&txn_manager);
+
+  auto *txn0 = txn_manager.BeginTransaction();
+  auto *insert_tuple = tested.GenerateRandomTuple(&generator_);
+  // Fill a block
+  for (uint32_t i = 0; i < tested.layout_.NumSlots(); i++) tested.table_.Insert(txn0, *insert_tuple);
+  EXPECT_EQ(tested.table_.NumSlots(), tested.layout_.NumSlots());
+  txn_manager.Commit(txn0, TestCallbacks::EmptyCallback, nullptr);
+
+  auto *txn1 = txn_manager.BeginTransaction();
+  // Delete a tuple, so there is an empty slot. Should always succeed
+  EXPECT_TRUE(tested.table_.Delete(txn1, *tested.table_.begin()));
+  txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
+  // Two garbage collection runs should free up the slot
+  EXPECT_EQ(std::make_pair(0u, 2u), gc.PerformGarbageCollection());
+  EXPECT_EQ(std::make_pair(2u, 0u), gc.PerformGarbageCollection());
+
+  auto *txn2 = txn_manager.BeginTransaction();
+  storage::TupleSlot slot = tested.table_.Insert(txn2, *insert_tuple);
+  // Should reuse the slot we deleted from and not grow the table.
+  EXPECT_EQ(tested.table_.NumSlots(), tested.layout_.NumSlots());
+  EXPECT_EQ(slot, *tested.table_.begin());
+  txn_manager.Commit(txn2, TestCallbacks::EmptyCallback, nullptr);
+
+  // Clean-up
+  EXPECT_EQ(std::make_pair(0u, 1u), gc.PerformGarbageCollection());
+  EXPECT_EQ(std::make_pair(1u, 0u), gc.PerformGarbageCollection());
+}
 }  // namespace terrier


### PR DESCRIPTION
One of those things we never got around to doing. This is surprisingly easy given the way we do GC and adds minimal overhead.

I am reasonably confident that this is correct because the change is minor, and with basic tests it works. To test this fully though we need to extend the current random testing framework to handle inserts and deletes as well, which would not be easy as the current version is being stretched close to its limit already. This might be a great project. Will write a separate issue with details.