### PR TITLE
Search path fix

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -176,7 +176,7 @@ common::ManagedPointer<DatabaseCatalog> Catalog::GetDatabaseCatalog(transaction:
 std::unique_ptr<CatalogAccessor> Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
-  return std::unique_ptr(new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database));
+  return { new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database)) };
 }
 
 bool Catalog::CreateDatabaseEntry(transaction::TransactionContext *const txn, const db_oid_t db,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -176,8 +176,7 @@ common::ManagedPointer<DatabaseCatalog> Catalog::GetDatabaseCatalog(transaction:
 std::unique_ptr<CatalogAccessor> Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
-  auto accessor = new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database);
-  return std::make_unique<CatalogAccessor>(accessor);
+  return std::make_unique<CatalogAccessor>(common::ManagedPointer(this), dbc, txn, database);
 }
 
 bool Catalog::CreateDatabaseEntry(transaction::TransactionContext *const txn, const db_oid_t db,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -176,7 +176,7 @@ common::ManagedPointer<DatabaseCatalog> Catalog::GetDatabaseCatalog(transaction:
 CatalogAccessor *Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
-  return new CatalogAccessor(this, dbc, txn, database);
+  return new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database);
 }
 
 bool Catalog::CreateDatabaseEntry(transaction::TransactionContext *const txn, const db_oid_t db,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -176,7 +176,7 @@ common::ManagedPointer<DatabaseCatalog> Catalog::GetDatabaseCatalog(transaction:
 std::unique_ptr<CatalogAccessor> Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
-  return std::make_unique<CatalogAccessor>(common::ManagedPointer(this), dbc, txn, database);
+  return std::unique_ptr(new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database));
 }
 
 bool Catalog::CreateDatabaseEntry(transaction::TransactionContext *const txn, const db_oid_t db,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -177,7 +177,7 @@ std::unique_ptr<CatalogAccessor> Catalog::GetAccessor(transaction::TransactionCo
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
   auto accessor = new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database);
-  return std::make_unique(accessor);
+  return std::make_unique<CatalogAccessor>(accessor);
 }
 
 bool Catalog::CreateDatabaseEntry(transaction::TransactionContext *const txn, const db_oid_t db,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -176,7 +176,8 @@ common::ManagedPointer<DatabaseCatalog> Catalog::GetDatabaseCatalog(transaction:
 std::unique_ptr<CatalogAccessor> Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
-  return { new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database) };
+  auto accessor = new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database)
+  return std::make_unique(accessor);
 }
 
 bool Catalog::CreateDatabaseEntry(transaction::TransactionContext *const txn, const db_oid_t db,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -177,7 +177,7 @@ common::ManagedPointer<DatabaseCatalog> Catalog::GetDatabaseCatalog(transaction:
 std::unique_ptr<CatalogAccessor> Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
-  return std::make_unique<CatalogAccessor>(common::ManagedPointer(this), dbc, txn, database);
+  return std::make_unique<CatalogAccessor>(common::ManagedPointer(this), dbc, txn);
 }
 
 bool Catalog::CreateDatabaseEntry(transaction::TransactionContext *const txn, const db_oid_t db,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -176,7 +176,7 @@ common::ManagedPointer<DatabaseCatalog> Catalog::GetDatabaseCatalog(transaction:
 std::unique_ptr<CatalogAccessor> Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
-  return { new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database)) };
+  return { new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database) };
 }
 
 bool Catalog::CreateDatabaseEntry(transaction::TransactionContext *const txn, const db_oid_t db,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -176,7 +176,7 @@ common::ManagedPointer<DatabaseCatalog> Catalog::GetDatabaseCatalog(transaction:
 std::unique_ptr<CatalogAccessor> Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
-  auto accessor = new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database)
+  auto accessor = new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database);
   return std::make_unique(accessor);
 }
 

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -173,10 +173,10 @@ common::ManagedPointer<DatabaseCatalog> Catalog::GetDatabaseCatalog(transaction:
   return common::ManagedPointer(dbc);
 }
 
