### PR TITLE
Bad words filter as "make check-censored" target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,8 @@ before_script:
       docker exec build /bin/sh -c "cd /repo/build && make gbenchmark_ep -j 4" &&
       docker exec build /bin/sh -c "cd /repo/build && make check-clang-tidy" &&
       docker exec build /bin/sh -c "cd /repo/build && make check-format" &&
-      docker exec build /bin/sh -c "cd /repo/build && make check-lint";
+      docker exec build /bin/sh -c "cd /repo/build && make check-lint" &&
+      docker exec build /bin/sh -c "cd /repo/build && make check-censored";
     else
       cd apidoc &&
       touch warnings.txt &&
@@ -81,7 +82,8 @@ before_script:
       ASAN_OPTIONS=detect_container_overflow=0 make gbenchmark_ep &&
       ASAN_OPTIONS=detect_container_overflow=0 make check-clang-tidy &&
       ASAN_OPTIONS=detect_container_overflow=0 make check-format &&
-      ASAN_OPTIONS=detect_container_overflow=0 make check-lint;
+      ASAN_OPTIONS=detect_container_overflow=0 make check-lint &&
+      ASAN_OPTIONS=detect_container_overflow=0 make check-censored;
     fi
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ endif ()
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 ###########################################################
-# "make check-lint" target
+# "make check-lint" and "make check-censored" targets
 ###########################################################
 if (NOT TERRIER_VERBOSE_LINT)
   set(TERRIER_LINT_QUIET "--quiet")
@@ -233,6 +233,21 @@ if (UNIX)
       --linelength=120
       --filter=-legal/copyright,-build/header_guard
       )
+
+  set(CENSOR_FILES ${LINT_FILES})
+
+  # If whitelisting becomes necessary, do it here. Make it harder so that people try not to do it.
+  #  list(REMOVE_ITEM CENSOR_FILES
+  #
+  #      )
+
+  add_custom_target(check-censored
+          grep --invert-match -n -e '^ *//' -e '^ *[*]' ${CENSOR_FILES} # check all uncommented lines w/ line num
+          | grep -i -f ${BUILD_SUPPORT_DIR}/bad_words.txt               # for bad words, not case sensitive
+          | grep --invert-match -e 'NOLINT'                             # the count of them that aren't NOLINT
+          || exit 0                                                     # if nothing found, return 0
+          && exit 1                                                     # else return 1, note || && left-associative
+          )
 endif (UNIX)
 
 ###########################################################

