### PR TITLE
Fix to null TransientValue serialization

### DIFF
--- a/src/include/type/transient_value.h
+++ b/src/include/type/transient_value.h
@@ -181,8 +181,7 @@ class TransientValue {
   nlohmann::json ToJson() const {
     nlohmann::json j;
     j["type"] = type_;
-    j["data"] = data_;
-    if (Type() == TypeId::VARCHAR) {
+    if (Type() == TypeId::VARCHAR && !Null()) {
       const uint32_t length = *reinterpret_cast<const uint32_t *const>(data_);
       auto varchar = std::string(reinterpret_cast<const char *const>(data_), length + sizeof(uint32_t));
       j["data"] = varchar;
@@ -199,10 +198,9 @@ class TransientValue {
    */
   void FromJson(const nlohmann::json &j) {
     type_ = j.at("type").get<TypeId>();
-    if (Type() == TypeId::VARCHAR) {
+    if (Type() == TypeId::VARCHAR && !Null()) {
       data_ = 0;
       CopyVarChar(reinterpret_cast<const char *const>(j.at("data").get<std::string>().c_str()));
-
     } else {
       data_ = j.at("data").get<uintptr_t>();
     }

--- a/test/parser/expression_test.cpp
+++ b/test/parser/expression_test.cpp
@@ -202,6 +202,30 @@ TEST(ExpressionTests, ConstantValueExpressionJsonTest) {
 }
 
 // NOLINTNEXTLINE
+TEST(ExpressionTests, NullConstantValueExpressionJsonTest) {
+  // Create expression
+  auto original_expr =
+      std::make_shared<ConstantValueExpression>(type::TransientValueFactory::GetNull(type::TypeId::VARCHAR));
+
+  EXPECT_EQ(*original_expr, *(original_expr->Copy()));
+
+  // Serialize expression
+  auto json = original_expr->ToJson();
+  EXPECT_FALSE(json.is_null());
+
+  const auto from_json_expr = new ConstantValueExpression();
+  from_json_expr->FromJson(json);
+  EXPECT_TRUE(*original_expr == *from_json_expr);
+
+  delete from_json_expr;
+
+  // Deserialize expression
+  auto deserialized_expression = DeserializeExpression(json);
+  EXPECT_EQ(*original_expr, *deserialized_expression);
+  EXPECT_TRUE(static_cast<ConstantValueExpression *>(deserialized_expression.get())->GetValue().Null());
+}
+
+// NOLINTNEXTLINE
 TEST(ExpressionTests, ConjunctionExpressionTest) {
   std::vector<std::shared_ptr<AbstractExpression>> children1;
   children1.emplace_back(std::make_shared<ConstantValueExpression>(type::TransientValueFactory::GetBoolean(true)));


### PR DESCRIPTION
As found by @jrolli, we don't correctly serialize/deserialize out null `TransientValue`. 