### PR TITLE
Fix to log persist timeout

### DIFF
--- a/src/storage/write_ahead_log/disk_log_consumer_task.cpp
+++ b/src/storage/write_ahead_log/disk_log_consumer_task.cpp
@@ -42,10 +42,11 @@ void DiskLogConsumerTask::PersistLogFile() {
 void DiskLogConsumerTask::DiskLogConsumerTaskLoop() {
   // Keeps track of how much data we've written to the log file since the last persist
   current_data_written_ = 0;
-  // disk log consumer task thread spins in this loop
-  // It dequeues a filled buffer and flushes it to disk
+  // Time since last log file persist
+  auto last_persist = std::chrono::high_resolution_clock::now();
+  // Disk log consumer task thread spins in this loop. When notified or periodically, we wake up and process serialized
+  // buffers
   do {
-    bool timeout;
     {
       // Wait until we are told to flush buffers
       std::unique_lock<std::mutex> lock(persist_lock_);
@@ -54,22 +55,26 @@ void DiskLogConsumerTask::DiskLogConsumerTaskLoop() {
       // 2) There is a filled buffer to write to the disk
       // 3) LogManager has shut down the task
       // 4) Our persist interval timed out
-      timeout = disk_log_writer_thread_cv_.wait_for(
-          lock, persist_interval_, [&] { return do_persist_ || !filled_buffer_queue_->Empty() || !run_task_; });
+      disk_log_writer_thread_cv_.wait_for(lock, persist_interval_,
+                                          [&] { return do_persist_ || !filled_buffer_queue_->Empty() || !run_task_; });
     }
 
     // Flush all the buffers to the log file
     WriteBuffersToLogFile();
 
     // We persist the log file if the following conditions are met
-    // 1) The persist interval amount of time has passed
+    // 1) The persist interval amount of time has passed since the last persist
     // 2) We have written more data since the last persist than the threshold
     // 3) We are signaled to persist
     // 4) We are shutting down this task
+    bool timeout = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() -
+                                                                         last_persist) > persist_interval_;
     if (timeout || current_data_written_ > persist_threshold_ || do_persist_ || !run_task_) {
       {
         std::unique_lock<std::mutex> lock(persist_lock_);
         PersistLogFile();
+        // Reset meta data
+        last_persist = std::chrono::high_resolution_clock::now();
         current_data_written_ = 0;
         do_persist_ = false;
       }


### PR DESCRIPTION
Resolves #448 

This PR resolves the problems with the timeout described in #448. Instead of completely relying on the timeout feature of `std::condition_variable::wait_for`, we keep a timestamp of the last time we persisted. When we decide if we should persist, we simply check if the time elapsed since that timestamp is larger than the persist interval. We still make use of the timeout on `std::condition_variable::wait_for` to ensure we break out of the wait if the interval has passed.

I made special care to not conflict with the changes in #439, it should be a clean merge (besides some simple formatting fixes).