### PR TITLE
Fix bulk insert for InsertPlanNode

### DIFF
--- a/src/include/planner/plannodes/insert_plan_node.h
+++ b/src/include/planner/plannodes/insert_plan_node.h
@@ -216,7 +216,7 @@ class InsertPlanNode : public AbstractPlanNode {
    */
   catalog::table_oid_t table_oid_;
 
-  // TODO: As an optimization, we can flatten this 2d vector because each inner vector is the same size.
+  // TODO(Gus, Wan): As an optimization, we can flatten this 2d vector because each inner vector is the same size.
   /**
    * vector of values to insert. Multiple vector of values corresponds to a bulk insert. Values for each tuple are
    * ordered the same across tuples. Parameter info provides column mapping of values

--- a/src/include/planner/plannodes/insert_plan_node.h
+++ b/src/include/planner/plannodes/insert_plan_node.h
@@ -216,6 +216,7 @@ class InsertPlanNode : public AbstractPlanNode {
    */
   catalog::table_oid_t table_oid_;
 
+  // TODO: As an optimization, we can flatten this 2d vector because each inner vector is the same size.
   /**
    * vector of values to insert. Multiple vector of values corresponds to a bulk insert. Values for each tuple are
    * ordered the same across tuples. Parameter info provides column mapping of values

--- a/src/include/planner/plannodes/insert_plan_node.h
+++ b/src/include/planner/plannodes/insert_plan_node.h
@@ -186,7 +186,7 @@ class InsertPlanNode : public AbstractPlanNode {
   const catalog::col_oid_t GetColumnOidForValue(uint32_t value_idx) const { return parameter_info_.at(value_idx); }
 
   /**
-   * @return number of times to insert
+   * @return number of tuples to insert
    */
   size_t GetBulkInsertCount() const { return values_.size(); }
 

--- a/src/include/planner/plannodes/insert_plan_node.h
+++ b/src/include/planner/plannodes/insert_plan_node.h
@@ -188,7 +188,7 @@ class InsertPlanNode : public AbstractPlanNode {
   /**
    * @return number of times to insert
    */
-  uint32_t GetBulkInsertCount() const { return values_.size(); }
+  size_t GetBulkInsertCount() const { return values_.size(); }
 
   /**
    * @return the hashed value of this plan node

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -671,18 +671,23 @@ TEST(PlanNodeJsonTest, IndexScanPlanNodeJsonTest) {
 // NOLINTNEXTLINE
 TEST(PlanNodeJsonTest, InsertPlanNodeJsonTest) {
   // Construct InsertPlanNode
-  std::vector<type::TransientValue> values;
-  values.push_back(type::TransientValueFactory::GetInteger(0));
-  values.push_back(type::TransientValueFactory::GetBoolean(true));
+  std::vector<type::TransientValue> tuple_1;
+  tuple_1.push_back(type::TransientValueFactory::GetInteger(0));
+  tuple_1.push_back(type::TransientValueFactory::GetBoolean(true));
+
+  std::vector<type::TransientValue> tuple_2;
+  tuple_2.push_back(type::TransientValueFactory::GetInteger(1));
+  tuple_2.push_back(type::TransientValueFactory::GetBoolean(false));
+
   InsertPlanNode::Builder builder;
   auto plan_node = builder.SetOutputSchema(PlanNodeJsonTest::BuildDummyOutputSchema())
                        .SetDatabaseOid(catalog::db_oid_t(0))
                        .SetNamespaceOid(catalog::namespace_oid_t(0))
                        .SetTableOid(catalog::table_oid_t(1))
-                       .SetValues(std::move(values))
-                       .AddParameterInfo(0, 1, 2)
-                       .AddParameterInfo(3, 4, 5)
-                       .SetBulkInsertCount(1)
+                       .AddValues(std::move(tuple_1))
+                       .AddValues(std::move(tuple_2))
+                       .AddParameterInfo(0, catalog::col_oid_t(0))
+                       .AddParameterInfo(1, catalog::col_oid_t(1))
                        .Build();
 
   // Serialize to Json


### PR DESCRIPTION
This PR changes how bulk inserts are represented in `InsertPlanNode`. Particularly, it makes the following changes:

* Change to `values_`
   * Values is now a vector of vectors. This represents a list of "tuples" to insert, where each tuple is a vector of the values for that tuple.
* Change to `parameter_info_`
  * Maps the index of a value to which column that value should be inserted into
  * This could have been a `std::vector`, but I wanted the mapping to be explicit
  * The `paramater_info_` allows for default values to be added during binding (in which case they would be in the `values_` vector and in `parameter_info`), or during execution (In which case there would be no entry for that column in `parameter_info`).
* Bulk insert count
   * This is now simply the size of `values_` 