### PR TITLE
Insert patch

### DIFF
--- a/src/include/common/container/concurrent_bitmap.h
+++ b/src/include/common/container/concurrent_bitmap.h
@@ -134,14 +134,7 @@ class RawConcurrentBitmap {
           for (uint32_t pos = 0; pos < BYTE_SIZE; pos++) {
             uint32_t current_pos = pos + byte_pos * BYTE_SIZE;
             // we are always padded to a byte, but we don't want to use the padding.
-            if (current_pos >= bitmap_num_bits) {
-              // wrap-around if possible.
-              if (start_pos != 0) {
-                return FirstUnsetPos(start_pos, 0, out_pos);
-              }
-              // otherwise, we have reached the padding. time to give up.
-              return false;
-            }
+            if (current_pos >= bitmap_num_bits) return false;
             // we want to make sure it is after the start pos.
             if (current_pos < start_pos) {
               continue;

--- a/src/include/storage/tuple_access_strategy.h
+++ b/src/include/storage/tuple_access_strategy.h
@@ -212,13 +212,12 @@ class TupleAccessStrategy {
   bool Allocate(RawBlock *block, TupleSlot *slot) const;
 
   /**
-   * Deallocates a slot, making it usable for later inserts.
+   * Deallocates a slot.
    * @param slot the slot to free up
    */
   void Deallocate(const TupleSlot slot) const {
     TERRIER_ASSERT(Allocated(slot), "Can only deallocate slots that are allocated");
     reinterpret_cast<Block *>(slot.GetBlock())->SlotAllocationBitmap(layout_)->Flip(slot.GetOffset(), true);
-    slot.GetBlock()->insert_head_--;
   }
 
   /**

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -287,8 +287,7 @@ TEST_F(DataTableTests, InsertNoWrap) {
     storage::RawBlock *block = nullptr;
     // fill the block. bypass the test object to be more efficient with buffers
     transaction::timestamp_t timestamp(0);
-    transaction::TransactionContext
-        *txn = new transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED);
     for (uint32_t i = 0; i < tested.Layout().NumSlots(); i++) {
       storage::RawBlock *inserted_block = tested.InsertRandomTuple(txn, &generator_, &buffer_pool_).GetBlock();
       if (block == nullptr) block = inserted_block;

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -13,7 +13,7 @@ namespace terrier {
 // Not thread-safe
 class RandomDataTableTestObject {
  public:
-  template<class Random>
+  template <class Random>
   RandomDataTableTestObject(storage::BlockStore *block_store, const uint16_t max_col, const double null_bias,
                             Random *generator)
       : layout_(StorageTestUtil::RandomLayoutNoVarlen(max_col, generator)),
@@ -26,7 +26,7 @@ class RandomDataTableTestObject {
     delete[] select_buffer_;
   }
 
-  template<class Random>
+  template <class Random>
   storage::TupleSlot InsertRandomTuple(const transaction::timestamp_t timestamp, Random *generator,
                                        storage::RecordBufferSegmentPool *buffer_pool) {
     // generate a random redo ProjectedRow to Insert
@@ -48,7 +48,7 @@ class RandomDataTableTestObject {
 
   // Generate an insert using the given transaction context. This is equivalent to the version of the call taking in
   // a timestamp, but more space efficient if the insertions are large.
-  template<class Random>
+  template <class Random>
   storage::TupleSlot InsertRandomTuple(transaction::TransactionContext *txn, Random *generator,
                                        storage::RecordBufferSegmentPool *buffer_pool) {
     // generate a random redo ProjectedRow to Insert
@@ -65,7 +65,7 @@ class RandomDataTableTestObject {
   }
 
   // be sure to only update tuple incrementally (cannot go back in time)
-  template<class Random>
+  template <class Random>
   bool RandomlyUpdateTuple(const transaction::timestamp_t timestamp, const storage::TupleSlot slot, Random *generator,
                            storage::RecordBufferSegmentPool *buffer_pool) {
     // tuple must already exist

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -13,7 +13,7 @@ namespace terrier {
 // Not thread-safe
 class RandomDataTableTestObject {
  public:
-  template <class Random>
+  template<class Random>
   RandomDataTableTestObject(storage::BlockStore *block_store, const uint16_t max_col, const double null_bias,
                             Random *generator)
       : layout_(StorageTestUtil::RandomLayoutNoVarlen(max_col, generator)),
@@ -26,7 +26,7 @@ class RandomDataTableTestObject {
     delete[] select_buffer_;
   }
 
-  template <class Random>
+  template<class Random>
   storage::TupleSlot InsertRandomTuple(const transaction::timestamp_t timestamp, Random *generator,
                                        storage::RecordBufferSegmentPool *buffer_pool) {
     // generate a random redo ProjectedRow to Insert
@@ -46,8 +46,26 @@ class RandomDataTableTestObject {
     return slot;
   }
 
+  // Generate an insert using the given transaction context. This is equivalent to the version of the call taking in
+  // a timestamp, but more space efficient if the insertions are large.
+  template<class Random>
+  storage::TupleSlot InsertRandomTuple(transaction::TransactionContext *txn, Random *generator,
+                                       storage::RecordBufferSegmentPool *buffer_pool) {
+    // generate a random redo ProjectedRow to Insert
+    auto *redo_buffer = common::AllocationUtil::AllocateAligned(redo_initializer_.ProjectedRowSize());
+    loose_pointers_.push_back(redo_buffer);
+    storage::ProjectedRow *redo = redo_initializer_.InitializeRow(redo_buffer);
+    StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
+
+    storage::TupleSlot slot = table_.Insert(txn, *redo);
+    inserted_slots_.push_back(slot);
+    tuple_versions_[slot].emplace_back(txn->StartTime(), redo);
+
+    return slot;
+  }
+
   // be sure to only update tuple incrementally (cannot go back in time)
-  template <class Random>
+  template<class Random>
   bool RandomlyUpdateTuple(const transaction::timestamp_t timestamp, const storage::TupleSlot slot, Random *generator,
                            storage::RecordBufferSegmentPool *buffer_pool) {
     // tuple must already exist
@@ -255,6 +273,32 @@ TEST_F(DataTableTests, WriteWriteConflictUpdateFails) {
     storage::ProjectedRow *stored = tested.SelectIntoBuffer(tuple, transaction::timestamp_t(UINT64_MAX), &buffer_pool_);
     const storage::ProjectedRow *ref = tested.GetReferenceVersionedTuple(tuple, transaction::timestamp_t(UINT64_MAX));
     EXPECT_TRUE(StorageTestUtil::ProjectionListEqual(tested.Layout(), ref, stored));
+  }
+}
+
+// Test that insertion into a block does not wrap around even in the presence of deleted slots. This makes compaction
+// a lot easier to write.
+// NOLINTNEXTLINE
+TEST_F(DataTableTests, InsertNoWrap) {
+  const uint32_t num_iterations = 10;
+  const uint16_t max_columns = 10;
+  for (uint32_t iteration = 0; iteration < num_iterations; ++iteration) {
+    RandomDataTableTestObject tested(&block_store_, max_columns, null_ratio_(generator_), &generator_);
+    storage::RawBlock *block;
+    // fill the block. bypass the test object to be more efficient with buffers
+    transaction::timestamp_t timestamp(0);
+    transaction::TransactionContext
+        *txn = new transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED);
+    for (uint32_t i = 0; i < tested.Layout().NumSlots(); i++)
+      block = tested.InsertRandomTuple(txn, &generator_, &buffer_pool_).GetBlock();
+
+    // Bypass concurrency control and remove some tuples
+    storage::TupleAccessStrategy accessor(tested.Layout());
+    accessor.Deallocate({block, 0});
+
+    // Even though there is still space available, we should insert into a new block
+    EXPECT_NE(block, tested.InsertRandomTuple(transaction::timestamp_t(0), &generator_, &buffer_pool_).GetBlock());
+    delete txn;
   }
 }
 }  // namespace terrier

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -1345,5 +1345,4 @@ TEST_F(MVCCTests, SimpleDelete2) {
     txn_manager.Commit(txn1, TestCallbacks::EmptyCallback, nullptr);
   }
 }
-
 }  // namespace terrier


### PR DESCRIPTION
Insert wrap-around behavior is not changed even though the corresponding GC change went in. A simple test case is added so the wrap-around behavior is specified.