### PR TITLE
Add clang-8 builds to Linux CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,13 @@ matrix:
         - docker cp . build:/repo
     - os: linux
       dist: trusty
+      compiler: clang
       env:
         - NAME="ubuntu-18.04/clang-8.0.0 (Debug/Dockerfile)" CMAKE_BUILD_TYPE=debug DOCKER=true
       install:
         - docker build -t cmu-db/terrier .
         - docker run -itd --name build cmu-db/terrier
         - docker cp . build:/repo
-        - docker exec build /bin/sh -c "export CC=/usr/bin/clang-8"
-        - docker exec build /bin/sh -c "export CXX=/usr/bin/clang++-8"
     - os: linux
       dist: trusty
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ matrix:
       osx_image: xcode10.1
       compiler: clang
       env:
-        - NAME="Mac [dbg/clang]" CMAKE_BUILD_TYPE=debug TERRIER_USE_ASAN=On
+        - NAME="macos-10.14/AppleClang-1001.0.46.4 (Debug/packages.sh)" CMAKE_BUILD_TYPE=debug
       install:
         - echo 'y' | ./script/installation/packages.sh
         - export LLVM_DIR=/usr/local/Cellar/llvm/8.0.1
     - os: linux
       dist: trusty
       env:
-        - NAME="Docker[dbg/packages.sh]" CMAKE_BUILD_TYPE=debug TERRIER_USE_ASAN=On DOCKER=true
+        - NAME="ubuntu-18.04/gcc-7.3.0 (Debug/packages.sh)" CMAKE_BUILD_TYPE=debug DOCKER=true
       install:
         - docker pull ubuntu:18.04
         - docker run -itd --name build ubuntu:18.04
@@ -23,7 +23,7 @@ matrix:
     - os: linux
       dist: trusty
       env:
-        - NAME="Docker[dbg/Dockerfile]" CMAKE_BUILD_TYPE=debug TERRIER_USE_ASAN=On DOCKER=true
+        - NAME="ubuntu-18.04/gcc-7.3.0 (Debug/Dockerfile)" CMAKE_BUILD_TYPE=debug DOCKER=true
       install:
         - docker build -t cmu-db/terrier .
         - docker run -itd --name build cmu-db/terrier
@@ -31,7 +31,17 @@ matrix:
     - os: linux
       dist: trusty
       env:
-      - NAME="Docker[Coverage/Dockerfile]" CMAKE_BUILD_TYPE=debug TERRIER_USE_ASAN=Off DOCKER=true ci_env=`bash <(curl -s https://codecov.io/env)`
+        - NAME="ubuntu-18.04/clang-8.0.0 (Debug/Dockerfile)" CMAKE_BUILD_TYPE=debug DOCKER=true
+      install:
+        - docker build -t cmu-db/terrier .
+        - docker run -itd --name build cmu-db/terrier
+        - docker cp . build:/repo
+        - docker exec build /bin/sh -c "export CC=/usr/bin/clang-8"
+        - docker exec build /bin/sh -c "export CXX=/usr/bin/clang++-8"
+    - os: linux
+      dist: trusty
+      env:
+      - NAME="ubuntu-18.04/gcc-7.3.0 (Debug/Coverage)" CMAKE_BUILD_TYPE=debug TERRIER_USE_ASAN=Off DOCKER=true ci_env=`bash <(curl -s https://codecov.io/env)`
       install:
       - ci_env=`bash <(curl -s https://codecov.io/env)`
       - docker build -t cmu-db/terrier .
@@ -57,7 +67,7 @@ before_script:
   - if [[ "$DOCKER" = true ]]; then
       docker exec build /bin/sh -c "cd /repo/apidoc && touch warnings.txt && doxygen Doxyfile.in 2>warnings.txt && (cat warnings.txt | grep -v Doxyfile.in > warnings.txt || true) && if [ -s warnings.txt ]; then cat warnings.txt; false; fi" &&
       docker exec build /bin/sh -c "mkdir -p /repo/build" &&
-      docker exec -e CMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" -e TERRIER_USE_ASAN="$TERRIER_USE_ASAN" build /bin/sh -c "cd /repo/build && cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DTERRIER_USE_ASAN=$TERRIER_USE_ASAN .." &&
+      docker exec -e CMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" build /bin/sh -c "cd /repo/build && cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE .." &&
       docker exec build /bin/sh -c "cd /repo/build && make check-format" &&
       docker exec build /bin/sh -c "cd /repo/build && make check-lint" &&
       docker exec build /bin/sh -c "cd /repo/build && make check-censored";
@@ -70,7 +80,7 @@ before_script:
       cd .. &&
       mkdir build &&
       cd build &&
-      cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DTERRIER_USE_ASAN=$TERRIER_USE_ASAN .. &&
+      cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE .. &&
       make check-format &&
       make check-lint &&
       make check-censored;
@@ -78,8 +88,8 @@ before_script:
 
 script:
   - if [[ "$DOCKER" = true ]]; then
-      docker exec build /bin/sh -c "cd /repo/build && make -j 4";
+      docker exec build /bin/sh -c "cd /repo/build && make -j4";
     else
-      ASAN_OPTIONS=detect_container_overflow=0 make -j 4;
+      make -j4;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,8 @@ matrix:
         - docker cp . build:/repo
     - os: linux
       dist: trusty
-      compiler: clang
       env:
