### PR TITLE
Checksum

### DIFF
--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -26,5 +26,13 @@ struct Constants {
    * The size of the buffers the log manager uses to buffer serialized logs and "group commit" them when writing to disk
    */
   static const uint32_t LOG_BUFFER_SIZE = (1 << 12);
+  /**
+   * The size of the checksum for the log buffer
+   */
+  static const uint32_t LOG_BUFFER_SUM_SIZE = (1 << 6);
+  /**
+   * The size of the payload in the log buffer
+   */
+  static const uint32_t LOG_BUFFER_PAYLOAD_SIZE = LOG_BUFFER_SIZE - LOG_BUFFER_SUM_SIZE;
 };
 }  // namespace terrier::common

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include "hash_util.h"
 
 namespace terrier::common {
 /**
@@ -27,13 +26,5 @@ struct Constants {
    * The size of the buffers the log manager uses to buffer serialized logs and "group commit" them when writing to disk
    */
   static const uint32_t LOG_BUFFER_SIZE = (1 << 12);
-  /**
-   * The size of the checksum for the log buffer
-   */
-  static const uint32_t LOG_BUFFER_SUM_SIZE = sizeof(common::hash_t);
-  /**
-   * The size of the payload in the log buffer
-   */
-  static const uint32_t LOG_BUFFER_PAYLOAD_SIZE = LOG_BUFFER_SIZE - LOG_BUFFER_SUM_SIZE;
 };
 }  // namespace terrier::common

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include "hash_util.h"
 
 namespace terrier::common {
 /**
@@ -26,5 +27,22 @@ struct Constants {
    * The size of the buffers the log manager uses to buffer serialized logs and "group commit" them when writing to disk
    */
   static const uint32_t LOG_BUFFER_SIZE = (1 << 12);
+  /**
+   * The width of the buffer checksum
+   */
+  static const uint32_t LOG_BUFFER_SUM_WIDTH = sizeof(common::hash_t);
+  /**
+   * The width of the size of the payload that checksum covers
+   */
+  static const uint32_t LOG_BUFFER_PAYLOAD_SIZE_WIDTH = sizeof(uint16_t);
+  /**
+   * The width of the buffer information
+   */
+  static const uint32_t LOG_BUFFER_INFO_WIDTH = sizeof(uint32_t);
+  /**
+   * The size of the buffer payload
+   */
+  static const uint32_t LOG_BUFFER_PAYLOAD_SIZE = LOG_BUFFER_SIZE
+      - LOG_BUFFER_SUM_WIDTH - LOG_BUFFER_PAYLOAD_SIZE_WIDTH - LOG_BUFFER_INFO_WIDTH;
 };
 }  // namespace terrier::common

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include "hash_util.h"
 
 namespace terrier::common {
 /**
@@ -29,7 +30,7 @@ struct Constants {
   /**
    * The size of the checksum for the log buffer
    */
-  static const uint32_t LOG_BUFFER_SUM_SIZE = (1 << 6);
+  static const uint32_t LOG_BUFFER_SUM_SIZE = sizeof(common::hash_t);
   /**
    * The size of the payload in the log buffer
    */

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -34,7 +34,7 @@ struct Constants {
   /**
    * The width of the size of the payload that checksum covers
    */
-  static const uint32_t LOG_BUFFER_PAYLOAD_SIZE_WIDTH = sizeof(uint16_t);
+  static const uint32_t LOG_BUFFER_PAYLOAD_SIZE_WIDTH = sizeof(uint32_t);
   /**
    * The width of the buffer information
    */
@@ -44,5 +44,9 @@ struct Constants {
    */
   static const uint32_t LOG_BUFFER_PAYLOAD_SIZE = LOG_BUFFER_SIZE
       - LOG_BUFFER_SUM_WIDTH - LOG_BUFFER_PAYLOAD_SIZE_WIDTH - LOG_BUFFER_INFO_WIDTH;
+  /**
+   * The size of header - everythine except the payload
+   */
+  static const uint32_t LOG_BUFFER_HEADER_SIZE = LOG_BUFFER_SIZE - LOG_BUFFER_PAYLOAD_SIZE;
 };
 }  // namespace terrier::common

--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -148,14 +148,13 @@ class BufferedLogWriter {
 
  private:
   int out_;  // fd of the output files
+  uint32_t payload_size_ = 0;
   struct {
     byte sum_[common::Constants::LOG_BUFFER_SUM_WIDTH];
     byte size_[common::Constants::LOG_BUFFER_PAYLOAD_SIZE_WIDTH];
     byte info_[common::Constants::LOG_BUFFER_INFO_WIDTH];
     byte payload_[common::Constants::LOG_BUFFER_PAYLOAD_SIZE];
   } buffer_;
-
-  uint32_t payload_size_ = 0;
 
   bool CanBuffer(uint32_t size) { return common::Constants::LOG_BUFFER_PAYLOAD_SIZE - payload_size_ >= size; }
 
@@ -207,11 +206,16 @@ class BufferedLogReader {
  private:
   int in_;  // or -1 if closed
   uint32_t read_head_ = 0, filled_size_ = 0;
-  char buffer_[common::Constants::LOG_BUFFER_SIZE];
+  struct {
+    byte sum_[common::Constants::LOG_BUFFER_SUM_WIDTH];
+    byte size_[common::Constants::LOG_BUFFER_PAYLOAD_SIZE_WIDTH];
+    byte info_[common::Constants::LOG_BUFFER_INFO_WIDTH];
+    byte payload_[common::Constants::LOG_BUFFER_PAYLOAD_SIZE];
+  } buffer_;
 
   void ReadFromBuffer(void *dest, uint32_t size) {
     TERRIER_ASSERT(read_head_ + size <= filled_size_, "Not enough bytes in buffer for the read");
-    std::memcpy(dest, buffer_ + read_head_, size);
+    std::memcpy(dest, buffer_.payload_ + read_head_, size);
     read_head_ += size;
   }
 

--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -10,6 +10,7 @@
 #include "common/constants.h"
 #include "common/macros.h"
 #include "loggers/storage_logger.h"
+#include "common/hash_util.h"
 
 namespace terrier::storage {
 
@@ -95,7 +96,8 @@ class BufferedLogWriter {
   /**
    * Write to the log file the given amount of bytes from the given location in memory, but buffer the write so the
    * update is only written out when the BufferedLogWriter is persisted. Note that this function writes to the buffer
-   * only until it is full. If buffer gets full, then call FlushBuffer() and call BufferWrite(..) again with the correct
+   * only until it is full. If buffer gets full, the checksum of the buffer is appended,
+   * then call FlushBuffer() and call BufferWrite(..) again with the correct
    * offset of the data, depending on the number of bytes that were already written.
    * @param data memory location of the bytes to write
    * @param size number of bytes to write
@@ -106,10 +108,19 @@ class BufferedLogWriter {
     // If we still do not have buffer space after flush, the write is too large to be buffered. We partially write the
     // buffer and return the number of bytes written
     if (!CanBuffer(size)) {
-      size = common::Constants::LOG_BUFFER_SIZE - buffer_size_;
+      size = common::Constants::LOG_BUFFER_PAYLOAD_SIZE - buffer_size_;
     }
     std::memcpy(buffer_ + buffer_size_, data, size);
     buffer_size_ += size;
+    // add checksum when the buffer is filled.
+    // the sum is stored in little endian.
+    if (buffer_size_ == common::Constants::LOG_BUFFER_PAYLOAD_SIZE) {
+      auto checksum = common::HashUtil::HashBytes(reinterpret_cast<const terrier::byte *>(buffer_),
+          common::Constants::LOG_BUFFER_PAYLOAD_SIZE);
+      auto le_sum = htole64(checksum);
+      std::memcpy(buffer_ + buffer_size_, &le_sum, common::Constants::LOG_BUFFER_SUM_SIZE);
+      buffer_size_ += common::Constants::LOG_BUFFER_SUM_SIZE;
+    }
     return size;
   }
 
@@ -142,7 +153,7 @@ class BufferedLogWriter {
 
   uint32_t buffer_size_ = 0;
 
-  bool CanBuffer(uint32_t size) { return common::Constants::LOG_BUFFER_SIZE - buffer_size_ >= size; }
+  bool CanBuffer(uint32_t size) { return common::Constants::LOG_BUFFER_PAYLOAD_SIZE - buffer_size_ >= size; }
 
   void WriteUnsynced(const void *data, uint32_t size) { PosixIoWrappers::WriteFully(out_, data, size); }
 };

--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -115,7 +115,7 @@ class BufferedLogWriter {
     // add checksum when the buffer is filled.
     // the sum is stored in little endian.
     if (buffer_size_ == common::Constants::LOG_BUFFER_PAYLOAD_SIZE) {
-      auto checksum = common::HashUtil::HashBytes(reinterpret_cast<const terrier::byte *>(buffer_),
+      auto checksum = common::HashUtil::HashBytes(reinterpret_cast<terrier::byte *>(buffer_),
           common::Constants::LOG_BUFFER_PAYLOAD_SIZE);
       auto le_sum = htole64(checksum);
       std::memcpy(buffer_ + buffer_size_, &le_sum, common::Constants::LOG_BUFFER_SUM_SIZE);

--- a/src/storage/write_ahead_log/log_io.cpp
+++ b/src/storage/write_ahead_log/log_io.cpp
@@ -63,15 +63,18 @@ void BufferedLogReader::RefillBuffer() {
   if (in_ == -1) throw std::runtime_error("No more bytes left in the log file");
   read_head_ = 0;
   PosixIoWrappers::ReadFully(in_, &buffer_, common::Constants::LOG_BUFFER_HEADER_SIZE);
+
   uint32_t payload_size;
   std::memcpy(&payload_size, buffer_.size_, common::Constants::LOG_BUFFER_PAYLOAD_SIZE_WIDTH);
   payload_size = le32toh(payload_size);
-  filled_size_ = PosixIoWrappers::ReadFully(in_, buffer_.payload_, filled_size_);
+  filled_size_ = PosixIoWrappers::ReadFully(in_, buffer_.payload_, payload_size);
+
   if (filled_size_ < payload_size) {
     // TODO(Tianyu): Is it better to make this an explicit close?
     PosixIoWrappers::Close(in_);
     in_ = -1;
   }
+
   common::hash_t sum;
   std::memcpy(&sum, buffer_.sum_, common::Constants::LOG_BUFFER_SUM_WIDTH);
   sum = le64toh(sum);

--- a/src/storage/write_ahead_log/log_io.cpp
+++ b/src/storage/write_ahead_log/log_io.cpp
@@ -74,7 +74,7 @@ void BufferedLogReader::RefillBuffer() {
     uint64_t le_sum;
     std::memcpy(&le_sum, buffer_ + filled_size_, common::Constants::LOG_BUFFER_SUM_SIZE);
     auto checksum = le64toh(le_sum);
-    TERRIER_ASSERT(checksum == common::HashUtil::HashBytes(reinterpret_cast<const terrier::byte *>(&(buffer_[0])),
+    TERRIER_ASSERT(checksum == common::HashUtil::HashBytes(reinterpret_cast<terrier::byte *>(buffer_),
           common::Constants::LOG_BUFFER_PAYLOAD_SIZE), "Checksum does not match, data corrupted");
   }
 }

--- a/src/storage/write_ahead_log/log_io.cpp
+++ b/src/storage/write_ahead_log/log_io.cpp
@@ -1,7 +1,5 @@
 #include "storage/write_ahead_log/log_io.h"
 #include <algorithm>
-#include <common/hash_util.h>
-
 namespace terrier::storage {
 void PosixIoWrappers::Close(int fd) {
   while (true) {
@@ -67,15 +65,6 @@ void BufferedLogReader::RefillBuffer() {
     // TODO(Tianyu): Is it better to make this an explicit close?
     PosixIoWrappers::Close(in_);
     in_ = -1;
-  }
-  // checksum
-  else {
-    filled_size_ -= common::Constants::LOG_BUFFER_SUM_SIZE;
-    uint64_t le_sum;
-    std::memcpy(&le_sum, buffer_ + filled_size_, common::Constants::LOG_BUFFER_SUM_SIZE);
-    auto checksum = le64toh(le_sum);
-    TERRIER_ASSERT(checksum == common::HashUtil::HashBytes(reinterpret_cast<terrier::byte *>(buffer_),
-          common::Constants::LOG_BUFFER_PAYLOAD_SIZE), "Checksum does not match, data corrupted");
   }
 }
 


### PR DESCRIPTION
This PR adds the checksum to log files #432 .

Questions: 
- How to deal with partially filled buffers?
  In `BufferedLogWriter::BufferWrite`, I checked if the buffer is full (or almost full with size `LOG_BUFFER_PAYLOAD_SIZE = LOG_BUFFER_SIZE - LOG_BUFFER_SUM_SIZE`) after each write. If it is, I write the sum to the buffer as well. In my understanding of the workflow, this buffer is then handed over by the log serializer to the log consumer using `LogSerializerTask::HandFilledBufferToWriter`. 
However, this function is also called in `LogSerializerTask::Process` without checking if the `filled_buffer_` is full. I am not sure how I should handle this case.