### PR TITLE
Include 'fmt/ostr.h' in all logger header files

### DIFF
--- a/src/include/loggers/catalog_logger.h
+++ b/src/include/loggers/catalog_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
 

--- a/src/include/loggers/index_logger.h
+++ b/src/include/loggers/index_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
 

--- a/src/include/loggers/main_logger.h
+++ b/src/include/loggers/main_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_sinks.h"
 #include "spdlog/spdlog.h"

--- a/src/include/loggers/network_logger.h
+++ b/src/include/loggers/network_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
 

--- a/src/include/loggers/parser_logger.h
+++ b/src/include/loggers/parser_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
 

--- a/src/include/loggers/settings_logger.h
+++ b/src/include/loggers/settings_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
 

--- a/src/include/loggers/storage_logger.h
+++ b/src/include/loggers/storage_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
 

--- a/src/include/loggers/test_logger.h
+++ b/src/include/loggers/test_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
 

--- a/src/include/loggers/transaction_logger.h
+++ b/src/include/loggers/transaction_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "spdlog/fmt/ostr.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
 


### PR DESCRIPTION
This fix allows you to output objects in log messages. This fixes #458

I don't think a review is really necessary but we should follow the rules.