### PR TITLE
Remove boost from build infrastructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get -y update && \
       doxygen \
       git \
       g++-7 \
-      libboost-filesystem-dev \
       libjemalloc-dev \
       libtbb-dev \
       libz-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN apt-get -y update && \
       g++-7 \
       libjemalloc-dev \
       libtbb-dev \
-      libz-dev \
+      zlib1g-dev \
       llvm-6.0

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -261,7 +261,7 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 list(APPEND TERRIER_LINK_LIBS ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 # LLVM 6.0+
-find_package(LLVM REQUIRED CONFIG)
+find_package(LLVM 6.0 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 if (${LLVM_PACKAGE_VERSION} VERSION_LESS "6.0")
   message(FATAL_ERROR "LLVM 6.0 or newer is required.")

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -255,11 +255,6 @@ find_package(TBB REQUIRED)
 include_directories(SYSTEM ${TBB_INCLUDE_DIRS})
 list(APPEND TERRIER_LINK_LIBS ${TBB_LIBRARIES})
 
-# Boost filesystem
-find_package(Boost COMPONENTS filesystem REQUIRED)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-list(APPEND TERRIER_LINK_LIBS ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
-
 # LLVM 6.0+
 find_package(LLVM 6.0 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -70,7 +70,6 @@ install_mac() {
   # Update Homebrew.
   brew update
   # Install packages.
-  brew ls --versions boost || brew install boost
   brew ls --versions cmake || brew install cmake
   brew ls --versions doxygen || brew install doxygen
   brew ls --versions git || brew install git
@@ -92,7 +91,6 @@ install_linux() {
       doxygen \
       git \
       g++-7 \
-      libboost-filesystem-dev \
       libjemalloc-dev \
       libtbb-dev \
       zlib1g-dev \


### PR DESCRIPTION
`boost filesystem` dependency was introduced last summer based on a perceived need for it for logging. It was never used.

Discuss bringing boost back in the future as needed.