### PR TITLE
Add 'timeout' for Ubuntu and 'gtimeout' for macOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j4'
                         sh 'cd build && make check-clang-tidy'
-                        sh 'cd build && make unittest'
+                        sh 'cd build && gtimeout 1h make unittest'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
                     }
                 }
@@ -35,7 +35,7 @@ pipeline {
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j4'
                         sh 'cd build && make check-clang-tidy'
-                        sh 'cd build && make unittest'
+                        sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
                     }
                 }
@@ -56,7 +56,7 @@ pipeline {
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j4'
                         sh 'cd build && make check-clang-tidy'
-                        sh 'cd build && make unittest'
+                        sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
                     }
                 }
@@ -71,7 +71,7 @@ pipeline {
                         sh 'echo y | ./script/installation/packages.sh'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j4'
-                        sh 'cd build && make unittest'
+                        sh 'cd build && gtimeout 1h make unittest'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
                     }
                 }
@@ -86,7 +86,7 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j4'
-                        sh 'cd build && make unittest'
+                        sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
                     }
                 }
@@ -105,7 +105,7 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j4'
-                        sh 'cd build && make unittest'
+                        sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
                     }
                 }
@@ -116,7 +116,7 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON .. && make -j4'
-                        sh 'cd build && make runbenchmark'
+                        sh 'cd build && timeout 1h make runbenchmark'
                         sh 'cd script/micro_bench && ./run_micro_bench.py'
                         archiveArtifacts 'script/micro_bench/*.json'
                         junit 'script/micro_bench/*.xml'

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -66,6 +66,7 @@ install_mac() {
   brew update
   # Install packages.
   brew ls --versions cmake || brew install cmake
+  brew ls --versions coreutils || brew install coreutils
   brew ls --versions doxygen || brew install doxygen
   brew ls --versions git || brew install git
   brew ls --versions jemalloc || brew install jemalloc


### PR DESCRIPTION
Adds a timeout mechanism for `make unittest` and `make runbenchmark` for Jenkins.  Motivated by a current bug in one PR that started causing resource starvation of our macOS build machines.

Uses a 1 hour timeout as a conservative baseline (double worst observed successful run).