### PR TITLE
Move clang-tidy to Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ before_script:
       docker exec build /bin/sh -c "cd /repo/build && make gflags_ep -j 4" &&
       docker exec build /bin/sh -c "cd /repo/build && make googletest_ep -j 4" &&
       docker exec build /bin/sh -c "cd /repo/build && make gbenchmark_ep -j 4" &&
-      docker exec build /bin/sh -c "cd /repo/build && make check-clang-tidy" &&
       docker exec build /bin/sh -c "cd /repo/build && make check-format" &&
       docker exec build /bin/sh -c "cd /repo/build && make check-lint" &&
       docker exec build /bin/sh -c "cd /repo/build && make check-censored";
@@ -80,7 +79,6 @@ before_script:
       ASAN_OPTIONS=detect_container_overflow=0 make gflags_ep &&
       ASAN_OPTIONS=detect_container_overflow=0 make googletest_ep &&
       ASAN_OPTIONS=detect_container_overflow=0 make gbenchmark_ep &&
-      ASAN_OPTIONS=detect_container_overflow=0 make check-clang-tidy &&
       ASAN_OPTIONS=detect_container_overflow=0 make check-format &&
       ASAN_OPTIONS=detect_container_overflow=0 make check-lint &&
       ASAN_OPTIONS=detect_container_overflow=0 make check-censored;

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
                         sh 'echo y | ./script/installation/packages.sh'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make gflags_ep -j 4 && make googletest_ep -j 4 && make gbenchmark_ep -j 4 && make -j4'
+                        sh 'cd build && make check-clang-tidy -j4'
                         sh 'cd build && make unittest -j4'
                     }
                 }
@@ -32,6 +33,7 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make gflags_ep -j 4 && make googletest_ep -j 4 && make gbenchmark_ep -j 4 && make -j4'
+                        sh 'cd build && make check-clang-tidy -j4'
                         sh 'cd build && make unittest -j4'
                     }
                 }


### PR DESCRIPTION
#378 avoids getting killed by Travis for no output being printed for 10 minutes. Instead it now gets killed for exceeding the maximum job duration.

Move clang-tidy to Jenkins.