### PR TITLE
Add GMock and associated macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,7 +364,7 @@ set(TERRIER_TEST_LINK_LIBS
     test_util
     terrier_static
     gtest
-    gtest_main
+    gmock_main
     pg_query
     ${CMAKE_DL_LIBS})
 

--- a/cmake_modules/FindGTest.cmake
+++ b/cmake_modules/FindGTest.cmake
@@ -45,7 +45,7 @@ if ( _gtest_roots )
     find_path( GTEST_INCLUDE_DIR NAMES gtest/gtest.h
         PATHS ${_gtest_roots} NO_DEFAULT_PATH
         PATH_SUFFIXES "include" )
-    find_library( GTEST_LIBRARIES NAMES gtest gtest_main
+    find_library( GTEST_LIBRARIES NAMES gtest gmock_main
         PATHS ${_gtest_roots} NO_DEFAULT_PATH
         PATH_SUFFIXES "lib" )
 else ()

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -126,7 +126,7 @@ if (TERRIER_BUILD_TESTS OR TERRIER_BUILD_BENCHMARKS)
     set(GTEST_STATIC_LIB
         "${GTEST_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(GTEST_MAIN_STATIC_LIB
-        "${GTEST_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        "${GTEST_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gmock_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(GTEST_VENDORED 1)
     set(GTEST_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX=${GTEST_PREFIX}
@@ -147,12 +147,12 @@ if (TERRIER_BUILD_TESTS OR TERRIER_BUILD_BENCHMARKS)
   include_directories(SYSTEM ${GTEST_INCLUDE_DIR})
   ADD_THIRDPARTY_LIB(gtest
       STATIC_LIB ${GTEST_STATIC_LIB})
-  ADD_THIRDPARTY_LIB(gtest_main
+  ADD_THIRDPARTY_LIB(gmock_main
       STATIC_LIB ${GTEST_MAIN_STATIC_LIB})
 
   if (GTEST_VENDORED)
     add_dependencies(gtest googletest_ep)
-    add_dependencies(gtest_main googletest_ep)
+    add_dependencies(gmock_main googletest_ep)
   endif ()
 
   # gflags (formerly Googleflags) command line parsing

--- a/src/include/common/macros.h
+++ b/src/include/common/macros.h
@@ -152,3 +152,10 @@
 #endif
 
 #define FRIEND_TEST(test_case_name, test_name) friend class test_case_name##_##test_name##_Test
+
+// Use this macro to add polymorphism to a class, when the sole purpose of it is to enable mocks and fakes
+// during testing. This makes it clear to the reader that no other form of polymorphism is expected. This
+// also means it is possible to get performance back through use of compiler macro magic
+// TODO(Tianyu): The easiest thing to do is to write this wrapped in a if on some macro flag (NO_FAKE),
+// and then we can turn this off and on from cmake
+#define FAKED_IN_TEST virtual

--- a/test/include/util/test_harness.h
+++ b/test/include/util/test_harness.h
@@ -1,16 +1,14 @@
 #pragma once
 #include <memory>
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "loggers/loggers_util.h"
 
 namespace terrier {
 
 class TerrierTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    LoggersUtil::Initialize(true);
-  }
+  void SetUp() override { LoggersUtil::Initialize(true); }
 
   void TearDown() override { LoggersUtil::ShutDown(); }
 };

--- a/test/include/util/test_harness.h
+++ b/test/include/util/test_harness.h
@@ -1,14 +1,16 @@
 #pragma once
-
 #include <memory>
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "loggers/loggers_util.h"
 
 namespace terrier {
 
 class TerrierTest : public ::testing::Test {
  protected:
-  void SetUp() override { LoggersUtil::Initialize(true); }
+  void SetUp() override {
+    LoggersUtil::Initialize(true);
+  }
 
   void TearDown() override { LoggersUtil::ShutDown(); }
 };


### PR DESCRIPTION
This PR adds gmock to our cmake tool chain (apparently gmock is a superset of gtest, so their doc recommends search and replace)

Also adds a macro (FAKED_IN_TEST) to inject polymorphism needed to make mocks work. An example of how this would work in practice is shown in `access_observer_test` in #377 