### PR TITLE
unique_ptr and nullptr support for ManagedPointer

### DIFF
--- a/src/include/common/managed_pointer.h
+++ b/src/include/common/managed_pointer.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <functional>
+#include <memory>
+
 namespace terrier::common {
 
 /**
@@ -26,6 +28,17 @@ class ManagedPointer {
   explicit ManagedPointer(Underlying *ptr) : underlying_(ptr) {}
 
   /**
+   * Constructs a new ManagedPointer.
+   * @param smart_ptr the pointer value this ManagedPointer wraps
+   */
+  explicit ManagedPointer(const std::unique_ptr<Underlying> &smart_ptr) : underlying_(smart_ptr.get()) {}
+
+  /**
+   * @param null_ptr null pointer
+   */
+  ManagedPointer(std::nullptr_t null_ptr) noexcept : underlying_(nullptr) {}  // NOLINT
+
+  /**
    * @return the underlying pointer
    */
   Underlying &operator*() const { return *underlying_; }
@@ -44,6 +57,33 @@ class ManagedPointer {
    * @return True if it is not a nullptr, false otherwise
    */
   explicit operator bool() const { return underlying_; }
+
+  /**
+   * Overloaded assignment operator for nullptr type
+   * @return reference to this
+   */
+  ManagedPointer &operator=(std::nullptr_t) {
+    underlying_ = nullptr;
+    return *this;
+  }
+
+  /**
+   * Overloaded assignment operator for unique_ptr type
+   * @return reference to this
+   */
+  ManagedPointer &operator=(const std::unique_ptr<Underlying> &smart_ptr) {
+    underlying_ = smart_ptr.get();
+    return *this;
+  }
+
+  /**
+   * Overloaded assignment operator for underlying ptr type
+   * @return reference to this
+   */
+  ManagedPointer &operator=(Underlying *const ptr) {
+    underlying_ = ptr;
+    return *this;
+  }
 
   /**
    * Equality operator

--- a/test/common/managed_pointer_test.cpp
+++ b/test/common/managed_pointer_test.cpp
@@ -30,10 +30,38 @@ TEST(ManagedPointerTests, PointerAccessTest) {
   char *raw_ptr1 = val1.data();
 
   common::ManagedPointer<char *> ptr0(&raw_ptr0);
-  common::ManagedPointer<char *> ptr1(&raw_ptr1);
+  common::ManagedPointer<char *> ptr1;
+  ptr1 = (&raw_ptr1);
 
   EXPECT_EQ(*ptr0, raw_ptr0);
   EXPECT_NE(*ptr0, raw_ptr1);
+  EXPECT_EQ(*ptr1, raw_ptr1);
+}
+
+// NOLINTNEXTLINE
+TEST(ManagedPointerTests, UniquePtr) {
+  auto unq_ptr0 = std::make_unique<int>(15445);
+  auto unq_ptr1 = std::make_unique<int>(15721);
+
+  common::ManagedPointer<int> ptr0(unq_ptr0);
+  common::ManagedPointer<int> ptr1;
+  ptr1 = unq_ptr1;
+
+  EXPECT_EQ(*ptr0, *unq_ptr0);
+  EXPECT_EQ(*ptr1, *unq_ptr1);
+  EXPECT_NE(*ptr0, *unq_ptr1);
+  EXPECT_NE(*ptr1, *unq_ptr0);
+}
+
+// NOLINTNEXTLINE
+TEST(ManagedPointerTests, NullPtr) {
+  common::ManagedPointer<int> ptr0(nullptr);
+  common::ManagedPointer<int> ptr1;
+  ptr1 = nullptr;
+
+  EXPECT_EQ(ptr0, nullptr);
+  EXPECT_EQ(ptr1, nullptr);
+  EXPECT_EQ(ptr0, ptr1);
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
I've had this in my metrics branch but people need this sooner than whenever that'll merge.

Fix #424, maybe not everything? Not clear about the casting stuff.