### PR TITLE
Updates now retry on failure

### DIFF
--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -21,10 +21,10 @@ class LargeGCTests : public TerrierTest {
     delete gc_;
   }
 
-  const uint32_t num_iterations = 50;
+  const uint32_t num_iterations = 10;
   const uint16_t max_columns = 20;
   const uint32_t initial_table_size = 1000;
-  const uint32_t num_txns = 10000;
+  const uint32_t num_txns = 1000;
   const uint32_t batch_size = 100;
   storage::BlockStore block_store_{1000, 1000};
   storage::RecordBufferSegmentPool buffer_pool_{10000, 10000};

--- a/test/storage/large_garbage_collector_test.cpp
+++ b/test/storage/large_garbage_collector_test.cpp
@@ -21,10 +21,10 @@ class LargeGCTests : public TerrierTest {
     delete gc_;
   }
 
-  const uint32_t num_iterations = 10;
+  const uint32_t num_iterations = 50;
   const uint16_t max_columns = 20;
   const uint32_t initial_table_size = 1000;
-  const uint32_t num_txns = 1000;
+  const uint32_t num_txns = 10000;
   const uint32_t batch_size = 100;
   storage::BlockStore block_store_{1000, 1000};
   storage::RecordBufferSegmentPool buffer_pool_{10000, 10000};


### PR DESCRIPTION
Updates were too conservative from before, and immediately return false when compare-and-swap fail on the version chain. The failure could be an innocuous one from the GC. In this PR we changed updates to retry on a CAS failure and only abort after seeing an actual conflict.