### PR TITLE
Add parser support for DISTINCT in aggregation functions.

### DIFF
--- a/src/include/parser/expression/aggregate_expression.h
+++ b/src/include/parser/expression/aggregate_expression.h
@@ -18,11 +18,20 @@ class AggregateExpression : public AbstractExpression {
    * Instantiates a new aggregate expression.
    * @param type type of aggregate expression
    * @param children children to be added
+   * @param distinct whether to eliminate duplicate values in aggregate function calculations
    */
-  AggregateExpression(ExpressionType type, std::vector<std::shared_ptr<AbstractExpression>> &&children)
-      : AbstractExpression(type, type::TypeId::INVALID, std::move(children)) {}
+  AggregateExpression(ExpressionType type, std::vector<std::shared_ptr<AbstractExpression>> &&children, bool distinct)
+      : AbstractExpression(type, type::TypeId::INVALID, std::move(children)), distinct_(distinct) {}
 
   std::unique_ptr<AbstractExpression> Copy() const override { return std::make_unique<AggregateExpression>(*this); }
+
+  /**
+   * @return true if we should eliminate duplicate values in aggregate function calculations
+   */
+  bool IsDistinct() { return distinct_; }
+
+ private:
+  bool distinct_;
 };
 
 }  // namespace terrier::parser

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -586,13 +586,12 @@ std::unique_ptr<AbstractExpression> PostgresParser::FuncCallTransform(FuncCall *
     if (root->agg_star) {
       auto child = std::make_unique<StarExpression>();
       children.emplace_back(std::move(child));
-      result = std::make_unique<AggregateExpression>(agg_fun_type, std::move(children));
+      result = std::make_unique<AggregateExpression>(agg_fun_type, std::move(children), root->agg_distinct);
     } else if (root->args->length < 2) {
-      // TODO(WAN): currently AggregateExpression doesn't support agg_distinct, add that and use root->agg_distinct
       auto expr_node = reinterpret_cast<Node *>(root->args->head->data.ptr_value);
       auto child = ExprTransform(expr_node);
       children.emplace_back(std::move(child));
-      result = std::make_unique<AggregateExpression>(agg_fun_type, std::move(children));
+      result = std::make_unique<AggregateExpression>(agg_fun_type, std::move(children), root->agg_distinct);
     } else {
       PARSER_LOG_DEBUG("FuncCallTransform: Aggregation over multiple cols not supported");
       throw PARSER_EXCEPTION("FuncCallTransform: Aggregation over multiple cols not supported");


### PR DESCRIPTION
e.g. SELECT COUNT(DISTINCT id) FROM foo;

Quick fix for @DarkForte's tests. Note that aggregate expressions are still pretty broken, e.g. I don't think we're using root->agg_filter yet.