### PR TITLE
Expressions-only version of 386, breaks plan nodes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,13 @@
 
 file(GLOB_RECURSE TERRIER_SRCS ${PROJECT_SOURCE_DIR}/src/*.cpp ${PROJECT_SOURCE_DIR}/src/include/*.h)
 list(REMOVE_ITEM TERRIER_SRCS ${PROJECT_SOURCE_DIR}/src/main/terrier.cpp)
+set (EXCLUDE_DIR "/planner/")
+foreach (TMP_PATH ${TERRIER_SRCS})
+    string (FIND ${TMP_PATH} ${EXCLUDE_DIR} EXCLUDE_DIR_FOUND)
+    if (NOT ${EXCLUDE_DIR_FOUND} EQUAL -1)
+        list (REMOVE_ITEM TERRIER_SRCS ${TMP_PATH})
+    endif ()
+endforeach(TMP_PATH)
 
 ###############################################
 # Third party sources

--- a/src/include/common/json.h
+++ b/src/include/common/json.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "common/managed_pointer.h"
 #include "nlohmann/json.hpp"
 
 namespace terrier::common {
@@ -9,20 +10,32 @@ namespace terrier::common {
  */
 using json = nlohmann::json;
 
-#define DEFINE_JSON_DECLARATIONS(ClassName)                                                    \
-  inline void to_json(nlohmann::json &j, const ClassName &c) { j = c.ToJson(); } /* NOLINT */  \
-  inline void to_json(nlohmann::json &j, const std::shared_ptr<ClassName> c) {   /* NOLINT */  \
-    if (c != nullptr) {                                                                        \
-      j = *c;                                                                                  \
-    } else {                                                                                   \
-      j = nullptr;                                                                             \
-    }                                                                                          \
-  }                                                                                            \
-  inline void from_json(const nlohmann::json &j, ClassName &c) { c.FromJson(j); } /* NOLINT */ \
-  inline void from_json(const nlohmann::json &j, std::shared_ptr<ClassName> c) {  /* NOLINT */ \
-    if (c != nullptr) {                                                                        \
-      c->FromJson(j);                                                                          \
-    }                                                                                          \
+#define DEFINE_JSON_DECLARATIONS(ClassName)                                                          \
+  inline void to_json(nlohmann::json &j, const ClassName &c) { j = c.ToJson(); } /* NOLINT */        \
+  inline void to_json(nlohmann::json &j, const ClassName *c) {                   /* NOLINT */        \
+    if (c != nullptr) {                                                                              \
+      j = *c;                                                                                        \
+    } else {                                                                                         \
+      j = nullptr;                                                                                   \
+    }                                                                                                \
+  }                                                                                                  \
+  inline void to_json(nlohmann::json &j, const common::ManagedPointer<ClassName> c) { /* NOLINT */   \
+    if (c) {                                                                                         \
+      j = *c;                                                                                        \
+    } else {                                                                                         \
+      j = nullptr;                                                                                   \
+    }                                                                                                \
+  }                                                                                                  \
+  inline void from_json(const nlohmann::json &j, ClassName &c) { c.FromJson(j); } /* NOLINT */       \
+  inline void from_json(const nlohmann::json &j, ClassName *c) {                  /* NOLINT */       \
+    if (c != nullptr) {                                                                              \
+      c->FromJson(j);                                                                                \
+    }                                                                                                \
+  }                                                                                                  \
+  inline void from_json(const nlohmann::json &j, common::ManagedPointer<ClassName> c) { /* NOLINT */ \
+    if (c) {                                                                                         \
+      c->FromJson(j);                                                                                \
+    }                                                                                                \
   }
 
 }  // namespace terrier::common

--- a/src/include/parser/analyze_statement.h
+++ b/src/include/parser/analyze_statement.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/managed_pointer.h"
 #include "common/sql_node_visitor.h"
 #include "parser/sql_statement.h"
 #include "parser/table_ref.h"
@@ -22,9 +23,9 @@ class AnalyzeStatement : public SQLStatement {
    * @param analyze_table table to be analyzed
    * @param analyze_columns columns to be analyzed
    */
-  AnalyzeStatement(std::shared_ptr<TableRef> analyze_table, std::shared_ptr<std::vector<std::string>> analyze_columns)
+  AnalyzeStatement(common::ManagedPointer<TableRef> analyze_table, std::vector<std::string> analyze_columns)
       : SQLStatement(StatementType::ANALYZE),
-        analyze_table_(std::move(analyze_table)),
+        analyze_table_(analyze_table),
         analyze_columns_(std::move(analyze_columns)) {}
 
   ~AnalyzeStatement() override = default;
@@ -34,16 +35,16 @@ class AnalyzeStatement : public SQLStatement {
   /**
    * @return analyze table
    */
-  std::shared_ptr<TableRef> GetAnalyzeTable() { return analyze_table_; }
+  common::ManagedPointer<TableRef> GetAnalyzeTable() { return analyze_table_; }
 
   /**
    * @return analyze columns
    */
-  std::shared_ptr<std::vector<std::string>> GetAnalyzeColumns() { return analyze_columns_; }
+  std::vector<std::string> GetAnalyzeColumns() { return analyze_columns_; }
 
  private:
-  const std::shared_ptr<TableRef> analyze_table_;
-  const std::shared_ptr<std::vector<std::string>> analyze_columns_;
+  const common::ManagedPointer<TableRef> analyze_table_;
+  const std::vector<std::string> analyze_columns_;
 };
 
 }  // namespace parser

--- a/src/include/parser/copy_statement.h
+++ b/src/include/parser/copy_statement.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 
+#include "common/managed_pointer.h"
 #include "common/sql_node_visitor.h"
 #include "parser/select_statement.h"
 #include "parser/sql_statement.h"
@@ -27,11 +28,11 @@ class CopyStatement : public SQLStatement {
    * @param quote quote character
    * @param escape escape character
    */
-  CopyStatement(std::shared_ptr<TableRef> table, std::shared_ptr<SelectStatement> select_stmt, std::string file_path,
-                ExternalFileFormat format, bool is_from, char delimiter, char quote, char escape)
+  CopyStatement(common::ManagedPointer<TableRef> table, common::ManagedPointer<SelectStatement> select_stmt,
+                std::string file_path, ExternalFileFormat format, bool is_from, char delimiter, char quote, char escape)
       : SQLStatement(StatementType::COPY),
-        table_(std::move(table)),
-        select_stmt_(std::move(select_stmt)),
+        table_(table),
+        select_stmt_(select_stmt),
         file_path_(std::move(file_path)),
         format_(format),
         is_from_(is_from),
@@ -46,12 +47,12 @@ class CopyStatement : public SQLStatement {
   /**
    * @return copy table
    */
-  std::shared_ptr<TableRef> GetCopyTable() { return table_; }
+  common::ManagedPointer<TableRef> GetCopyTable() { return table_; }
 
   /**
    * @return select statement
    */
-  std::shared_ptr<SelectStatement> GetSelectStatement() { return select_stmt_; }
+  common::ManagedPointer<SelectStatement> GetSelectStatement() { return select_stmt_; }
 
   /**
    * @return file path
@@ -84,8 +85,8 @@ class CopyStatement : public SQLStatement {
   char GetEscapeChar() { return escape_; }
 
  private:
-  const std::shared_ptr<TableRef> table_;
-  const std::shared_ptr<SelectStatement> select_stmt_;
+  const common::ManagedPointer<TableRef> table_;
+  const common::ManagedPointer<SelectStatement> select_stmt_;
   const std::string file_path_;
   const ExternalFileFormat format_;
 

--- a/src/include/parser/create_function_statement.h
+++ b/src/include/parser/create_function_statement.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/managed_pointer.h"
 #include "common/sql_node_visitor.h"
 #include "expression/abstract_expression.h"
 #include "parser/sql_statement.h"
@@ -100,12 +101,13 @@ class CreateFunctionStatement : public SQLStatement {
    * @param as_type executable or query string
    */
   CreateFunctionStatement(bool replace, std::string func_name, std::vector<std::string> func_body,
-                          std::shared_ptr<ReturnType> return_type,
-                          std::vector<std::shared_ptr<FuncParameter>> func_parameters, PLType pl_type, AsType as_type)
+                          common::ManagedPointer<ReturnType> return_type,
+                          std::vector<common::ManagedPointer<FuncParameter>> func_parameters, PLType pl_type,
+                          AsType as_type)
       : SQLStatement(StatementType::CREATE_FUNC),
         replace_(replace),
         func_name_(std::move(func_name)),
-        return_type_(std::move(return_type)),
+        return_type_(return_type),
         func_body_(std::move(func_body)),
         func_parameters_(std::move(func_parameters)),
         pl_type_(pl_type),
@@ -126,7 +128,7 @@ class CreateFunctionStatement : public SQLStatement {
   /**
    * @return return type
    */
-  std::shared_ptr<ReturnType> GetFuncReturnType() { return return_type_; }
+  common::ManagedPointer<ReturnType> GetFuncReturnType() { return return_type_; }
 
   /**
    * @return function body
@@ -136,7 +138,7 @@ class CreateFunctionStatement : public SQLStatement {
   /**
    * @return function parameters
    */
-  std::vector<std::shared_ptr<FuncParameter>> GetFuncParameters() { return func_parameters_; }
+  std::vector<common::ManagedPointer<FuncParameter>> GetFuncParameters() { return func_parameters_; }
 
   /**
    * @return programming language type
@@ -151,9 +153,9 @@ class CreateFunctionStatement : public SQLStatement {
  private:
   const bool replace_ = false;
   const std::string func_name_;
-  const std::shared_ptr<ReturnType> return_type_;
+  const common::ManagedPointer<ReturnType> return_type_;
   const std::vector<std::string> func_body_;
-  const std::vector<std::shared_ptr<FuncParameter>> func_parameters_;
+  const std::vector<common::ManagedPointer<FuncParameter>> func_parameters_;
   const PLType pl_type_;
   const AsType as_type_;
 };

--- a/src/include/parser/delete_statement.h
+++ b/src/include/parser/delete_statement.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 
+#include "common/managed_pointer.h"
 #include "common/sql_node_visitor.h"
 #include "expression/abstract_expression.h"
 #include "parser/sql_statement.h"
@@ -28,33 +29,35 @@ class DeleteStatement : public SQLStatement {
    * @param table deletion target
    * @param expr condition for deletion
    */
-  DeleteStatement(std::shared_ptr<TableRef> table, std::shared_ptr<AbstractExpression> expr)
-      : SQLStatement(StatementType::DELETE), table_ref_(std::move(table)), expr_(std::move(expr)) {}
+  DeleteStatement(common::ManagedPointer<TableRef> table, common::ManagedPointer<AbstractExpression> expr)
+      : SQLStatement(StatementType::DELETE), table_ref_(table), expr_(expr) {}
 
   /**
    * Delete all rows (truncate).
    * @param table deletion target
    */
-  explicit DeleteStatement(std::shared_ptr<TableRef> table)
-      : SQLStatement(StatementType::DELETE), table_ref_(std::move(table)), expr_(nullptr) {}
+  explicit DeleteStatement(common::ManagedPointer<TableRef> table)
+      : SQLStatement(StatementType::DELETE),
+        table_ref_(table),
+        expr_(nullptr) {}
 
   ~DeleteStatement() override = default;
 
   /**
    * @return deletion target table
    */
-  std::shared_ptr<TableRef> GetDeletionTable() const { return table_ref_; }
+  common::ManagedPointer<TableRef> GetDeletionTable() const { return table_ref_; }
 
   /**
    * @return expression that represents deletion condition
    */
-  std::shared_ptr<AbstractExpression> GetDeleteCondition() { return expr_; }
+  common::ManagedPointer<AbstractExpression> GetDeleteCondition() { return expr_; }
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
  private:
-  std::shared_ptr<TableRef> table_ref_;
-  std::shared_ptr<AbstractExpression> expr_;
+  const common::ManagedPointer<TableRef> table_ref_;
+  const common::ManagedPointer<AbstractExpression> expr_;
 };
 
 }  // namespace terrier::parser

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -25,16 +25,16 @@ class DropStatement : public TableRefStatement {
    * @param type kDatabase or kTable
    * @param if_exists true if "IF EXISTS" was used
    */
-  DropStatement(std::unique_ptr<TableInfo> table_info, DropType type, bool if_exists)
-      : TableRefStatement(StatementType::DROP, std::move(table_info)), type_(type), if_exists_(if_exists) {}
+  DropStatement(common::ManagedPointer<TableInfo> table_info, DropType type, bool if_exists)
+      : TableRefStatement(StatementType::DROP, table_info), type_(type), if_exists_(if_exists) {}
 
   /**
    * DROP INDEX
    * @param table_info table information
    * @param index_name index name
    */
-  DropStatement(std::unique_ptr<TableInfo> table_info, std::string index_name)
-      : TableRefStatement(StatementType::DROP, std::move(table_info)),
+  DropStatement(common::ManagedPointer<TableInfo> table_info, std::string index_name)
+      : TableRefStatement(StatementType::DROP, table_info),
         type_(DropType::kIndex),
         index_name_(std::move(index_name)) {}
 
@@ -44,8 +44,8 @@ class DropStatement : public TableRefStatement {
    * @param if_exists true if "IF EXISTS" was used
    * @param cascade true if "CASCADE" was used
    */
-  DropStatement(std::unique_ptr<TableInfo> table_info, bool if_exists, bool cascade)
-      : TableRefStatement(StatementType::DROP, std::move(table_info)),
+  DropStatement(common::ManagedPointer<TableInfo> table_info, bool if_exists, bool cascade)
+      : TableRefStatement(StatementType::DROP, table_info),
         type_(DropType::kSchema),
         if_exists_(if_exists),
         cascade_(cascade) {}
@@ -57,8 +57,8 @@ class DropStatement : public TableRefStatement {
    * @param type kTrigger
    * @param trigger_name trigger name
    */
-  DropStatement(std::unique_ptr<TableInfo> table_info, DropType type, std::string trigger_name)
-      : TableRefStatement(StatementType::DROP, std::move(table_info)),
+  DropStatement(common::ManagedPointer<TableInfo> table_info, DropType type, std::string trigger_name)
+      : TableRefStatement(StatementType::DROP, table_info),
         type_(DropType::kTrigger),
         trigger_name_(std::move(trigger_name)) {}
 

--- a/src/include/parser/execute_statement.h
+++ b/src/include/parser/execute_statement.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/managed_pointer.h"
 #include "common/sql_node_visitor.h"
 #include "parser/expression/abstract_expression.h"
 #include "parser/sql_statement.h"
@@ -21,7 +22,7 @@ class ExecuteStatement : public SQLStatement {
    * @param name name of execute statement
    * @param parameters parameters for execute statement
    */
-  ExecuteStatement(std::string name, std::vector<std::shared_ptr<AbstractExpression>> parameters)
+  ExecuteStatement(std::string name, std::vector<common::ManagedPointer<AbstractExpression>> parameters)
       : SQLStatement(StatementType::EXECUTE), name_(std::move(name)), parameters_(std::move(parameters)) {}
 
   ~ExecuteStatement() override = default;
@@ -34,13 +35,22 @@ class ExecuteStatement : public SQLStatement {
   std::string GetName() { return name_; }
 
   /**
-   * @return execute statement parameters
+   * @return number of execute statement parameters
    */
-  std::vector<std::shared_ptr<AbstractExpression>> GetParameters() { return parameters_; }
+  size_t GetParametersSize() const { return parameters_.size(); }
+
+  /**
+   * @param idx index of parameter
+   * @return execute statement parameter
+   */
+  common::ManagedPointer<AbstractExpression> GetParameter(size_t idx) {
+    TERRIER_ASSERT(idx < GetParametersSize(), "Index must be less than number of parameters");
+    return parameters_[idx];
+  }
 
  private:
   const std::string name_;
-  const std::vector<std::shared_ptr<AbstractExpression>> parameters_;
+  const std::vector<common::ManagedPointer<AbstractExpression>> parameters_;
 };
 
 }  // namespace parser

--- a/src/include/parser/explain_statement.h
+++ b/src/include/parser/explain_statement.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <utility>
 
+#include "common/managed_pointer.h"
 #include "parser/sql_statement.h"
 
 namespace terrier::parser {
@@ -15,8 +16,9 @@ class ExplainStatement : public SQLStatement {
   /**
    * @param real_sql_stmt the SQL statement to be explained
    */
-  explicit ExplainStatement(std::shared_ptr<SQLStatement> real_sql_stmt)
-      : SQLStatement(StatementType::EXPLAIN), real_sql_stmt_(std::move(real_sql_stmt)) {}
+  explicit ExplainStatement(common::ManagedPointer<SQLStatement> real_sql_stmt)
+      : SQLStatement(StatementType::EXPLAIN), real_sql_stmt_(real_sql_stmt) {}
+
   ~ExplainStatement() override = default;
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
@@ -24,10 +26,10 @@ class ExplainStatement : public SQLStatement {
   /**
    * @return the SQL statement to be explained
    */
-  std::shared_ptr<SQLStatement> GetSQLStatement() { return real_sql_stmt_; }
+  common::ManagedPointer<SQLStatement> GetSQLStatement() { return real_sql_stmt_; }
 
  private:
-  std::shared_ptr<SQLStatement> real_sql_stmt_;
+  common::ManagedPointer<SQLStatement> real_sql_stmt_;
 };
 
 }  // namespace terrier::parser

--- a/src/include/parser/expression/abstract_expression.h
+++ b/src/include/parser/expression/abstract_expression.h
@@ -26,7 +26,7 @@ class AbstractExpression {
    * @param children the list of children for this node
    */
   AbstractExpression(const ExpressionType expression_type, const type::TypeId return_value_type,
-                     std::vector<std::shared_ptr<AbstractExpression>> &&children)
+                     std::vector<common::ManagedPointer<AbstractExpression>> &&children)
       : expression_type_(expression_type), return_value_type_(return_value_type), children_(std::move(children)) {}
   /**
    * Instantiates a new abstract expression with alias used for select statement column references.
@@ -36,7 +36,7 @@ class AbstractExpression {
    * @param children the list of children for this node
    */
   AbstractExpression(const ExpressionType expression_type, const type::TypeId return_value_type, std::string alias,
-                     std::vector<std::shared_ptr<AbstractExpression>> &&children)
+                     std::vector<common::ManagedPointer<AbstractExpression>> &&children)
       : expression_type_(expression_type),
         alias_(std::move(alias)),
         return_value_type_(return_value_type),
@@ -117,7 +117,7 @@ class AbstractExpression {
    */
   // It is incorrect to supply a default implementation here since that will return an object
   // of base type AbstractExpression instead of the desired non-abstract type.
-  virtual std::shared_ptr<AbstractExpression> Copy() const = 0;
+  virtual AbstractExpression *Copy() const = 0;
 
   /**
    * @return type of this expression
@@ -137,13 +137,13 @@ class AbstractExpression {
   /**
    * @return children of this abstract expression
    */
-  const std::vector<std::shared_ptr<AbstractExpression>> &GetChildren() const { return children_; }
+  const std::vector<common::ManagedPointer<AbstractExpression>> &GetChildren() const { return children_; }
 
   /**
    * @param index index of child
    * @return child of abstract expression at that index
    */
-  std::shared_ptr<AbstractExpression> GetChild(uint64_t index) const {
+  common::ManagedPointer<AbstractExpression> GetChild(uint64_t index) const {
     TERRIER_ASSERT(index < children_.size(), "Index must be in bounds.");
     return children_[index];
   }
@@ -244,9 +244,9 @@ class AbstractExpression {
   bool has_subquery_ = false;
 
   /**
-   * List fo children expressions
+   * List of children expressions
    */
-  std::vector<std::shared_ptr<AbstractExpression>> children_;
+  std::vector<common::ManagedPointer<AbstractExpression>> children_;
 };
 
 DEFINE_JSON_DECLARATIONS(AbstractExpression);
@@ -256,7 +256,7 @@ DEFINE_JSON_DECLARATIONS(AbstractExpression);
  * @param json json to deserialize
  * @return pointer to deserialized expression
  */
-std::shared_ptr<AbstractExpression> DeserializeExpression(const nlohmann::json &j);
+AbstractExpression *DeserializeExpression(const nlohmann::json &j);
 
 }  // namespace terrier::parser
 

--- a/src/include/parser/expression/aggregate_expression.h
+++ b/src/include/parser/expression/aggregate_expression.h
@@ -20,7 +20,7 @@ class AggregateExpression : public AbstractExpression {
    * @param children children to be added
    * @param distinct whether to eliminate duplicate values in aggregate function calculations
    */
-  AggregateExpression(ExpressionType type, std::vector<std::shared_ptr<AbstractExpression>> &&children, bool distinct)
+  AggregateExpression(ExpressionType type, std::vector<common::ManagedPointer<AbstractExpression>> &&children, bool distinct)
       : AbstractExpression(type, type::TypeId::INVALID, std::move(children)), distinct_(distinct) {}
 
   /**
@@ -28,7 +28,7 @@ class AggregateExpression : public AbstractExpression {
    */
   AggregateExpression() = default;
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<AggregateExpression>(*this); }
+  AbstractExpression *Copy() const override { return new AggregateExpression(*this); }
 
   common::hash_t Hash() const override {
     common::hash_t hash = AbstractExpression::Hash();

--- a/src/include/parser/expression/case_expression.h
+++ b/src/include/parser/expression/case_expression.h
@@ -20,11 +20,20 @@ class CaseExpression : public AbstractExpression {
     /**
      * The condition to be checked for this case expression.
      */
-    std::shared_ptr<AbstractExpression> condition;
+    common::ManagedPointer<AbstractExpression> condition;
     /**
      * The value that this expression should have if the corresponding condition is true.
      */
-    std::shared_ptr<AbstractExpression> then;
+    common::ManagedPointer<AbstractExpression> then;
+
+    /**
+     * When clause in a case expression.
+     * @param condition condition to be checked
+     * @param then if condition is true, the when clause evaluates to this
+     */
+    WhenClause(common::ManagedPointer<AbstractExpression> condition, common::ManagedPointer<AbstractExpression> then) : condition(condition), then(then) {}
+
+    explicit WhenClause() : condition(nullptr), then(nullptr) {}
 
     /**
      * Equality check
@@ -68,10 +77,10 @@ class CaseExpression : public AbstractExpression {
    * @param default_expr default expression for this case
    */
   CaseExpression(const type::TypeId return_value_type, std::vector<WhenClause> &&when_clauses,
-                 std::shared_ptr<AbstractExpression> default_expr)
+                 common::ManagedPointer<AbstractExpression> default_expr)
       : AbstractExpression(ExpressionType::OPERATOR_CASE_EXPR, return_value_type, {}),
         when_clauses_(std::move(when_clauses)),
-        default_expr_(std::move(default_expr)) {}
+        default_expr_(default_expr) {}
 
   /**
    * Default constructor for deserialization
@@ -106,7 +115,7 @@ class CaseExpression : public AbstractExpression {
     return *default_exp == *other_default_exp;
   }
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<CaseExpression>(*this); }
+  AbstractExpression *Copy() const override { return new CaseExpression(*this); }
 
   /**
    * @return the number of when clauses
@@ -117,7 +126,7 @@ class CaseExpression : public AbstractExpression {
    * @param index index of when clause to get
    * @return condition at that index
    */
-  std::shared_ptr<AbstractExpression> GetWhenClauseCondition(size_t index) const {
+  common::ManagedPointer<AbstractExpression> GetWhenClauseCondition(size_t index) const {
     TERRIER_ASSERT(index < when_clauses_.size(), "Index must be in bounds.");
     return when_clauses_[index].condition;
   }
@@ -126,7 +135,7 @@ class CaseExpression : public AbstractExpression {
    * @param index index of when clause to get
    * @return result at that index
    */
-  std::shared_ptr<AbstractExpression> GetWhenClauseResult(size_t index) const {
+  common::ManagedPointer<AbstractExpression> GetWhenClauseResult(size_t index) const {
     TERRIER_ASSERT(index < when_clauses_.size(), "Index must be in bounds.");
     return when_clauses_[index].then;
   }
@@ -134,7 +143,7 @@ class CaseExpression : public AbstractExpression {
   /**
    * @return default clause, if it exists
    */
-  std::shared_ptr<AbstractExpression> GetDefaultClause() const { return default_expr_; }
+  common::ManagedPointer<AbstractExpression> GetDefaultClause() const { return default_expr_; }
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
@@ -167,9 +176,9 @@ class CaseExpression : public AbstractExpression {
    */
   std::vector<WhenClause> when_clauses_;
   /**
-   * default conditon and result case
+   * default condition and result case
    */
-  std::shared_ptr<AbstractExpression> default_expr_;
+  common::ManagedPointer<AbstractExpression> default_expr_;
 };
 
 DEFINE_JSON_DECLARATIONS(CaseExpression::WhenClause);

--- a/src/include/parser/expression/column_value_expression.h
+++ b/src/include/parser/expression/column_value_expression.h
@@ -96,7 +96,7 @@ class ColumnValueExpression : public AbstractExpression {
    */
   catalog::col_oid_t GetColumnOid() const { return column_oid_; }
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<ColumnValueExpression>(*this); }
+  AbstractExpression *Copy() const override { return new ColumnValueExpression(*this); }
 
   common::hash_t Hash() const override {
     common::hash_t hash = AbstractExpression::Hash();

--- a/src/include/parser/expression/comparison_expression.h
+++ b/src/include/parser/expression/comparison_expression.h
@@ -17,7 +17,7 @@ class ComparisonExpression : public AbstractExpression {
    * @param cmp_type type of comparison
    * @param children vector containing exactly two children, left then right
    */
-  ComparisonExpression(const ExpressionType cmp_type, std::vector<std::shared_ptr<AbstractExpression>> &&children)
+  ComparisonExpression(const ExpressionType cmp_type, std::vector<common::ManagedPointer<AbstractExpression>> &&children)
       : AbstractExpression(cmp_type, type::TypeId::BOOLEAN, std::move(children)) {}
 
   /**
@@ -25,7 +25,7 @@ class ComparisonExpression : public AbstractExpression {
    */
   ComparisonExpression() = default;
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<ComparisonExpression>(*this); }
+  AbstractExpression *Copy() const override { return new ComparisonExpression(*this); }
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 };

--- a/src/include/parser/expression/conjunction_expression.h
+++ b/src/include/parser/expression/conjunction_expression.h
@@ -17,7 +17,7 @@ class ConjunctionExpression : public AbstractExpression {
    * @param cmp_type type of conjunction
    * @param children vector containing exactly two children, left then right
    */
-  ConjunctionExpression(const ExpressionType cmp_type, std::vector<std::shared_ptr<AbstractExpression>> &&children)
+  ConjunctionExpression(const ExpressionType cmp_type, std::vector<common::ManagedPointer<AbstractExpression>> &&children)
       : AbstractExpression(cmp_type, type::TypeId::BOOLEAN, std::move(children)) {}
 
   /**
@@ -25,7 +25,7 @@ class ConjunctionExpression : public AbstractExpression {
    */
   ConjunctionExpression() = default;
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<ConjunctionExpression>(*this); }
+  AbstractExpression *Copy() const override { return new ConjunctionExpression(*this); }
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 };

--- a/src/include/parser/expression/constant_value_expression.h
+++ b/src/include/parser/expression/constant_value_expression.h
@@ -43,7 +43,7 @@ class ConstantValueExpression : public AbstractExpression {
       this->SetExpressionName(value_.ToString());
   }
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<ConstantValueExpression>(*this); }
+  AbstractExpression *Copy() const override { return new ConstantValueExpression(*this); }
 
   /**
    * @return the constant value stored in this expression

--- a/src/include/parser/expression/default_value_expression.h
+++ b/src/include/parser/expression/default_value_expression.h
@@ -16,7 +16,7 @@ class DefaultValueExpression : public AbstractExpression {
    */
   DefaultValueExpression() : AbstractExpression(ExpressionType::VALUE_DEFAULT, type::TypeId::INVALID, {}) {}
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<DefaultValueExpression>(*this); }
+  AbstractExpression *Copy() const override { return new DefaultValueExpression(*this); }
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 };

--- a/src/include/parser/expression/derived_value_expression.h
+++ b/src/include/parser/expression/derived_value_expression.h
@@ -27,7 +27,7 @@ class DerivedValueExpression : public AbstractExpression {
    */
   DerivedValueExpression() = default;
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<DerivedValueExpression>(*this); }
+  AbstractExpression *Copy() const override { return new DerivedValueExpression(*this); }
 
   /**
    * @return index of the tuple

--- a/src/include/parser/expression/function_expression.h
+++ b/src/include/parser/expression/function_expression.h
@@ -21,7 +21,7 @@ class FunctionExpression : public AbstractExpression {
    * @param children children arguments for the function
    */
   FunctionExpression(std::string &&func_name, const type::TypeId return_value_type,
-                     std::vector<std::shared_ptr<AbstractExpression>> &&children)
+                     std::vector<common::ManagedPointer<AbstractExpression>> &&children)
       : AbstractExpression(ExpressionType::FUNCTION, return_value_type, std::move(children)),
         func_name_(std::move(func_name)) {}
 
@@ -30,7 +30,7 @@ class FunctionExpression : public AbstractExpression {
    */
   FunctionExpression() = default;
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<FunctionExpression>(*this); }
+  AbstractExpression *Copy() const override { return new FunctionExpression(*this); }
 
   common::hash_t Hash() const override {
     common::hash_t hash = AbstractExpression::Hash();
@@ -94,7 +94,7 @@ class FunctionExpression : public AbstractExpression {
   // TODO(WAN): until codegen is in.
   // Does it really make sense to store BuiltInFuncType AND name though?
   // Old code already had map name->func
-  // std::shared_ptr<codegen::CodeContext> func_context_;
+  // common::ManagedPointer<codegen::CodeContext> func_context_;
   // function::BuiltInFuncType func_;
 
   // TODO(WAN): will user defined functions need special treatment?

--- a/src/include/parser/expression/operator_expression.h
+++ b/src/include/parser/expression/operator_expression.h
@@ -19,7 +19,7 @@ class OperatorExpression : public AbstractExpression {
    * @param children vector containing arguments to the operator left to right
    */
   OperatorExpression(const ExpressionType expression_type, const type::TypeId return_value_type,
-                     std::vector<std::shared_ptr<AbstractExpression>> &&children)
+                     std::vector<common::ManagedPointer<AbstractExpression>> &&children)
       : AbstractExpression(expression_type, return_value_type, std::move(children)) {}
 
   /**
@@ -46,7 +46,7 @@ class OperatorExpression : public AbstractExpression {
     this->SetReturnValueType(type);
   }
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<OperatorExpression>(*this); }
+  AbstractExpression *Copy() const override { return new OperatorExpression(*this); }
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 };

--- a/src/include/parser/expression/parameter_value_expression.h
+++ b/src/include/parser/expression/parameter_value_expression.h
@@ -23,8 +23,8 @@ class ParameterValueExpression : public AbstractExpression {
    */
   ParameterValueExpression() = default;
 
-  std::shared_ptr<AbstractExpression> Copy() const override {
-    return std::make_shared<ParameterValueExpression>(*this);
+  AbstractExpression *Copy() const override {
+    return new ParameterValueExpression(*this);
   }
 
   /**

--- a/src/include/parser/expression/star_expression.h
+++ b/src/include/parser/expression/star_expression.h
@@ -15,9 +15,9 @@ class StarExpression : public AbstractExpression {
    */
   StarExpression() : AbstractExpression(ExpressionType::STAR, type::TypeId::INVALID, {}) {}
 
-  std::shared_ptr<AbstractExpression> Copy() const override {
+  AbstractExpression *Copy() const override {
     // TODO(Tianyu): This really should be a singleton object
-    return std::make_shared<StarExpression>(*this);
+    return new StarExpression(*this);
   }
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }

--- a/src/include/parser/expression/type_cast_expression.h
+++ b/src/include/parser/expression/type_cast_expression.h
@@ -15,7 +15,7 @@ class TypeCastExpression : public AbstractExpression {
   /**
    * Instantiates a new type cast expression.
    */
-  TypeCastExpression(type::TypeId type, std::vector<std::shared_ptr<AbstractExpression>> &&children)
+  TypeCastExpression(type::TypeId type, std::vector<common::ManagedPointer<AbstractExpression>> &&children)
       : AbstractExpression(ExpressionType::OPERATOR_CAST, type, std::move(children)) {}
 
   /**
@@ -23,7 +23,7 @@ class TypeCastExpression : public AbstractExpression {
    */
   TypeCastExpression() = default;
 
-  std::shared_ptr<AbstractExpression> Copy() const override { return std::make_shared<TypeCastExpression>(*this); }
+  AbstractExpression *Copy() const override { return new TypeCastExpression(*this); }
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 };

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -11,6 +11,56 @@
 namespace terrier {
 namespace parser {
 
+// General guidelines for working with this file
+// If it takes in a parse result, or returns a managed pointer,
+// it will add all it creates to the parse result.
+
+struct ParseResult {
+  /* Statements to be executed. */
+  std::vector<SQLStatement *> stmts;
+  /* Auxiliary statements that we saw while parsing, e.g. nested statements. */
+  std::vector<SQLStatement *> aux_stmts;
+  /* Expressions. */
+  std::vector<AbstractExpression *> exprs;
+  /* Table location information. */
+  std::vector<TableInfo *> table_infos;
+  /* Table locator (i.e. contains table info or select statement. */
+  std::vector<TableRef *> table_refs;
+  /* Group by description. */
+  std::vector<GroupByDescription *> group_bys;
+  /* Order by description. */
+  std::vector<OrderByDescription *> order_bys;
+  /* Limit descriptions. */
+  std::vector<LimitDescription *> limit_descriptions;
+  /* Update clauses. */
+  std::vector<UpdateClause *> update_clauses;
+  /* Join definitions. */
+  std::vector<JoinDefinition *> join_definitions;
+  /* Index attributes. */
+  std::vector<IndexAttr *> index_attrs;
+  /* Column definitions. */
+  std::vector<ColumnDefinition *> column_definitions;
+  /* Function parameters. */
+  std::vector<FuncParameter *> func_parameters;
+  /* Return types. */
+  std::vector<ReturnType *> return_types;
+
+  void AddStatement(bool is_top_level, SQLStatement *stmt) {
+    if (is_top_level) {
+      this->stmts.emplace_back(stmt);
+    } else {
+      this->aux_stmts.emplace_back(stmt);
+    }
+  }
+
+  void AddExpression(bool is_top_level, AbstractExpression *expr) {
+    // TODO(WAN): get rid of this. formerly, expressions would own their subexpressions, but
+    // with the removal of .get() it seems that we're headed deeper into managed pointer land.
+    // The alternative I see would be to have raw pointers flying around this already messy file.
+    this->exprs.emplace_back(expr);
+  }
+};
+
 /**
  * PostgresParser obtains and transforms the Postgres parse tree into our Terrier parse tree.
  * In the future, we may want to replace this with our own parser.
@@ -36,7 +86,7 @@ class PostgresParser {
    * @param query_string query string to be parsed
    * @return unique pointer to parse tree
    */
-  std::vector<std::unique_ptr<parser::SQLStatement>> BuildParseTree(const std::string &query_string);
+  ParseResult BuildParseTree(const std::string &query_string);
 
  private:
   static FKConstrActionType CharToActionType(const char &type) {
@@ -78,106 +128,135 @@ class PostgresParser {
    * @param root list of parsed nodes
    * @return SQLStatementList corresponding to the parsed node list
    */
-  static std::vector<std::unique_ptr<parser::SQLStatement>> ListTransform(List *root);
+  static ParseResult ListTransform(List *root);
 
   /**
    * Transforms a single node in the parse list into a terrier SQLStatement object.
+   * @param result result context to be updated
+   * @param is_top_level whether this parse node is a top-level node
    * @param node parsed node
    * @return SQLStatement corresponding to the parsed node
    */
-  static std::unique_ptr<parser::SQLStatement> NodeTransform(Node *node);
+  static common::ManagedPointer<SQLStatement> NodeTransform(ParseResult *result, bool is_top_level, Node *node);
 
   // expressions
-  static std::unique_ptr<AbstractExpression> ExprTransform(Node *node);
-  static std::unique_ptr<AbstractExpression> ExprTransform(Node *node, char *alias);
+  static common::ManagedPointer<AbstractExpression> ExprTransform(ParseResult *result, bool is_top_level, Node *node, char *alias);
   static ExpressionType StringToExpressionType(const std::string &parser_str);
-  static std::unique_ptr<AbstractExpression> AExprTransform(A_Expr *root);
-  static std::unique_ptr<AbstractExpression> BoolExprTransform(BoolExpr *root);
-  static std::unique_ptr<AbstractExpression> CaseExprTransform(CaseExpr *root);
-  static std::unique_ptr<AbstractExpression> ColumnRefTransform(ColumnRef *root, char *alias);
-  static std::unique_ptr<AbstractExpression> ConstTransform(A_Const *root);
-  static std::unique_ptr<AbstractExpression> FuncCallTransform(FuncCall *root);
-  static std::unique_ptr<AbstractExpression> NullTestTransform(NullTest *root);
-  static std::unique_ptr<AbstractExpression> ParamRefTransform(ParamRef *root);
-  static std::unique_ptr<AbstractExpression> SubqueryExprTransform(SubLink *node);
-  static std::unique_ptr<AbstractExpression> TypeCastTransform(TypeCast *root);
-  static std::unique_ptr<AbstractExpression> ValueTransform(value val);
+
+  static common::ManagedPointer<AbstractExpression> AExprTransform(ParseResult *result, bool is_top_level,
+                                                                   A_Expr *root);
+  static common::ManagedPointer<AbstractExpression> BoolExprTransform(ParseResult *result, bool is_top_level,
+                                                                      BoolExpr *root);
+  static common::ManagedPointer<AbstractExpression> CaseExprTransform(ParseResult *result, bool is_top_level,
+                                                                      CaseExpr *root);
+  static common::ManagedPointer<AbstractExpression> ColumnRefTransform(ParseResult *result, bool is_top_level,
+                                                                       ColumnRef *root, char *alias);
+  static common::ManagedPointer<AbstractExpression> ConstTransform(ParseResult *result, bool is_top_level,
+                                                                   A_Const *root);
+  static common::ManagedPointer<AbstractExpression> FuncCallTransform(ParseResult *result, bool is_top_level,
+                                                                      FuncCall *root);
+  static common::ManagedPointer<AbstractExpression> NullTestTransform(ParseResult *result, bool is_top_level,
+                                                                      NullTest *root);
+  static common::ManagedPointer<AbstractExpression> ParamRefTransform(ParseResult *result, bool is_top_level,
+                                                                      ParamRef *root);
+  static common::ManagedPointer<AbstractExpression> SubqueryExprTransform(ParseResult *result, bool is_top_level,
+                                                                          SubLink *node);
+  static common::ManagedPointer<AbstractExpression> TypeCastTransform(ParseResult *result, bool is_top_level,
+                                                                      TypeCast *root);
+  static common::ManagedPointer<AbstractExpression> ValueTransform(ParseResult *result, bool is_top_level, value val);
 
   // SELECT statements
-  static std::unique_ptr<SelectStatement> SelectTransform(SelectStmt *root);
+  static common::ManagedPointer<SQLStatement> SelectTransform(ParseResult *result, bool is_top_level, SelectStmt *root);
   // SELECT helpers
-  static std::vector<std::shared_ptr<AbstractExpression>> TargetTransform(List *root);
-  static std::unique_ptr<TableRef> FromTransform(SelectStmt *select_root);
-  static std::unique_ptr<GroupByDescription> GroupByTransform(List *group, Node *having_node);
-  static std::unique_ptr<OrderByDescription> OrderByTransform(List *order);
-  static std::unique_ptr<AbstractExpression> WhereTransform(Node *root);
+  static std::vector<common::ManagedPointer<AbstractExpression>> TargetTransform(ParseResult *result, List *root);
+  static common::ManagedPointer<TableRef> FromTransform(ParseResult *result, SelectStmt *select_root);
+  static common::ManagedPointer<GroupByDescription> GroupByTransform(ParseResult *result, List *group,
+                                                                     Node *having_node);
+  static common::ManagedPointer<OrderByDescription> OrderByTransform(ParseResult *result, List *order);
+  static common::ManagedPointer<AbstractExpression> WhereTransform(ParseResult *result, Node *root);
 
   // FromTransform helpers
-  static std::unique_ptr<JoinDefinition> JoinTransform(JoinExpr *root);
+  static common::ManagedPointer<JoinDefinition> JoinTransform(ParseResult *result, JoinExpr *root);
   static std::string AliasTransform(Alias *root);
-  static std::unique_ptr<TableRef> RangeVarTransform(RangeVar *root);
-  static std::unique_ptr<TableRef> RangeSubselectTransform(RangeSubselect *root);
+  static common::ManagedPointer<TableRef> RangeVarTransform(ParseResult *result, RangeVar *root);
+  static common::ManagedPointer<TableRef> RangeSubselectTransform(ParseResult *result, RangeSubselect *root);
 
   // COPY statements
-  static std::unique_ptr<CopyStatement> CopyTransform(CopyStmt *root);
+  static common::ManagedPointer<SQLStatement> CopyTransform(ParseResult *result, bool is_top_level, CopyStmt *root);
 
   // CREATE statements
-  static std::unique_ptr<SQLStatement> CreateTransform(CreateStmt *root);
-  static std::unique_ptr<SQLStatement> CreateDatabaseTransform(CreateDatabaseStmt *root);
-  static std::unique_ptr<SQLStatement> CreateFunctionTransform(CreateFunctionStmt *root);
-  static std::unique_ptr<SQLStatement> CreateIndexTransform(IndexStmt *root);
-  static std::unique_ptr<SQLStatement> CreateSchemaTransform(CreateSchemaStmt *root);
-  static std::unique_ptr<SQLStatement> CreateTriggerTransform(CreateTrigStmt *root);
-  static std::unique_ptr<SQLStatement> CreateViewTransform(ViewStmt *root);
+  static common::ManagedPointer<SQLStatement> CreateTransform(ParseResult *result, bool is_top_level, CreateStmt *root);
+  static common::ManagedPointer<SQLStatement> CreateDatabaseTransform(ParseResult *result, bool is_top_level,
+                                                                      CreateDatabaseStmt *root);
+  static common::ManagedPointer<SQLStatement> CreateFunctionTransform(ParseResult *result, bool is_top_level,
+                                                                      CreateFunctionStmt *root);
+  static common::ManagedPointer<SQLStatement> CreateIndexTransform(ParseResult *result, bool is_top_level,
+                                                                   IndexStmt *root);
+  static common::ManagedPointer<SQLStatement> CreateSchemaTransform(ParseResult *result, bool is_top_level,
+                                                                    CreateSchemaStmt *root);
+  static common::ManagedPointer<SQLStatement> CreateTriggerTransform(ParseResult *result, bool is_top_level,
+                                                                     CreateTrigStmt *root);
+  static common::ManagedPointer<SQLStatement> CreateViewTransform(ParseResult *result, bool is_top_level,
+                                                                  ViewStmt *root);
 
   // CREATE helpers
   using ColumnDefTransResult = struct {
-    std::unique_ptr<ColumnDefinition> col;
-    std::vector<std::shared_ptr<ColumnDefinition>> fks;
+    common::ManagedPointer<ColumnDefinition> col;
+    std::vector<common::ManagedPointer<ColumnDefinition>> fks;
   };
-  static ColumnDefTransResult ColumnDefTransform(ColumnDef *root);
+  static ColumnDefTransResult ColumnDefTransform(ParseResult *result, ColumnDef *root);
 
   // CREATE FUNCTION helpers
-  static std::unique_ptr<FuncParameter> FunctionParameterTransform(FunctionParameter *root);
-  static std::unique_ptr<ReturnType> ReturnTypeTransform(TypeName *root);
+  static common::ManagedPointer<FuncParameter> FunctionParameterTransform(ParseResult *result, FunctionParameter *root);
+  static common::ManagedPointer<ReturnType> ReturnTypeTransform(ParseResult *result, TypeName *root);
 
   // CREATE TRIGGER helpers
-  static std::unique_ptr<AbstractExpression> WhenTransform(Node *root);
+  static common::ManagedPointer<AbstractExpression> WhenTransform(ParseResult *result, Node *root);
 
   // DELETE statements
-  static std::unique_ptr<DeleteStatement> DeleteTransform(DeleteStmt *root);
+  static common::ManagedPointer<SQLStatement> DeleteTransform(ParseResult *result, bool is_top_level, DeleteStmt *root);
 
   // DELETE helpers
   // static parser::DeleteStatement *TruncateTransform(TruncateStmt *root);
 
   // DROP statements
-  static std::unique_ptr<DropStatement> DropTransform(DropStmt *root);
-  static std::unique_ptr<DropStatement> DropDatabaseTransform(DropDatabaseStmt *root);
-  static std::unique_ptr<DropStatement> DropIndexTransform(DropStmt *root);
-  static std::unique_ptr<DropStatement> DropSchemaTransform(DropStmt *root);
-  static std::unique_ptr<DropStatement> DropTableTransform(DropStmt *root);
-  static std::unique_ptr<DropStatement> DropTriggerTransform(DropStmt *root);
+  static common::ManagedPointer<SQLStatement> DropTransform(ParseResult *result, bool is_top_level, DropStmt *root);
+  static common::ManagedPointer<SQLStatement> DropDatabaseTransform(ParseResult *result, bool is_top_level,
+                                                                    DropDatabaseStmt *root);
+  static common::ManagedPointer<SQLStatement> DropIndexTransform(ParseResult *result, bool is_top_level,
+                                                                 DropStmt *root);
+  static common::ManagedPointer<SQLStatement> DropSchemaTransform(ParseResult *result, bool is_top_level,
+                                                                  DropStmt *root);
+  static common::ManagedPointer<SQLStatement> DropTableTransform(ParseResult *result, bool is_top_level,
+                                                                 DropStmt *root);
+  static common::ManagedPointer<SQLStatement> DropTriggerTransform(ParseResult *result, bool is_top_level,
+                                                                   DropStmt *root);
 
   // EXECUTE statements
-  static std::unique_ptr<ExecuteStatement> ExecuteTransform(ExecuteStmt *root);
+  static common::ManagedPointer<SQLStatement> ExecuteTransform(ParseResult *result, bool is_top_level,
+                                                               ExecuteStmt *root);
 
   // EXECUTE helpers
-  static std::vector<std::shared_ptr<AbstractExpression>> ParamListTransform(List *root);
+  static std::vector<common::ManagedPointer<AbstractExpression>> ParamListTransform(ParseResult *result, List *root);
 
   // EXPLAIN statements
-  static std::unique_ptr<ExplainStatement> ExplainTransform(ExplainStmt *root);
+  static common::ManagedPointer<SQLStatement> ExplainTransform(ParseResult *result, bool is_top_level,
+                                                               ExplainStmt *root);
 
   // INSERT statements
-  static std::unique_ptr<InsertStatement> InsertTransform(InsertStmt *root);
+  static common::ManagedPointer<SQLStatement> InsertTransform(ParseResult *result, bool is_top_level, InsertStmt *root);
 
   // INSERT helpers
-  static std::unique_ptr<std::vector<std::string>> ColumnNameTransform(List *root);
-  static std::unique_ptr<std::vector<std::vector<std::shared_ptr<AbstractExpression>>>> ValueListsTransform(List *root);
+  static std::vector<std::string> ColumnNameTransform(List *root);
+  static std::vector<std::vector<common::ManagedPointer<AbstractExpression>>> ValueListsTransform(ParseResult *result,
+                                                                                                  List *root);
 
   // PREPARE statements
-  static std::unique_ptr<PrepareStatement> PrepareTransform(PrepareStmt *root);
+  static common::ManagedPointer<SQLStatement> PrepareTransform(ParseResult *result, bool is_top_level,
+                                                               PrepareStmt *root);
 
-  static std::unique_ptr<DeleteStatement> TruncateTransform(TruncateStmt *truncate_stmt);
+  static common::ManagedPointer<SQLStatement> TruncateTransform(ParseResult *result, bool is_top_level,
+                                                                TruncateStmt *truncate_stmt);
 
   /**
    * Converts a TRANSACTION statement from postgres parser form to internal form
@@ -185,21 +264,24 @@ class PostgresParser {
    * @param transaction_stmt from the postgres parser
    * @return converted to parser::TransactionStatement
    */
-  static std::unique_ptr<TransactionStatement> TransactionTransform(TransactionStmt *transaction_stmt);
+  static common::ManagedPointer<SQLStatement> TransactionTransform(ParseResult *result, bool is_top_level,
+                                                                   TransactionStmt *transaction_stmt);
 
   // VACUUM statements as ANALYZE statements
-  static std::unique_ptr<AnalyzeStatement> VacuumTransform(VacuumStmt *root);
+  static common::ManagedPointer<SQLStatement> VacuumTransform(ParseResult *result, bool is_top_level, VacuumStmt *root);
 
   // VARIABLE SET statements
-  static std::unique_ptr<VariableSetStatement> VariableSetTransform(VariableSetStmt *root);
+  static common::ManagedPointer<SQLStatement> VariableSetTransform(ParseResult *result, bool is_top_level,
+                                                                   VariableSetStmt *root);
 
   /**
    * Converts the target of an update clause, i.e. one or more column = expression
    * statements, from postgres parser form to internal form
+   * @param result parse result to hold the update clauses
    * @param root list of targets
    * @return vector of update clauses
    */
-  static std::vector<std::shared_ptr<parser::UpdateClause>> UpdateTargetTransform(List *root);
+  static std::vector<common::ManagedPointer<UpdateClause>> UpdateTargetTransform(ParseResult *result, List *root);
 
   /**
    * Converts an UPDATE statement from postgres parser form to our internal form.
@@ -211,7 +293,8 @@ class PostgresParser {
    * - from clause
    * - returning a list
    */
-  static std::unique_ptr<UpdateStatement> UpdateTransform(UpdateStmt *update_stmt);
+  static common::ManagedPointer<SQLStatement> UpdateTransform(ParseResult *result, bool is_top_level,
+                                                              UpdateStmt *update_stmt);
 };
 
 }  // namespace parser

--- a/src/include/parser/prepare_statement.h
+++ b/src/include/parser/prepare_statement.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/managed_pointer.h"
 #include "common/sql_node_visitor.h"
 #include "parser/expression/parameter_value_expression.h"
 #include "parser/select_statement.h"
@@ -29,11 +30,11 @@ class PrepareStatement : public SQLStatement {
    * @param query - the parsed form of statement
    * @param placeholders - placeholder values? (explain)
    */
-  PrepareStatement(std::string name, std::shared_ptr<SQLStatement> query,
-                   std::vector<std::shared_ptr<ParameterValueExpression>> placeholders)
+  PrepareStatement(std::string name, common::ManagedPointer<SQLStatement> query,
+                   std::vector<common::ManagedPointer<ParameterValueExpression>> placeholders)
       : SQLStatement(StatementType::PREPARE),
         name_(std::move(name)),
-        query_(std::move(query)),
+        query_(query),
         placeholders_(std::move(placeholders)) {}
 
   ~PrepareStatement() override = default;
@@ -48,17 +49,23 @@ class PrepareStatement : public SQLStatement {
   /**
    * @return query
    */
-  std::shared_ptr<SQLStatement> GetQuery() { return query_; }
+  common::ManagedPointer<SQLStatement> GetQuery() { return query_; }
 
   /**
-   * @return placeholders
+   * @return number of placeholders
    */
-  std::vector<std::shared_ptr<ParameterValueExpression>> GetPlaceholders() { return placeholders_; }
+  size_t GetPlaceholdersSize() const { return placeholders_.size(); }
+
+  /**
+   * @param idx index of placeholder
+   * @return placeholder
+   */
+  common::ManagedPointer<ParameterValueExpression> GetPlaceholder(size_t idx) { return placeholders_[idx]; }
 
  private:
-  const std::string name_;
-  const std::shared_ptr<SQLStatement> query_;
-  const std::vector<std::shared_ptr<ParameterValueExpression>> placeholders_;
+  std::string name_;
+  common::ManagedPointer<SQLStatement> query_;
+  std::vector<common::ManagedPointer<ParameterValueExpression>> placeholders_;
 };
 
 }  // namespace parser

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -135,8 +135,8 @@ class TableRefStatement : public SQLStatement {
    * @param type type of SQLStatement being referred to
    * @param table_info table being referred to
    */
-  TableRefStatement(const StatementType type, std::shared_ptr<TableInfo> table_info)
-      : SQLStatement(type), table_info_(std::move(table_info)) {}
+  TableRefStatement(const StatementType type, common::ManagedPointer<TableInfo> table_info)
+      : SQLStatement(type), table_info_(table_info) {}
 
   ~TableRefStatement() override = default;
 
@@ -156,7 +156,7 @@ class TableRefStatement : public SQLStatement {
   virtual std::string GetDatabaseName() const { return table_info_->GetDatabaseName(); }
 
  private:
-  const std::shared_ptr<TableInfo> table_info_ = nullptr;
+  const common::ManagedPointer<TableInfo> table_info_;
 };
 
 }  // namespace parser

--- a/src/include/parser/table_ref.h
+++ b/src/include/parser/table_ref.h
@@ -4,7 +4,9 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "common/json.h"
+#include "common/managed_pointer.h"
 #include "common/sql_node_visitor.h"
 #include "expression/abstract_expression.h"
 #include "parser/parser_defs.h"
@@ -26,9 +28,9 @@ class JoinDefinition {
    * @param right right table
    * @param condition join condition
    */
-  JoinDefinition(JoinType type, std::shared_ptr<TableRef> left, std::shared_ptr<TableRef> right,
-                 std::shared_ptr<AbstractExpression> condition)
-      : type_(type), left_(std::move(left)), right_(std::move(right)), condition_(std::move(condition)) {}
+  JoinDefinition(JoinType type, common::ManagedPointer<TableRef> left, common::ManagedPointer<TableRef> right,
+                 common::ManagedPointer<AbstractExpression> condition)
+      : type_(type), left_(left), right_(right), condition_(condition) {}
 
   /**
    * Default constructor used for deserialization
@@ -49,17 +51,17 @@ class JoinDefinition {
   /**
    * @return left table
    */
-  std::shared_ptr<TableRef> GetLeftTable() { return left_; }
+  common::ManagedPointer<TableRef> GetLeftTable() { return left_; }
 
   /**
    * @return right table
    */
-  std::shared_ptr<TableRef> GetRightTable() { return right_; }
+  common::ManagedPointer<TableRef> GetRightTable() { return right_; }
 
   /**
    * @return join condition
    */
-  std::shared_ptr<AbstractExpression> GetJoinCondition() { return condition_; }
+  common::ManagedPointer<AbstractExpression> GetJoinCondition() { return condition_; }
 
   /**
    * @return JoinDefinition serialized to json
@@ -73,9 +75,9 @@ class JoinDefinition {
 
  private:
   JoinType type_;
-  std::shared_ptr<TableRef> left_;
-  std::shared_ptr<TableRef> right_;
-  std::shared_ptr<AbstractExpression> condition_;
+  common::ManagedPointer<TableRef> left_;
+  common::ManagedPointer<TableRef> right_;
+  common::ManagedPointer<AbstractExpression> condition_;
 };
 
 DEFINE_JSON_DECLARATIONS(JoinDefinition);
@@ -96,61 +98,59 @@ class TableRef {
    * @param alias alias for table ref
    * @param table_info table information to use in creation
    */
-  TableRef(std::string alias, std::shared_ptr<TableInfo> table_info)
-      : type_(TableReferenceType::NAME), alias_(std::move(alias)), table_info_(std::move(table_info)) {}
+  TableRef(std::string alias, common::ManagedPointer<TableInfo> table_info)
+      : type_(TableReferenceType::NAME), alias_(std::move(alias)), table_info_(table_info) {}
 
   /**
    * @param alias alias for table ref
    * @param select select statement to use in creation
    */
-  TableRef(std::string alias, std::shared_ptr<SelectStatement> select)
-      : type_(TableReferenceType::SELECT), alias_(std::move(alias)), select_(std::move(select)) {}
+  TableRef(std::string alias, common::ManagedPointer<SelectStatement> select)
+      : type_(TableReferenceType::SELECT), alias_(std::move(alias)), select_(select) {}
 
   /**
    * @param list table refs to use in creation
    */
-  explicit TableRef(std::vector<std::shared_ptr<TableRef>> list)
+  explicit TableRef(std::vector<common::ManagedPointer<TableRef>> list)
       : type_(TableReferenceType::CROSS_PRODUCT), alias_(""), list_(std::move(list)) {}
 
   /**
    * @param join join definition to use in creation
    */
-  explicit TableRef(std::shared_ptr<JoinDefinition> join)
-      : type_(TableReferenceType::JOIN), alias_(""), join_(std::move(join)) {}
+  explicit TableRef(common::ManagedPointer<JoinDefinition> join)
+      : type_(TableReferenceType::JOIN), alias_(""), join_(join) {}
 
   /**
    * @param alias alias for table ref
    * @param table_info table info to use in creation
-   * @return unique pointer to the created table ref
+   * @return pointer to the created table ref
    */
-  static std::unique_ptr<TableRef> CreateTableRefByName(std::string alias, std::shared_ptr<TableInfo> table_info) {
-    return std::make_unique<TableRef>(alias, std::move(table_info));
+  static TableRef *CreateTableRefByName(std::string alias, common::ManagedPointer<TableInfo> table_info) {
+    return new TableRef(alias, table_info);
   }
 
   /**
    * @param alias alias for table ref
    * @param select select statement to use in creation
-   * @return unique pointer to the created table ref
+   * @return pointer to the created table ref
    */
-  static std::unique_ptr<TableRef> CreateTableRefBySelect(std::string alias, std::shared_ptr<SelectStatement> select) {
-    return std::make_unique<TableRef>(alias, std::move(select));
+  static TableRef *CreateTableRefBySelect(std::string alias, common::ManagedPointer<SelectStatement> select) {
+    return new TableRef(alias, select);
   }
 
   /**
    * @param list table refs to use in creation
-   * @return unique pointer to the created table ref
+   * @return pointer to the created table ref
    */
-  static std::unique_ptr<TableRef> CreateTableRefByList(std::vector<std::shared_ptr<TableRef>> list) {
-    return std::make_unique<TableRef>(std::move(list));
+  static TableRef *CreateTableRefByList(std::vector<common::ManagedPointer<TableRef>> list) {
+    return new TableRef(std::move(list));
   }
 
   /**
    * @param join join definition to use in creation
-   * @return unique pointer to the created table ref
+   * @return pointer to the created table ref
    */
-  static std::unique_ptr<TableRef> CreateTableRefByJoin(std::shared_ptr<JoinDefinition> join) {
-    return std::make_unique<TableRef>(std::move(join));
-  }
+  static TableRef *CreateTableRefByJoin(common::ManagedPointer<JoinDefinition> join) { return new TableRef(join); }
 
   /**
    * @param v visitor
@@ -185,17 +185,17 @@ class TableRef {
   /**
    * @return select statement
    */
-  std::shared_ptr<SelectStatement> GetSelect() { return select_; }
+  common::ManagedPointer<SelectStatement> GetSelect() { return select_; }
 
   /**
    * @return list of table references
    */
-  std::vector<std::shared_ptr<TableRef>> GetList() { return list_; }
+  std::vector<common::ManagedPointer<TableRef>> GetList() { return list_; }
 
   /**
    * @return join
    */
-  std::shared_ptr<JoinDefinition> GetJoin() { return join_; }
+  common::ManagedPointer<JoinDefinition> GetJoin() { return join_; }
 
   /**
    * @return TableRef serialized to json
@@ -209,13 +209,13 @@ class TableRef {
  private:
   TableReferenceType type_;
   std::string alias_;
-  std::shared_ptr<TableInfo> table_info_;
+  common::ManagedPointer<TableInfo> table_info_;
 
-  std::shared_ptr<SelectStatement> select_;
+  common::ManagedPointer<SelectStatement> select_;
 
-  std::vector<std::shared_ptr<TableRef>> list_;
+  std::vector<common::ManagedPointer<TableRef>> list_;
 
-  std::shared_ptr<JoinDefinition> join_;
+  common::ManagedPointer<JoinDefinition> join_;
 };
 
 DEFINE_JSON_DECLARATIONS(TableRef);

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -26,6 +26,7 @@ class UpdateClause {
    */
   UpdateClause(std::string column, common::ManagedPointer<AbstractExpression> value)
       : column_(std::move(column)), value_(value) {}
+
   ~UpdateClause() = default;
 
   /**
@@ -40,7 +41,7 @@ class UpdateClause {
 
  private:
   const std::string column_;
-  const common::ManagedPointer<AbstractExpression> value_;
+  common::ManagedPointer<AbstractExpression> value_;
 };
 
 /**
@@ -54,14 +55,14 @@ class UpdateStatement : public SQLStatement {
    * @param updates update clauses
    * @param where update conditions
    */
-  UpdateStatement(std::shared_ptr<TableRef> table, std::vector<std::shared_ptr<UpdateClause>> updates,
-                  std::shared_ptr<AbstractExpression> where)
-      : SQLStatement(StatementType::UPDATE),
-        table_(std::move(table)),
-        updates_(std::move(updates)),
-        where_(std::move(where)) {}
+  UpdateStatement(common::ManagedPointer<TableRef> table, std::vector<common::ManagedPointer<UpdateClause>> updates,
+                  common::ManagedPointer<AbstractExpression> where)
+      : SQLStatement(StatementType::UPDATE), table_(table), updates_(std::move(updates)), where_(where) {}
 
-  UpdateStatement() : SQLStatement(StatementType::UPDATE), table_(nullptr), where_(nullptr) {}
+  UpdateStatement()
+      : SQLStatement(StatementType::UPDATE),
+        table_(nullptr),
+        where_(nullptr) {}
 
   ~UpdateStatement() override = default;
 
@@ -70,22 +71,22 @@ class UpdateStatement : public SQLStatement {
   /**
    * @return update table target
    */
-  std::shared_ptr<TableRef> GetUpdateTable() { return table_; }
+  common::ManagedPointer<TableRef> GetUpdateTable() { return table_; }
 
   /**
    * @return update clauses
    */
-  std::vector<std::shared_ptr<UpdateClause>> GetUpdateClauses() { return updates_; }
+  std::vector<common::ManagedPointer<UpdateClause>> GetUpdateClauses() { return updates_; }
 
   /**
    * @return update condition
    */
-  std::shared_ptr<AbstractExpression> GetUpdateCondition() { return where_; }
+  common::ManagedPointer<AbstractExpression> GetUpdateCondition() { return where_; }
 
  private:
-  const std::shared_ptr<TableRef> table_;
-  const std::vector<std::shared_ptr<UpdateClause>> updates_;
-  const std::shared_ptr<AbstractExpression> where_ = nullptr;
+  common::ManagedPointer<TableRef> table_;
+  std::vector<common::ManagedPointer<UpdateClause>> updates_;
+  common::ManagedPointer<AbstractExpression> where_;
 };
 
 }  // namespace parser

--- a/src/parser/expression/abstract_expression.cpp
+++ b/src/parser/expression/abstract_expression.cpp
@@ -52,12 +52,14 @@ void AbstractExpression::FromJson(const nlohmann::json &j) {
   // Deserialize children
   auto children_json = j.at("children").get<std::vector<nlohmann::json>>();
   for (const auto &child_json : children_json) {
-    children_.push_back(DeserializeExpression(child_json));
+    // TODO(WAN): memory leak
+    children_.emplace_back(DeserializeExpression(child_json));
   }
 }
 
-std::shared_ptr<AbstractExpression> DeserializeExpression(const nlohmann::json &j) {
-  std::shared_ptr<AbstractExpression> expr;
+AbstractExpression *DeserializeExpression(const nlohmann::json &j) {
+  // TODO(WAN): this has to live somewhere
+  AbstractExpression *expr;
 
   auto expression_type = j.at("expression_type").get<ExpressionType>();
   switch (expression_type) {
@@ -66,12 +68,12 @@ std::shared_ptr<AbstractExpression> DeserializeExpression(const nlohmann::json &
     case ExpressionType::AGGREGATE_MIN:
     case ExpressionType::AGGREGATE_MAX:
     case ExpressionType::AGGREGATE_AVG: {
-      expr = std::make_shared<AggregateExpression>();
+      expr = new AggregateExpression();
       break;
     }
 
     case ExpressionType::OPERATOR_CASE_EXPR: {
-      expr = std::make_shared<CaseExpression>();
+      expr = new CaseExpression();
       break;
     }
 
@@ -85,27 +87,28 @@ std::shared_ptr<AbstractExpression> DeserializeExpression(const nlohmann::json &
     case ExpressionType::COMPARE_NOT_LIKE:
     case ExpressionType::COMPARE_IN:
     case ExpressionType::COMPARE_IS_DISTINCT_FROM: {
-      expr = std::make_shared<ComparisonExpression>();
+      expr = new ComparisonExpression();
       break;
     }
 
     case ExpressionType::CONJUNCTION_AND:
     case ExpressionType::CONJUNCTION_OR: {
-      expr = std::make_shared<ConjunctionExpression>();
+      expr = new ConjunctionExpression();
       break;
     }
 
     case ExpressionType::VALUE_CONSTANT: {
-      expr = std::make_shared<ConstantValueExpression>();
+      expr = new ConstantValueExpression();
       break;
     }
 
     case ExpressionType ::VALUE_DEFAULT: {
-      expr = std::make_shared<DefaultValueExpression>();
+      expr = new DefaultValueExpression();
       break;
     }
+
     case ExpressionType::FUNCTION: {
-      expr = std::make_shared<FunctionExpression>();
+      expr = new FunctionExpression();
       break;
     }
 
@@ -120,37 +123,37 @@ std::shared_ptr<AbstractExpression> DeserializeExpression(const nlohmann::json &
     case ExpressionType::OPERATOR_IS_NULL:
     case ExpressionType::OPERATOR_IS_NOT_NULL:
     case ExpressionType::OPERATOR_EXISTS: {
-      expr = std::make_shared<OperatorExpression>();
+      expr = new OperatorExpression();
       break;
     }
 
     case ExpressionType::VALUE_PARAMETER: {
-      expr = std::make_shared<ParameterValueExpression>();
+      expr = new ParameterValueExpression();
       break;
     }
 
     case ExpressionType::STAR: {
-      expr = std::make_shared<StarExpression>();
+      expr = new StarExpression();
       break;
     }
 
     case ExpressionType::ROW_SUBQUERY: {
-      expr = std::make_shared<SubqueryExpression>();
+      expr = new SubqueryExpression();
       break;
     }
 
     case ExpressionType::VALUE_TUPLE: {
-      expr = std::make_shared<DerivedValueExpression>();
+      expr = new DerivedValueExpression();
       break;
     }
 
     case ExpressionType::COLUMN_VALUE: {
-      expr = std::make_shared<ColumnValueExpression>();
+      expr = new ColumnValueExpression();
       break;
     }
 
     case ExpressionType::OPERATOR_CAST: {
-      expr = std::make_shared<TypeCastExpression>();
+      expr = new TypeCastExpression();
       break;
     }
 

--- a/src/parser/select_statement.cpp
+++ b/src/parser/select_statement.cpp
@@ -30,36 +30,41 @@ void SelectStatement::FromJson(const nlohmann::json &j) {
 
   // Deserialize from
   if (!j.at("from").is_null()) {
-    from_ = std::make_shared<TableRef>();
+    from_ = common::ManagedPointer<TableRef>();
     from_->FromJson(j.at("from"));
   }
 
   // Deserialize where
   if (!j.at("where").is_null()) {
-    where_ = DeserializeExpression(j.at("where"));
+    // TODO(WAN): lifetime
+    where_ = common::ManagedPointer(DeserializeExpression(j.at("where")));
   }
 
   // Deserialize group by
   if (!j.at("group_by").is_null()) {
-    group_by_ = std::make_shared<GroupByDescription>();
+    // TODO(WAN): lifetime
+    group_by_ = common::ManagedPointer(new GroupByDescription());
     group_by_->FromJson(j.at("group_by"));
   }
 
   // Deserialize order by
   if (!j.at("order_by").is_null()) {
-    order_by_ = std::make_shared<OrderByDescription>();
+    // TODO(WAN): lifetime
+    order_by_ = common::ManagedPointer(new OrderByDescription());
     order_by_->FromJson(j.at("order_by"));
   }
 
   // Deserialize limit
   if (!j.at("limit").is_null()) {
-    limit_ = std::make_shared<LimitDescription>();
+    // TODO(WAN): lifetime
+    limit_ = common::ManagedPointer(new LimitDescription());
     limit_->FromJson(j.at("limit"));
   }
 
   // Deserialize select
   if (!j.at("union_select").is_null()) {
-    union_select_ = std::make_shared<parser::SelectStatement>();
+    // TODO(WAN): lifetime
+    union_select_ = common::ManagedPointer(new SelectStatement());
     union_select_->FromJson(j.at("union_select"));
   }
 }

--- a/src/parser/table_ref.cpp
+++ b/src/parser/table_ref.cpp
@@ -27,19 +27,22 @@ void JoinDefinition::FromJson(const nlohmann::json &j) {
 
   // Deserialize left
   if (!j.at("left").is_null()) {
-    left_ = std::make_shared<TableRef>();
+    // TODO(WAN): lifetime
+    left_ = common::ManagedPointer(new TableRef());
     left_->FromJson(j.at("left"));
   }
 
   // Deserialize right
   if (!j.at("right").is_null()) {
-    right_ = std::make_shared<TableRef>();
+    // TODO(WAN): lifetime
+    right_ = common::ManagedPointer(new TableRef());
     right_->FromJson(j.at("right"));
   }
 
   // Deserialize condition
   if (!j.at("condition").is_null()) {
-    condition_ = DeserializeExpression(j.at("condition"));
+    // TODO(WAN): lifetime
+    condition_ = common::ManagedPointer(DeserializeExpression(j.at("condition")));
   }
 }
 
@@ -63,27 +66,31 @@ void TableRef::FromJson(const nlohmann::json &j) {
 
   // Deserialize table info
   if (!j.at("table_info").is_null()) {
-    table_info_ = std::make_shared<TableInfo>();
+    // TODO(WAN): lifetime
+    table_info_ = common::ManagedPointer(new TableInfo());
     table_info_->FromJson(j.at("table_info"));
   }
 
   // Deserialize select
   if (!j.at("select").is_null()) {
-    select_ = std::make_shared<parser::SelectStatement>();
+    // TODO(WAN): lifetime
+    select_ = common::ManagedPointer(new SelectStatement());
     select_->FromJson(j.at("select"));
   }
 
   // Deserialize list
   auto list_jsons = j.at("list").get<std::vector<nlohmann::json>>();
   for (const auto &list_json : list_jsons) {
-    auto ref = std::make_shared<TableRef>();
+    // TODO(WAN): lifetime
+    auto ref = common::ManagedPointer(new TableRef());
     ref->FromJson(list_json);
-    list_.push_back(std::move(ref));
+    list_.push_back(ref);
   }
 
   // Deserialize join
   if (!j.at("join").is_null()) {
-    join_ = std::make_shared<JoinDefinition>();
+    // TODO(WAN): lifetime
+    join_ = common::ManagedPointer(new JoinDefinition());
     join_->FromJson(j.at("join"));
   }
 }


### PR DESCRIPTION
Separated out into a new PR, the old one fell quite far behind. Goal is to pull a couple of all nighters in the next couple of days and have this in by Friday.

Converts just expressions to use managed pointers. Temporarily disables plan nodes entirely, and plan nodes are not in scope for this PR, my understanding @jrolli is that just expressions are enough to unblock #470?

Questions remaining (Slack had some more context):
- [ ] For going from (Parent) to (More specific class), e.g. (SQLStatement -> SelectStatement), I don't think you can eliminate CastManagedPointerTo like @jrolli wanted?
- [ ] DeserializeJSON creates things which have managed pointers. If we eliminate .get() per @mush-zhang @GustavoAngulo ?, I don't see how you can clean this up without refactoring to pass in some deferred action magic thing to the expression classes.

Reviewer suggestion:
- Every time I create a raw pointer, make sure it gets added to the ParseResult... every couple of git diff passes I catch a new one leaking. Thinking about pairing up these with code comments like malloclab..

Work remaining:
- [x] Pull in my commits
- [x] Compiles terrier target
- [ ] Pull in Gus commits (I saw some smaller bug fixes, etc) -- goal Wednesday
- [ ] Compiles parser test targets, i.e. fix parser tests to use ParseResult and cleanup -- goal Thursday
- [ ] Check for memory leaks -- hopefully valgrind will help; see questions, some will definitely leak
- [ ] CI (format, tidy, lint, doxygen -- right now Windows isn't letting me do any of that) -- goal Friday