### PR TITLE
Add std::string_view accessor for VarlenEntry

### DIFF
--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -257,7 +257,7 @@ class VarlenEntry {
    * @warning It is the programmer's responsibility to ensure that std::string_view does not outlive the VarlenEntry
    */
   std::string_view StringView() const {
-    return std::string_view(reinterpret_cast<const char *const>(Content(), Size()));
+    return std::string_view(reinterpret_cast<const char *const>(Content()), Size());
   }
 
  private:

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <functional>
 #include <ostream>
-#include <string_view>
+#include <string_view>  // NOLINT
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <functional>
 #include <ostream>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -250,6 +251,14 @@ class VarlenEntry {
    * @return pointer to the varlen entry contents.
    */
   const byte *Content() const { return IsInlined() ? prefix_ : content_; }
+
+  /**
+   * @return zero-copy view of the VarlenEntry as an immutable string that allows use with convenient STL functions
+   * @warning It is the programmer's responsibility to ensure that std::string_view does not outlive the VarlenEntry
+   */
+  std::string_view StringView() const {
+    return std::string_view(reinterpret_cast<const char *const>(Content(), Size()));
+  }
 
  private:
   int32_t size_;                   // buffer reclaimable => sign bit is 0 or size <= InlineThreshold

--- a/test/storage/varlen_entry_test.cpp
+++ b/test/storage/varlen_entry_test.cpp
@@ -46,8 +46,8 @@ TEST(VarlenEntryTests, Basic) {
 // NOLINTNEXTLINE
 TEST(VarlenEntryTests, StringView) {
   std::string hello_world = "hello world";
-  const auto inlined_entry =
-      storage::VarlenEntry::CreateInline(reinterpret_cast<byte *const>(hello_world.data()), hello_world.length());
+  const auto inlined_entry = storage::VarlenEntry::CreateInline(reinterpret_cast<byte *const>(hello_world.data()),
+                                                                static_cast<uint32_t>(hello_world.length()));
   auto inlined_string_view = inlined_entry.StringView();
   EXPECT_EQ(inlined_string_view, hello_world);
 


### PR DESCRIPTION
I knew there was a reason we went with C++17. I found myself relying on [std::string_view](https://en.cppreference.com/w/cpp/string/basic_string_view) for some of the TPC-C implementation, and @tli2 suggested just adding an accessor to VarlenEntry since this is probably something we can use elsewhere in the system (catalog?).

Given a byte buffer (not necessarily null-terminated) and a length as arguments (which is basically what a VarlenEntry is) a std::string_view presents a zero-copy, immutable view that provides access to STL string functions (compare, find, etc.). It's awesome.