### PR TITLE
Rename TransactionContext::TxnId() to FinishTime()

### DIFF
--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -26,23 +26,32 @@ class TransactionContext {
   /**
    * Constructs a new transaction context.
    *
+   * @warning In the src/ folder this should only be called in TransactionManager::BeginTransaction to adhere to MVCC
+   * semantics. Tests are allowed to deterministically construct them in ways that violate the current MVCC semantics.
    * @warning Beware that the buffer pool given must be the same one the log manager uses,
    * if logging is enabled.
-   * @param start the start timestamp of the transaction
-   * @param txn_id the id of the transaction, should be larger than all start time and commit time
+   * @param start the start timestamp of the transaction. Should be unique within the system.
+   * @param finish in HyPer parlance this is txn id. Should be larger than all start times and commit times in current
+   * MVCC semantics
    * @param buffer_pool the buffer pool to draw this transaction's undo buffer from
    * @param log_manager pointer to log manager in the system, or nullptr, if logging is disabled
    * @param transaction_manager pointer to transaction manager in the system (used for action framework)
    */
-  TransactionContext(const timestamp_t start, const timestamp_t txn_id,
+  TransactionContext(const timestamp_t start, const timestamp_t finish,
                      storage::RecordBufferSegmentPool *const buffer_pool, storage::LogManager *const log_manager,
                      TransactionManager *transaction_manager)
       : start_time_(start),
-        txn_id_(txn_id),
+        finish_time_(finish),
         undo_buffer_(buffer_pool),
         redo_buffer_(log_manager, buffer_pool),
         txn_mgr_(transaction_manager) {}
 
+  /**
+   * @warning In the src/ folder this should only be called by the Garbage Collector to adhere to MVCC semantics. Tests
+   * are allowed to deterministically delete them in ways that violate the current MVCC semantics, but you should really
+   * know what you're doing when you delete a TransactionContext since its UndoRecords may still be pointed to by a
+   * DataTable.
+   */
   ~TransactionContext() {
     for (const byte *ptr : loose_ptrs_) delete[] ptr;
   }
@@ -55,19 +64,18 @@ class TransactionContext {
   bool Aborted() const { return aborted_; }
 
   /**
-   * @return start time of this transaction
+   * @return start time of this transaction. Can be used as a unique identifier of this object in the current MVCC
+   * semantics because it is both constant and unique within the system
    */
   timestamp_t StartTime() const { return start_time_; }
 
   /**
-   * @return id of this transaction
+   * @return finish time of this transaction if it has been aborted or logged as a commit. Otherwise, current
+   * MVCC semantics define it as StartTime + INT64_MIN. TransactionContexts generated outside of the TransactionManager
+   * (i.e. in tests) may not reflect this. Should NOT be used as a unique identifier of this object because its value
+   * changes at txn completion in the current MVCC semantics.
    */
-  const std::atomic<timestamp_t> &TxnId() const { return txn_id_; }
-
-  /**
-   * @return id of this transaction
-   */
-  std::atomic<timestamp_t> &TxnId() { return txn_id_; }
+  timestamp_t FinishTime() const { return finish_time_.load(); }
 
   /**
    * Reserve space on this transaction's undo buffer for a record to log the update given
@@ -79,7 +87,7 @@ class TransactionContext {
   storage::UndoRecord *UndoRecordForUpdate(storage::DataTable *const table, const storage::TupleSlot slot,
                                            const storage::ProjectedRow &redo) {
     const uint32_t size = storage::UndoRecord::Size(redo);
-    return storage::UndoRecord::InitializeUpdate(undo_buffer_.NewEntry(size), txn_id_.load(), slot, table, redo);
+    return storage::UndoRecord::InitializeUpdate(undo_buffer_.NewEntry(size), finish_time_.load(), slot, table, redo);
   }
 
   /**
@@ -90,7 +98,7 @@ class TransactionContext {
    */
   storage::UndoRecord *UndoRecordForInsert(storage::DataTable *const table, const storage::TupleSlot slot) {
     byte *const result = undo_buffer_.NewEntry(sizeof(storage::UndoRecord));
-    return storage::UndoRecord::InitializeInsert(result, txn_id_.load(), slot, table);
+    return storage::UndoRecord::InitializeInsert(result, finish_time_.load(), slot, table);
   }
 
   /**
@@ -101,7 +109,7 @@ class TransactionContext {
    */
   storage::UndoRecord *UndoRecordForDelete(storage::DataTable *const table, const storage::TupleSlot slot) {
     byte *const result = undo_buffer_.NewEntry(sizeof(storage::UndoRecord));
-    return storage::UndoRecord::InitializeDelete(result, txn_id_.load(), slot, table);
+    return storage::UndoRecord::InitializeDelete(result, finish_time_.load(), slot, table);
   }
 
   /**
@@ -168,7 +176,7 @@ class TransactionContext {
   friend class storage::SqlTable;
   friend class storage::WriteAheadLoggingTests;  // Needs access to redo buffer
   const timestamp_t start_time_;
-  std::atomic<timestamp_t> txn_id_;
+  std::atomic<timestamp_t> finish_time_;
   storage::UndoBuffer undo_buffer_;
   storage::RedoBuffer redo_buffer_;
   // TODO(Tianyu): Maybe not so much of a good idea to do this. Make explicit queue in GC?

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -235,7 +235,7 @@ bool DataTable::SelectIntoBuffer(transaction::TransactionContext *const txn, con
 
   // Nullptr in version chain means no other versions visible to any transaction alive at this point.
   // Alternatively, if the current transaction holds the write lock, it should be able to read its own updates.
-  if (version_ptr == nullptr || version_ptr->Timestamp().load() == txn->TxnId().load()) {
+  if (version_ptr == nullptr || version_ptr->Timestamp().load() == txn->FinishTime()) {
     return visible;
   }
 
@@ -290,7 +290,7 @@ bool DataTable::Visible(const TupleSlot slot, const TupleAccessStrategy &accesso
 bool DataTable::HasConflict(const transaction::TransactionContext &txn, UndoRecord *const version_ptr) const {
   if (version_ptr == nullptr) return false;  // Nobody owns this tuple's write lock, no older version visible
   const transaction::timestamp_t version_timestamp = version_ptr->Timestamp().load();
-  const transaction::timestamp_t txn_id = txn.TxnId().load();
+  const transaction::timestamp_t txn_id = txn.FinishTime();
   const transaction::timestamp_t start_time = txn.StartTime();
   const bool owned_by_other_txn =
       (!transaction::TransactionUtil::Committed(version_timestamp) && version_timestamp != txn_id);
@@ -347,7 +347,7 @@ bool DataTable::IsVisible(const transaction::TransactionContext &txn, const Tupl
 
   // Nullptr in version chain means no other versions visible to any transaction alive at this point.
   // Alternatively, if the current transaction holds the write lock, it should be able to read its own updates.
-  if (version_ptr == nullptr || version_ptr->Timestamp().load() == txn.TxnId().load()) {
+  if (version_ptr == nullptr || version_ptr->Timestamp().load() == txn.FinishTime()) {
     return visible;
   }
 

--- a/src/storage/garbage_collector.cpp
+++ b/src/storage/garbage_collector.cpp
@@ -82,7 +82,7 @@ uint32_t GarbageCollector::ProcessUnlinkQueue() {
       // This is a read-only transaction so this is safe to immediately delete
       delete txn;
       txns_processed++;
-    } else if (transaction::TransactionUtil::NewerThan(oldest_txn, txn->TxnId().load())) {
+    } else if (transaction::TransactionUtil::NewerThan(oldest_txn, txn->FinishTime())) {
       // Safe to garbage collect.
       for (auto &undo_record : txn->undo_buffer_) {
         // It is possible for the table field to be null, for aborted transaction's last conflicting record


### PR DESCRIPTION
Found that the metrics PR was using `TxnId()` as a unique identifier for a transaction (not unreasonable given the function name). You can't do that because that value actually changes at completion. 

Rename `TransactionContext::TxnId()` to `FinishTime()` with some comments about what it means under current MVCC semantics. Also added a comment that `StartTime()` can be used as a unique identifier for a transaction. Removed the reference accessor since classes that used it were already friends of `TransactionContext`. Added some stronger warnings to `TransactionContext`'s constructor and destructor for funsies after some recent instances of `TransactionContext`s getting manually deleted. I'm still considering making the destructor private but that sounds like a nightmare to refactor.