-        - NAME="ubuntu-18.04/clang-8.0.0 (Debug/Dockerfile)" CMAKE_BUILD_TYPE=debug DOCKER=true
+        - NAME="ubuntu-18.04/clang-8.0.0 (Debug/Dockerfile)" CMAKE_BUILD_TYPE=debug DOCKER=true CC=/usr/bin/clang-8 CXX=/usr/bin/clang++-8
       install:
         - docker build -t cmu-db/terrier .
         - docker run -itd --name build cmu-db/terrier

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ matrix:
     - os: linux
       dist: trusty
       env:
-        - NAME="ubuntu-18.04/clang-8.0.0 (Debug/Dockerfile)" CMAKE_BUILD_TYPE=debug DOCKER=true CC=/usr/bin/clang-8 CXX=/usr/bin/clang++-8
+        - NAME="ubuntu-18.04/clang-8.0.0 (Debug/Dockerfile)" CMAKE_BUILD_TYPE=debug DOCKER=true
       install:
         - docker build -t cmu-db/terrier .
-        - docker run -itd --name build cmu-db/terrier
+        - docker run -itd -e "CC=/usr/bin/clang-8" -e "CXX=/usr/bin/clang++-8" --name build cmu-db/terrier
         - docker cp . build:/repo
     - os: linux
       dist: trusty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,9 @@ set(TERRIER_LINK_LIBS
         pg_query)
 
 set(TERRIER_DEPENDENCIES
-        gflags)
+        gflags
+        gmock_main
+        gtest)
 
 set(TERRIER_TEST_LINK_LIBS
         test_util
@@ -372,3 +374,6 @@ set(TERRIER_BENCHMARK_LINK_LIBS
 add_subdirectory(src)
 add_subdirectory(test)
 add_subdirectory(benchmark)
+
+add_dependencies(unittest ${TERRIER_DEPENDENCIES})
+add_dependencies(runbenchmark ${TERRIER_DEPENDENCIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,9 +348,7 @@ set(TERRIER_LINK_LIBS
         pg_query)
 
 set(TERRIER_DEPENDENCIES
-        gflags
-        gmock_main
-        gtest)
+        gflags)
 
 set(TERRIER_TEST_LINK_LIBS
         test_util
@@ -374,6 +372,3 @@ set(TERRIER_BENCHMARK_LINK_LIBS
 add_subdirectory(src)
 add_subdirectory(test)
 add_subdirectory(benchmark)
-
-add_dependencies(unittest ${TERRIER_DEPENDENCIES})
-add_dependencies(runbenchmark ${TERRIER_DEPENDENCIES})

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         stage('Build') {
             parallel {
 
-                stage('macOS 10.14/Apple clang-1001.0.46.4/llvm-8.0.1 (Debug/ASAN)') {
+                stage('macos-10.14/AppleClang-1001.0.46.4 (Debug/ASAN/unittest)') {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
@@ -23,7 +23,7 @@ pipeline {
                     }
                 }
 
-                stage('Ubuntu Bionic/gcc-7.3.0/llvm-8.0.1 (Debug/ASAN)') {
+                stage('ubuntu-18.04/gcc-7.3.0 (Debug/ASAN/unittest)') {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
@@ -40,7 +40,28 @@ pipeline {
                     }
                 }
 
-                stage('macOS 10.14/Apple clang-1001.0.46.4/llvm-8.0.1 (Release/unittest)') {
+                stage('ubuntu-18.04/clang-8.0.0 (Debug/ASAN/unittest)') {
+                    agent {
+                        docker {
+                            image 'ubuntu:bionic'
+                            args '--cap-add sys_ptrace'
+                        }
+                    }
+                    environment {
+                        CC="/usr/bin/clang-8"
+                        CXX="/usr/bin/clang++-8"
+                    }
+                    steps {
+                        sh 'echo y | sudo ./script/installation/packages.sh'
+                        sh 'mkdir build'
+                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j4'
+                        sh 'cd build && make check-clang-tidy'
+                        sh 'cd build && make unittest'
+                        sh 'cd build && python ../script/testing/junit/run_junit.py'
+                    }
+                }
+
+                stage('macOS-10.14/AppleClang-1001.0.46.4 (Release/unittest)') {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
@@ -55,7 +76,7 @@ pipeline {
                     }
                 }
 
-                stage('Ubuntu Bionic/gcc-7.3.0/llvm-8.0.1 (Release/unittest)') {
+                stage('ubuntu-18.04/gcc-7.3.0 (Release/unittest)') {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
@@ -70,7 +91,26 @@ pipeline {
                     }
                 }
 
-                stage('Ubuntu Bionic/gcc-7.3.0/llvm-8.0.1 (Release/benchmark)') {
+                stage('ubuntu-18.04/clang-8.0.0 (Release/unittest)') {
+                    agent {
+                        docker {
+                            image 'ubuntu:bionic'
+                        }
+                    }
+                    environment {
+                        CC="/usr/bin/clang-8"
+                        CXX="/usr/bin/clang++-8"
+                    }
+                    steps {
+                        sh 'echo y | sudo ./script/installation/packages.sh'
+                        sh 'mkdir build'
+                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j4'
+                        sh 'cd build && make unittest'
+                        sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
+                    }
+                }
+
+                stage('ubuntu-18.04/gcc-7.3.0 (Release/benchmark)') {
                     agent { label 'benchmark' }
                     steps {
                         sh 'echo y | sudo ./script/installation/packages.sh'


### PR DESCRIPTION
Also rename the different configurations to be consistent. Remove ASAN related stuff from Travis since all we do is static analysis and building, not execute (except for Coverage where we run ASAN off).

I'll watch the build times tonight to see if this completely wrecks our CI time.