### PR TITLE
Abort Record Fix

### DIFF
--- a/src/include/storage/write_ahead_log/log_record.h
+++ b/src/include/storage/write_ahead_log/log_record.h
@@ -359,10 +359,23 @@ class AbortRecord {
    *
    * @param head pointer location to initialize, this is also the returned address (reinterpreted)
    * @param txn_begin begin timestamp of the transaction that generated this log record
+   * @param txn transaction that is aborted
    * @return pointer to the initialized log record, always equal in value to the given head
    */
-  static LogRecord *Initialize(byte *const head, const transaction::timestamp_t txn_begin) {
-    return LogRecord::InitializeHeader(head, LogRecordType::ABORT, Size(), txn_begin);
+  static LogRecord *Initialize(byte *const head, const transaction::timestamp_t txn_begin,
+                               transaction::TransactionContext *txn) {
+    auto *result = LogRecord::InitializeHeader(head, LogRecordType::ABORT, Size(), txn_begin);
+    auto *body = result->GetUnderlyingRecordBodyAs<AbortRecord>();
+    body->txn_ = txn;
+    return result;
   }
+
+  /**
+   * @return pointer to the aborting transaction.
+   */
+  transaction::TransactionContext *Txn() const { return txn_; }
+
+ private:
+  transaction::TransactionContext *txn_;
 };
 }  // namespace terrier::storage

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -121,7 +121,7 @@ class TransactionManager {
   void LogCommit(TransactionContext *txn, timestamp_t commit_time, transaction::callback_fn callback,
                  void *callback_arg);
 
-  void LogAbort(TransactionContext *txn, timestamp_t abort_time);
+  void LogAbort(TransactionContext *txn);
 
   void Rollback(TransactionContext *txn, const storage::UndoRecord &record) const;
 

--- a/src/storage/write_ahead_log/log_serializer_task.cpp
+++ b/src/storage/write_ahead_log/log_serializer_task.cpp
@@ -75,6 +75,11 @@ void LogSerializerTask::SerializeBuffer(IterableBufferSegment<LogRecord> *buffer
       // Not safe to mark read only transactions as the transactions are deallocated preemptively without waiting for
       // logging (there is nothing to log after all)
       if (!commit_record->IsReadOnly()) commit_record->Txn()->log_processed_ = true;
+    }
+    if (record.RecordType() == LogRecordType::ABORT) {
+      // If an abort record shows up at all, the transaction cannot be read-only
+      SerializeRecord(record);
+      record.GetUnderlyingRecordBodyAs<AbortRecord>()->Txn()->log_processed_ = true;
     } else {
       // Any record that is not a commit record is always serialized.`
       SerializeRecord(record);

--- a/src/storage/write_ahead_log/log_serializer_task.cpp
+++ b/src/storage/write_ahead_log/log_serializer_task.cpp
@@ -75,8 +75,7 @@ void LogSerializerTask::SerializeBuffer(IterableBufferSegment<LogRecord> *buffer
       // Not safe to mark read only transactions as the transactions are deallocated preemptively without waiting for
       // logging (there is nothing to log after all)
       if (!commit_record->IsReadOnly()) commit_record->Txn()->log_processed_ = true;
-    }
-    if (record.RecordType() == LogRecordType::ABORT) {
+    } else if (record.RecordType() == LogRecordType::ABORT) {
       // If an abort record shows up at all, the transaction cannot be read-only
       SerializeRecord(record);
       record.GetUnderlyingRecordBodyAs<AbortRecord>()->Txn()->log_processed_ = true;

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -118,7 +118,7 @@ timestamp_t TransactionManager::Commit(TransactionContext *const txn, transactio
   return result;
 }
 
-void TransactionManager::LogAbort(TransactionContext *const txn, const timestamp_t abort_time) {
+void TransactionManager::LogAbort(TransactionContext *const txn) {
   if (log_manager_ != LOGGING_DISABLED) {
     // If we are logging the AbortRecord, then the transaction must have previously flushed records, so it must have
     // made updates
@@ -170,7 +170,7 @@ timestamp_t TransactionManager::Abort(TransactionContext *const txn) {
   // We flush the buffer containing an AbortRecord only if this transaction has previously flushed a RedoBuffer. This
   // way the Recovery manager knows to rollback changes for the aborted transaction.
   if (txn->redo_buffer_.HasFlushed()) {
-    LogAbort(txn, abort_time);
+    LogAbort(txn);
   } else {
     // Discard the redo buffer that is not yet logged out
     txn->redo_buffer_.Finalize(false);

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -126,7 +126,7 @@ void TransactionManager::LogAbort(TransactionContext *const txn, const timestamp
     // Here we will manually add an abort record and flush the buffer to ensure the logger
     // sees this record.
     byte *const abort_record = txn->redo_buffer_.NewEntry(storage::AbortRecord::Size());
-    storage::AbortRecord::Initialize(abort_record, txn->StartTime());
+    storage::AbortRecord::Initialize(abort_record, txn->StartTime(), txn);
     // Signal to the log manager that we are ready to be logged out
   } else {
     // Otherwise, logging is disabled. We should pretend to have flushed the record so the rest of the system proceeds

--- a/test/storage/log_test.cpp
+++ b/test/storage/log_test.cpp
@@ -31,7 +31,7 @@ class WriteAheadLoggingTests : public TerrierTest {
   const uint64_t num_log_buffers_ = 100;
   const std::chrono::milliseconds log_serialization_interval_{10};
   const std::chrono::milliseconds log_persist_interval_{20};
-  const uint64_t log_persist_threshold_ = (1 << 20);  // 1MB
+  const uint64_t log_persist_threshold_ = (1u << 20);  // 1MB
 
   std::default_random_engine generator_;
   storage::RecordBufferSegmentPool pool_{2000, 100};
@@ -69,9 +69,7 @@ class WriteAheadLoggingTests : public TerrierTest {
       return storage::CommitRecord::Initialize(buf, txn_begin, txn_commit, nullptr, nullptr, false, nullptr);
     }
 
-    if (record_type == storage::LogRecordType::ABORT) {
-      return storage::AbortRecord::Initialize(buf, txn_begin);
-    }
+    if (record_type == storage::LogRecordType::ABORT) return storage::AbortRecord::Initialize(buf, txn_begin, nullptr);
 
     // TODO(Tianyu): Without a lookup mechanism this oid is not exactly meaningful. Implement lookup when possible
     auto database_oid = in->ReadValue<catalog::db_oid_t>();
@@ -351,7 +349,6 @@ TEST_F(WriteAheadLoggingTests, AbortRecordTest) {
   // Perform GC, will clean up transactions for us
   gc_thread_ = new storage::GarbageCollectorThread(&txn_manager_, gc_period_);
   delete gc_thread_;
-  delete second_txn;
   delete sql_table;
 }
 


### PR DESCRIPTION
We never actually set the log_processed flag on the abort code path, so it will be missed by garbage collector.