### PR TITLE
Removed GetCopy() from TransientValueFactory

### DIFF
--- a/src/include/parser/expression/default_value_expression.h
+++ b/src/include/parser/expression/default_value_expression.h
@@ -14,8 +14,7 @@ class DefaultValueExpression : public AbstractExpression {
   /**
    * Instantiates a new default value expression.
    */
-  DefaultValueExpression()
-      : AbstractExpression(ExpressionType::VALUE_DEFAULT, type::TypeId::INVALID, {}) {}
+  DefaultValueExpression() : AbstractExpression(ExpressionType::VALUE_DEFAULT, type::TypeId::INVALID, {}) {}
 
   std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<DefaultValueExpression>(*this); }
 

--- a/src/include/settings/settings_manager.h
+++ b/src/include/settings/settings_manager.h
@@ -120,7 +120,7 @@ class SettingsManager {
   void ValidateSetting(Param param, const type::TransientValue &min_value, const type::TransientValue &max_value);
 
   type::TransientValue &GetValue(Param param);
-  bool SetValue(Param param, const type::TransientValue &value);
+  bool SetValue(Param param, type::TransientValue value);
   bool ValidateValue(const type::TransientValue &value, const type::TransientValue &min_value,
                      const type::TransientValue &max_value);
   common::ActionState InvokeCallback(Param param, void *old_value, void *new_value,

--- a/src/include/type/transient_value_factory.h
+++ b/src/include/type/transient_value_factory.h
@@ -94,45 +94,6 @@ class TransientValueFactory {
     std::memcpy(varchar_contents, value.data(), length);
     return {TypeId::VARCHAR, varchar};
   }
-
-  /**
-   * Get a full copy of a transient value.
-   */
-  static type::TransientValue GetCopy(const type::TransientValue &value) {
-    // NOLINTNEXTLINE
-    switch (value.Type()) {
-      case type::TypeId::BOOLEAN:
-        return type::TransientValueFactory::GetBoolean(type::TransientValuePeeker::PeekBoolean(value));
-        break;
-      case type::TypeId::TINYINT:
-        return type::TransientValueFactory::GetTinyInt(type::TransientValuePeeker::PeekTinyInt(value));
-        break;
-      case type::TypeId::SMALLINT:
-        return type::TransientValueFactory::GetSmallInt(type::TransientValuePeeker::PeekSmallInt(value));
-        break;
-      case type::TypeId::INTEGER:
-        return type::TransientValueFactory::GetInteger(type::TransientValuePeeker::PeekInteger(value));
-        break;
-      case type::TypeId::BIGINT:
-        return type::TransientValueFactory::GetBigInt(type::TransientValuePeeker::PeekBigInt(value));
-        break;
-      case type::TypeId::DECIMAL:
-        return type::TransientValueFactory::GetDecimal(type::TransientValuePeeker::PeekDecimal(value));
-        break;
-      case type::TypeId::TIMESTAMP:
-        return type::TransientValueFactory::GetTimestamp(type::TransientValuePeeker::PeekTimestamp(value));
-        break;
-      case type::TypeId::DATE:
-        return type::TransientValueFactory::GetDate(type::TransientValuePeeker::PeekDate(value));
-        break;
-      case type::TypeId::VARCHAR:
-        return type::TransientValueFactory::GetVarChar(type::TransientValuePeeker::PeekVarChar(value));
-        break;
-      default:
-        throw NOT_IMPLEMENTED_EXCEPTION("invalid TransientValue copy.");
-        break;
-    }
-  }
 };
 
 }  // namespace terrier::type

--- a/src/settings/settings_manager.cpp
+++ b/src/settings/settings_manager.cpp
@@ -1,6 +1,7 @@
 #include <gflags/gflags.h>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/macros.h"
@@ -150,12 +151,12 @@ type::TransientValue &SettingsManager::GetValue(Param param) {
   return param_info.value_;
 }
 
