### PR TITLE
List checks when invoking make check-clang-tidy.

### DIFF
--- a/build-support/run-clang-tidy.py
+++ b/build-support/run-clang-tidy.py
@@ -252,17 +252,16 @@ def main():
         # Find our database
         build_path = find_compilation_database(db_path)
 
-    # TERRIER: we don't need to list checks
-    # try:
-    #     invocation = [args.clang_tidy_binary, '-list-checks']
-    #     invocation.append('-p=' + build_path)
-    #     if args.checks:
-    #         invocation.append('-checks=' + args.checks)
-    #     invocation.append('-')
-    #     subprocess.check_call(invocation)
-    # except:
-    #     print("Unable to run clang-tidy.", file=sys.stderr)
-    #     sys.exit(1)
+    try:
+        invocation = [args.clang_tidy_binary, '-list-checks']
+        invocation.append('-p=' + build_path)
+        if args.checks:
+            invocation.append('-checks=' + args.checks)
+        invocation.append('-')
+        subprocess.check_call(invocation)
+    except:
+        print("Unable to run clang-tidy.", file=sys.stderr)
+        sys.exit(1)
 
     # Load the database and extract all files.
     database = json.load(open(os.path.join(build_path, db_path)))


### PR DESCRIPTION
It turns out that having this enabled is pretty useful because people may be running different versions of clang-tidy, and we're using "give us all your checks" e.g. bugprone- instead of manually specifying all the checks that we're running. @tanujnay112 and I wasted some time on this.

@tli2 @mbutrovich should be a simple merge? And happy new year!

EDIT: We might want to discuss whether we should be explicitly listing the checks we want. If we do,
Pros: wouldn't waste time like this, guaranteed same checks regardless of platform or version
Cons: upgrading versions of clang-tidy would probably break (e.g. bugprone-macro-parentheses in this scenario), but this is autofixable and we probably would want to look at it anyway