### PR TITLE
Add bwtree_benchmark to the nightly suite

### DIFF
--- a/script/micro_bench/run_micro_bench.py
+++ b/script/micro_bench/run_micro_bench.py
@@ -35,7 +35,8 @@ class TestConfig(object):
                                "large_transaction_benchmark",
                                "logging_benchmark",
                                "tuple_access_strategy_benchmark",
-                               "tpcc_benchmark"]
+                               "tpcc_benchmark",
+                               "bwtree_benchmark"]
 
         # how many historical values are "required".
         self.min_ref_values = 10
@@ -55,7 +56,7 @@ class TestConfig(object):
         self.ref_data_sources = [
             {"project" : "terrier-nightly",
              "min_build" : 263,
-            },
+             },
         ]
         return
 
@@ -716,7 +717,8 @@ class RunMicroBenchmarks(object):
                                "large_transaction_benchmark",
                                "logging_benchmark",
                                "tuple_access_strategy_benchmark",
-                               "tpcc_benchmark"]
+                               "tpcc_benchmark",
+                               "bwtree_benchmark"]
 
         # minimum run time for the benchmark
         self.min_time = 10


### PR DESCRIPTION
This enables the bwtree_benchmark suite to run as part of the nightly performance tests. We previously did not run them as it's exercising "third party" code with benchmarks that aren't ours either. However, we want to watch for any regressions on this data structure in the future, and in preparation for running the same tests against the hash index, we should enable this.