### PR TITLE
GC contention benchmark

### DIFF
--- a/benchmark/storage/garbage_collector_benchmark.cpp
+++ b/benchmark/storage/garbage_collector_benchmark.cpp
@@ -127,14 +127,15 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, ReclaimTime)(benchmark::State &sta
 }
 
 /**
- * Run a high number of statements with lots of updates to try to trigger aborts.
+ * Run a large number of updates on a small table to generate contention with the GC. Measure the number of transactions
+ * that the GC managed to free during the workload by subtracting the number of "lagging" transactions that still
+ * remained to be cleaned up by the GC after the workload was done running.
  */
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, HighContention)(benchmark::State &state) {
   uint64_t lag_count = 0;
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    // use a smaller table to make aborts more likely
     LargeTransactionBenchmarkObject tested({8, 8, 8}, 100, txn_length, update_select_ratio, &block_store_,
                                            &buffer_pool_, &generator_, true);
     StartGC(tested.GetTxnManager());

--- a/benchmark/storage/garbage_collector_benchmark.cpp
+++ b/benchmark/storage/garbage_collector_benchmark.cpp
@@ -130,7 +130,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, ReclaimTime)(benchmark::State &sta
  * Run a high number of statements with lots of updates to try to trigger aborts.
  */
 // NOLINTNEXTLINE
-BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, GarbageCollectorLag)(benchmark::State &state) {
+BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, HighContention)(benchmark::State &state) {
   uint64_t lag_count = 0;
   // NOLINTNEXTLINE
   for (auto _ : state) {

--- a/benchmark/storage/garbage_collector_benchmark.cpp
+++ b/benchmark/storage/garbage_collector_benchmark.cpp
@@ -10,15 +10,43 @@ namespace terrier {
 
 class GarbageCollectorBenchmark : public benchmark::Fixture {
  public:
+  void StartGC(transaction::TransactionManager *const txn_manager) {
+    gc_ = new storage::GarbageCollector(txn_manager);
+    run_gc_ = true;
+    gc_thread_ = std::thread([this] { GCThreadLoop(); });
+  }
+
+  uint32_t EndGC() {
+    run_gc_ = false;
+    gc_thread_.join();
+    // Make sure all garbage is collected. This take 2 runs for unlink and deallocate
+    gc_->PerformGarbageCollection();
+    const uint32_t lag_count = gc_->PerformGarbageCollection().first;
+    delete gc_;
+    return lag_count;
+  }
+
   const uint32_t txn_length = 5;
   const std::vector<double> update_select_ratio = {0, 1, 0};
   const uint32_t num_concurrent_txns = 4;
   const uint32_t initial_table_size = 100000;
   const uint32_t num_txns = 100000;
   storage::BlockStore block_store_{1000, 1000};
-  storage::RecordBufferSegmentPool buffer_pool_{100000, 100000};
+  storage::RecordBufferSegmentPool buffer_pool_{1000000, 1000000};
   std::default_random_engine generator_;
   storage::GarbageCollector *gc_ = nullptr;
+
+ private:
+  std::thread gc_thread_;
+  volatile bool run_gc_ = false;
+  const std::chrono::milliseconds gc_period_{10};
+
+  void GCThreadLoop() {
+    while (run_gc_) {
+      std::this_thread::sleep_for(gc_period_);
+      gc_->PerformGarbageCollection();
+    }
+  }
 };
 
 // Create a table with 100,000 tuples, then run 100,000 txns running update statements. Then run GC and profile how long
@@ -98,9 +126,36 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, ReclaimTime)(benchmark::State &sta
   state.SetItemsProcessed(state.iterations() * num_txns);
 }
 
+/**
+ * Run a high number of statements with lots of updates to try to trigger aborts.
+ */
+// NOLINTNEXTLINE
+BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, GarbageCollectorLag)(benchmark::State &state) {
+  uint64_t lag_count = 0;
+  // NOLINTNEXTLINE
+  for (auto _ : state) {
+    // use a smaller table to make aborts more likely
+    LargeTransactionBenchmarkObject tested({8, 8, 8}, 100, txn_length, update_select_ratio, &block_store_,
+                                           &buffer_pool_, &generator_, true);
+    StartGC(tested.GetTxnManager());
+    uint64_t elapsed_ms;
+    {
+      common::ScopedTimer timer(&elapsed_ms);
+      tested.SimulateOltp(num_txns, num_concurrent_txns);
+    }
+    lag_count += EndGC();
+    state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
+  }
+  state.SetItemsProcessed(state.iterations() * num_txns - lag_count);
+}
+
 BENCHMARK_REGISTER_F(GarbageCollectorBenchmark, UnlinkTime)->Unit(benchmark::kMillisecond)->UseManualTime()->MinTime(1);
 BENCHMARK_REGISTER_F(GarbageCollectorBenchmark, ReclaimTime)
     ->Unit(benchmark::kMillisecond)
     ->UseManualTime()
     ->MinTime(1);
+BENCHMARK_REGISTER_F(GarbageCollectorBenchmark, HighContention)
+    ->Unit(benchmark::kMillisecond)
+    ->UseManualTime()
+    ->MinTime(2);
 }  // namespace terrier


### PR DESCRIPTION
This new test supports #325 as a positive change, despite performance regressions on existing GC benchmarks, which strictly evaluate the GC's unlink and reclaim performance in isolation (i.e. no concurrent transactions). While this is useful for spotting regressions in the core GC algorithms, they doesn't properly evaluate how well the GC runs at the same time as the real system, particularly in high contention workloads from transactions. This PR adds a benchmark for that. On master the GC can clean up ~50k txns/second in this update-heavy workload. #325 increases that by an order of magnitude to ~500k txns/second on my laptop.