### PR TITLE
Normalize catalog names

### DIFF
--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -5,21 +5,34 @@
 #include "catalog/catalog.h"
 
 namespace terrier::catalog {
-db_oid_t CatalogAccessor::GetDatabaseOid(const std::string &name) { return catalog_->GetDatabaseOid(txn_, name); }
+db_oid_t CatalogAccessor::GetDatabaseOid(std::string name) {
+  NormalizeObjectName(name);
+  return catalog_->GetDatabaseOid(txn_, name);
+}
 
-db_oid_t CatalogAccessor::CreateDatabase(const std::string &name) { return catalog_->CreateDatabase(txn_, name, true); }
+db_oid_t CatalogAccessor::CreateDatabase(std::string name) {
+  NormalizeObjectName(name);
+  return catalog_->CreateDatabase(txn_, name, true);
+}
 
 bool CatalogAccessor::DropDatabase(db_oid_t db) { return catalog_->DeleteDatabase(txn_, db); }
 
 void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) { search_path_ = std::move(namespaces); }
 
-namespace_oid_t CatalogAccessor::GetNamespaceOid(const std::string &name) { return dbc_->GetNamespaceOid(txn_, name); }
+namespace_oid_t CatalogAccessor::GetNamespaceOid(std::string name) {
+  NormalizeObjectName(name);
+  return dbc_->GetNamespaceOid(txn_, name);
+}
 
-namespace_oid_t CatalogAccessor::CreateNamespace(const std::string &name) { return dbc_->CreateNamespace(txn_, name); }
+namespace_oid_t CatalogAccessor::CreateNamespace(std::string name) {
+  NormalizeObjectName(name);
+  return dbc_->CreateNamespace(txn_, name);
+}
 
 bool CatalogAccessor::DropNamespace(namespace_oid_t ns) { return dbc_->DeleteNamespace(txn_, ns); }
 
