### PR TITLE
BwTreeIndex::Scan and PRI accessor.

### DIFF
--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -104,7 +104,7 @@ class Index {
   /**
    * @return mapping from key oid to projected row offset
    */
-  const std::unordered_map<catalog::indexkeycol_oid_t, uint32_t> &GetKeyOidToOffsetMap() const {
+  const std::unordered_map<catalog::indexkeycol_oid_t, uint16_t> &GetKeyOidToOffsetMap() const {
     return metadata_.GetKeyOidToOffsetMap();
   }
 

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <unordered_map>
 #include <utility>
 #include <vector>
 #include "catalog/catalog_defs.h"
@@ -83,6 +84,14 @@ class Index {
   virtual void ScanKey(const ProjectedRow &key, std::vector<TupleSlot> *value_list) = 0;
 
   /**
+   * Finds all the values between the given keys in our index.
+   * @param low_key the key to start at
+   * @param high_key the key to end at
+   * @param[out] value_list the values associated with the keys
+   */
+  virtual void Scan(const ProjectedRow &low_key, const ProjectedRow &high_key, std::vector<TupleSlot> *value_list) = 0;
+
+  /**
    * @return type of this index
    */
   ConstraintType GetConstraintType() const { return constraint_type_; }
@@ -91,6 +100,18 @@ class Index {
    * @return oid of this indes
    */
   catalog::index_oid_t GetOid() const { return oid_; }
+
+  /**
+   * @return mapping from key oid to projected row offset
+   */
+  const std::unordered_map<catalog::indexkeycol_oid_t, uint32_t> &GetKeyOidToOffsetMap() const {
+    return metadata_.GetKeyOidToOffsetMap();
+  }
+
+  /**
+   * @return projected row initializer for the given key schema
+   */
+  const ProjectedRowInitializer &GetProjectedRowInitializer() const { return metadata_.GetProjectedRowInitializer(); }
 };
 
 }  // namespace terrier::storage::index

--- a/src/include/storage/index/index_metadata.h
+++ b/src/include/storage/index/index_metadata.h
@@ -76,7 +76,7 @@ class IndexMetadata {
   /**
    * @return mapping from key oid to projected row offset
    */
-  const std::unordered_map<catalog::indexkeycol_oid_t, uint32_t> &GetKeyOidToOffsetMap() const {
+  const std::unordered_map<catalog::indexkeycol_oid_t, uint16_t> &GetKeyOidToOffsetMap() const {
     return key_oid_to_offset_;
   }
 
@@ -101,7 +101,7 @@ class IndexMetadata {
   std::vector<uint16_t> inlined_attr_sizes_;                                    // for GenericKey
   bool must_inline_varlen_;                                                     // for GenericKey
   std::vector<uint8_t> compact_ints_offsets_;                                   // for CompactIntsKey
-  std::unordered_map<catalog::indexkeycol_oid_t, uint32_t> key_oid_to_offset_;  // for execution layer
+  std::unordered_map<catalog::indexkeycol_oid_t, uint16_t> key_oid_to_offset_;  // for execution layer
   ProjectedRowInitializer initializer_;                                         // user-facing initializer
   ProjectedRowInitializer inlined_initializer_;                                 // for GenericKey, internal only
 
@@ -208,9 +208,9 @@ class IndexMetadata {
   /**
    * Computes the mapping from key oid to projected row offset.
    */
-  static std::unordered_map<catalog::indexkeycol_oid_t, uint32_t> ComputeKeyOidToOffset(
+  static std::unordered_map<catalog::indexkeycol_oid_t, uint16_t> ComputeKeyOidToOffset(
       const IndexKeySchema &key_schema, const std::vector<uint16_t> &pr_offsets) {
-    std::unordered_map<catalog::indexkeycol_oid_t, uint32_t> key_oid_to_offset;
+    std::unordered_map<catalog::indexkeycol_oid_t, uint16_t> key_oid_to_offset;
     key_oid_to_offset.reserve(key_schema.size());
     for (uint16_t i = 0; i < key_schema.size(); i++) {
       key_oid_to_offset[key_schema[i].GetOid()] = pr_offsets[i];


### PR DESCRIPTION
**ProjectedRow Initializer accessor:**
We need a way to get the index's PR initializer without having access to the metadata object (similar to how it works DataTable).

**Index range scan:**
I added a basic range scan to the BwTree wrapper and a simple functionality test. We need this for some of the remaining TPC-C queries. Peloton's Scan function took in a (complicated to me) ConjugateScanPredicate object that looks like it was constructed in the Planner. Peloton's Scan method just extracted the low and high keys from that object, so as long as those are defined we can do range scans. I changed the Scan arguments to just take the low and high keys directly. I'm punting on understanding the 2000 lines of code of index scan plan nodes, index scan executors, and the scan optimizer stuff (CSP) and will worry about that once we need to actually write the index scanner for the new execution engine since I expect a lot of that code will need to change anyway.