### PR TITLE
NUM_RESERVED_COLUMNS fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ if (UNIX)
   # Full lint
   # Balancing act: cpplint.py takes a non-trivial time to launch,
   # so process 12 files per invocation, while still ensuring parallelism
-  add_custom_target(check-lint echo ${LINT_FILES} | xargs -n12 -P8
+  add_custom_target(check-lint echo '${LINT_FILES}' | xargs -n12 -P8
       ${CPPLINT_BIN}
       --verbose=2 ${TERRIER_LINT_QUIET}
       --linelength=120

--- a/src/storage/block_layout.cpp
+++ b/src/storage/block_layout.cpp
@@ -18,8 +18,8 @@ BlockLayout::BlockLayout(std::vector<uint8_t> attr_sizes)
                  "number of columns must be between 1 and 32767");
   TERRIER_ASSERT(num_slots_ != 0, "number of slots cannot be 0!");
   // sort the attributes when laying out memory to minimize impact of padding
-  // This is always safe because we know there are at last 2 columns
-  std::sort(attr_sizes_.begin() + 1, attr_sizes_.end(), std::greater<>());
+  // skip the reserved columns because we still want those first and shouldn't mess up 8-byte alignment
+  std::sort(attr_sizes_.begin() + NUM_RESERVED_COLUMNS, attr_sizes_.end(), std::greater<>());
   for (uint32_t i = 0; i < attr_sizes_.size(); i++)
     if (attr_sizes_[i] == VARLEN_COLUMN) varlens_.emplace_back(i);
 }

--- a/src/storage/storage_util.cpp
+++ b/src/storage/storage_util.cpp
@@ -96,14 +96,21 @@ uint32_t StorageUtil::PadUpToSize(const uint8_t word_size, const uint32_t offset
 
 // TODO(Tianyu): Rewrite these two functions to deal with varlens
 std::pair<BlockLayout, ColumnMap> StorageUtil::BlockLayoutFromSchema(const catalog::Schema &schema) {
-  uint16_t num_8_byte_attrs = NUM_RESERVED_COLUMNS;
+  uint16_t num_8_byte_attrs = 0;
   uint16_t num_4_byte_attrs = 0;
   uint16_t num_2_byte_attrs = 0;
   uint16_t num_1_byte_attrs = 0;
   uint16_t num_varlen_byte_attrs = 0;
 
   // Begin with the NUM_RESERVED_COLUMNS in the attr_sizes
-  std::vector<uint8_t> attr_sizes({8});
+  std::vector<uint8_t> attr_sizes;
+  attr_sizes.reserve(NUM_RESERVED_COLUMNS + schema.GetColumns().size());
+
+  for (uint8_t i = 0; i < NUM_RESERVED_COLUMNS; i++) {
+    attr_sizes.emplace_back(8);
+    num_8_byte_attrs++;
+  }
+
   TERRIER_ASSERT(attr_sizes.size() == NUM_RESERVED_COLUMNS,
                  "attr_sizes should be initialized with NUM_RESERVED_COLUMNS elements.");
 
@@ -137,7 +144,7 @@ std::pair<BlockLayout, ColumnMap> StorageUtil::BlockLayoutFromSchema(const catal
   // Initialize the offsets for each attr_size
   auto offset_varlen_byte_attrs = static_cast<uint16_t>(NUM_RESERVED_COLUMNS);
   auto offset_8_byte_attrs = static_cast<uint16_t>(offset_varlen_byte_attrs + num_varlen_byte_attrs);
-  auto offset_4_byte_attrs = static_cast<uint16_t>(offset_8_byte_attrs + num_8_byte_attrs - NUM_RESERVED_COLUMNS);
+  auto offset_4_byte_attrs = static_cast<uint16_t>(offset_8_byte_attrs + (num_8_byte_attrs - NUM_RESERVED_COLUMNS));
   auto offset_2_byte_attrs = static_cast<uint16_t>(offset_4_byte_attrs + num_4_byte_attrs);
   auto offset_1_byte_attrs = static_cast<uint16_t>(offset_2_byte_attrs + num_2_byte_attrs);
 

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -239,7 +239,11 @@ struct StorageTestUtil {
     const uint16_t num_attrs = std::uniform_int_distribution<uint16_t>(NUM_RESERVED_COLUMNS + 1, max_cols)(*generator);
     std::vector<uint8_t> possible_attr_sizes{1, 2, 4, 8}, attr_sizes(num_attrs);
     if (allow_varlen) possible_attr_sizes.push_back(VARLEN_COLUMN);
-    attr_sizes[0] = 8;
+
+    for (uint16_t i = 0; i < NUM_RESERVED_COLUMNS; i++) {
+      attr_sizes[i] = 8;
+    }
+
     for (uint16_t i = NUM_RESERVED_COLUMNS; i < num_attrs; i++)
       attr_sizes[i] = *RandomTestUtil::UniformRandomElement(&possible_attr_sizes, generator);
     return storage::BlockLayout(attr_sizes);


### PR DESCRIPTION
While working on index stuff, we spotted a bug introduced in the code related to BlockLayouts introduced by VARLEN stuff. If the value of NUM_RESERVED_COLUMNS is changed from 1 to 2, the system dies. This fixes the bug and verified it works again with arbitrary NUM_RESERVED_COLUMNS.