### PR TITLE
clang-tidy heartbeat

### DIFF
--- a/build-support/run-clang-tidy.py
+++ b/build-support/run-clang-tidy.py
@@ -311,9 +311,15 @@ def main():
 
         # Fill the queue with files.
         for i, name in enumerate(files):
-            if file_name_re.search(name):
-                task_queue.put(name)
-            update_progress(i, len(files))
+            put_file = False
+            while not put_file:
+                try:
+                    if file_name_re.search(name):
+                        task_queue.put(name, block=True, timeout=300)
+                        put_file = True
+                    update_progress(i, len(files))
+                except queue.Full:
+                    print('Still waiting to put files into clang-tidy queue.')
 
         # Wait for all threads to be done.
         task_queue.join()


### PR DESCRIPTION
clang-tidy can be so slow that Travis kills us while waiting for our progress bar to update.
This just prints stuff to stdout every 300 seconds (half Travis timeout) so that we don't get killed.