### PR TITLE
Be smarter about Column copies

### DIFF
--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -216,7 +216,7 @@ class Schema {
    * @param col_offset offset into the schema specifying which Column to access
    * @return description of the schema for a specific column
    */
-  Column GetColumn(const uint32_t col_offset) const {
+  const Column &GetColumn(const uint32_t col_offset) const {
     TERRIER_ASSERT(col_offset < columns_.size(), "column id is out of bounds for this Schema");
     return columns_[col_offset];
   }
@@ -224,7 +224,7 @@ class Schema {
    * @param col_oid identifier of a Column in the schema
    * @return description of the schema for a specific column
    */
-  Column GetColumn(const col_oid_t col_oid) const {
+  const Column &GetColumn(const col_oid_t col_oid) const {
     TERRIER_ASSERT(col_oid_to_offset.count(col_oid) > 0, "col_oid does not exist in this Schema");
     const uint32_t col_offset = col_oid_to_offset.at(col_oid);
     return columns_[col_offset];
@@ -235,8 +235,8 @@ class Schema {
    * @return description of the schema for a specific column
    * @throw std::out_of_range if the column doesn't exist.
    */
-  Column GetColumn(const std::string &name) const {
-    for (auto &c : columns_) {
+  const Column &GetColumn(const std::string &name) const {
+    for (const auto &c : columns_) {
       if (c.Name() == name) {
         return c;
       }

--- a/test/include/util/tpcc/util.h
+++ b/test/include/util/tpcc/util.h
@@ -55,7 +55,7 @@ struct Util {
   static void SetKeyAttribute(const catalog::IndexSchema &schema, const uint32_t col_offset,
                               const std::unordered_map<catalog::indexkeycol_oid_t, uint16_t> &projection_map,
                               storage::ProjectedRow *const pr, T value) {
-    auto key_cols = schema.GetColumns();
+    const auto &key_cols = schema.GetColumns();
     TERRIER_ASSERT((type::TypeUtil::GetTypeSize(key_cols.at(col_offset).Type()) & INT8_MAX) == sizeof(T),
                    "Invalid attribute size.");
     const auto col_oid = key_cols.at(col_offset).Oid();


### PR DESCRIPTION
We noticed that `tpcc_test` was taking longer than it used to (2-3x), but throughput on the benchmark hasn't suffered so I suspected the loader. Quickly tracked it down to deep copies of `Schema::Column` and `IndexSchema::Column` objects in `tpcc/util.h` introduced with #481 when writing tuple and index key attributes. These aren't used in the workload because we cache all of the column offsets as if it were compiled code.

- Changed `Schema::GetColumn()` methods to return `const &` to avoid deep copies where possible.
- Changed `tpcc/util.h`'s call to `IndexSchema::GetColumns()` to be used as a `const auto &` to avoid deep copies. The perils of `auto`...