### PR TITLE
Reset benchmark lookback due to jemalloc being enabled

### DIFF
--- a/script/micro_bench/run_micro_bench.py
+++ b/script/micro_bench/run_micro_bench.py
@@ -54,7 +54,7 @@ class TestConfig(object):
         # of sources. Stop if the history requirements are met.
         self.ref_data_sources = [
             {"project" : "terrier-nightly",
-             "min_build" : 263,
+             "min_build" : 323,
             },
         ]
         return


### PR DESCRIPTION
We want to reset the lookback threshold due to enabling jemalloc on the benchmark runs. Any PRs in the next few weeks should have their benchmark numbers inspected manually to look for anomalies because they automatic regression failure won't trigger again until we have 10 nightly runs.