### PR TITLE
Templatize ScopedTimer

### DIFF
--- a/benchmark/integration/tpcc_benchmark.cpp
+++ b/benchmark/integration/tpcc_benchmark.cpp
@@ -99,7 +99,7 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithoutLogging)(benchmark::State &
     // run the TPCC workload to completion, timing the execution
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       for (int8_t i = 0; i < num_threads_; i++) {
         thread_pool_.SubmitTask([i, tpcc_db, &txn_manager, precomputed_args, &workers] {
           Workload(i, tpcc_db, &txn_manager, precomputed_args, &workers);
@@ -177,7 +177,7 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithLogging)(benchmark::State &sta
     // run the TPCC workload to completion, timing the execution
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       for (int8_t i = 0; i < num_threads_; i++) {
         thread_pool_.SubmitTask([i, tpcc_db, &txn_manager, precomputed_args, &workers] {
           Workload(i, tpcc_db, &txn_manager, precomputed_args, &workers);

--- a/benchmark/storage/bwtree_benchmark.cpp
+++ b/benchmark/storage/bwtree_benchmark.cpp
@@ -54,7 +54,7 @@ BENCHMARK_DEFINE_F(BwTreeBenchmark, RandomInsert)(benchmark::State &state) {
     uint64_t elapsed_ms;
     tree->UpdateThreadLocal(num_threads_ + 1);
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, workload);
     }
     tree->UpdateThreadLocal(1);
@@ -87,7 +87,7 @@ BENCHMARK_DEFINE_F(BwTreeBenchmark, SequentialInsert)(benchmark::State &state) {
     uint64_t elapsed_ms;
     tree->UpdateThreadLocal(num_threads_ + 1);
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, workload);
     }
     tree->UpdateThreadLocal(1);
@@ -127,7 +127,7 @@ BENCHMARK_DEFINE_F(BwTreeBenchmark, RandomInsertRandomRead)(benchmark::State &st
     uint64_t elapsed_ms;
     tree->UpdateThreadLocal(num_threads_ + 1);
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, workload);
     }
     tree->UpdateThreadLocal(1);
@@ -168,7 +168,7 @@ BENCHMARK_DEFINE_F(BwTreeBenchmark, RandomInsertSequentialRead)(benchmark::State
     uint64_t elapsed_ms;
     tree->UpdateThreadLocal(num_threads_ + 1);
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, workload);
     }
     tree->UpdateThreadLocal(1);
@@ -209,7 +209,7 @@ BENCHMARK_DEFINE_F(BwTreeBenchmark, SequentialInsertRandomRead)(benchmark::State
     uint64_t elapsed_ms;
     tree->UpdateThreadLocal(num_threads_ + 1);
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, workload);
     }
     tree->UpdateThreadLocal(1);
@@ -250,7 +250,7 @@ BENCHMARK_DEFINE_F(BwTreeBenchmark, SequentialInsertSequentialRead)(benchmark::S
     uint64_t elapsed_ms;
     tree->UpdateThreadLocal(num_threads_ + 1);
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, workload);
     }
     tree->UpdateThreadLocal(1);

--- a/benchmark/storage/garbage_collector_benchmark.cpp
+++ b/benchmark/storage/garbage_collector_benchmark.cpp
@@ -71,7 +71,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, UnlinkTime)(benchmark::State &stat
     uint64_t elapsed_ms;
     std::pair<uint32_t, uint32_t> result;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       result = gc_->PerformGarbageCollection();
     }
     EXPECT_EQ(result.first, 0);
@@ -113,7 +113,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, ReclaimTime)(benchmark::State &sta
     // time just the deallocation process, verify nothing unlinked
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       result = gc_->PerformGarbageCollection();
     }
     EXPECT_EQ(result.first, num_txns);
@@ -141,7 +141,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, HighContention)(benchmark::State &
     StartGC(tested.GetTxnManager());
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       tested.SimulateOltp(num_txns, num_concurrent_txns);
     }
     lag_count += EndGC();

--- a/benchmark/storage/logging_benchmark.cpp
+++ b/benchmark/storage/logging_benchmark.cpp
@@ -54,7 +54,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, TPCCish)(benchmark::State &state) {
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }
@@ -90,7 +90,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, HighAbortRate)(benchmark::State &state) {
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }
@@ -125,7 +125,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementInsert)(benchmark::State &st
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }
@@ -160,7 +160,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementUpdate)(benchmark::State &st
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }
@@ -195,7 +195,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementSelect)(benchmark::State &st
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }

--- a/benchmark/transaction/large_transaction_benchmark.cpp
+++ b/benchmark/transaction/large_transaction_benchmark.cpp
@@ -34,7 +34,7 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, TPCCish)(benchmark::State &state) 
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
@@ -59,7 +59,7 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, HighAbortRate)(benchmark::State &s
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
@@ -84,7 +84,7 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, SingleStatementInsert)(benchmark::
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
@@ -108,7 +108,7 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, SingleStatementUpdate)(benchmark::
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
@@ -132,7 +132,7 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, SingleStatementSelect)(benchmark::
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
-      common::ScopedTimer timer(&elapsed_ms);
+      common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);


### PR DESCRIPTION
We need an easy way to change the resolution for different metrics, so implemented the TODO that's been sitting in ScopedTimer for a while.