--- a/build-support/bad_words.txt
+++ b/build-support/bad_words.txt
@@ -1,0 +1,8 @@
+#include "include/
+\binline\b
+\bcalloc(
+\bmalloc(
+\bfree(
+\bstd::cout\b
+\bcout\b
+\bprintf(

--- a/src/include/common/performance_counter.h
+++ b/src/include/common/performance_counter.h
@@ -192,3 +192,7 @@ class PerformanceCounter {
                                                                                                \
   inline void to_json(nlohmann::json &j, const ClassName &c) { j = c.ToJson(); }  /* NOLINT */ \
   inline void from_json(const nlohmann::json &j, ClassName &c) { c.FromJson(j); } /* NOLINT */
+
+// note: this is a rare correct usage of inline in modern C++
+// If you include a header file in multiple translation units, the multiple definitions conflict
+// and you get linker errors. We mark it inline so that the compiler figures it out.

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -97,17 +97,17 @@ class TableRefStatement : public SQLStatement {
   /**
    * @return table name
    */
-  virtual inline std::string GetTableName() const { return table_info_->GetTableName(); }
+  virtual std::string GetTableName() const { return table_info_->GetTableName(); }
 
   /**
    * @return table schema name (aka namespace)
    */
-  virtual inline std::string GetSchemaName() const { return table_info_->GetSchemaName(); }
+  virtual std::string GetSchemaName() const { return table_info_->GetSchemaName(); }
 
   /**
    * @return database name
    */
-  virtual inline std::string GetDatabaseName() const { return table_info_->GetDatabaseName(); }
+  virtual std::string GetDatabaseName() const { return table_info_->GetDatabaseName(); }
 
  private:
   const std::shared_ptr<TableInfo> table_info_ = nullptr;

--- a/src/include/type/transient_value_peeker.h
+++ b/src/include/type/transient_value_peeker.h
@@ -18,7 +18,7 @@ class TransientValuePeeker {
    * @return bool representing the value of the TransientValue
    * @warning TransientValue must be non-NULL. @see TransientValue::Null() first
    */
-  static inline bool PeekBoolean(const TransientValue &value) {
+  static bool PeekBoolean(const TransientValue &value) {
     TERRIER_ASSERT(!value.Null(), "Doesn't make sense to peek a NULL value.");
     TERRIER_ASSERT(value.Type() == TypeId::BOOLEAN, "TypeId mismatch.");
     return value.GetAs<bool>();
@@ -29,7 +29,7 @@ class TransientValuePeeker {
    * @return int8_t representing the value of the TransientValue
    * @warning TransientValue must be non-NULL. @see TransientValue::Null() first
    */
-  static inline int8_t PeekTinyInt(const TransientValue &value) {
+  static int8_t PeekTinyInt(const TransientValue &value) {
     TERRIER_ASSERT(!value.Null(), "Doesn't make sense to peek a NULL value.");
     TERRIER_ASSERT(value.Type() == TypeId::TINYINT, "TypeId mismatch.");
     return value.GetAs<int8_t>();
@@ -40,7 +40,7 @@ class TransientValuePeeker {
    * @return int16_t representing the value of the TransientValue
    * @warning TransientValue must be non-NULL. @see TransientValue::Null() first
    */
-  static inline int16_t PeekSmallInt(const TransientValue &value) {
+  static int16_t PeekSmallInt(const TransientValue &value) {
     TERRIER_ASSERT(!value.Null(), "Doesn't make sense to peek a NULL value.");
     TERRIER_ASSERT(value.Type() == TypeId::SMALLINT, "TypeId mismatch.");
     return value.GetAs<int16_t>();
@@ -51,7 +51,7 @@ class TransientValuePeeker {
    * @return int32_t representing the value of the TransientValue
    * @warning TransientValue must be non-NULL. @see TransientValue::Null() first
    */
-  static inline int32_t PeekInteger(const TransientValue &value) {
+  static int32_t PeekInteger(const TransientValue &value) {
     TERRIER_ASSERT(!value.Null(), "Doesn't make sense to peek a NULL value.");
     TERRIER_ASSERT(value.Type() == TypeId::INTEGER, "TypeId mismatch.");
     return value.GetAs<int32_t>();
@@ -62,7 +62,7 @@ class TransientValuePeeker {
    * @return int64_t representing the value of the TransientValue
    * @warning TransientValue must be non-NULL. @see TransientValue::Null() first
    */
-  static inline int64_t PeekBigInt(const TransientValue &value) {
+  static int64_t PeekBigInt(const TransientValue &value) {
     TERRIER_ASSERT(!value.Null(), "Doesn't make sense to peek a NULL value.");
     TERRIER_ASSERT(value.Type() == TypeId::BIGINT, "TypeId mismatch.");
     return value.GetAs<int64_t>();
@@ -73,7 +73,7 @@ class TransientValuePeeker {
    * @return double representing the value of the TransientValue
    * @warning TransientValue must be non-NULL. @see TransientValue::Null() first
    */
-  static inline double PeekDecimal(const TransientValue &value) {
+  static double PeekDecimal(const TransientValue &value) {
     TERRIER_ASSERT(!value.Null(), "Doesn't make sense to peek a NULL value.");
     TERRIER_ASSERT(value.Type() == TypeId::DECIMAL, "TypeId mismatch.");
     return value.GetAs<double>();
@@ -84,7 +84,7 @@ class TransientValuePeeker {
    * @return timestamp_t representing the value of the TransientValue
    * @warning TransientValue must be non-NULL. @see TransientValue::Null() first
    */
-  static inline timestamp_t PeekTimestamp(const TransientValue &value) {
+  static timestamp_t PeekTimestamp(const TransientValue &value) {
     TERRIER_ASSERT(!value.Null(), "Doesn't make sense to peek a NULL value.");
     TERRIER_ASSERT(value.Type() == TypeId::TIMESTAMP, "TypeId mismatch.");
     return value.GetAs<timestamp_t>();
@@ -95,7 +95,7 @@ class TransientValuePeeker {
    * @return date_t representing the value of the TransientValue
    * @warning TransientValue must be non-NULL. @see TransientValue::Null() first
    */
-  static inline date_t PeekDate(const TransientValue &value) {
+  static date_t PeekDate(const TransientValue &value) {
     TERRIER_ASSERT(!value.Null(), "Doesn't make sense to peek a NULL value.");
     TERRIER_ASSERT(value.Type() == TypeId::DATE, "TypeId mismatch.");
     return value.GetAs<date_t>();
@@ -107,7 +107,7 @@ class TransientValuePeeker {
    * should be freed after use by the caller.
    * @warning TransientValue must be non-NULL. @see TransientValue::Null() first
    */
-  static inline const char *const PeekVarChar(const TransientValue &value) {
+  static const char *const PeekVarChar(const TransientValue &value) {
     TERRIER_ASSERT(!value.Null(), "Doesn't make sense to peek a NULL value.");
     TERRIER_ASSERT(value.Type() == TypeId::VARCHAR, "TypeId mismatch.");
     const auto *const varchar = value.GetAs<const char *const>();

--- a/src/main/terrier.cpp
+++ b/src/main/terrier.cpp
@@ -31,7 +31,7 @@ int main() {
     // Registered loggers must be thread safe for this to work correctly
     spdlog::flush_every(std::chrono::seconds(DEBUG_LOG_FLUSH_INTERVAL));
   } catch (const spdlog::spdlog_ex &ex) {
-    std::cout << "debug log init failed " << ex.what() << std::endl;
+    std::cout << "debug log init failed " << ex.what() << std::endl;  // NOLINT
     return 1;
   }
 

--- a/test/common/stat_registry_test.cpp
+++ b/test/common/stat_registry_test.cpp
@@ -178,7 +178,6 @@ TEST(StatRegistryTest, GTEST_DEBUG_ONLY(DataTableStatTest)) {
   // initialize stat registry
   auto test_stat_reg = std::make_shared<terrier::common::StatisticsRegistry>();
   test_stat_reg->Register({"Storage"}, data_table_.GetDataTableCounter(), &data_table_);
-  std::cout << test_stat_reg->DumpStats() << std::endl;
   delete[] redo_buffer_;
   delete txn;
 

--- a/test/include/util/bwtree_test_util.h
+++ b/test/include/util/bwtree_test_util.h
@@ -27,7 +27,7 @@ struct BwTreeTestUtil {
    */
   class KeyComparator {
    public:
-    inline bool operator()(const int64_t k1, const int64_t k2) const { return k1 < k2; }
+    bool operator()(const int64_t k1, const int64_t k2) const { return k1 < k2; }
 
     explicit KeyComparator(int dummy UNUSED_ATTRIBUTE) {}
 
@@ -44,7 +44,7 @@ struct BwTreeTestUtil {
    */
   class KeyEqualityChecker {
    public:
-    inline bool operator()(const int64_t k1, const int64_t k2) const { return k1 == k2; }
+    bool operator()(const int64_t k1, const int64_t k2) const { return k1 == k2; }
 
     explicit KeyEqualityChecker(int dummy UNUSED_ATTRIBUTE) {}
 

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -209,7 +209,7 @@ struct StorageTestUtil {
       } else {
         os << "col_id: " << !col_id;
         os << " is ";
-        for (uint8_t pos = 0; pos < layout.AttrSize(col_id); pos++){
+        for (uint8_t pos = 0; pos < layout.AttrSize(col_id); pos++) {
           os << std::setfill('0') << std::setw(2) << std::hex << static_cast<uint8_t>(attr[pos]);
         }
         os << std::endl;

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -184,28 +184,38 @@ struct StorageTestUtil {
   }
 
   template <class RowType>
-  static void PrintRow(const RowType &row, const storage::BlockLayout &layout) {
-    printf("num_cols: %u\n", row.NumColumns());
+  static std::string PrintRow(const RowType &row, const storage::BlockLayout &layout) {
+    std::ostringstream os;
+    os << "num_cols: " << row.NumColumns() << std::endl;
     for (uint16_t i = 0; i < row.NumColumns(); i++) {
       storage::col_id_t col_id = row.ColumnIds()[i];
       const byte *attr = row.AccessWithNullCheck(i);
       if (attr == nullptr) {
-        printf("col_id: %u is NULL\n", !col_id);
+        os << "col_id: " << !col_id << " is NULL" << std::endl;
         continue;
       }
 
       if (layout.IsVarlen(col_id)) {
         auto *entry = reinterpret_cast<const storage::VarlenEntry *>(attr);
-        printf("col_id: %u is varlen, ptr %p, size %u, reclaimable %d, content ", !col_id, entry->Content(),
-               entry->Size(), entry->NeedReclaim());
-        for (uint8_t pos = 0; pos < entry->Size(); pos++) printf("%02x", static_cast<uint8_t>(entry->Content()[pos]));
-        printf("\n");
+        os << "col_id: " << !col_id;
+        os << " is varlen, ptr " << entry->Content();
+        os << ", size " << entry->Size();
+        os << ", reclaimable " << entry->NeedReclaim();
+        os << ", content ";
+        for (uint8_t pos = 0; pos < entry->Size(); pos++) {
+          os << std::setfill('0') << std::setw(2) << std::hex << static_cast<uint8_t>(entry->Content()[pos]);
+        }
+        os << std::endl;
       } else {
-        printf("col_id: %u is ", !col_id);
-        for (uint8_t pos = 0; pos < layout.AttrSize(col_id); pos++) printf("%02x", static_cast<uint8_t>(attr[pos]));
-        printf("\n");
+        os << "col_id: " << !col_id;
+        os << " is ";
+        for (uint8_t pos = 0; pos < layout.AttrSize(col_id); pos++){
+          os << std::setfill('0') << std::setw(2) << std::hex << static_cast<uint8_t>(attr[pos]);
+        }
+        os << std::endl;
       }
     }
+    return os.str();
   }
 
   // Write the given tuple (projected row) into a block using the given access strategy,

--- a/test/include/util/storage_test_util.h
+++ b/test/include/util/storage_test_util.h
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <cstring>
 #include <random>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -123,7 +123,7 @@ class SqlTableRW {
     // stored string has no null terminator, add space for it
     uint32_t size = entry->Size() + 1;
     // allocate return string
-    auto *ret_st = static_cast<char *>(malloc(size));
+    auto *ret_st = reinterpret_cast<char *>(common::AllocationUtil::AllocateAligned(size));
     std::memcpy(ret_st, entry->Content(), size);
     // add the null terminator
     *(ret_st + size - 1) = 0;
@@ -217,7 +217,7 @@ TEST_F(SqlTableTests, VarlenInsertTest) {
   EXPECT_EQ(100, id);
   char *table_name = table.GetVarcharColInRow(1, row_slot);
   EXPECT_STREQ("name", table_name);
-  free(table_name);
+  delete[] table_name;
 }
 
 }  // namespace terrier


### PR DESCRIPTION
This uses a blacklist of regex in build-support/bad_words.txt.
By carefully picking regex, we don't need to // NOLINT innocuous uses too much, e.g. schema.h had a variable called inlined_ that we were picking up.

As a general rule of thumb, if the word is standalone, use the word boundary regex,
\bWORD\b   e.g. \binline\b
if the word is part of a function, include the calling paren in the regex,
func(            e.g. malloc(

Also added this check to CI and fixed up all existing files.

NB: I didn't think it was worth porting over the old validator script. That's a lot of Python, the include-what-you-use and namespace-closing functionality has been subsumed by check-lint, we basically just want to run an intelligent grep. And grep is pretty fast.

It is also much easier to understand how the make checks work compared to the old git-hook system.