### PR TITLE
Add another Column constructor with a field for max VARLEN length

### DIFF
--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -86,7 +86,7 @@ class Schema {
     }
 
     /**
-     * @return true if the attribute is inlined, false if it's a pointer to a varlen entry
+     * @return SQL type for this column
      */
     type::TypeId GetType() const { return type_; }
     /**

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -27,7 +27,7 @@ class Schema {
   class Column {
    public:
     /**
-     * Instantiates a Column object, primary to be used for building a Schema object
+     * Instantiates a Column object, primary to be used for building a Schema object (non VARLEN attributes)
      * @param name column name
      * @param type SQL type for this column
      * @param nullable true if the column is nullable, false otherwise
@@ -38,18 +38,32 @@ class Schema {
           type_(type),
           attr_size_(type::TypeUtil::GetTypeSize(type_)),
           nullable_(nullable),
-          inlined_(true),
           oid_(oid) {
-      if (attr_size_ == VARLEN_COLUMN) {
-        // this is a varlen attribute
-        // attr_size_ is actual size + high bit via GetTypeSize
-        inlined_ = false;
-      }
-      TERRIER_ASSERT(
-          attr_size_ == 1 || attr_size_ == 2 || attr_size_ == 4 || attr_size_ == 8 || attr_size_ == VARLEN_COLUMN,
-          "Attribute size must be 1, 2, 4, 8 or VARLEN_COLUMN bytes.");
+      TERRIER_ASSERT(attr_size_ == 1 || attr_size_ == 2 || attr_size_ == 4 || attr_size_ == 8,
+                     "This constructor is meant for non-VARLEN columns.");
       TERRIER_ASSERT(type_ != type::TypeId::INVALID, "Attribute type cannot be INVALID.");
     }
+
+    /**
+     * Instantiates a Column object, primary to be used for building a Schema object (VARLEN attributes only)
+     * @param name column name
+     * @param type SQL type for this column
+     * @param max_varlen_size the maximum length of the varlen entry
+     * @param nullable true if the column is nullable, false otherwise
+     * @param oid internal unique identifier for this column
+     */
+    Column(std::string name, const type::TypeId type, const uint16_t max_varlen_size, const bool nullable,
+           const col_oid_t oid)
+        : name_(std::move(name)),
+          type_(type),
+          attr_size_(type::TypeUtil::GetTypeSize(type_)),
+          max_varlen_size_(max_varlen_size),
+          nullable_(nullable),
+          oid_(oid) {
+      TERRIER_ASSERT(attr_size_ == VARLEN_COLUMN, "This constructor is meant for VARLEN columns.");
+      TERRIER_ASSERT(type_ != type::TypeId::INVALID, "Attribute type cannot be INVALID.");
+    }
+
     /**
      * @return column name
      */
@@ -62,12 +76,17 @@ class Schema {
      * @return size of the attribute in bytes. Varlen attributes have the sign bit set.
      */
     uint8_t GetAttrSize() const { return attr_size_; }
+
+    /**
+     * @return The maximum length of this column (only valid if it's VARLEN)
+     */
+    uint16_t GetMaxVarlenSize() const {
+      TERRIER_ASSERT(attr_size_ == VARLEN_COLUMN, "This attribute has no meaning for non-VARLEN columns.");
+      return max_varlen_size_;
+    }
+
     /**
      * @return true if the attribute is inlined, false if it's a pointer to a varlen entry
-     */
-    bool GetInlined() const { return inlined_; }
-    /**
-     * @return SQL type for this column
      */
     type::TypeId GetType() const { return type_; }
     /**
@@ -79,8 +98,8 @@ class Schema {
     const std::string name_;
     const type::TypeId type_;
     uint8_t attr_size_;
+    uint16_t max_varlen_size_;
     const bool nullable_;
-    bool inlined_;
     const col_oid_t oid_;
     // TODO(Matt): default value would go here
     // Value default_;

--- a/test/include/util/catalog_test_util.h
+++ b/test/include/util/catalog_test_util.h
@@ -26,7 +26,10 @@ struct CatalogTestUtil {
     for (uint16_t i = 0; i < num_attrs; i++) {
       type::TypeId attr_type = *RandomTestUtil::UniformRandomElement(&possible_attr_types, generator);
       bool attr_nullable = *RandomTestUtil::UniformRandomElement(&possible_attr_nullable, generator);
-      columns.emplace_back("col_name", attr_type, attr_nullable, col_oid++);
+      if (attr_type != type::TypeId::VARCHAR && attr_type != type::TypeId::VARBINARY)
+        columns.emplace_back("col_name", attr_type, attr_nullable, col_oid++);
+      else
+        columns.emplace_back("col_name", attr_type, 255, attr_nullable, col_oid++);
     }
     return catalog::Schema(columns);
   }

--- a/test/storage/sql_table_test.cpp
+++ b/test/storage/sql_table_test.cpp
@@ -32,7 +32,10 @@ class SqlTableRW {
    * @param oid for the column
    */
   void DefineColumn(std::string name, type::TypeId type, bool nullable, catalog::col_oid_t oid) {
-    cols_.emplace_back(name, type, nullable, oid);
+    if (type != type::TypeId::VARCHAR && type != type::TypeId::VARBINARY)
+      cols_.emplace_back(name, type, nullable, oid);
+    else
+      cols_.emplace_back(name, type, 255, nullable, oid);
   }
 
   /**


### PR DESCRIPTION
@lmwnshn and I realized that we needed this information while constructing TPC-C schemas. This cherry-picks the change out of the TPC-C branch. Also got rid of the inlined field in the Column object since I'm not sure it has any meaning at this level. SQL level shouldn't know anything about attributes being inlined in the storage layer or not, as best as I can tell.