### PR TITLE
Replace running_txns map with unordered_set

### DIFF
--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <map>
+#include <unordered_set>
 #include <utility>
 #include "common/shared_latch.h"
 #include "common/spin_latch.h"
@@ -85,8 +85,8 @@ class TransactionManager {
   common::SharedLatch commit_latch_;
 
   // TODO(Matt): consider a different data structure if this becomes a measured bottleneck
-  std::map<timestamp_t, TransactionContext *> curr_running_txns_;
-  mutable common::SpinLatch running_txns_table_latch_;
+  std::unordered_set<timestamp_t> curr_running_txns_;
+  mutable common::SpinLatch curr_running_txns_set_latch_;
 
   bool gc_enabled_ = false;
   TransactionQueue completed_txns_;

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -86,7 +86,7 @@ class TransactionManager {
 
   // TODO(Matt): consider a different data structure if this becomes a measured bottleneck
   std::unordered_set<timestamp_t> curr_running_txns_;
-  mutable common::SpinLatch curr_running_txns_set_latch_;
+  mutable common::SpinLatch curr_running_txns_latch_;
 
   bool gc_enabled_ = false;
   TransactionQueue completed_txns_;

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -1,4 +1,5 @@
 #include "transaction/transaction_manager.h"
+#include <algorithm>
 #include <utility>
 
 namespace terrier::transaction {
@@ -15,10 +16,10 @@ TransactionContext *TransactionManager::BeginTransaction() {
   // guarantee that the iterator or underlying pointer is stable across operations.
   // (That is, they may change as concurrent inserts and deletes happen)
   auto *result = new TransactionContext(start_time, start_time + INT64_MIN, buffer_pool_, log_manager_);
-  running_txns_table_latch_.Lock();
-  auto ret UNUSED_ATTRIBUTE = curr_running_txns_.emplace(result->StartTime(), result);
+  curr_running_txns_set_latch_.Lock();
+  auto ret UNUSED_ATTRIBUTE = curr_running_txns_.emplace(result->StartTime());
   TERRIER_ASSERT(ret.second, "commit start time should be globally unique");
-  running_txns_table_latch_.Unlock();
+  curr_running_txns_set_latch_.Unlock();
   return result;
 }
 
@@ -83,7 +84,7 @@ timestamp_t TransactionManager::Commit(TransactionContext *const txn, transactio
                                                  : UpdatingCommitCriticalSection(txn, callback, callback_arg);
   {
     // In a critical section, remove this transaction from the table of running transactions
-    common::SpinLatch::ScopedSpinLatch guard(&running_txns_table_latch_);
+    common::SpinLatch::ScopedSpinLatch guard(&curr_running_txns_set_latch_);
     const timestamp_t start_time = txn->StartTime();
     size_t result UNUSED_ATTRIBUTE = curr_running_txns_.erase(start_time);
     TERRIER_ASSERT(result == 1, "Committed transaction did not exist in global transactions table");
@@ -103,7 +104,7 @@ void TransactionManager::Abort(TransactionContext *const txn) {
   txn->redo_buffer_.Finalize(false);
   {
     // In a critical section, remove this transaction from the table of running transactions
-    common::SpinLatch::ScopedSpinLatch guard(&running_txns_table_latch_);
+    common::SpinLatch::ScopedSpinLatch guard(&curr_running_txns_set_latch_);
     const timestamp_t start_time = txn->StartTime();
     size_t ret UNUSED_ATTRIBUTE = curr_running_txns_.erase(start_time);
     TERRIER_ASSERT(ret == 1, "Aborted transaction did not exist in global transactions table");
@@ -112,14 +113,14 @@ void TransactionManager::Abort(TransactionContext *const txn) {
 }
 
 timestamp_t TransactionManager::OldestTransactionStartTime() const {
-  common::SpinLatch::ScopedSpinLatch guard(&running_txns_table_latch_);
-  auto oldest_txn = curr_running_txns_.begin();
-  timestamp_t result = (oldest_txn != curr_running_txns_.end()) ? oldest_txn->second->StartTime() : time_.load();
+  common::SpinLatch::ScopedSpinLatch guard(&curr_running_txns_set_latch_);
+  const auto &oldest_txn = std::min_element(curr_running_txns_.cbegin(), curr_running_txns_.cend());
+  const timestamp_t result = (oldest_txn != curr_running_txns_.end()) ? *oldest_txn : time_.load();
   return result;
 }
 
 TransactionQueue TransactionManager::CompletedTransactionsForGC() {
-  common::SpinLatch::ScopedSpinLatch guard(&running_txns_table_latch_);
+  common::SpinLatch::ScopedSpinLatch guard(&curr_running_txns_set_latch_);
   TransactionQueue hand_to_gc(std::move(completed_txns_));
   TERRIER_ASSERT(completed_txns_.empty(), "TransactionManager's queue should now be empty.");
   return hand_to_gc;


### PR DESCRIPTION
It's slower for us to always maintain this as an ordered data structure just so the GC can quickly ask who the oldest running txn is. We can maintain this as an unordered set and then let the GC scan quickly for the smallest value (it's typically a small set anyway) when it needs it. It also doesn't need to be a map at all that stores TransacationContext pointers. We had this in case we eventually extended to serializable following the HyPer model.

We still might eventually replace this with something else that scales better, but for now I saw minor performance gains from this on dev4 and an AWS instance with a large number of workers (16).