-CatalogAccessor *Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
+std::unique_ptr<CatalogAccessor> Catalog::GetAccessor(transaction::TransactionContext *txn, db_oid_t database) {
   auto dbc = this->GetDatabaseCatalog(txn, database);
   if (dbc == nullptr) return nullptr;
-  return new CatalogAccessor(common::ManagedPointer(this), dbc, txn, database);
+  return std::make_unique<CatalogAccessor>(common::ManagedPointer(this), dbc, txn, database);
 }
 
 bool Catalog::CreateDatabaseEntry(transaction::TransactionContext *const txn, const db_oid_t db,

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -32,8 +32,7 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
   search_path_.clear();
   search_path_.reserve(namespaces.size() + 1);
   search_path_.emplace_back(NAMESPACE_CATALOG_NAMESPACE_OID);
-  for (auto ns : namespaces)
-    search_path_.emplace_back(ns);
+  for (auto ns : namespaces) search_path_.emplace_back(ns);
 }
 
 namespace_oid_t CatalogAccessor::GetNamespaceOid(std::string name) {

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -24,7 +24,7 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
   search_path_ = std::move(namespaces);
 
     // Check if 'pg_catalog is explicitly set'
-  for (auto ns : namespaces) {
+  for (auto &ns : namespaces) {
     if (ns == NAMESPACE_CATALOG_NAMESPACE_OID)
       return;
   }

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -19,12 +19,14 @@ bool CatalogAccessor::DropDatabase(db_oid_t db) const { return catalog_->DeleteD
 
 void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
   TERRIER_ASSERT(!namespaces.empty(), "search path cannot be empty");
+
   default_namespace_ = namespaces[0];
   search_path_ = std::move(namespaces);
 
     // Check if 'pg_catalog is explicitly set'
-  for (auto ns : namespaces)
+  for (auto ns : namespaces) {
     if (ns == NAMESPACE_CATALOG_NAMESPACE_OID) return;
+  }
 
   search_path_.emplace(search_path_.begin(), NAMESPACE_CATALOG_NAMESPACE_OID);
 }

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -67,7 +67,7 @@ bool CatalogAccessor::RenameTable(table_oid_t table, std::string new_table_name)
 
 bool CatalogAccessor::DropTable(table_oid_t table) const { return dbc_->DeleteTable(txn_, table); }
 
-bool CatalogAccessor::SetTablePointer(table_oid_t table, storage::SqlTable *table_ptr) {
+bool CatalogAccessor::SetTablePointer(table_oid_t table, storage::SqlTable *table_ptr) const {
   return dbc_->SetTablePointer(txn_, table, table_ptr);
 }
 

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -25,7 +25,8 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
 
     // Check if 'pg_catalog is explicitly set'
   for (auto ns : namespaces) {
-    if (ns == NAMESPACE_CATALOG_NAMESPACE_OID) return;
+    if (ns == NAMESPACE_CATALOG_NAMESPACE_OID)
+      return;
   }
 
   search_path_.emplace(search_path_.begin(), NAMESPACE_CATALOG_NAMESPACE_OID);

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -20,19 +20,13 @@ bool CatalogAccessor::DropDatabase(db_oid_t db) { return catalog_->DeleteDatabas
 void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
   TERRIER_ASSERT(!namespaces.empty(), "search path cannot be empty");
   default_namespace_ = namespaces[0];
+  search_path_ = std::move(namespaces);
 
-  for (auto ns : namespaces) {
     // Check if 'pg_catalog is explicitly set'
-    if (ns == NAMESPACE_CATALOG_NAMESPACE_OID) {
-      search_path_ = std::move(namespaces);
-      return;
-    }
-  }
+  for (auto ns : namespaces)
+    if (ns == NAMESPACE_CATALOG_NAMESPACE_OID) return;
 
-  search_path_.clear();
-  search_path_.reserve(namespaces.size() + 1);
-  search_path_.emplace_back(NAMESPACE_CATALOG_NAMESPACE_OID);
-  for (auto ns : namespaces) search_path_.emplace_back(ns);
+  search_path_.emplace(search_path_.begin(), NAMESPACE_CATALOG_NAMESPACE_OID);
 }
 
 namespace_oid_t CatalogAccessor::GetNamespaceOid(std::string name) {

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -23,7 +23,7 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
   default_namespace_ = namespaces[0];
   search_path_ = std::move(namespaces);
 
-    // Check if 'pg_catalog is explicitly set'
+  // Check if 'pg_catalog is explicitly set'
   for (auto &ns : search_path_)
     if (ns == NAMESPACE_CATALOG_NAMESPACE_OID) return;
 
@@ -102,7 +102,9 @@ index_oid_t CatalogAccessor::GetIndexOid(namespace_oid_t ns, std::string name) c
   return dbc_->GetIndexOid(txn_, ns, name);
 }
 
-std::vector<index_oid_t> CatalogAccessor::GetIndexOids(table_oid_t table) const { return dbc_->GetIndexes(txn_, table); }
+std::vector<index_oid_t> CatalogAccessor::GetIndexOids(table_oid_t table) const {
+  return dbc_->GetIndexes(txn_, table);
+}
 
 index_oid_t CatalogAccessor::CreateIndex(namespace_oid_t ns, table_oid_t table, std::string name,
                                          const IndexSchema &schema) const {
@@ -110,7 +112,9 @@ index_oid_t CatalogAccessor::CreateIndex(namespace_oid_t ns, table_oid_t table, 
   return dbc_->CreateIndex(txn_, ns, name, table, schema);
 }
 
-const IndexSchema &CatalogAccessor::GetIndexSchema(index_oid_t index) const { return dbc_->GetIndexSchema(txn_, index); }
+const IndexSchema &CatalogAccessor::GetIndexSchema(index_oid_t index) const {
+  return dbc_->GetIndexSchema(txn_, index);
+}
 
 bool CatalogAccessor::DropIndex(index_oid_t index) const { return dbc_->DeleteIndex(txn_, index); }
 

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -5,17 +5,17 @@
 #include "catalog/catalog.h"
 
 namespace terrier::catalog {
-db_oid_t CatalogAccessor::GetDatabaseOid(std::string name) {
+db_oid_t CatalogAccessor::GetDatabaseOid(std::string name) const {
   NormalizeObjectName(&name);
   return catalog_->GetDatabaseOid(txn_, name);
 }
 
-db_oid_t CatalogAccessor::CreateDatabase(std::string name) {
+db_oid_t CatalogAccessor::CreateDatabase(std::string name) const {
   NormalizeObjectName(&name);
   return catalog_->CreateDatabase(txn_, name, true);
 }
 
-bool CatalogAccessor::DropDatabase(db_oid_t db) { return catalog_->DeleteDatabase(txn_, db); }
+bool CatalogAccessor::DropDatabase(db_oid_t db) const { return catalog_->DeleteDatabase(txn_, db); }
 
 void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
   TERRIER_ASSERT(!namespaces.empty(), "search path cannot be empty");
@@ -29,19 +29,19 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
   search_path_.emplace(search_path_.begin(), NAMESPACE_CATALOG_NAMESPACE_OID);
 }
 
-namespace_oid_t CatalogAccessor::GetNamespaceOid(std::string name) {
+namespace_oid_t CatalogAccessor::GetNamespaceOid(std::string name) const {
   NormalizeObjectName(&name);
   return dbc_->GetNamespaceOid(txn_, name);
 }
 
-namespace_oid_t CatalogAccessor::CreateNamespace(std::string name) {
+namespace_oid_t CatalogAccessor::CreateNamespace(std::string name) const {
   NormalizeObjectName(&name);
   return dbc_->CreateNamespace(txn_, name);
 }
 
-bool CatalogAccessor::DropNamespace(namespace_oid_t ns) { return dbc_->DeleteNamespace(txn_, ns); }
+bool CatalogAccessor::DropNamespace(namespace_oid_t ns) const { return dbc_->DeleteNamespace(txn_, ns); }
 
-table_oid_t CatalogAccessor::GetTableOid(std::string name) {
+table_oid_t CatalogAccessor::GetTableOid(std::string name) const {
   NormalizeObjectName(&name);
   for (auto &path : search_path_) {
     table_oid_t search_result = dbc_->GetTableOid(txn_, path, name);
@@ -50,44 +50,44 @@ table_oid_t CatalogAccessor::GetTableOid(std::string name) {
   return INVALID_TABLE_OID;
 }
 
-table_oid_t CatalogAccessor::GetTableOid(namespace_oid_t ns, std::string name) {
+table_oid_t CatalogAccessor::GetTableOid(namespace_oid_t ns, std::string name) const {
   NormalizeObjectName(&name);
   return dbc_->GetTableOid(txn_, ns, name);
 }
 
-table_oid_t CatalogAccessor::CreateTable(namespace_oid_t ns, std::string name, const Schema &schema) {
+table_oid_t CatalogAccessor::CreateTable(namespace_oid_t ns, std::string name, const Schema &schema) const {
   NormalizeObjectName(&name);
   return dbc_->CreateTable(txn_, ns, name, schema);
 }
 
-bool CatalogAccessor::RenameTable(table_oid_t table, std::string new_table_name) {
+bool CatalogAccessor::RenameTable(table_oid_t table, std::string new_table_name) const {
   NormalizeObjectName(&new_table_name);
   return dbc_->RenameTable(txn_, table, new_table_name);
 }
 
-bool CatalogAccessor::DropTable(table_oid_t table) { return dbc_->DeleteTable(txn_, table); }
+bool CatalogAccessor::DropTable(table_oid_t table) const { return dbc_->DeleteTable(txn_, table); }
 
 bool CatalogAccessor::SetTablePointer(table_oid_t table, storage::SqlTable *table_ptr) {
   return dbc_->SetTablePointer(txn_, table, table_ptr);
 }
 
-common::ManagedPointer<storage::SqlTable> CatalogAccessor::GetTable(table_oid_t table) {
+common::ManagedPointer<storage::SqlTable> CatalogAccessor::GetTable(table_oid_t table) const {
   return dbc_->GetTable(txn_, table);
 }
 
-bool CatalogAccessor::UpdateSchema(table_oid_t table, Schema *new_schema) {
+bool CatalogAccessor::UpdateSchema(table_oid_t table, Schema *new_schema) const {
   return dbc_->UpdateSchema(txn_, table, new_schema);
 }
 
-const Schema &CatalogAccessor::GetSchema(table_oid_t table) { return dbc_->GetSchema(txn_, table); }
+const Schema &CatalogAccessor::GetSchema(table_oid_t table) const { return dbc_->GetSchema(txn_, table); }
 
-std::vector<constraint_oid_t> CatalogAccessor::GetConstraints(table_oid_t table) {
+std::vector<constraint_oid_t> CatalogAccessor::GetConstraints(table_oid_t table) const {
   return dbc_->GetConstraints(txn_, table);
 }
 
-std::vector<index_oid_t> CatalogAccessor::GetIndexes(table_oid_t table) { return dbc_->GetIndexes(txn_, table); }
+std::vector<index_oid_t> CatalogAccessor::GetIndexes(table_oid_t table) const { return dbc_->GetIndexes(txn_, table); }
 
-index_oid_t CatalogAccessor::GetIndexOid(std::string name) {
+index_oid_t CatalogAccessor::GetIndexOid(std::string name) const {
   NormalizeObjectName(&name);
   for (auto &path : search_path_) {
     index_oid_t search_result = dbc_->GetIndexOid(txn_, path, name);
@@ -96,28 +96,28 @@ index_oid_t CatalogAccessor::GetIndexOid(std::string name) {
   return INVALID_INDEX_OID;
 }
 
-index_oid_t CatalogAccessor::GetIndexOid(namespace_oid_t ns, std::string name) {
+index_oid_t CatalogAccessor::GetIndexOid(namespace_oid_t ns, std::string name) const {
   NormalizeObjectName(&name);
   return dbc_->GetIndexOid(txn_, ns, name);
 }
 
-std::vector<index_oid_t> CatalogAccessor::GetIndexOids(table_oid_t table) { return dbc_->GetIndexes(txn_, table); }
+std::vector<index_oid_t> CatalogAccessor::GetIndexOids(table_oid_t table) const { return dbc_->GetIndexes(txn_, table); }
 
 index_oid_t CatalogAccessor::CreateIndex(namespace_oid_t ns, table_oid_t table, std::string name,
-                                         const IndexSchema &schema) {
+                                         const IndexSchema &schema) const {
   NormalizeObjectName(&name);
   return dbc_->CreateIndex(txn_, ns, name, table, schema);
 }
 
-const IndexSchema &CatalogAccessor::GetIndexSchema(index_oid_t index) { return dbc_->GetIndexSchema(txn_, index); }
+const IndexSchema &CatalogAccessor::GetIndexSchema(index_oid_t index) const { return dbc_->GetIndexSchema(txn_, index); }
 
-bool CatalogAccessor::DropIndex(index_oid_t index) { return dbc_->DeleteIndex(txn_, index); }
+bool CatalogAccessor::DropIndex(index_oid_t index) const { return dbc_->DeleteIndex(txn_, index); }
 
-bool CatalogAccessor::SetIndexPointer(index_oid_t index, storage::index::Index *index_ptr) {
+bool CatalogAccessor::SetIndexPointer(index_oid_t index, storage::index::Index *index_ptr) const {
   return dbc_->SetIndexPointer(txn_, index, index_ptr);
 }
 
-common::ManagedPointer<storage::index::Index> CatalogAccessor::GetIndex(index_oid_t index) {
+common::ManagedPointer<storage::index::Index> CatalogAccessor::GetIndex(index_oid_t index) const {
   return dbc_->GetIndex(txn_, index);
 }
 

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -18,7 +18,7 @@ db_oid_t CatalogAccessor::CreateDatabase(std::string name) {
 bool CatalogAccessor::DropDatabase(db_oid_t db) { return catalog_->DeleteDatabase(txn_, db); }
 
 void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
-  TERRIER_ASSERT(namespaces.size() > 0, "search path cannot be empty");
+  TERRIER_ASSERT(namespaces.empty(), "search path cannot be empty");
   default_namespace_ = namespaces[0];
 
   for (auto ns : namespaces) {

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -29,7 +29,7 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
     }
   }
 
-  search_path_.clear()
+  search_path_.clear();
   search_path_.reserve(namespaces.size() + 1);
   search_path_.emplace_back(NAMESPACE_CATALOG_NAMESPACE_OID);
   for (auto ns : namespaces)

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -29,11 +29,11 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
     }
   }
 
-  std::vector<namespace_oid_t> path;
-  path.reserve(namespaces.size() + 1);
-  path.emplace_back(NAMESPACE_CATALOG_NAMESPACE_OID);
+  search_path_.clear()
+  search_path_.reserve(namespaces.size() + 1);
+  search_path_.emplace_back(NAMESPACE_CATALOG_NAMESPACE_OID);
   for (auto ns : namespaces)
-    path.emplace_back(ns);
+    search_path_.emplace_back(ns);
 }
 
 namespace_oid_t CatalogAccessor::GetNamespaceOid(std::string name) {

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -18,7 +18,7 @@ db_oid_t CatalogAccessor::CreateDatabase(std::string name) {
 bool CatalogAccessor::DropDatabase(db_oid_t db) { return catalog_->DeleteDatabase(txn_, db); }
 
 void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
-  TERRIER_ASSERT(namespaces.empty(), "search path cannot be empty");
+  TERRIER_ASSERT(!namespaces.empty(), "search path cannot be empty");
   default_namespace_ = namespaces[0];
 
   for (auto ns : namespaces) {

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -24,10 +24,8 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
   search_path_ = std::move(namespaces);
 
     // Check if 'pg_catalog is explicitly set'
-  for (auto &ns : namespaces) {
-    if (ns == NAMESPACE_CATALOG_NAMESPACE_OID)
-      return;
-  }
+  for (auto &ns : search_path_)
+    if (ns == NAMESPACE_CATALOG_NAMESPACE_OID) return;
 
   search_path_.emplace(search_path_.begin(), NAMESPACE_CATALOG_NAMESPACE_OID);
 }

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1088,12 +1088,16 @@ void DatabaseCatalog::TearDown(transaction::TransactionContext *txn) {
     for (uint i = 0; i < pc->NumTuples(); i++) {
       switch (classes[i]) {
         case postgres::ClassKind::REGULAR_TABLE:
-          table_schemas.emplace_back(reinterpret_cast<Schema *>(schemas[i]));
-          tables.emplace_back(reinterpret_cast<storage::SqlTable *>(objects[i]));
+          if (schemas[i] != nullptr)
+            table_schemas.emplace_back(reinterpret_cast<Schema *>(schemas[i]));
+          if (objects[i] != nullptr)
+            tables.emplace_back(reinterpret_cast<storage::SqlTable *>(objects[i]));
           break;
         case postgres::ClassKind::INDEX:
-          index_schemas.emplace_back(reinterpret_cast<IndexSchema *>(schemas[i]));
-          indexes.emplace_back(reinterpret_cast<storage::index::Index *>(objects[i]));
+          if (schemas[i] != nullptr)
+            index_schemas.emplace_back(reinterpret_cast<IndexSchema *>(schemas[i]));
+          if (objects[i] != nullptr)
+            indexes.emplace_back(reinterpret_cast<storage::index::Index *>(objects[i]));
           break;
         default:
           throw std::runtime_error("Unimplemented destructor needed");

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1088,16 +1088,12 @@ void DatabaseCatalog::TearDown(transaction::TransactionContext *txn) {
     for (uint i = 0; i < pc->NumTuples(); i++) {
       switch (classes[i]) {
         case postgres::ClassKind::REGULAR_TABLE:
-          if (schemas[i] != nullptr)
-            table_schemas.emplace_back(reinterpret_cast<Schema *>(schemas[i]));
-          if (objects[i] != nullptr)
-            tables.emplace_back(reinterpret_cast<storage::SqlTable *>(objects[i]));
+          table_schemas.emplace_back(reinterpret_cast<Schema *>(schemas[i]));
+          tables.emplace_back(reinterpret_cast<storage::SqlTable *>(objects[i]));
           break;
         case postgres::ClassKind::INDEX:
-          if (schemas[i] != nullptr)
-            index_schemas.emplace_back(reinterpret_cast<IndexSchema *>(schemas[i]));
-          if (objects[i] != nullptr)
-            indexes.emplace_back(reinterpret_cast<storage::index::Index *>(objects[i]));
+          index_schemas.emplace_back(reinterpret_cast<IndexSchema *>(schemas[i]));
+          indexes.emplace_back(reinterpret_cast<storage::index::Index *>(objects[i]));
           break;
         default:
           throw std::runtime_error("Unimplemented destructor needed");

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -103,7 +103,7 @@ class Catalog {
    * @param database in which this transaction is scoped
    * @return a CatalogAccessor object for use with this transaction
    */
-  CatalogAccessor *GetAccessor(transaction::TransactionContext *txn, db_oid_t database);
+  std::unique_ptr<CatalogAccessor> GetAccessor(transaction::TransactionContext *txn, db_oid_t database);
 
  private:
   transaction::TransactionManager *txn_manager_;

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -260,10 +260,10 @@ class CatalogAccessor {
   common::ManagedPointer<storage::index::Index> GetIndex(index_oid_t index);
 
  private:
-  Catalog *catalog_;
-  common::ManagedPointer<DatabaseCatalog> dbc_;
-  transaction::TransactionContext *txn_;
-  db_oid_t db_oid_;
+  const common::ManagedPointer<Catalog> catalog_;
+  const common::ManagedPointer<DatabaseCatalog> dbc_;
+  const transaction::TransactionContext *txn_;
+  const db_oid_t db_oid_;
   std::vector<namespace_oid_t> search_path_;
   namespace_oid_t default_namespace_;
 

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -262,7 +262,7 @@ class CatalogAccessor {
  private:
   const common::ManagedPointer<Catalog> catalog_;
   const common::ManagedPointer<DatabaseCatalog> dbc_;
-  const transaction::TransactionContext *txn_;
+  transaction::TransactionContext *txn_;
   const db_oid_t db_oid_;
   std::vector<namespace_oid_t> search_path_;
   namespace_oid_t default_namespace_;

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -42,21 +42,21 @@ class CatalogAccessor {
    * @param name of the database
    * @return OID for the database, INVALID_DATABASE_OID if the database does not exist
    */
-  db_oid_t GetDatabaseOid(std::string name);
+  db_oid_t GetDatabaseOid(std::string name) const;
 
   /**
    * Given a database name, create a new database entry in the catalog and assign it an OID
    * @param name of the new database
    * @return OID for the database, INVALID_DATABASE_OID if the database already exists
    */
-  db_oid_t CreateDatabase(std::string name);
+  db_oid_t CreateDatabase(std::string name) const;
 
   /**
    * Drop all entries in the catalog that belong to the database, including the database entry
    * @param db the OID of the database to drop
    * @return true, unless there was no database entry with the given OID
    */
-  bool DropDatabase(db_oid_t db);
+  bool DropDatabase(db_oid_t db) const;
 
   /**
    * Sets the search path of namespaces that should be checked when looking up an
@@ -68,35 +68,35 @@ class CatalogAccessor {
   /**
    * @return the current default namespace (first one in search path)
    */
-  namespace_oid_t GetDefaultNamespace() { return default_namespace_; }
+  namespace_oid_t GetDefaultNamespace() const { return default_namespace_; }
 
   /**
    * Given a namespace name, resolve it to the corresponding OID
    * @param name of the namespace
    * @return OID of the namespace, INVALID_NAMESPACE_OID if the namespace was not found
    */
-  namespace_oid_t GetNamespaceOid(std::string name);
+  namespace_oid_t GetNamespaceOid(std::string name) const;
 
   /**
    * Given a namespace name, resolve it to the corresponding OID
    * @param name of the namespace
    * @return OID of the namespace, INVALID_NAMESPACE_OID if the namespace was not found
    */
-  namespace_oid_t CreateNamespace(std::string name);
+  namespace_oid_t CreateNamespace(std::string name) const;
 
   /**
    * Drop all entries in the catalog that belong to the namespace, including the namespace entry
    * @param ns the OID of the namespace to drop
    * @return true, unless there was no namespace entry with the given OID
    */
-  bool DropNamespace(namespace_oid_t ns);
+  bool DropNamespace(namespace_oid_t ns) const;
 
   /**
    * Given a table name, resolve it to the corresponding OID
    * @param name of the table
    * @return OID of the table, INVALID_TABLE_OID if the table was not found
    */
-  table_oid_t GetTableOid(std::string name);
+  table_oid_t GetTableOid(std::string name) const;
 
   /**
    * Given a table name and its owning namespace, resolve it to the corresponding OID
@@ -104,7 +104,7 @@ class CatalogAccessor {
    * @param name of the table
    * @return OID of the table, INVALID_TABLE_OID if the table was not found
    */
-  table_oid_t GetTableOid(namespace_oid_t ns, std::string name);
+  table_oid_t GetTableOid(namespace_oid_t ns, std::string name) const;
 
   /**
    * Given a table name, create a new table entry in the catalog and assign it an OID. This
@@ -119,7 +119,7 @@ class CatalogAccessor {
    * schema object after this call, they should use the GetSchema function to
    * obtain the authoritative schema for this table.
    */
-  table_oid_t CreateTable(namespace_oid_t ns, std::string name, const Schema &schema);
+  table_oid_t CreateTable(namespace_oid_t ns, std::string name, const Schema &schema) const;
 
   /**
    * Rename the table from its current string to the new one.  The renaming could fail
@@ -131,7 +131,7 @@ class CatalogAccessor {
    *
    * @note This operation will write-lock the table entry until the transaction closes.
    */
-  bool RenameTable(table_oid_t table, std::string new_table_name);
+  bool RenameTable(table_oid_t table, std::string new_table_name) const;
 
   /**
    * Drop the table and all corresponding indices from the catalog.
@@ -139,7 +139,7 @@ class CatalogAccessor {
    * @return true, unless there was no table entry for the given OID or the entry
    *         was write-locked by a different transaction
    */
-  bool DropTable(table_oid_t table);
+  bool DropTable(table_oid_t table) const;
 
   /**
    * Inform the catalog of where the underlying storage for a table is
@@ -150,14 +150,14 @@ class CatalogAccessor {
    * catalog will take ownership of it and schedule its deletion with the GC
    * at the appropriate time.
    */
-  bool SetTablePointer(table_oid_t table, storage::SqlTable *table_ptr);
+  bool SetTablePointer(table_oid_t table, storage::SqlTable *table_ptr) const;
 
   /**
    * Obtain the storage pointer for a SQL table
    * @param table to which we want the storage object
    * @return the storage object corresponding to the passed OID
    */
-  common::ManagedPointer<storage::SqlTable> GetTable(table_oid_t table);
+  common::ManagedPointer<storage::SqlTable> GetTable(table_oid_t table) const;
 
   /**
    * Apply a new schema to the given table.  The changes should modify the latest
@@ -172,35 +172,35 @@ class CatalogAccessor {
    * schema object after this call, they should use the GetSchema function to
    * obtain the authoritative schema for this table.
    */
-  bool UpdateSchema(table_oid_t table, Schema *new_schema);
+  bool UpdateSchema(table_oid_t table, Schema *new_schema) const;
 
   /**
    * Get the visible schema describing the table.
    * @param table corresponding to the requested schema
    * @return the visible schema object for the identified table
    */
-  const Schema &GetSchema(table_oid_t table);
+  const Schema &GetSchema(table_oid_t table) const;
 
   /**
    * A list of all constraints on this table
    * @param table being queried
    * @return vector of OIDs for all of the constraints that apply to this table
    */
-  std::vector<constraint_oid_t> GetConstraints(table_oid_t table);
+  std::vector<constraint_oid_t> GetConstraints(table_oid_t table) const;
 
   /**
    * A list of all indexes on the given table
    * @param table being queried
    * @return vector of OIDs for all of the indexes on this table
    */
-  std::vector<index_oid_t> GetIndexes(table_oid_t table);
+  std::vector<index_oid_t> GetIndexes(table_oid_t table) const;
 
   /**
    * Given an index name, resolve it to the corresponding OID
    * @param name of the index
    * @return OID of the index, INVALID_INDEX_OID if the index was not found
    */
-  index_oid_t GetIndexOid(std::string name);
+  index_oid_t GetIndexOid(std::string name) const;
 
   /**
    * Given an index name and the owning namespace, resolve it to the corresponding OID
@@ -208,14 +208,14 @@ class CatalogAccessor {
    * @param name of the index
    * @return OID of the index, INVALID_INDEX_OID if the index was not found
    */
-  index_oid_t GetIndexOid(namespace_oid_t ns, std::string name);
+  index_oid_t GetIndexOid(namespace_oid_t ns, std::string name) const;
 
   /**
    * Given a table, find all indexes for data in that table
    * @param table OID being queried
    * @return vector of index OIDs that reference the queried table
    */
-  std::vector<index_oid_t> GetIndexOids(table_oid_t table);
+  std::vector<index_oid_t> GetIndexOids(table_oid_t table) const;
 
   /**
    * Given the index name and its specification, add it to the catalog
@@ -225,21 +225,21 @@ class CatalogAccessor {
    * @param schema describing the new index
    * @return OID for the index, INVALID_INDEX_OID if the operation failed
    */
-  index_oid_t CreateIndex(namespace_oid_t ns, table_oid_t table, std::string name, const IndexSchema &schema);
+  index_oid_t CreateIndex(namespace_oid_t ns, table_oid_t table, std::string name, const IndexSchema &schema) const;
 
   /**
    * Gets the schema that was used to define the index
    * @param index corresponding to the requested key schema
    * @return the key schema for this index
    */
-  const IndexSchema &GetIndexSchema(index_oid_t index);
+  const IndexSchema &GetIndexSchema(index_oid_t index) const;
 
   /**
    * Drop the corresponding index from the catalog.
    * @param index to be dropped
    * @return whether the operation succeeded
    */
-  bool DropIndex(index_oid_t index);
+  bool DropIndex(index_oid_t index) const;
 
   /**
    * Inform the catalog of where the underlying implementation of the index is
@@ -250,14 +250,14 @@ class CatalogAccessor {
    * catalog will take ownership of it and schedule its deletion with the GC
    * at the appropriate time.
    */
-  bool SetIndexPointer(index_oid_t index, storage::index::Index *index_ptr);
+  bool SetIndexPointer(index_oid_t index, storage::index::Index *index_ptr) const;
 
   /**
    * Obtain the pointer to the index
    * @param index to which we want a pointer
    * @return the pointer to the index
    */
-  common::ManagedPointer<storage::index::Index> GetIndex(index_oid_t index);
+  common::ManagedPointer<storage::index::Index> GetIndex(index_oid_t index) const;
 
  private:
   const common::ManagedPointer<Catalog> catalog_;

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -276,7 +276,7 @@ class CatalogAccessor {
  private:
   const common::ManagedPointer<Catalog> catalog_;
   const common::ManagedPointer<DatabaseCatalog> dbc_;
-  transaction::TransactionContext *txn_;
+  transaction::TransactionContext *const txn_;
   std::vector<namespace_oid_t> search_path_;
   namespace_oid_t default_namespace_;
 

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -287,7 +287,8 @@ class CatalogAccessor {
         dbc_(dbc),
         txn_(txn),
         db_oid_(database),
-        search_path_({NAMESPACE_CATALOG_NAMESPACE_OID, NAMESPACE_DEFAULT_NAMESPACE_OID}) {}
+        search_path_({NAMESPACE_CATALOG_NAMESPACE_OID, NAMESPACE_DEFAULT_NAMESPACE_OID}),
+        default_namespace_(NAMESPACE_DEFAULT_NAMESPACE_OID) {}
   friend class Catalog;
 };
 

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -281,8 +281,8 @@ class CatalogAccessor {
    * @param txn the transaction context for this accessor
    * @param database the OID of the database
    */
-  CatalogAccessor(Catalog *catalog, common::ManagedPointer<DatabaseCatalog> dbc, transaction::TransactionContext *txn,
-                  db_oid_t database)
+  CatalogAccessor(common::ManagedPointer<Catalog> catalog, common::ManagedPointer<DatabaseCatalog> dbc,
+                  transaction::TransactionContext *txn, db_oid_t database)
       : catalog_(catalog),
         dbc_(dbc),
         txn_(txn),

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -263,15 +263,13 @@ class CatalogAccessor {
    * Instantiates a new accessor into the catalog for the given database.
    * @param catalog pointer to the catalog being accessed
    * @param txn the transaction context for this accessor
-   * @param database the OID of the database
    * @warning This constructor should never be called directly.  Instead you should get accessors from the catalog.
    */
   CatalogAccessor(common::ManagedPointer<Catalog> catalog, common::ManagedPointer<DatabaseCatalog> dbc,
-                  transaction::TransactionContext *txn, db_oid_t database)
+                  transaction::TransactionContext *txn)
       : catalog_(catalog),
         dbc_(dbc),
         txn_(txn),
-        db_oid_(database),
         search_path_({NAMESPACE_CATALOG_NAMESPACE_OID, NAMESPACE_DEFAULT_NAMESPACE_OID}),
         default_namespace_(NAMESPACE_DEFAULT_NAMESPACE_OID) {}
 
@@ -279,7 +277,6 @@ class CatalogAccessor {
   const common::ManagedPointer<Catalog> catalog_;
   const common::ManagedPointer<DatabaseCatalog> dbc_;
   transaction::TransactionContext *txn_;
-  const db_oid_t db_oid_;
   std::vector<namespace_oid_t> search_path_;
   namespace_oid_t default_namespace_;
 

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -259,6 +259,22 @@ class CatalogAccessor {
    */
   common::ManagedPointer<storage::index::Index> GetIndex(index_oid_t index) const;
 
+  /**
+   * Instantiates a new accessor into the catalog for the given database.
+   * @param catalog pointer to the catalog being accessed
+   * @param txn the transaction context for this accessor
+   * @param database the OID of the database
+   * @warning This constructor should never be called directly.  Instead you should get accessors from the catalog.
+   */
+  CatalogAccessor(common::ManagedPointer<Catalog> catalog, common::ManagedPointer<DatabaseCatalog> dbc,
+                  transaction::TransactionContext *txn, db_oid_t database)
+      : catalog_(catalog),
+        dbc_(dbc),
+        txn_(txn),
+        db_oid_(database),
+        search_path_({NAMESPACE_CATALOG_NAMESPACE_OID, NAMESPACE_DEFAULT_NAMESPACE_OID}),
+        default_namespace_(NAMESPACE_DEFAULT_NAMESPACE_OID) {}
+
  private:
   const common::ManagedPointer<Catalog> catalog_;
   const common::ManagedPointer<DatabaseCatalog> dbc_;
@@ -274,22 +290,6 @@ class CatalogAccessor {
   static void NormalizeObjectName(std::string *name) {
     std::transform(name->begin(), name->end(), name->begin(), [](auto &&c) { return std::tolower(c); });
   }
-
-  /**
-   * Instantiates a new accessor into the catalog for the given database.
-   * @param catalog pointer to the catalog being accessed
-   * @param txn the transaction context for this accessor
-   * @param database the OID of the database
-   */
-  CatalogAccessor(common::ManagedPointer<Catalog> catalog, common::ManagedPointer<DatabaseCatalog> dbc,
-                  transaction::TransactionContext *txn, db_oid_t database)
-      : catalog_(catalog),
-        dbc_(dbc),
-        txn_(txn),
-        db_oid_(database),
-        search_path_({NAMESPACE_CATALOG_NAMESPACE_OID, NAMESPACE_DEFAULT_NAMESPACE_OID}),
-        default_namespace_(NAMESPACE_DEFAULT_NAMESPACE_OID) {}
-  friend class Catalog;
 };
 
 }  // namespace terrier::catalog

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -68,7 +68,7 @@ class CatalogAccessor {
   /**
    * @return the current default namespace (first one in search path)
    */
-  namespace_oid_t GetDefaultNamespace() { return search_path_[0]; }
+  namespace_oid_t GetDefaultNamespace() { return default_namespace_; }
 
   /**
    * Given a namespace name, resolve it to the corresponding OID
@@ -265,6 +265,7 @@ class CatalogAccessor {
   transaction::TransactionContext *txn_;
   db_oid_t db_oid_;
   std::vector<namespace_oid_t> search_path_;
+  namespace_oid_t default_namespace_;
 
   /**
    * A helper function to ensure that user-defined object names are standardized prior to doing catalog operations
@@ -282,7 +283,11 @@ class CatalogAccessor {
    */
   CatalogAccessor(Catalog *catalog, common::ManagedPointer<DatabaseCatalog> dbc, transaction::TransactionContext *txn,
                   db_oid_t database)
-      : catalog_(catalog), dbc_(dbc), txn_(txn), db_oid_(database), search_path_({NAMESPACE_DEFAULT_NAMESPACE_OID}) {}
+      : catalog_(catalog),
+        dbc_(dbc),
+        txn_(txn),
+        db_oid_(database),
+        search_path_({NAMESPACE_CATALOG_NAMESPACE_OID, NAMESPACE_DEFAULT_NAMESPACE_OID}) {}
   friend class Catalog;
 };
 

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -59,12 +59,12 @@ struct CatalogTests : public TerrierTest {
     EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);
     EXPECT_EQ(ns_oid, catalog::NAMESPACE_CATALOG_NAMESPACE_OID);
 
-    VerifyTablePresent(*accessor, ns_oid, "pg_attribute");
-    VerifyTablePresent(*accessor, ns_oid, "pg_class");
-    VerifyTablePresent(*accessor, ns_oid, "pg_constraint");
-    VerifyTablePresent(*accessor, ns_oid, "pg_index");
-    VerifyTablePresent(*accessor, ns_oid, "pg_namespace");
-    VerifyTablePresent(*accessor, ns_oid, "pg_type");
+    VerifyTablePresent(accessor, ns_oid, "pg_attribute");
+    VerifyTablePresent(accessor, ns_oid, "pg_class");
+    VerifyTablePresent(accessor, ns_oid, "pg_constraint");
+    VerifyTablePresent(accessor, ns_oid, "pg_index");
+    VerifyTablePresent(accessor, ns_oid, "pg_namespace");
+    VerifyTablePresent(accessor, ns_oid, "pg_type");
   }
 
   void VerifyTablePresent(const catalog::CatalogAccessor &accessor, catalog::namespace_oid_t ns_oid,

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -382,7 +382,7 @@ TEST_F(CatalogTests, CatalogSearchPathTest) {
   EXPECT_EQ(accessor->GetTableOid("pg_namespace"), catalog::NAMESPACE_TABLE_OID);
 
   // Close out
-  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+  txn_manager_->Abort(txn);
   delete accessor;
 }
 

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -380,6 +380,10 @@ TEST_F(CatalogTests, CatalogSearchPathTest) {
   accessor->SetSearchPath({catalog::NAMESPACE_DEFAULT_NAMESPACE_OID});
   EXPECT_EQ(accessor->GetTableOid(catalog::NAMESPACE_DEFAULT_NAMESPACE_OID, "pg_namespace"), user_table_oid);
   EXPECT_EQ(accessor->GetTableOid("pg_namespace"), catalog::NAMESPACE_TABLE_OID);
+
+  // Close out
+  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+  delete accessor;
 }
 
 /*

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -354,7 +354,7 @@ TEST_F(CatalogTests, UserSearchPathTest) {
 TEST_F(CatalogTests, CatalogSearchPathTest) {
   auto txn = txn_manager_->BeginTransaction();
   auto accessor = catalog_->GetAccessor(txn, db_);
-  EXPECT_EQ(accessor->GetTableOid("pg_namespace"), NAMESPACE_TABLE_OID);
+  EXPECT_EQ(accessor->GetTableOid("pg_namespace"), catalog::NAMESPACE_TABLE_OID);
 
   // Create the column definition (no OIDs)
   std::vector<catalog::Schema::Column> cols;
@@ -367,18 +367,19 @@ TEST_F(CatalogTests, CatalogSearchPathTest) {
   // Check whether name conflict is inserted into the proper default (first in search path) and masked by implicit
   // addition of 'pg_catalog' at start of search path
   auto user_table_oid = accessor->CreateTable(accessor->GetDefaultNamespace(), "pg_namespace", tmp_schema);
-  EXPECT_EQ(accessor->GetTableOid(NAMESPACE_DEFAULT_NAMESPACE_OID, "pg_namespace"), user_table_oid);
-  EXPECT_EQ(accessor->GetTableOid("pg_namespace"), NAMESPACE_TABLE_OID);
+  EXPECT_EQ(accessor->GetTableOid(catalog::NAMESPACE_DEFAULT_NAMESPACE_OID, "pg_namespace"), user_table_oid);
+  EXPECT_EQ(accessor->GetTableOid("pg_namespace"), catalog::NAMESPACE_TABLE_OID);
 
   // Explicitly set 'pg_catalog' as second in the search path and check proper searching
-  accessor->SetSearchPath({NAMESPACE_DEFAULT_NAMESPACE_OID, NAMESPACE_CATALOG_NAMESPACE_OID});
+  accessor->SetSearchPath({catalog::NAMESPACE_DEFAULT_NAMESPACE_OID, catalog::NAMESPACE_CATALOG_NAMESPACE_OID});
   EXPECT_EQ(accessor->GetTableOid("pg_namespace"), user_table_oid);
-  EXPECT_EQ(accessor->GetTableOid(NAMESPACE_CATALOG_NAMESPACE_OID, "pg_namespace"), NAMESPACE_TABLE_OID);
+  EXPECT_EQ(accessor->GetTableOid(catalog::NAMESPACE_CATALOG_NAMESPACE_OID, "pg_namespace"),
+                                  catalog::NAMESPACE_TABLE_OID);
 
   // Return to implicit declaration to ensure logic works correctly
-  accessor->SetSearchPath({NAMESPACE_DEFAULT_NAMESPACE_OID});
-  EXPECT_EQ(accessor->GetTableOid(NAMESPACE_DEFAULT_NAMESPACE_OID, "pg_namespace"), user_table_oid);
-  EXPECT_EQ(accessor->GetTableOid("pg_namespace"), NAMESPACE_TABLE_OID);
+  accessor->SetSearchPath({catalog::NAMESPACE_DEFAULT_NAMESPACE_OID});
+  EXPECT_EQ(accessor->GetTableOid(catalog::NAMESPACE_DEFAULT_NAMESPACE_OID, "pg_namespace"), user_table_oid);
+  EXPECT_EQ(accessor->GetTableOid("pg_namespace"), catalog::NAMESPACE_TABLE_OID);
 }
 
 /*

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -6,6 +6,7 @@
 #include "catalog/catalog_accessor.h"
 #include "catalog/catalog_defs.h"
 #include "catalog/postgres/pg_namespace.h"
+#include "common/managed_pointer.h"
 #include "parser/expression/column_value_expression.h"
 #include "parser/expression/constant_value_expression.h"
 #include "storage/garbage_collector.h"
@@ -67,13 +68,13 @@ struct CatalogTests : public TerrierTest {
     VerifyTablePresent(accessor, ns_oid, "pg_type");
   }
 
-  void VerifyTablePresent(catalog::CatalogAccessor *accessor, catalog::namespace_oid_t ns_oid,
+  void VerifyTablePresent(common::ManagedPointer<catalog::CatalogAccessor> accessor, catalog::namespace_oid_t ns_oid,
                           const std::string &table_name) {
     auto table_oid = accessor->GetTableOid(ns_oid, table_name);
     EXPECT_NE(table_oid, catalog::INVALID_TABLE_OID);
   }
 
-  void VerifyTableAbsent(catalog::CatalogAccessor *accessor, catalog::namespace_oid_t ns_oid,
+  void VerifyTableAbsent(common::ManagedPointer<catalog::CatalogAccessor> accessor, catalog::namespace_oid_t ns_oid,
                          const std::string &table_name) {
     auto table_oid = accessor->GetTableOid(ns_oid, table_name);
     EXPECT_EQ(table_oid, catalog::INVALID_TABLE_OID);
@@ -102,7 +103,6 @@ TEST_F(CatalogTests, DatabaseTest) {
   EXPECT_NE(accessor, nullptr);
   VerifyCatalogTables(accessor);  // Check visibility to me
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 
   // Cannot add a database twice
   txn = txn_manager_->BeginTransaction();
@@ -110,7 +110,6 @@ TEST_F(CatalogTests, DatabaseTest) {
   auto tmp_oid = accessor->CreateDatabase("test_database");
   EXPECT_EQ(tmp_oid, catalog::INVALID_DATABASE_OID);  // Should cause a name conflict
   txn_manager_->Abort(txn);
-  delete accessor;
 
   // Get an accessor into the database and validate the catalog tables exist
   // then delete it and verify an invalid OID is now returned for the lookup
@@ -123,14 +122,12 @@ TEST_F(CatalogTests, DatabaseTest) {
   tmp_oid = accessor->GetDatabaseOid("test_database");
   EXPECT_EQ(tmp_oid, catalog::INVALID_DATABASE_OID);
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 
   // Cannot get an accessor to a non-existent database
   txn = txn_manager_->BeginTransaction();
   accessor = catalog_->GetAccessor(txn, db_oid);
   EXPECT_EQ(accessor, nullptr);
   txn_manager_->Abort(txn);
-  delete accessor;
 }
 
 /*
@@ -146,14 +143,12 @@ TEST_F(CatalogTests, NamespaceTest) {
   EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);
   VerifyCatalogTables(accessor);  // Check visibility to me
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 
   txn = txn_manager_->BeginTransaction();
   accessor = catalog_->GetAccessor(txn, db_);
   ns_oid = accessor->CreateNamespace("test_namespace");
   EXPECT_EQ(ns_oid, catalog::INVALID_NAMESPACE_OID);  // Should cause a name conflict
   txn_manager_->Abort(txn);
-  delete accessor;
 
   // Get an accessor into the database and validate the catalog tables exist
   // then delete it and verify an invalid OID is now returned for the lookup
@@ -166,13 +161,11 @@ TEST_F(CatalogTests, NamespaceTest) {
   ns_oid = accessor->GetNamespaceOid("test_namespace");
   EXPECT_EQ(ns_oid, catalog::INVALID_NAMESPACE_OID);
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 
   txn = txn_manager_->BeginTransaction();
   accessor = catalog_->GetAccessor(txn, db_);
   EXPECT_FALSE(accessor->DropNamespace(ns_oid));
   txn_manager_->Abort(txn);
-  delete accessor;
 }
 
 /*
@@ -209,7 +202,6 @@ TEST_F(CatalogTests, UserTableTest) {
   EXPECT_TRUE(accessor->SetTablePointer(table_oid, table));
   EXPECT_EQ(common::ManagedPointer(table), accessor->GetTable(table_oid));
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 
   // Get an accessor into the database and validate the catalog tables exist
   // then delete it and verify an invalid OID is now returned for the lookup
@@ -222,7 +214,6 @@ TEST_F(CatalogTests, UserTableTest) {
   table_oid = accessor->GetTableOid("test_table");
   EXPECT_EQ(table_oid, catalog::INVALID_TABLE_OID);
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 }
 
 /*
@@ -263,7 +254,6 @@ TEST_F(CatalogTests, UserIndexTest) {
   EXPECT_TRUE(accessor->SetIndexPointer(idx_oid, index));
   EXPECT_EQ(common::ManagedPointer(index), accessor->GetIndex(idx_oid));
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 
   // Get an accessor into the database and validate the catalog tables exist
   // then delete it and verify an invalid OID is now returned for the lookup
@@ -276,7 +266,6 @@ TEST_F(CatalogTests, UserIndexTest) {
   idx_oid = accessor->GetIndexOid("test_table_index_mabobberwithareallylongnamethatstillneedsmore");
   EXPECT_EQ(idx_oid, catalog::INVALID_INDEX_OID);
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 }
 
 /*
@@ -317,7 +306,6 @@ TEST_F(CatalogTests, UserSearchPathTest) {
   EXPECT_TRUE(accessor->SetTablePointer(test_table_oid, table));
 
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 
   // Check that it matches the table in the first namespace in path
   txn = txn_manager_->BeginTransaction();
@@ -334,7 +322,6 @@ TEST_F(CatalogTests, UserSearchPathTest) {
   table_oid = accessor->CreateTable(test_ns_oid, "test_table", tmp_schema);
   EXPECT_EQ(table_oid, catalog::INVALID_TABLE_OID);
   txn_manager_->Abort(txn);
-  delete accessor;
 
   txn = txn_manager_->BeginTransaction();
   accessor = catalog_->GetAccessor(txn, db_);
@@ -344,7 +331,6 @@ TEST_F(CatalogTests, UserSearchPathTest) {
   accessor->SetSearchPath({test_ns_oid, public_ns_oid});
   EXPECT_EQ(accessor->GetTableOid("test_table"), public_table_oid);
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 }
 
 /*
@@ -383,7 +369,6 @@ TEST_F(CatalogTests, CatalogSearchPathTest) {
 
   // Close out
   txn_manager_->Abort(txn);
-  delete accessor;
 }
 
 /*
@@ -396,7 +381,6 @@ TEST_F(CatalogTests, NameNormalizationTest) {
   auto ns_oid = accessor->CreateNamespace("TeSt_NaMeSpAcE");
   EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-  delete accessor;
 
   txn = txn_manager_->BeginTransaction();
   accessor = catalog_->GetAccessor(txn, db_);
@@ -406,7 +390,6 @@ TEST_F(CatalogTests, NameNormalizationTest) {
   EXPECT_EQ(ns_oid, dbc->GetNamespaceOid(txn, "test_namespace"));  // Should match (normalized form)
   EXPECT_EQ(catalog::INVALID_NAMESPACE_OID, dbc->GetNamespaceOid(txn, "TeSt_NaMeSpAcE"));  // Not normalized
   txn_manager_->Abort(txn);
-  delete accessor;
 }
 
 }  // namespace terrier

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -374,7 +374,7 @@ TEST_F(CatalogTests, CatalogSearchPathTest) {
   accessor->SetSearchPath({catalog::NAMESPACE_DEFAULT_NAMESPACE_OID, catalog::NAMESPACE_CATALOG_NAMESPACE_OID});
   EXPECT_EQ(accessor->GetTableOid("pg_namespace"), user_table_oid);
   EXPECT_EQ(accessor->GetTableOid(catalog::NAMESPACE_CATALOG_NAMESPACE_OID, "pg_namespace"),
-                                  catalog::NAMESPACE_TABLE_OID);
+            catalog::NAMESPACE_TABLE_OID);
 
   // Return to implicit declaration to ensure logic works correctly
   accessor->SetSearchPath({catalog::NAMESPACE_DEFAULT_NAMESPACE_OID});

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -6,7 +6,6 @@
 #include "catalog/catalog_accessor.h"
 #include "catalog/catalog_defs.h"
 #include "catalog/postgres/pg_namespace.h"
-#include "common/managed_pointer.h"
 #include "parser/expression/column_value_expression.h"
 #include "parser/expression/constant_value_expression.h"
 #include "storage/garbage_collector.h"
@@ -68,13 +67,13 @@ struct CatalogTests : public TerrierTest {
     VerifyTablePresent(accessor, ns_oid, "pg_type");
   }
 
-  void VerifyTablePresent(common::ManagedPointer<catalog::CatalogAccessor> accessor, catalog::namespace_oid_t ns_oid,
+  void VerifyTablePresent(std::unique_ptr<catalog::CatalogAccessor> accessor, catalog::namespace_oid_t ns_oid,
                           const std::string &table_name) {
     auto table_oid = accessor->GetTableOid(ns_oid, table_name);
     EXPECT_NE(table_oid, catalog::INVALID_TABLE_OID);
   }
 
-  void VerifyTableAbsent(common::ManagedPointer<catalog::CatalogAccessor> accessor, catalog::namespace_oid_t ns_oid,
+  void VerifyTableAbsent(std::unique_ptr<catalog::CatalogAccessor> accessor, catalog::namespace_oid_t ns_oid,
                          const std::string &table_name) {
     auto table_oid = accessor->GetTableOid(ns_oid, table_name);
     EXPECT_EQ(table_oid, catalog::INVALID_TABLE_OID);


### PR DESCRIPTION
Updates the accessor to correctly handle the implicit placement of `pg_catalog` namespace in the search path when it is not explicitly set.  Specifically, PostgreSQL will always search `pg_catalog` first when resolving an unqualified object name unless `pg_catalog` was explicitly placed somewhere in the search path.  For unqualified object creation, the default namespace that is used is the first namespace in the explicit path.

Fixes #473 