-table_oid_t CatalogAccessor::GetTableOid(const std::string &name) {
+table_oid_t CatalogAccessor::GetTableOid(std::string name) {
+  NormalizeObjectName(name);
   for (auto &path : search_path_) {
     table_oid_t search_result = dbc_->GetTableOid(txn_, path, name);
     if (search_result != INVALID_TABLE_OID) return search_result;
@@ -27,15 +40,17 @@ table_oid_t CatalogAccessor::GetTableOid(const std::string &name) {
   return INVALID_TABLE_OID;
 }
 
-table_oid_t CatalogAccessor::GetTableOid(namespace_oid_t ns, const std::string &name) {
+table_oid_t CatalogAccessor::GetTableOid(namespace_oid_t ns, std::string name) {
+  NormalizeObjectName(name);
   return dbc_->GetTableOid(txn_, ns, name);
 }
 
-table_oid_t CatalogAccessor::CreateTable(namespace_oid_t ns, const std::string &name, const Schema &schema) {
+table_oid_t CatalogAccessor::CreateTable(namespace_oid_t ns, std::string name, const Schema &schema) {
+  NormalizeObjectName(name);
   return dbc_->CreateTable(txn_, ns, name, schema);
 }
 
-bool CatalogAccessor::RenameTable(table_oid_t table, const std::string &new_table_name) {
+bool CatalogAccessor::RenameTable(table_oid_t table, std::string new_table_name) {
   return dbc_->RenameTable(txn_, table, new_table_name);
 }
 
@@ -61,7 +76,8 @@ std::vector<constraint_oid_t> CatalogAccessor::GetConstraints(table_oid_t table)
 
 std::vector<index_oid_t> CatalogAccessor::GetIndexes(table_oid_t table) { return dbc_->GetIndexes(txn_, table); }
 
-index_oid_t CatalogAccessor::GetIndexOid(const std::string &name) {
+index_oid_t CatalogAccessor::GetIndexOid(std::string name) {
+  NormalizeObjectName(name);
   for (auto &path : search_path_) {
     index_oid_t search_result = dbc_->GetIndexOid(txn_, path, name);
     if (search_result != INVALID_INDEX_OID) return search_result;
@@ -69,14 +85,16 @@ index_oid_t CatalogAccessor::GetIndexOid(const std::string &name) {
   return INVALID_INDEX_OID;
 }
 
-index_oid_t CatalogAccessor::GetIndexOid(namespace_oid_t ns, const std::string &name) {
+index_oid_t CatalogAccessor::GetIndexOid(namespace_oid_t ns, std::string name) {
+  NormalizeObjectName(name);
   return dbc_->GetIndexOid(txn_, ns, name);
 }
 
 std::vector<index_oid_t> CatalogAccessor::GetIndexOids(table_oid_t table) { return dbc_->GetIndexes(txn_, table); }
 
-index_oid_t CatalogAccessor::CreateIndex(namespace_oid_t ns, table_oid_t table, const std::string &name,
+index_oid_t CatalogAccessor::CreateIndex(namespace_oid_t ns, table_oid_t table, std::string name,
                                          const IndexSchema &schema) {
+  NormalizeObjectName(name);
   return dbc_->CreateIndex(txn_, ns, name, table, schema);
 }
 

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -51,7 +51,7 @@ table_oid_t CatalogAccessor::CreateTable(namespace_oid_t ns, std::string name, c
 }
 
 bool CatalogAccessor::RenameTable(table_oid_t table, std::string new_table_name) {
-  NormalizeObjectName(new_table_name);
+  NormalizeObjectName(&new_table_name);
   return dbc_->RenameTable(txn_, table, new_table_name);
 }
 

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -51,6 +51,7 @@ table_oid_t CatalogAccessor::CreateTable(namespace_oid_t ns, std::string name, c
 }
 
 bool CatalogAccessor::RenameTable(table_oid_t table, std::string new_table_name) {
+  NormalizeObjectName(new_table_name);
   return dbc_->RenameTable(txn_, table, new_table_name);
 }
 

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -6,12 +6,12 @@
 
 namespace terrier::catalog {
 db_oid_t CatalogAccessor::GetDatabaseOid(std::string name) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   return catalog_->GetDatabaseOid(txn_, name);
 }
 
 db_oid_t CatalogAccessor::CreateDatabase(std::string name) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   return catalog_->CreateDatabase(txn_, name, true);
 }
 
@@ -20,19 +20,19 @@ bool CatalogAccessor::DropDatabase(db_oid_t db) { return catalog_->DeleteDatabas
 void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) { search_path_ = std::move(namespaces); }
 
 namespace_oid_t CatalogAccessor::GetNamespaceOid(std::string name) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   return dbc_->GetNamespaceOid(txn_, name);
 }
 
 namespace_oid_t CatalogAccessor::CreateNamespace(std::string name) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   return dbc_->CreateNamespace(txn_, name);
 }
 
 bool CatalogAccessor::DropNamespace(namespace_oid_t ns) { return dbc_->DeleteNamespace(txn_, ns); }
 
 table_oid_t CatalogAccessor::GetTableOid(std::string name) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   for (auto &path : search_path_) {
     table_oid_t search_result = dbc_->GetTableOid(txn_, path, name);
     if (search_result != INVALID_TABLE_OID) return search_result;
@@ -41,12 +41,12 @@ table_oid_t CatalogAccessor::GetTableOid(std::string name) {
 }
 
 table_oid_t CatalogAccessor::GetTableOid(namespace_oid_t ns, std::string name) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   return dbc_->GetTableOid(txn_, ns, name);
 }
 
 table_oid_t CatalogAccessor::CreateTable(namespace_oid_t ns, std::string name, const Schema &schema) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   return dbc_->CreateTable(txn_, ns, name, schema);
 }
 
@@ -77,7 +77,7 @@ std::vector<constraint_oid_t> CatalogAccessor::GetConstraints(table_oid_t table)
 std::vector<index_oid_t> CatalogAccessor::GetIndexes(table_oid_t table) { return dbc_->GetIndexes(txn_, table); }
 
 index_oid_t CatalogAccessor::GetIndexOid(std::string name) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   for (auto &path : search_path_) {
     index_oid_t search_result = dbc_->GetIndexOid(txn_, path, name);
     if (search_result != INVALID_INDEX_OID) return search_result;
@@ -86,7 +86,7 @@ index_oid_t CatalogAccessor::GetIndexOid(std::string name) {
 }
 
 index_oid_t CatalogAccessor::GetIndexOid(namespace_oid_t ns, std::string name) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   return dbc_->GetIndexOid(txn_, ns, name);
 }
 
@@ -94,7 +94,7 @@ std::vector<index_oid_t> CatalogAccessor::GetIndexOids(table_oid_t table) { retu
 
 index_oid_t CatalogAccessor::CreateIndex(namespace_oid_t ns, table_oid_t table, std::string name,
                                          const IndexSchema &schema) {
-  NormalizeObjectName(name);
+  NormalizeObjectName(&name);
   return dbc_->CreateIndex(txn_, ns, name, table, schema);
 }
 

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -205,8 +205,7 @@ namespace_oid_t DatabaseCatalog::CreateNamespace(transaction::TransactionContext
 bool DatabaseCatalog::CreateNamespace(transaction::TransactionContext *const txn, const std::string &name,
                                       const namespace_oid_t ns_oid) {
   // Step 1: Insert into table
-  auto name_varlen = storage::StorageUtil::CreateVarlen(name);
-  name_varlen.ToLower();
+  const auto name_varlen = storage::StorageUtil::CreateVarlen(name);
   // Get & Fill Redo Record
   const std::vector<col_oid_t> table_oids{NSPNAME_COL_OID, NSPOID_COL_OID};
   // NOLINTNEXTLINE
@@ -309,8 +308,7 @@ namespace_oid_t DatabaseCatalog::GetNamespaceOid(transaction::TransactionContext
   byte *const buffer = common::AllocationUtil::AllocateAligned(name_pri.ProjectedRowSize());
   auto *pr = name_pri.InitializeRow(buffer);
   // Scan the name index
-  auto name_varlen = storage::StorageUtil::CreateVarlen(name);
-  name_varlen.ToLower();
+  const auto name_varlen = storage::StorageUtil::CreateVarlen(name);
   *(reinterpret_cast<storage::VarlenEntry *>(pr->AccessForceNotNull(0))) = name_varlen;
   std::vector<storage::TupleSlot> index_results;
   namespaces_name_index_->ScanKey(*txn, *pr, &index_results);
@@ -362,8 +360,7 @@ bool DatabaseCatalog::CreateColumn(transaction::TransactionContext *const txn, c
       reinterpret_cast<storage::VarlenEntry *>(redo->Delta()->AccessForceNotNull(table_pm[ADSRC_COL_OID]));
   *oid_entry = static_cast<uint32_t>(col.Oid());
   *relid_entry = class_oid;
-  storage::VarlenEntry name_varlen = storage::StorageUtil::CreateVarlen(col.Name());
-  name_varlen.ToLower();
+  const auto name_varlen = storage::StorageUtil::CreateVarlen(col.Name());
 
   *name_entry = name_varlen;
   *type_entry = col.Type();
@@ -709,8 +706,7 @@ std::pair<uint32_t, postgres::ClassKind> DatabaseCatalog::GetClassOidKind(transa
                                                                           const std::string &name) {
   const auto name_pri = classes_name_index_->GetProjectedRowInitializer();
 
-  auto name_varlen = storage::StorageUtil::CreateVarlen(name);
-  name_varlen.ToLower();
+  const auto name_varlen = storage::StorageUtil::CreateVarlen(name);
 
   // Buffer is large enough to hold all prs
   auto *const buffer = common::AllocationUtil::AllocateAligned(name_pri.ProjectedRowSize());
@@ -1180,8 +1176,7 @@ bool DatabaseCatalog::CreateIndexEntry(transaction::TransactionContext *const tx
   auto *index_oid_ptr = class_insert_pr->AccessForceNotNull(index_oid_offset);
   *(reinterpret_cast<uint32_t *>(index_oid_ptr)) = static_cast<uint32_t>(index_oid);
 
-  auto name_varlen = storage::StorageUtil::CreateVarlen(name);
-  name_varlen.ToLower();
+  const auto name_varlen = storage::StorageUtil::CreateVarlen(name);
 
   // Write the name into the PR
   const auto name_offset = pr_map[RELNAME_COL_OID];
@@ -1345,8 +1340,7 @@ void DatabaseCatalog::InsertType(transaction::TransactionContext *txn, type::Typ
 
   // Populate type name
   offset = col_map[TYPNAME_COL_OID];
-  auto name_varlen = storage::StorageUtil::CreateVarlen(name);
-  name_varlen.ToLower();
+  const auto name_varlen = storage::StorageUtil::CreateVarlen(name);
 
   *(reinterpret_cast<storage::VarlenEntry *>(delta->AccessForceNotNull(offset))) = name_varlen;
 
@@ -1483,8 +1477,7 @@ bool DatabaseCatalog::CreateTableEntry(transaction::TransactionContext *const tx
   *(reinterpret_cast<char *>(kind_ptr)) = static_cast<char>(postgres::ClassKind::REGULAR_TABLE);
 
   // Create the necessary varlen for storage operations
-  auto name_varlen = storage::StorageUtil::CreateVarlen(name);
-  name_varlen.ToLower();
+  const auto name_varlen = storage::StorageUtil::CreateVarlen(name);
 
   // Write the name into the PR
   const auto name_offset = pr_map[RELNAME_COL_OID];

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <utility>
 #include <vector>
@@ -265,6 +266,10 @@ class CatalogAccessor {
   db_oid_t db_oid_;
   std::vector<namespace_oid_t> search_path_;
 
+  /**
+   * A helper function to ensure that user-defined object names are standardized prior to doing catalog operations
+   * @param name of object that should be sanitized/normalized
+   */
   static void NormalizeObjectName(std::string *name) {
     std::transform(name->begin(), name->end(), name->begin(), [](auto &&c) { return std::tolower(c); });
   }

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -41,14 +41,14 @@ class CatalogAccessor {
    * @param name of the database
    * @return OID for the database, INVALID_DATABASE_OID if the database does not exist
    */
-  db_oid_t GetDatabaseOid(const std::string &name);
+  db_oid_t GetDatabaseOid(std::string name);
 
   /**
    * Given a database name, create a new database entry in the catalog and assign it an OID
    * @param name of the new database
    * @return OID for the database, INVALID_DATABASE_OID if the database already exists
    */
-  db_oid_t CreateDatabase(const std::string &name);
+  db_oid_t CreateDatabase(std::string name);
 
   /**
    * Drop all entries in the catalog that belong to the database, including the database entry
@@ -74,14 +74,14 @@ class CatalogAccessor {
    * @param name of the namespace
    * @return OID of the namespace, INVALID_NAMESPACE_OID if the namespace was not found
    */
-  namespace_oid_t GetNamespaceOid(const std::string &name);
+  namespace_oid_t GetNamespaceOid(std::string name);
 
   /**
    * Given a namespace name, resolve it to the corresponding OID
    * @param name of the namespace
    * @return OID of the namespace, INVALID_NAMESPACE_OID if the namespace was not found
    */
-  namespace_oid_t CreateNamespace(const std::string &name);
+  namespace_oid_t CreateNamespace(std::string name);
 
   /**
    * Drop all entries in the catalog that belong to the namespace, including the namespace entry
@@ -95,7 +95,7 @@ class CatalogAccessor {
    * @param name of the table
    * @return OID of the table, INVALID_TABLE_OID if the table was not found
    */
-  table_oid_t GetTableOid(const std::string &name);
+  table_oid_t GetTableOid(std::string name);
 
   /**
    * Given a table name and its owning namespace, resolve it to the corresponding OID
@@ -103,7 +103,7 @@ class CatalogAccessor {
    * @param name of the table
    * @return OID of the table, INVALID_TABLE_OID if the table was not found
    */
-  table_oid_t GetTableOid(namespace_oid_t ns, const std::string &name);
+  table_oid_t GetTableOid(namespace_oid_t ns, std::string name);
 
   /**
    * Given a table name, create a new table entry in the catalog and assign it an OID. This
@@ -118,7 +118,7 @@ class CatalogAccessor {
    * schema object after this call, they should use the GetSchema function to
    * obtain the authoritative schema for this table.
    */
-  table_oid_t CreateTable(namespace_oid_t ns, const std::string &name, const Schema &schema);
+  table_oid_t CreateTable(namespace_oid_t ns, std::string name, const Schema &schema);
 
   /**
    * Rename the table from its current string to the new one.  The renaming could fail
@@ -130,7 +130,7 @@ class CatalogAccessor {
    *
    * @note This operation will write-lock the table entry until the transaction closes.
    */
-  bool RenameTable(table_oid_t table, const std::string &new_table_name);
+  bool RenameTable(table_oid_t table, std::string new_table_name);
 
   /**
    * Drop the table and all corresponding indices from the catalog.
@@ -199,7 +199,7 @@ class CatalogAccessor {
    * @param name of the index
    * @return OID of the index, INVALID_INDEX_OID if the index was not found
    */
-  index_oid_t GetIndexOid(const std::string &name);
+  index_oid_t GetIndexOid(std::string name);
 
   /**
    * Given an index name and the owning namespace, resolve it to the corresponding OID
@@ -207,7 +207,7 @@ class CatalogAccessor {
    * @param name of the index
    * @return OID of the index, INVALID_INDEX_OID if the index was not found
    */
-  index_oid_t GetIndexOid(namespace_oid_t ns, const std::string &name);
+  index_oid_t GetIndexOid(namespace_oid_t ns, std::string name);
 
   /**
    * Given a table, find all indexes for data in that table
@@ -224,7 +224,7 @@ class CatalogAccessor {
    * @param schema describing the new index
    * @return OID for the index, INVALID_INDEX_OID if the operation failed
    */
-  index_oid_t CreateIndex(namespace_oid_t ns, table_oid_t table, const std::string &name, const IndexSchema &schema);
+  index_oid_t CreateIndex(namespace_oid_t ns, table_oid_t table, std::string name, const IndexSchema &schema);
 
   /**
    * Gets the schema that was used to define the index
@@ -264,6 +264,10 @@ class CatalogAccessor {
   transaction::TransactionContext *txn_;
   db_oid_t db_oid_;
   std::vector<namespace_oid_t> search_path_;
+
+  static void NormalizeObjectName(std::string *name) {
+    std::transform(name->begin(), name->end(), name->begin(), std::tolower);
+  }
 
   /**
    * Instantiates a new accessor into the catalog for the given database.

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -266,7 +266,7 @@ class CatalogAccessor {
   std::vector<namespace_oid_t> search_path_;
 
   static void NormalizeObjectName(std::string *name) {
-    std::transform(name->begin(), name->end(), name->begin(), std::tolower);
+    std::transform(name->begin(), name->end(), name->begin(), [](auto &&c) { return std::tolower(c); });
   }
 
   /**

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -314,7 +314,7 @@ class VarlenEntry {
     byte *content = prefix_;
     if (!IsInlined()) {
       content = content_;
-      for (auto i = 0u; i < sizeof(uint32_t); i++)
+      for (auto & i : prefix_)
         prefix_[i] = static_cast<byte>(std::tolower(static_cast<unsigned char>(prefix_[i])));
     }
 

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -314,8 +314,8 @@ class VarlenEntry {
     byte *content = prefix_;
     if (!IsInlined()) {
       content = content_;
-      for (auto & i : prefix_)
-        prefix_[i] = static_cast<byte>(std::tolower(static_cast<unsigned char>(prefix_[i])));
+      for (auto &c : prefix_)
+        c = static_cast<byte>(std::tolower(static_cast<unsigned char>(c)));
     }
 
     // Process the full content (doubles as the prefix for inlined strings)

--- a/src/include/storage/storage_defs.h
+++ b/src/include/storage/storage_defs.h
@@ -306,27 +306,10 @@ class VarlenEntry {
     return std::string_view(reinterpret_cast<const char *const>(Content()), Size());
   }
 
-  /**
-   * Helper function to normalize a varlen to lowercase in place
-   */
-  void ToLower() {
-    // If we're not inlined, then we need to fix the prefix array in addition to the actual string
-    byte *content = prefix_;
-    if (!IsInlined()) {
-      content = content_;
-      for (auto &c : prefix_)
-        c = static_cast<byte>(std::tolower(static_cast<unsigned char>(c)));
-    }
-
-    // Process the full content (doubles as the prefix for inlined strings)
-    for (auto i = 0; i < (size_ & (INT32_MAX - 1)); i++)
-      content[i] = static_cast<byte>(std::tolower(static_cast<unsigned char>(content[i])));
-  }
-
  private:
   int32_t size_;                   // buffer reclaimable => sign bit is 0 or size <= InlineThreshold
   byte prefix_[sizeof(uint32_t)];  // Explicit padding so that we can use these bits for inlined values or prefix
-  byte *content_;                  // pointer to content of the varlen entry if not inlined
+  const byte *content_;            // pointer to content of the varlen entry if not inlined
 };
 // To make sure our explicit padding is not screwing up the layout
 static_assert(sizeof(VarlenEntry) == 16, "size of the class should be 16 bytes");

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -361,7 +361,8 @@ TEST_F(CatalogTests, NameNormalizationTest) {
 
   txn = txn_manager_->BeginTransaction();
   accessor = catalog_->GetAccessor(txn, db_);
-  EXPECT_EQ(ns_oid, accessor->CreateNamespace("TEST_NAMESPACE"));  // Should cause a name conflict
+  EXPECT_EQ(catalog::INVALID_NAMESPACE_OID, accessor->CreateNamespace("TEST_NAMESPACE"));  // should conflict
+  EXPECT_EQ(ns_oid, accessor->GetNamespaceOid("TEST_NAMESPACE"));  // Should succeed
   auto dbc = catalog_->GetDatabaseCatalog(txn, db_);
   EXPECT_EQ(ns_oid, dbc->GetNamespaceOid(txn, "test_namespace")); // Should match (normalized form)
   EXPECT_NE(catalog::INVALID_NAMESPACE_OID, dbc->GetNamespaceOid(txn, "TeSt_NaMeSpAcE")); // Not normalized

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -363,8 +363,8 @@ TEST_F(CatalogTests, NameNormalizationTest) {
   accessor = catalog_->GetAccessor(txn, db_);
   EXPECT_EQ(ns_oid, accessor->CreateNamespace("TEST_NAMESPACE"));  // Should cause a name conflict
   auto dbc = catalog_->GetDatabaseCatalog(txn, db_);
-  EXPECT_EQ(ns_oid, dbc_->GetNamespaceOid(txn, "test_namespace")); // Should match (normalized form)
-  EXPECT_NE(catalog::INVALID_NAMESPACE_OID, dbc_->GetNamespaceOid(txn, "TeSt_NaMeSpAcE")); // Not normalized
+  EXPECT_EQ(ns_oid, dbc->GetNamespaceOid(txn, "test_namespace")); // Should match (normalized form)
+  EXPECT_NE(catalog::INVALID_NAMESPACE_OID, dbc->GetNamespaceOid(txn, "TeSt_NaMeSpAcE")); // Not normalized
   txn_manager_->Abort(txn);
   delete accessor;
 }

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -365,7 +365,7 @@ TEST_F(CatalogTests, NameNormalizationTest) {
   EXPECT_EQ(ns_oid, accessor->GetNamespaceOid("TEST_NAMESPACE"));  // Should succeed
   auto dbc = catalog_->GetDatabaseCatalog(txn, db_);
   EXPECT_EQ(ns_oid, dbc->GetNamespaceOid(txn, "test_namespace")); // Should match (normalized form)
-  EXPECT_NE(catalog::INVALID_NAMESPACE_OID, dbc->GetNamespaceOid(txn, "TeSt_NaMeSpAcE")); // Not normalized
+  EXPECT_EQ(catalog::INVALID_NAMESPACE_OID, dbc->GetNamespaceOid(txn, "TeSt_NaMeSpAcE")); // Not normalized
   txn_manager_->Abort(txn);
   delete accessor;
 }

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -361,9 +361,7 @@ TEST_F(CatalogTests, NameNormalizationTest) {
 
   txn = txn_manager_->BeginTransaction();
   accessor = catalog_->GetAccessor(txn, db_);
-
   EXPECT_EQ(ns_oid, accessor->CreateNamespace("TEST_NAMESPACE"));  // Should cause a name conflict
-
   auto dbc = catalog_->GetDatabaseCatalog(txn, db_);
   EXPECT_EQ(ns_oid, dbc_->GetNamespaceOid(txn, "test_namespace")); // Should match (normalized form)
   EXPECT_NE(catalog::INVALID_NAMESPACE_OID, dbc_->GetNamespaceOid(txn, "TeSt_NaMeSpAcE")); // Not normalized

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -362,10 +362,10 @@ TEST_F(CatalogTests, NameNormalizationTest) {
   txn = txn_manager_->BeginTransaction();
   accessor = catalog_->GetAccessor(txn, db_);
   EXPECT_EQ(catalog::INVALID_NAMESPACE_OID, accessor->CreateNamespace("TEST_NAMESPACE"));  // should conflict
-  EXPECT_EQ(ns_oid, accessor->GetNamespaceOid("TEST_NAMESPACE"));  // Should succeed
+  EXPECT_EQ(ns_oid, accessor->GetNamespaceOid("TEST_NAMESPACE"));                          // Should succeed
   auto dbc = catalog_->GetDatabaseCatalog(txn, db_);
-  EXPECT_EQ(ns_oid, dbc->GetNamespaceOid(txn, "test_namespace")); // Should match (normalized form)
-  EXPECT_EQ(catalog::INVALID_NAMESPACE_OID, dbc->GetNamespaceOid(txn, "TeSt_NaMeSpAcE")); // Not normalized
+  EXPECT_EQ(ns_oid, dbc->GetNamespaceOid(txn, "test_namespace"));  // Should match (normalized form)
+  EXPECT_EQ(catalog::INVALID_NAMESPACE_OID, dbc->GetNamespaceOid(txn, "TeSt_NaMeSpAcE"));  // Not normalized
   txn_manager_->Abort(txn);
   delete accessor;
 }


### PR DESCRIPTION
This PR fixes type sensitivity for catalog items (naming objects and fetching objects by name) by forcing all user-defined input strings to lowercase before proceeding.  To avoid copying the string into an intermediary value, I opted to make the internal varlen field `contents_` mutable but this should not be too risky as the getter methods only expose immutable views.