-bool SettingsManager::SetValue(Param param, const type::TransientValue &value) {
+bool SettingsManager::SetValue(Param param, type::TransientValue value) {
   auto &param_info = db_->param_map_.find(param)->second;
 
   if (!param_info.is_mutable_) return false;
 
-  param_info.value_ = ValueFactory::GetCopy(value);
+  param_info.value_ = std::move(value);
   return true;
 }
 

--- a/test/type/transient_value_test.cpp
+++ b/test/type/transient_value_test.cpp
@@ -36,7 +36,6 @@ TEST_F(ValueTests, BooleanTest) {
     auto value = type::TransientValueFactory::GetBoolean(data);
     EXPECT_FALSE(value.Null());
     EXPECT_EQ(data, type::TransientValuePeeker::PeekBoolean(value));
-    EXPECT_EQ(data, type::TransientValuePeeker::PeekBoolean(type::TransientValueFactory::GetCopy(value)));
 
     auto null = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
     value.SetNull(null);
@@ -76,7 +75,6 @@ TEST_F(ValueTests, TinyIntTest) {
     auto value = type::TransientValueFactory::GetTinyInt(data);
     EXPECT_FALSE(value.Null());
     EXPECT_EQ(data, type::TransientValuePeeker::PeekTinyInt(value));
-    EXPECT_EQ(data, type::TransientValuePeeker::PeekTinyInt(type::TransientValueFactory::GetCopy(value)));
 
     auto null = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
     value.SetNull(null);
@@ -116,7 +114,6 @@ TEST_F(ValueTests, SmallIntTest) {
     auto value = type::TransientValueFactory::GetSmallInt(data);
     EXPECT_FALSE(value.Null());
     EXPECT_EQ(data, type::TransientValuePeeker::PeekSmallInt(value));
-    EXPECT_EQ(data, type::TransientValuePeeker::PeekSmallInt(type::TransientValueFactory::GetCopy(value)));
 
     auto null = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
     value.SetNull(null);
@@ -156,7 +153,6 @@ TEST_F(ValueTests, IntegerTest) {
     auto value = type::TransientValueFactory::GetInteger(data);
     EXPECT_FALSE(value.Null());
     EXPECT_EQ(data, type::TransientValuePeeker::PeekInteger(value));
-    EXPECT_EQ(data, type::TransientValuePeeker::PeekInteger(type::TransientValueFactory::GetCopy(value)));
 
     auto null = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
     value.SetNull(null);
@@ -196,7 +192,6 @@ TEST_F(ValueTests, BigIntTest) {
     auto value = type::TransientValueFactory::GetBigInt(data);
     EXPECT_FALSE(value.Null());
     EXPECT_EQ(data, type::TransientValuePeeker::PeekBigInt(value));
-    EXPECT_EQ(data, type::TransientValuePeeker::PeekBigInt(type::TransientValueFactory::GetCopy(value)));
 
     auto null = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
     value.SetNull(null);
@@ -236,7 +231,6 @@ TEST_F(ValueTests, DecimalTest) {
     auto value = type::TransientValueFactory::GetDecimal(data);
     EXPECT_FALSE(value.Null());
     EXPECT_EQ(data, type::TransientValuePeeker::PeekDecimal(value));
-    EXPECT_EQ(data, type::TransientValuePeeker::PeekDecimal(type::TransientValueFactory::GetCopy(value)));
 
     auto null = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
     value.SetNull(null);
@@ -276,7 +270,6 @@ TEST_F(ValueTests, TimestampTest) {
     auto value = type::TransientValueFactory::GetTimestamp(data);
     EXPECT_FALSE(value.Null());
     EXPECT_EQ(data, type::TransientValuePeeker::PeekTimestamp(value));
-    EXPECT_EQ(data, type::TransientValuePeeker::PeekTimestamp(type::TransientValueFactory::GetCopy(value)));
 
     auto null = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
     value.SetNull(null);
@@ -316,7 +309,6 @@ TEST_F(ValueTests, DateTest) {
     auto value = type::TransientValueFactory::GetDate(data);
     EXPECT_FALSE(value.Null());
     EXPECT_EQ(data, type::TransientValuePeeker::PeekDate(value));
-    EXPECT_EQ(data, type::TransientValuePeeker::PeekDate(type::TransientValueFactory::GetCopy(value)));
 
     auto null = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
     value.SetNull(null);
@@ -362,7 +354,6 @@ TEST_F(ValueTests, VarCharTest) {
     EXPECT_FALSE(value.Null());
     std::string_view string_view = type::TransientValuePeeker::PeekVarChar(value);
     EXPECT_EQ(data, string_view);
-    EXPECT_EQ(data, type::TransientValuePeeker::PeekVarChar(type::TransientValueFactory::GetCopy(value)));
 
     auto null = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
     value.SetNull(null);


### PR DESCRIPTION
The whole point was not being able to easily copy TransientValues. If this is needed in the future we can discuss who gets access to the copy constructor.