### PR TITLE
LLVM_DIR set to 6.0.1_1 due to version change on Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         - NAME="Mac [dbg/clang]" CMAKE_BUILD_TYPE=debug TERRIER_USE_ASAN=On
       install:
         - echo 'y' | ./script/installation/packages.sh
-        - export LLVM_DIR=/usr/local/Cellar/llvm@6/6.0.1
+        - export LLVM_DIR=/usr/local/Cellar/llvm@6/6.0.1_1
     - os: linux
       dist: trusty
       env:


### PR DESCRIPTION
Fixes compiler issues seen on macOS Travis this week (see [this PR](https://travis-ci.org/cmu-db/terrier/jobs/459466255)) I don't think we see this on Jenkins because it has 6.0.1 baked into the image already, but if we do a `brew upgrade` or set up a new image then we'll have to update the LLVM_DIR environment variable on Jenkins as well.

Will discuss with @crd477 if we just want to update the Jenkins image at the same time as resolving #247.