### PR TITLE
Switch InsertPlanNode.parameter_info to use std::vector

### DIFF
--- a/src/include/planner/plannodes/insert_plan_node.h
+++ b/src/include/planner/plannodes/insert_plan_node.h
@@ -69,7 +69,6 @@ class InsertPlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param value_idx index of value in values vector
      * @param col_oid oid of column where value at value_idx should be inserted
      * @return builder object
      */

--- a/src/include/planner/plannodes/insert_plan_node.h
+++ b/src/include/planner/plannodes/insert_plan_node.h
@@ -85,7 +85,7 @@ class InsertPlanNode : public AbstractPlanNode {
      */
     std::shared_ptr<InsertPlanNode> Build() {
       TERRIER_ASSERT(!values_.empty(), "Can't have an empty insert plan");
-      TERRIER_ASSERT(values_[0].size() == parameter_info_.size(), "Must have one col idx for each field of value");
+      TERRIER_ASSERT(values_[0].size() == parameter_info_.size(), "Must have parameter info for each value");
       return std::shared_ptr<InsertPlanNode>(new InsertPlanNode(std::move(children_), std::move(output_schema_),
                                                                 database_oid_, namespace_oid_, table_oid_,
                                                                 std::move(values_), std::move(parameter_info_)));

--- a/src/include/planner/plannodes/insert_plan_node.h
+++ b/src/include/planner/plannodes/insert_plan_node.h
@@ -71,9 +71,10 @@ class InsertPlanNode : public AbstractPlanNode {
     /**
      * @param col_oid oid of column where value at value_idx should be inserted
      * @return builder object
+     * @warning The caller must push column index in order. The ith call to AddParameterInfo means for a value tuple
+     * values_[t], values_[t][i] will be inserted into the column indicated by the input col_oid.
      */
     Builder &AddParameterInfo(catalog::col_oid_t col_oid) {
-      // We rely on the caller to push col idx in order
       parameter_info_.emplace_back(col_oid);
       return *this;
     }

--- a/src/planner/plannodes/drop_trigger_plan_node.cpp
+++ b/src/planner/plannodes/drop_trigger_plan_node.cpp
@@ -6,7 +6,7 @@ namespace terrier::planner {
 common::hash_t DropTriggerPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Hash databse_oid
+  // Hash database_oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
 
   // Hash namespace oid

--- a/src/planner/plannodes/drop_view_plan_node.cpp
+++ b/src/planner/plannodes/drop_view_plan_node.cpp
@@ -14,11 +14,11 @@ common::hash_t DropViewPlanNode::Hash() const {
 
   // Hash view_oid
   auto view_oid = GetViewOid();
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(&view_oid));
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(!view_oid));
 
   // Hash if_exists_
   auto if_exist = IsIfExists();
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(&if_exist));
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(!if_exist));
 
   return hash;
 }

--- a/src/planner/plannodes/insert_plan_node.cpp
+++ b/src/planner/plannodes/insert_plan_node.cpp
@@ -24,12 +24,8 @@ common::hash_t InsertPlanNode::Hash() const {
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(table_oid_));
 
   // Hash parameter_info
-  // Important: The ordering of the keys matter when we want to compute the hash!
-  // HACK HACK HACK
-  std::map<uint32_t, catalog::col_oid_t> ordered(parameter_info_.begin(), parameter_info_.end());
-  for (const auto pair : ordered) {
-    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(pair.first));
-    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(pair.second));
+  for (const auto &col_oid : parameter_info_) {
+    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(col_oid));
   }
 
   // Values
@@ -64,12 +60,10 @@ bool InsertPlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   // Parameter info
   if (parameter_info_.size() != other.parameter_info_.size()) return false;
-  for (const auto this_pair : parameter_info_) {
-    auto other_pair = other.parameter_info_.find(this_pair.first);
-    if (other_pair == other.parameter_info_.end()) return false;
-    if (this_pair.second != other_pair->second) return false;
-  }
 
+  for (int i = 0; i < static_cast<int>(parameter_info_.size()); i++) {
+    if (parameter_info_[i] != other.parameter_info_[i]) return false;
+  }
   return true;
 }
 
@@ -89,7 +83,7 @@ void InsertPlanNode::FromJson(const nlohmann::json &j) {
   namespace_oid_ = j.at("namespace_oid").get<catalog::namespace_oid_t>();
   table_oid_ = j.at("table_oid").get<catalog::table_oid_t>();
   values_ = j.at("values").get<std::vector<std::vector<type::TransientValue>>>();
-  parameter_info_ = j.at("parameter_info").get<std::unordered_map<uint32_t, catalog::col_oid_t>>();
+  parameter_info_ = j.at("parameter_info").get<std::vector<catalog::col_oid_t>>();
 }
 
 }  // namespace terrier::planner

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -758,8 +758,8 @@ TEST(PlanNodeJsonTest, InsertPlanNodeJsonTest) {
                        .SetTableOid(catalog::table_oid_t(1))
                        .AddValues(get_values(0, 2))
                        .AddValues(get_values(1, 2))
-                       .AddParameterInfo(0, catalog::col_oid_t(0))
-                       .AddParameterInfo(1, catalog::col_oid_t(1))
+                       .AddParameterInfo(catalog::col_oid_t(0))
+                       .AddParameterInfo(catalog::col_oid_t(1))
                        .Build();
 
   // Serialize to Json
@@ -782,9 +782,9 @@ TEST(PlanNodeJsonTest, InsertPlanNodeJsonTest) {
                         .SetTableOid(catalog::table_oid_t(1))
                         .AddValues(get_values(0, 3))
                         .AddValues(get_values(1, 3))
-                        .AddParameterInfo(0, catalog::col_oid_t(0))
-                        .AddParameterInfo(1, catalog::col_oid_t(1))
-                        .AddParameterInfo(2, catalog::col_oid_t(2))
+                        .AddParameterInfo(catalog::col_oid_t(0))
+                        .AddParameterInfo(catalog::col_oid_t(1))
+                        .AddParameterInfo(catalog::col_oid_t(2))
                         .Build();
   auto json2 = plan_node2->ToJson();
   EXPECT_FALSE(json2.is_null());

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -784,7 +784,7 @@ TEST(PlanNodeJsonTest, InsertPlanNodeJsonTest) {
                         .AddValues(get_values(1, 3))
                         .AddParameterInfo(0, catalog::col_oid_t(0))
                         .AddParameterInfo(1, catalog::col_oid_t(1))
-                        .AddParameterInfo(8, catalog::col_oid_t(999))
+                        .AddParameterInfo(2, catalog::col_oid_t(2))
                         .Build();
   auto json2 = plan_node2->ToJson();
   EXPECT_FALSE(json2.is_null());


### PR DESCRIPTION
This commit tries to fix #427
1. Change parameter_info_ from `std::unordered_map<uint32_t /* value index */, catalog::col_oid_t>` to `std::vecto\<catalog::col_oid_t\>`
2. Change method signature AddParameterInfo from` Builder &AddParameterInfo(uint32_t value_idx, catalog::col_oid_t col_oid)` to `Builder &AddParameterInfo(catalog::col_oid_t col_oid)`. We rely on the caller to push col idx in order.
3. Fix hash function in src/planner/plannodes/drop_view_plan_node.cpp. From my understanding, we should calculate hash on the value (`! view_oid `) instead of on the address (`& view_oid`).