### PR TITLE
Merge CAST() and ExpressionType::OPERATOR_CAST

### DIFF
--- a/src/include/parser/expression/type_cast_expression.h
+++ b/src/include/parser/expression/type_cast_expression.h
@@ -17,7 +17,7 @@ class TypeCastExpression : public AbstractExpression {
    * Instantiates a new type cast expression.
    */
   TypeCastExpression(type::TypeId type, std::vector<std::shared_ptr<AbstractExpression>> &&children)
-      : AbstractExpression(ExpressionType::CAST, type, std::move(children)) {}
+      : AbstractExpression(ExpressionType::OPERATOR_CAST, type, std::move(children)) {}
 
   std::unique_ptr<AbstractExpression> Copy() const override { return std::make_unique<TypeCastExpression>(*this); }
 };

--- a/src/include/parser/expression_defs.h
+++ b/src/include/parser/expression_defs.h
@@ -68,9 +68,7 @@ enum class ExpressionType : uint8_t {
   PLACEHOLDER,
   COLUMN_REF,
   FUNCTION_REF,
-  TABLE_REF,
-
-  CAST
+  TABLE_REF
 };
 
 }  // namespace terrier::parser

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -409,6 +409,8 @@ std::unique_ptr<AbstractExpression> PostgresParser::AExprTransform(A_Expr *root)
 
   if (root->kind == AEXPR_DISTINCT) {
     target_type = ExpressionType::COMPARE_IS_DISTINCT_FROM;
+    children.emplace_back(ExprTransform(root->lexpr));
+    children.emplace_back(ExprTransform(root->rexpr));
   } else if (root->kind == AEXPR_OP && root->type == T_TypeCast) {
     target_type = ExpressionType::OPERATOR_CAST;
   } else {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -230,7 +230,7 @@ std::unique_ptr<AbstractExpression> PostgresParser::ExprTransform(Node *node) {
       break;
     }
     case T_TypeCast: {
-      expr = TypeCastTransform(reinterpret_cast<TypeCast *>(node));
+      expr = AExprTransform(reinterpret_cast<A_Expr *>(node));
       break;
     }
     default: {
@@ -270,9 +270,6 @@ ExpressionType PostgresParser::StringToExpressionType(const std::string &parser_
   }
   if (str == "OPERATOR_MOD" || str == "%") {
     return ExpressionType::OPERATOR_MOD;
-  }
-  if (str == "OPERATOR_CAST") {
-    return ExpressionType::OPERATOR_CAST;
   }
   if (str == "OPERATOR_NOT") {
     return ExpressionType::OPERATOR_NOT;
@@ -394,9 +391,6 @@ ExpressionType PostgresParser::StringToExpressionType(const std::string &parser_
   if (str == "TABLE_REF") {
     return ExpressionType::TABLE_REF;
   }
-  if (str == "CAST") {
-    return ExpressionType::CAST;
-  }
 
   PARSER_LOG_DEBUG("StringToExpressionType: type {} unsupported", str.c_str());
   throw PARSER_EXCEPTION("StringToExpressionType: unsupported type");
@@ -411,17 +405,18 @@ std::unique_ptr<AbstractExpression> PostgresParser::AExprTransform(A_Expr *root)
   }
 
   ExpressionType target_type;
+  std::vector<std::shared_ptr<AbstractExpression>> children;
 
   if (root->kind == AEXPR_DISTINCT) {
     target_type = ExpressionType::COMPARE_IS_DISTINCT_FROM;
+  } else if (root->kind == AEXPR_OP && root->type == T_TypeCast) {
+    target_type = ExpressionType::OPERATOR_CAST;
   } else {
     auto name = (reinterpret_cast<value *>(root->name->head->data.ptr_value))->val.str;
     target_type = StringToExpressionType(name);
+    children.emplace_back(ExprTransform(root->lexpr));
+    children.emplace_back(ExprTransform(root->rexpr));
   }
-
-  std::vector<std::shared_ptr<AbstractExpression>> children;
-  children.emplace_back(ExprTransform(root->lexpr));
-  children.emplace_back(ExprTransform(root->rexpr));
 
   switch (target_type) {
     case ExpressionType::OPERATOR_UNARY_MINUS:
@@ -431,12 +426,14 @@ std::unique_ptr<AbstractExpression> PostgresParser::AExprTransform(A_Expr *root)
     case ExpressionType::OPERATOR_DIVIDE:
     case ExpressionType::OPERATOR_CONCAT:
     case ExpressionType::OPERATOR_MOD:
-    case ExpressionType::OPERATOR_CAST:
     case ExpressionType::OPERATOR_NOT:
     case ExpressionType::OPERATOR_IS_NULL:
     case ExpressionType::OPERATOR_IS_NOT_NULL:
     case ExpressionType::OPERATOR_EXISTS: {
       return std::make_unique<OperatorExpression>(target_type, type::TypeId::INVALID, std::move(children));
+    }
+    case ExpressionType::OPERATOR_CAST: {
+      return TypeCastTransform(reinterpret_cast<TypeCast *>(root));
     }
     case ExpressionType::COMPARE_EQUAL:
     case ExpressionType::COMPARE_NOT_EQUAL:

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -381,7 +381,7 @@ TEST_F(ParserTestBase, OperatorTest) {
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectColumns().at(0).get();
-    EXPECT_EQ(expr->GetExpressionType(), ExpressionType::CAST);
+    EXPECT_EQ(expr->GetExpressionType(), ExpressionType::OPERATOR_CAST);
     EXPECT_EQ(expr->GetReturnValueType(), type::TypeId::INTEGER);
   }
 

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -57,8 +57,10 @@ TEST_F(ParserTestBase, AnalyzeTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, CastTest) {
   auto stmts = pgparser.BuildParseTree("SELECT CAST('100' AS INTEGER);");
-  auto copy_stmt = reinterpret_cast<SelectStatement *>(stmts[0].get());
-  EXPECT_EQ(copy_stmt->GetType(), StatementType::SELECT);
+  auto cast_stmt = reinterpret_cast<SelectStatement *>(stmts[0].get());
+  EXPECT_EQ(cast_stmt->GetType(), StatementType::SELECT);
+  EXPECT_EQ(cast_stmt->GetSelectColumns().at(0)->GetExpressionType(), ExpressionType::OPERATOR_CAST);
+  EXPECT_EQ(cast_stmt->GetSelectColumns().at(0)->GetReturnValueType(), type::TypeId::INTEGER);
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
As discussed in #292 merging the CAST() operator with the ExpressionType::OPERATOR_CAST.
All `OPERATOR_*` operators are treated as AbstractExpressions which are handled as `T_A_Expr` by `AExprTransform()`, while CAST() was being handled separately as T_TypeCast under TypeCastTransform.

In order to make all cast operations use OPERATOR_CAST() we need to make the casting operation of the AbstractExpression type - which is what is being done here.

So now a casting operator goes through AExprTransform() where it gets triaged to the existing TypeCastTransform() there by reusing the existing code.