### PR TITLE
Add action framework

### DIFF
--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -88,7 +88,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
     storage::DataTable table(&block_store_, layout_, storage::layout_version_t(0));
     // We can use dummy timestamps here since we're not invoking concurrency control
     transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                        LOGGING_DISABLED, nullptr);
+                                        LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
     for (uint32_t i = 0; i < num_inserts_; ++i) {
       table.Insert(&txn, *redo_);
     }
@@ -106,7 +106,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state
     auto workload = [&](uint32_t id) {
       // We can use dummy timestamps here since we're not invoking concurrency control
       transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                          LOGGING_DISABLED, nullptr);
+                                          LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
       for (uint32_t i = 0; i < num_inserts_ / num_threads_; i++) table.Insert(&txn, *redo_);
     };
     common::WorkerPool thread_pool(num_threads_, {});
@@ -123,7 +123,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SequentialRead)(benchmark::State &state) 
   // Populate read_table by inserting tuples
   // We can use dummy timestamps here since we're not invoking concurrency control
   transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                      LOGGING_DISABLED, nullptr);
+                                      LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
   std::vector<storage::TupleSlot> read_order;
   for (uint32_t i = 0; i < num_reads_; ++i) {
     read_order.emplace_back(read_table.Insert(&txn, *redo_));
@@ -145,7 +145,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, RandomRead)(benchmark::State &state) {
   // Populate read_table_ by inserting tuples
   // We can use dummy timestamps here since we're not invoking concurrency control
   transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                      LOGGING_DISABLED, nullptr);
+                                      LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
   std::vector<storage::TupleSlot> read_order;
   for (uint32_t i = 0; i < num_reads_; ++i) {
     read_order.emplace_back(read_table.Insert(&txn, *redo_));
@@ -170,7 +170,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentRandomRead)(benchmark::State &s
   // populate read_table_ by inserting tuples
   // We can use dummy timestamps here since we're not invoking concurrency control
   transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                      LOGGING_DISABLED, nullptr);
+                                      LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
   std::vector<storage::TupleSlot> read_order;
   for (uint32_t i = 0; i < num_reads_; ++i) {
     read_order.emplace_back(read_table.Insert(&txn, *redo_));
@@ -188,7 +188,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentRandomRead)(benchmark::State &s
     auto workload = [&](uint32_t id) {
       // We can use dummy timestamps here since we're not invoking concurrency control
       transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                          LOGGING_DISABLED, nullptr);
+                                          LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
       for (uint32_t i = 0; i < num_reads_ / num_threads_; i++)
         read_table.Select(&txn, read_order[(rand_read_offsets[id] + i) % read_order.size()], reads_[id]);
     };

--- a/benchmark/storage/data_table_benchmark.cpp
+++ b/benchmark/storage/data_table_benchmark.cpp
@@ -88,7 +88,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SimpleInsert)(benchmark::State &state) {
     storage::DataTable table(&block_store_, layout_, storage::layout_version_t(0));
     // We can use dummy timestamps here since we're not invoking concurrency control
     transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                        LOGGING_DISABLED);
+                                        LOGGING_DISABLED, nullptr);
     for (uint32_t i = 0; i < num_inserts_; ++i) {
       table.Insert(&txn, *redo_);
     }
@@ -106,7 +106,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentInsert)(benchmark::State &state
     auto workload = [&](uint32_t id) {
       // We can use dummy timestamps here since we're not invoking concurrency control
       transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                          LOGGING_DISABLED);
+                                          LOGGING_DISABLED, nullptr);
       for (uint32_t i = 0; i < num_inserts_ / num_threads_; i++) table.Insert(&txn, *redo_);
     };
     common::WorkerPool thread_pool(num_threads_, {});
@@ -123,7 +123,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, SequentialRead)(benchmark::State &state) 
   // Populate read_table by inserting tuples
   // We can use dummy timestamps here since we're not invoking concurrency control
   transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                      LOGGING_DISABLED);
+                                      LOGGING_DISABLED, nullptr);
   std::vector<storage::TupleSlot> read_order;
   for (uint32_t i = 0; i < num_reads_; ++i) {
     read_order.emplace_back(read_table.Insert(&txn, *redo_));
@@ -145,7 +145,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, RandomRead)(benchmark::State &state) {
   // Populate read_table_ by inserting tuples
   // We can use dummy timestamps here since we're not invoking concurrency control
   transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                      LOGGING_DISABLED);
+                                      LOGGING_DISABLED, nullptr);
   std::vector<storage::TupleSlot> read_order;
   for (uint32_t i = 0; i < num_reads_; ++i) {
     read_order.emplace_back(read_table.Insert(&txn, *redo_));
@@ -170,7 +170,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentRandomRead)(benchmark::State &s
   // populate read_table_ by inserting tuples
   // We can use dummy timestamps here since we're not invoking concurrency control
   transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                      LOGGING_DISABLED);
