### PR TITLE
Fix bwtree tests for odd numbered hardware_concurrency()

### DIFF
--- a/test/storage/bwtree_test.cpp
+++ b/test/storage/bwtree_test.cpp
@@ -208,6 +208,10 @@ TEST_F(BwTreeTests, ConcurrentRandomInsert) {
  */
 // NOLINTNEXTLINE
 TEST_F(BwTreeTests, ConcurrentMixed) {
+  // This test's logic expects an even number of threads for the logic to work. That's not an ideal assumption, but
+  // we'll test the index more robustly through the wrapper.
+  if (num_threads_ % 2 != 0) return;
+
   // This defines the key space (0 ~ (1M - 1))
   const uint32_t key_num = 1024 * 1024;
 

--- a/test/storage/bwtree_test.cpp
+++ b/test/storage/bwtree_test.cpp
@@ -18,7 +18,8 @@ struct BwTreeTests : public TerrierTest {
 
   void TearDown() override { TerrierTest::TearDown(); }
 
-  const uint32_t num_threads_ = MultiThreadTestUtil::HardwareConcurrency();
+  const uint32_t num_threads_ =
+      MultiThreadTestUtil::HardwareConcurrency() + (MultiThreadTestUtil::HardwareConcurrency() % 2);
 };
 
 /**
@@ -208,9 +209,8 @@ TEST_F(BwTreeTests, ConcurrentRandomInsert) {
  */
 // NOLINTNEXTLINE
 TEST_F(BwTreeTests, ConcurrentMixed) {
-  // This test's logic expects an even number of threads for the logic to work. That's not an ideal assumption, but
-  // we'll test the index more robustly through the wrapper.
-  if (num_threads_ % 2 != 0) return;
+  TERRIER_ASSERT(num_threads_ % 2 == 0,
+                 "This test requires an even number of threads. This should have been handled when it was assigned.");
 
   // This defines the key space (0 ~ (1M - 1))
   const uint32_t key_num = 1024 * 1024;


### PR DESCRIPTION
The bwtree tests assume an even number of threads, particularly the ConcurrentMixed test's logic. This forces the `num_threads_` variable to be even for that test suite.

This resolves the other issue reported by @pervazea in #264 when running the bwtree tests with 1 thread in a VM, which I reproduced.