+                                      LOGGING_DISABLED, nullptr);
   std::vector<storage::TupleSlot> read_order;
   for (uint32_t i = 0; i < num_reads_; ++i) {
     read_order.emplace_back(read_table.Insert(&txn, *redo_));
@@ -188,7 +188,7 @@ BENCHMARK_DEFINE_F(DataTableBenchmark, ConcurrentRandomRead)(benchmark::State &s
     auto workload = [&](uint32_t id) {
       // We can use dummy timestamps here since we're not invoking concurrency control
       transaction::TransactionContext txn(transaction::timestamp_t(0), transaction::timestamp_t(0), &buffer_pool_,
-                                          LOGGING_DISABLED);
+                                          LOGGING_DISABLED, nullptr);
       for (uint32_t i = 0; i < num_reads_ / num_threads_; i++)
         read_table.Select(&txn, read_order[(rand_read_offsets[id] + i) % read_order.size()], reads_[id]);
     };

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -70,7 +70,7 @@ class GarbageCollector {
   // queue of txns that need to be unlinked
   transaction::TransactionQueue txns_to_unlink_;
   // queue of unexecuted deferred actions
-  transaction::ActionQueue deferred_actions_;
+  std::queue<std::pair<transaction::timestamp_t, transaction::Action>> deferred_actions_;
 };
 
 }  // namespace terrier::storage

--- a/src/include/storage/garbage_collector.h
+++ b/src/include/storage/garbage_collector.h
@@ -51,6 +51,11 @@ class GarbageCollector {
    */
   uint32_t ProcessUnlinkQueue();
 
+  /**
+   * Process deferred actions
+   */
+  void ProcessDeferredActions();
+
   void ReclaimSlotIfDeleted(UndoRecord *undo_record) const;
 
   void ReclaimBufferIfVarlen(transaction::TransactionContext *txn, UndoRecord *undo_record) const;
@@ -64,6 +69,8 @@ class GarbageCollector {
   transaction::TransactionQueue txns_to_deallocate_;
   // queue of txns that need to be unlinked
   transaction::TransactionQueue txns_to_unlink_;
+  // queue of unexecuted deferred actions
+  transaction::ActionQueue deferred_actions_;
 };
 
 }  // namespace terrier::storage

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -19,6 +19,7 @@
 namespace terrier::storage {
 // Write Ahead Logging:
 #define LOGGING_DISABLED nullptr
+#define ACTION_FRAMEWORK_DISABLED nullptr
 
 // All tuples potentially visible to txns should have a non-null attribute of version vector.
 // This is not to be confused with a non-null version vector that has value nullptr (0).

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -38,8 +38,7 @@ class TransactionContext {
       : start_time_(start),
         txn_id_(txn_id),
         undo_buffer_(buffer_pool),
-        redo_buffer_(log_manager,
-        buffer_pool),
+        redo_buffer_(log_manager, buffer_pool),
         txn_mgr_(transaction_manager) {}
 
   ~TransactionContext() {

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -35,9 +35,12 @@ class TransactionContext {
   TransactionContext(const timestamp_t start, const timestamp_t txn_id,
                      storage::RecordBufferSegmentPool *const buffer_pool, storage::LogManager *const log_manager,
                      TransactionManager *transaction_manager)
-      : start_time_(start), txn_id_(txn_id), undo_buffer_(buffer_pool), redo_buffer_(log_manager, buffer_pool) {
-    txn_mgr_ = transaction_manager;
-  }
+      : start_time_(start),
+        txn_id_(txn_id),
+        undo_buffer_(buffer_pool),
+        redo_buffer_(log_manager,
+        buffer_pool),
+        txn_mgr_(transaction_manager) {}
 
   ~TransactionContext() {
     for (const byte *ptr : loose_ptrs_) delete[] ptr;

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -30,6 +30,7 @@ class TransactionContext {
    * @param txn_id the id of the transaction, should be larger than all start time and commit time
    * @param buffer_pool the buffer pool to draw this transaction's undo buffer from
    * @param log_manager pointer to log manager in the system, or nullptr, if logging is disabled
+   * @param txn_mgr pointer to transaction manager int the system (used for action framework)
    */
   TransactionContext(const timestamp_t start, const timestamp_t txn_id,
                      storage::RecordBufferSegmentPool *const buffer_pool, storage::LogManager *const log_manager,

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -124,13 +124,13 @@ class TransactionContext {
    * Defers an action to be called if and only if the transaction aborts.  Actions executed LIFO.
    * @param a the action to be executed
    */
-  void RegisterAbortAction(Action const &a) { abort_actions_.push_front(a); }
+  void RegisterAbortAction(const Action &a) { abort_actions_.push_front(a); }
 
   /**
    * Defers an action to be called if and only if the transaction commits.  Actions executed LIFO.
    * @param a the action to be executed
    */
-  void RegisterCommitAction(Action const &a) { commit_actions_.push_front(a); }
+  void RegisterCommitAction(const Action &a) { commit_actions_.push_front(a); }
 
   /**
    * Get the transaction manager responsible for this context (should be singleton).

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -131,6 +131,7 @@ class TransactionContext {
 
   /**
    * Defers an action to be called if and only if the transaction commits.  Actions executed LIFO.
+   * @warning these actions are run after commit and are not atomic with the commit itself
    * @param a the action to be executed
    */
   void RegisterCommitAction(const Action &a) { commit_actions_.push_front(a); }

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -30,13 +30,13 @@ class TransactionContext {
    * @param txn_id the id of the transaction, should be larger than all start time and commit time
    * @param buffer_pool the buffer pool to draw this transaction's undo buffer from
    * @param log_manager pointer to log manager in the system, or nullptr, if logging is disabled
-   * @param txn_mgr pointer to transaction manager int the system (used for action framework)
+   * @param transaction_manager pointer to transaction manager in the system (used for action framework)
    */
   TransactionContext(const timestamp_t start, const timestamp_t txn_id,
                      storage::RecordBufferSegmentPool *const buffer_pool, storage::LogManager *const log_manager,
-                     TransactionManager *txn_mgr)
+                     TransactionManager *transaction_manager)
       : start_time_(start), txn_id_(txn_id), undo_buffer_(buffer_pool), redo_buffer_(log_manager, buffer_pool) {
-    txn_mgr_ = txn_mgr;
+    txn_mgr_ = transaction_manager;
   }
 
   ~TransactionContext() {

--- a/src/include/transaction/transaction_defs.h
+++ b/src/include/transaction/transaction_defs.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <forward_list>
+#include <functional>
+#include <queue>
+#include <utility>
 #include "common/strong_typedef.h"
 namespace terrier::transaction {
 STRONG_TYPEDEF(timestamp_t, uint64_t);
@@ -14,4 +17,7 @@ class TransactionContext;
 // bottleneck.
 using TransactionQueue = std::forward_list<transaction::TransactionContext *>;
 using callback_fn = void (*)(void *);
+
+using Action = std::function<void()>;
+using ActionQueue = std::queue<std::pair<timestamp_t, Action>>;
 }  // namespace terrier::transaction

--- a/src/include/transaction/transaction_defs.h
+++ b/src/include/transaction/transaction_defs.h
@@ -19,5 +19,4 @@ using TransactionQueue = std::forward_list<transaction::TransactionContext *>;
 using callback_fn = void (*)(void *);
 
 using Action = std::function<void()>;
-using ActionQueue = std::queue<std::pair<timestamp_t, Action>>;
 }  // namespace terrier::transaction

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -79,7 +79,7 @@ class TransactionManager {
    * Adds the action to a buffered list of deferred actions.  This action will
    * be triggered no sooner than when the epoch (timestamp of oldest running
    * transaction) is more recent than the time this function was called.
-   * @param action functional implementation of the action that is deferred
+   * @param a functional implementation of the action that is deferred
    */
   void DeferAction(Action a);
 

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <queue>
 #include <unordered_set>
 #include <utility>
 #include "common/shared_latch.h"
@@ -86,9 +87,10 @@ class TransactionManager {
   /**
    * Transfers the buffered list of deferred actions to the GC for eventual
    * execution.
-   * @return the deferred actions
+   * @return the deferred actions as a sorted queue of pairs where the timestamp is
+   *         earliest epoch the associated action can safely fire
    */
-  ActionQueue DeferredActionsForGC();
+  std::queue<std::pair<timestamp_t, Action>> DeferredActionsForGC();
 
  private:
   storage::RecordBufferSegmentPool *buffer_pool_;
@@ -107,7 +109,7 @@ class TransactionManager {
   TransactionQueue completed_txns_;
   storage::LogManager *const log_manager_;
 
-  ActionQueue deferred_actions_;
+  std::queue<std::pair<timestamp_t, Action>> deferred_actions_;
   mutable common::SpinLatch deferred_actions_latch_;
 
   timestamp_t ReadOnlyCommitCriticalSection(TransactionContext *txn, transaction::callback_fn callback,

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -114,7 +114,7 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
 }
 
 void GarbageCollector::ProcessDeferredActions() {
-  transaction::ActionQueue new_actions = txn_manager_->DeferredActionsForGC();
+  auto new_actions = txn_manager_->DeferredActionsForGC();
   while (!new_actions.empty()) {
     deferred_actions_.push(new_actions.front());
     new_actions.pop();

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -13,6 +13,7 @@
 namespace terrier::storage {
 
 std::pair<uint32_t, uint32_t> GarbageCollector::PerformGarbageCollection() {
+  ProcessDeferredActions();
   uint32_t txns_deallocated = ProcessDeallocateQueue();
   STORAGE_LOG_TRACE("GarbageCollector::PerformGarbageCollection(): txns_deallocated: {}", txns_deallocated);
   uint32_t txns_unlinked = ProcessUnlinkQueue();
@@ -110,6 +111,22 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
   txns_to_unlink_ = transaction::TransactionQueue(std::move(requeue));
 
   return txns_processed;
+}
+
+void GarbageCollector::ProcessDeferredActions() {
+  transaction::ActionQueue new_actions = txn_manager_->DeferredActionsForGC();
+  while (!new_actions.empty()) {
+    deferred_actions_.push(new_actions.front());
+    new_actions.pop();
+  }
+
+  const transaction::timestamp_t oldest_txn = txn_manager_->OldestTransactionStartTime();
+
+  // Execute as many deferred actions as we can at this time.
+  while ((!deferred_actions_.empty()) && deferred_actions_.front().first <= oldest_txn) {
+    deferred_actions_.front().second();
+    deferred_actions_.pop();
+  }
 }
 
 void GarbageCollector::TruncateVersionChain(DataTable *const table, const TupleSlot slot,

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -1,5 +1,6 @@
 #include "transaction/transaction_manager.h"
 #include <algorithm>
+#include <queue>
 #include <utility>
 
 namespace terrier::transaction {
@@ -182,7 +183,7 @@ void TransactionManager::DeferAction(Action a) {
   deferred_actions_.push({time_.load(), a});
 }
 
-ActionQueue TransactionManager::DeferredActionsForGC() {
+std::queue<std::pair<timestamp_t, Action>> TransactionManager::DeferredActionsForGC() {
   common::SpinLatch::ScopedSpinLatch guard(&deferred_actions_latch_);
   return std::move(deferred_actions_);
 }

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -87,7 +87,7 @@ timestamp_t TransactionManager::Commit(TransactionContext *const txn, transactio
                                        void *callback_arg) {
   const timestamp_t result = txn->undo_buffer_.Empty() ? ReadOnlyCommitCriticalSection(txn, callback, callback_arg)
                                                        : UpdatingCommitCriticalSection(txn, callback, callback_arg);
-   while (!txn->commit_actions_.empty()) {
+  while (!txn->commit_actions_.empty()) {
     txn->commit_actions_.front()();
     txn->commit_actions_.pop_front();
   }

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -45,7 +45,13 @@ void TransactionManager::LogCommit(TransactionContext *const txn, const timestam
 
 timestamp_t TransactionManager::ReadOnlyCommitCriticalSection(TransactionContext *const txn, const callback_fn callback,
                                                               void *const callback_arg) {
+  // TODO(John):
+  // This constraint is not inherent to the action framework.  If we want to allow read-only transactions to execute
+  // actions at commit, then we need to come to a decision about whether those actions need to be atomic with the
+  // commit timestampt or not.  If they need to be atomic, then we need to divide up the code path to have a conditional
+  // section when we have actions where we grab the commit latch, our commit timestamp, and then execute the actions.
   TERRIER_ASSERT(txn->commit_actions_.empty(), "Only updating transactions can have deferred actions");
+
   // No records to update. No commit will ever depend on us. We can do all the work outside of the critical section
   const timestamp_t commit_time = time_++;
   // TODO(Tianyu): Notice here that for a read-only transaction, it is necessary to communicate the commit with the

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -180,9 +180,7 @@ timestamp_t TransactionManager::OldestTransactionStartTime() const {
 
 TransactionQueue TransactionManager::CompletedTransactionsForGC() {
   common::SpinLatch::ScopedSpinLatch guard(&curr_running_txns_latch_);
-  TransactionQueue hand_to_gc(std::move(completed_txns_));
-  TERRIER_ASSERT(completed_txns_.empty(), "TransactionManager's queue should now be empty.");
-  return hand_to_gc;
+  return std::move(completed_txns_);
 }
 
 void TransactionManager::DeferAction(Action a) {
@@ -192,9 +190,7 @@ void TransactionManager::DeferAction(Action a) {
 
 ActionQueue TransactionManager::DeferredActionsForGC() {
   common::SpinLatch::ScopedSpinLatch guard(&deferred_actions_latch_);
-  ActionQueue hand_to_gc(std::move(deferred_actions_));
-  TERRIER_ASSERT(deferred_actions_.empty(), "TransactionManager's queue should now be empty.");
-  return hand_to_gc;
+  return std::move(deferred_actions_);
 }
 
 void TransactionManager::Rollback(TransactionContext *txn, const storage::UndoRecord &record) const {

--- a/test/common/stat_registry_test.cpp
+++ b/test/common/stat_registry_test.cpp
@@ -168,8 +168,8 @@ TEST(StatRegistryTest, GTEST_DEBUG_ONLY(DataTableStatTest)) {
                                                            terrier::storage::col_id_t{2}};
   terrier::storage::DataTable data_table_(&block_store_, block_layout_, terrier::storage::layout_version_t{0});
   terrier::transaction::timestamp_t timestamp(0);
-  auto *txn =
-      new terrier::transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
+  auto *txn = new terrier::transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED,
+                                                           ACTION_FRAMEWORK_DISABLED);
   auto init = terrier::storage::ProjectedRowInitializer::CreateProjectedRowInitializer(block_layout_, col_ids);
   auto *redo_buffer_ = terrier::common::AllocationUtil::AllocateAligned(init.ProjectedRowSize());
   auto *redo = init.InitializeRow(redo_buffer_);

--- a/test/common/stat_registry_test.cpp
+++ b/test/common/stat_registry_test.cpp
@@ -169,7 +169,7 @@ TEST(StatRegistryTest, GTEST_DEBUG_ONLY(DataTableStatTest)) {
   terrier::storage::DataTable data_table_(&block_store_, block_layout_, terrier::storage::layout_version_t{0});
   terrier::transaction::timestamp_t timestamp(0);
   auto *txn =
-      new terrier::transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED, nullptr);
+      new terrier::transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
   auto init = terrier::storage::ProjectedRowInitializer::CreateProjectedRowInitializer(block_layout_, col_ids);
   auto *redo_buffer_ = terrier::common::AllocationUtil::AllocateAligned(init.ProjectedRowSize());
   auto *redo = init.InitializeRow(redo_buffer_);

--- a/test/common/stat_registry_test.cpp
+++ b/test/common/stat_registry_test.cpp
@@ -168,7 +168,8 @@ TEST(StatRegistryTest, GTEST_DEBUG_ONLY(DataTableStatTest)) {
                                                            terrier::storage::col_id_t{2}};
   terrier::storage::DataTable data_table_(&block_store_, block_layout_, terrier::storage::layout_version_t{0});
   terrier::transaction::timestamp_t timestamp(0);
-  auto *txn = new terrier::transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED);
+  auto *txn =
+      new terrier::transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED, nullptr);
   auto init = terrier::storage::ProjectedRowInitializer::CreateProjectedRowInitializer(block_layout_, col_ids);
   auto *redo_buffer_ = terrier::common::AllocationUtil::AllocateAligned(init.ProjectedRowSize());
   auto *redo = init.InitializeRow(redo_buffer_);

--- a/test/storage/data_table_concurrent_test.cpp
+++ b/test/storage/data_table_concurrent_test.cpp
@@ -16,7 +16,7 @@ class FakeTransaction {
       : layout_(layout),
         table_(table),
         null_bias_(null_bias),
-        txn_(start_time, txn_id, buffer_pool, LOGGING_DISABLED, nullptr) {}
+        txn_(start_time, txn_id, buffer_pool, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED) {}
 
   ~FakeTransaction() {
     for (auto ptr : loose_pointers_) delete[] ptr;

--- a/test/storage/data_table_concurrent_test.cpp
+++ b/test/storage/data_table_concurrent_test.cpp
@@ -16,7 +16,7 @@ class FakeTransaction {
       : layout_(layout),
         table_(table),
         null_bias_(null_bias),
-        txn_(start_time, txn_id, buffer_pool, LOGGING_DISABLED) {}
+        txn_(start_time, txn_id, buffer_pool, LOGGING_DISABLED, nullptr) {}
 
   ~FakeTransaction() {
     for (auto ptr : loose_pointers_) delete[] ptr;

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -37,7 +37,7 @@ class RandomDataTableTestObject {
     StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
 
     // generate a txn with an UndoRecord to populate on Insert
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, nullptr);
     loose_txns_.push_back(txn);
 
     storage::TupleSlot slot = table_.Insert(txn, *redo);
@@ -81,7 +81,7 @@ class RandomDataTableTestObject {
     StorageTestUtil::PopulateRandomRow(update, layout_, null_bias_, generator);
 
     // generate a txn with an UndoRecord to populate on Insert
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, nullptr);
     loose_txns_.push_back(txn);
 
     bool result = table_.Update(txn, slot, *update);
@@ -122,7 +122,7 @@ class RandomDataTableTestObject {
   storage::ProjectedRow *SelectIntoBuffer(const storage::TupleSlot slot, const transaction::timestamp_t timestamp,
                                           storage::RecordBufferSegmentPool *buffer_pool) {
     // generate a txn with an UndoRecord to populate on Insert
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, nullptr);
     loose_txns_.push_back(txn);
 
     // generate a redo ProjectedRow for Select
@@ -133,7 +133,7 @@ class RandomDataTableTestObject {
 
   void Scan(storage::DataTable::SlotIterator *begin, const transaction::timestamp_t timestamp,
             storage::ProjectedColumns *buffer, storage::RecordBufferSegmentPool *buffer_pool) {
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, nullptr);
     loose_txns_.push_back(txn);
     table_.Scan(txn, begin, buffer);
   }
@@ -297,7 +297,7 @@ TEST_F(DataTableTests, InsertNoWrap) {
     storage::RawBlock *block = nullptr;
     // fill the block. bypass the test object to be more efficient with buffers
     transaction::timestamp_t timestamp(0);
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED, nullptr);
     for (uint32_t i = 0; i < tested.Layout().NumSlots(); i++) {
       storage::RawBlock *inserted_block = tested.InsertRandomTuple(txn, &generator_, &buffer_pool_).GetBlock();
       if (block == nullptr) block = inserted_block;

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -37,7 +37,7 @@ class RandomDataTableTestObject {
     StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
 
     // generate a txn with an UndoRecord to populate on Insert
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, nullptr);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
     loose_txns_.push_back(txn);
 
     storage::TupleSlot slot = table_.Insert(txn, *redo);
@@ -81,7 +81,7 @@ class RandomDataTableTestObject {
     StorageTestUtil::PopulateRandomRow(update, layout_, null_bias_, generator);
 
     // generate a txn with an UndoRecord to populate on Insert
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, nullptr);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
     loose_txns_.push_back(txn);
 
     bool result = table_.Update(txn, slot, *update);
@@ -122,7 +122,7 @@ class RandomDataTableTestObject {
   storage::ProjectedRow *SelectIntoBuffer(const storage::TupleSlot slot, const transaction::timestamp_t timestamp,
                                           storage::RecordBufferSegmentPool *buffer_pool) {
     // generate a txn with an UndoRecord to populate on Insert
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, nullptr);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
     loose_txns_.push_back(txn);
 
     // generate a redo ProjectedRow for Select
@@ -133,7 +133,7 @@ class RandomDataTableTestObject {
 
   void Scan(storage::DataTable::SlotIterator *begin, const transaction::timestamp_t timestamp,
             storage::ProjectedColumns *buffer, storage::RecordBufferSegmentPool *buffer_pool) {
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, nullptr);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
     loose_txns_.push_back(txn);
     table_.Scan(txn, begin, buffer);
   }
@@ -297,7 +297,7 @@ TEST_F(DataTableTests, InsertNoWrap) {
     storage::RawBlock *block = nullptr;
     // fill the block. bypass the test object to be more efficient with buffers
     transaction::timestamp_t timestamp(0);
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED, nullptr);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
     for (uint32_t i = 0; i < tested.Layout().NumSlots(); i++) {
       storage::RawBlock *inserted_block = tested.InsertRandomTuple(txn, &generator_, &buffer_pool_).GetBlock();
       if (block == nullptr) block = inserted_block;

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -37,7 +37,8 @@ class RandomDataTableTestObject {
     StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
 
     // generate a txn with an UndoRecord to populate on Insert
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED,
+                                                    ACTION_FRAMEWORK_DISABLED);
     loose_txns_.push_back(txn);
 
     storage::TupleSlot slot = table_.Insert(txn, *redo);
@@ -81,7 +82,8 @@ class RandomDataTableTestObject {
     StorageTestUtil::PopulateRandomRow(update, layout_, null_bias_, generator);
 
     // generate a txn with an UndoRecord to populate on Insert
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED,
+                                                    ACTION_FRAMEWORK_DISABLED);
     loose_txns_.push_back(txn);
 
     bool result = table_.Update(txn, slot, *update);
@@ -122,7 +124,8 @@ class RandomDataTableTestObject {
   storage::ProjectedRow *SelectIntoBuffer(const storage::TupleSlot slot, const transaction::timestamp_t timestamp,
                                           storage::RecordBufferSegmentPool *buffer_pool) {
     // generate a txn with an UndoRecord to populate on Insert
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED,
+                                                    ACTION_FRAMEWORK_DISABLED);
     loose_txns_.push_back(txn);
 
     // generate a redo ProjectedRow for Select
@@ -133,7 +136,8 @@ class RandomDataTableTestObject {
 
   void Scan(storage::DataTable::SlotIterator *begin, const transaction::timestamp_t timestamp,
             storage::ProjectedColumns *buffer, storage::RecordBufferSegmentPool *buffer_pool) {
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, buffer_pool, LOGGING_DISABLED,
+                                                    ACTION_FRAMEWORK_DISABLED);
     loose_txns_.push_back(txn);
     table_.Scan(txn, begin, buffer);
   }
@@ -297,7 +301,8 @@ TEST_F(DataTableTests, InsertNoWrap) {
     storage::RawBlock *block = nullptr;
     // fill the block. bypass the test object to be more efficient with buffers
     transaction::timestamp_t timestamp(0);
-    auto *txn = new transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED, ACTION_FRAMEWORK_DISABLED);
+    auto *txn = new transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED,
+                                                    ACTION_FRAMEWORK_DISABLED);
     for (uint32_t i = 0; i < tested.Layout().NumSlots(); i++) {
       storage::RawBlock *inserted_block = tested.InsertRandomTuple(txn, &generator_, &buffer_pool_).GetBlock();
       if (block == nullptr) block = inserted_block;

--- a/test/transaction/deferred_actions_test.cpp
+++ b/test/transaction/deferred_actions_test.cpp
@@ -1,0 +1,299 @@
+#include <vector>
+#include "storage/garbage_collector.h"
+#include "storage/sql_table.h"
+#include "storage/storage_defs.h"
+#include "transaction/transaction_context.h"
+#include "transaction/transaction_defs.h"
+#include "transaction/transaction_manager.h"
+#include "util/test_harness.h"
+#include "util/transaction_test_util.h"
+
+namespace terrier {
+
+class DeferredActionsTest : public TerrierTest {
+ protected:
+  DeferredActionsTest() : gc_(&txn_mgr_) {}
+
+  void SetUp() override { TerrierTest::SetUp(); }
+
+  void TearDown() override {
+    gc_.PerformGarbageCollection();
+    gc_.PerformGarbageCollection();
+    TerrierTest::TearDown();
+  }
+
+  storage::RecordBufferSegmentPool buffer_pool_ = {100, 100};
+  transaction::TransactionManager txn_mgr_ = {&buffer_pool_, true, LOGGING_DISABLED};
+  storage::GarbageCollector gc_;
+};
+
+// NOLINTNEXTLINE
+TEST_F(DeferredActionsTest, AbortAction) {
+  auto *txn = txn_mgr_.BeginTransaction();
+
+  bool aborted = false;
+  bool committed = false;
+  txn->RegisterAbortAction([&]() { aborted = true; });
+  txn->RegisterCommitAction([&]() { committed = true; });
+
+  EXPECT_FALSE(aborted);
+  EXPECT_FALSE(committed);
+
+  txn_mgr_.Abort(txn);
+
+  EXPECT_TRUE(aborted);
+  EXPECT_FALSE(committed);
+}
+
+// NOLINTNEXTLINE
+TEST_F(DeferredActionsTest, CommitAction) {
+  // Setup an entire database so that we can do a updating commit
+  auto col_oid = catalog::col_oid_t(42);
+  std::vector<catalog::col_oid_t> col_oids;
+  col_oids.emplace_back(col_oid);
+
+  std::vector<catalog::Schema::Column> cols;
+  cols.emplace_back("dummy", type::TypeId::INTEGER, false, col_oid);
+
+  storage::BlockStore block_store{100, 100};
+  catalog::Schema schema(cols);
+  storage::SqlTable table(&block_store, schema, catalog::table_oid_t(24));
+
+  auto row_pair = table.InitializerForProjectedRow(col_oids);
+  auto pri = new storage::ProjectedRowInitializer(std::get<0>(row_pair));
+  auto pr_map = new storage::ProjectionMap(std::get<1>(row_pair));
+
+  auto insert_buffer = common::AllocationUtil::AllocateAligned(pri->ProjectedRowSize());
+  auto insert = pri->InitializeRow(insert_buffer);
+
+  auto *txn = txn_mgr_.BeginTransaction();
+
+  bool aborted = false;
+  bool committed = false;
+  txn->RegisterAbortAction([&]() { aborted = true; });
+  txn->RegisterCommitAction([&]() { committed = true; });
+
+  EXPECT_FALSE(aborted);
+  EXPECT_FALSE(committed);
+
+  auto *data = reinterpret_cast<int32_t *>(insert->AccessForceNotNull(pr_map->at(col_oid)));
+  *data = 42;
+  table.Insert(txn, *insert);
+
+  EXPECT_FALSE(aborted);
+  EXPECT_FALSE(committed);
+
+  txn_mgr_.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
+
+  EXPECT_TRUE(committed);
+  EXPECT_FALSE(aborted);
+
+  gc_.PerformGarbageCollection();
+  gc_.PerformGarbageCollection();
+
+  insert = nullptr;
+  delete[] insert_buffer;
+  delete pr_map;
+  delete pri;
+}
+
+// NOLINTNEXTLINE
+TEST_F(DeferredActionsTest, SimpleDefer) {
+  bool deferred = false;
+  txn_mgr_.DeferAction([&]() { deferred = true; });
+
+  EXPECT_FALSE(deferred);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_TRUE(deferred);
+}
+
+// NOLINTNEXTLINE
+TEST_F(DeferredActionsTest, DelayedDefer) {
+  auto *txn = txn_mgr_.BeginTransaction();
+
+  bool deferred = false;
+  txn_mgr_.DeferAction([&]() { deferred = true; });
+
+  EXPECT_FALSE(deferred);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_FALSE(deferred);  // txn is still open
+
+  txn_mgr_.Abort(txn);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_TRUE(deferred);
+}
+
+// NOLINTNEXTLINE
+TEST_F(DeferredActionsTest, ChainedDefer) {
+  bool defer1 = false;
+  bool defer2 = false;
+
+  txn_mgr_.DeferAction([&]() {
+    defer1 = true;
+    txn_mgr_.DeferAction([&]() { defer2 = true; });
+  });
+
+  EXPECT_FALSE(defer1);
+  EXPECT_FALSE(defer2);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_TRUE(defer1);
+  EXPECT_FALSE(defer2);  // Sitting in txn_mgr_'s deferral queue
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_TRUE(defer1);
+  EXPECT_TRUE(defer2);
+}
+
+// NOLINTNEXTLINE
+TEST_F(DeferredActionsTest, AbortBootstrapDefer) {
+  auto *txn = txn_mgr_.BeginTransaction();
+
+  bool defer1 = false;
+  bool defer2 = false;
+  bool aborted = false;
+  bool committed = false;
+
+  txn->RegisterCommitAction([&]() { committed = true; });
+
+  // Bootstrap into the lamda.  Need to eliminate the reference to txn since
+  // it could get garbage collected before the lambda derefernces it.
+  auto tm = txn->GetTransactionManager();
+  txn->RegisterAbortAction([&, tm]() {
+    aborted = true;
+    tm->DeferAction([&, tm]() {
+      defer1 = true;
+      tm->DeferAction([&]() { defer2 = true; });
+    });
+  });
+
+  EXPECT_FALSE(aborted);
+  EXPECT_FALSE(committed);
+  EXPECT_FALSE(defer1);
+  EXPECT_FALSE(defer2);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_FALSE(aborted);
+  EXPECT_FALSE(committed);
+  EXPECT_FALSE(defer1);
+  EXPECT_FALSE(defer2);
+
+  txn_mgr_.Abort(txn);
+
+  EXPECT_TRUE(aborted);
+  EXPECT_FALSE(committed);
+  EXPECT_FALSE(defer1);
+  EXPECT_FALSE(defer2);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_TRUE(aborted);
+  EXPECT_FALSE(committed);
+  EXPECT_TRUE(defer1);
+  EXPECT_FALSE(defer2);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_TRUE(aborted);
+  EXPECT_FALSE(committed);
+  EXPECT_TRUE(defer1);
+  EXPECT_TRUE(defer2);
+}
+
+// NOLINTNEXTLINE
+TEST_F(DeferredActionsTest, CommitBootstrapDefer) {
+  auto col_oid = catalog::col_oid_t(42);
+  std::vector<catalog::col_oid_t> col_oids;
+  col_oids.emplace_back(col_oid);
+
+  std::vector<catalog::Schema::Column> cols;
+  cols.emplace_back("dummy", type::TypeId::INTEGER, false, col_oid);
+
+  storage::BlockStore block_store{100, 100};
+  catalog::Schema schema(cols);
+  storage::SqlTable table(&block_store, schema, catalog::table_oid_t(24));
+
+  auto row_pair = table.InitializerForProjectedRow(col_oids);
+  auto pri = new storage::ProjectedRowInitializer(std::get<0>(row_pair));
+  auto pr_map = new storage::ProjectionMap(std::get<1>(row_pair));
+
+  auto insert_buffer = common::AllocationUtil::AllocateAligned(pri->ProjectedRowSize());
+  auto insert = pri->InitializeRow(insert_buffer);
+
+  auto *txn = txn_mgr_.BeginTransaction();
+
+  bool defer1 = false;
+  bool defer2 = false;
+  bool aborted = false;
+  bool committed = false;
+
+  txn->RegisterAbortAction([&]() { aborted = true; });
+
+  // Bootstrap into the lamda.  Need to eliminate the reference to txn since
+  // it could get garbage collected before the lambda derefernces it.
+  auto tm = txn->GetTransactionManager();
+  txn->RegisterCommitAction([&, tm]() {
+    committed = true;
+    tm->DeferAction([&, tm]() {
+      defer1 = true;
+      tm->DeferAction([&]() { defer2 = true; });
+    });
+  });
+
+  EXPECT_FALSE(aborted);
+  EXPECT_FALSE(committed);
+  EXPECT_FALSE(defer1);
+  EXPECT_FALSE(defer2);
+
+  auto *data = reinterpret_cast<int32_t *>(insert->AccessForceNotNull(pr_map->at(col_oid)));
+  *data = 42;
+  table.Insert(txn, *insert);
+
+  EXPECT_FALSE(aborted);
+  EXPECT_FALSE(committed);
+  EXPECT_FALSE(defer1);
+  EXPECT_FALSE(defer2);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_FALSE(aborted);
+  EXPECT_FALSE(committed);
+  EXPECT_FALSE(defer1);
+  EXPECT_FALSE(defer2);
+
+  txn_mgr_.Commit(txn, TestCallbacks::EmptyCallback, nullptr);
+
+  EXPECT_FALSE(aborted);
+  EXPECT_TRUE(committed);
+  EXPECT_FALSE(defer1);
+  EXPECT_FALSE(defer2);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_FALSE(aborted);
+  EXPECT_TRUE(committed);
+  EXPECT_TRUE(defer1);
+  EXPECT_FALSE(defer2);
+
+  gc_.PerformGarbageCollection();
+
+  EXPECT_FALSE(aborted);
+  EXPECT_TRUE(committed);
+  EXPECT_TRUE(defer1);
+  EXPECT_TRUE(defer2);
+
+  insert = nullptr;
+  delete[] insert_buffer;
+  delete pr_map;
+  delete pri;
+}
+}  // namespace terrier


### PR DESCRIPTION
This is an implementation of the epoch-based callback framework discussed during the meeting today and is a superset of the abort callbacks that #351 implements.  The framework allows the database to register callbacks into a transaction context to execute at either abort or commit (commit callbacks are currently disallowed in read-only transactions).  Additionally, deferred callbacks can be registered with the TransactionManager which will execute once all currently active transactions have exited (same logic as cleaning up undo records).

In order to allow the specific use case of cleaning up arbitrary side-effects within the system (temporary constraints, staged-then-aborted schema versions, etc.), I had to expose  the transaction manager to the storage layer through the transaction context.  This was the only way that I could figure out of how to get the correct function handle visible when building the lambdas for the callback chain.