### PR TITLE
Bump CMake minimum version from 3.2 to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 # Modified from the Apache Arrow project for the Terrier project.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.8)
 
 # Extract Terrier version number
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/build-support/version.xml" POM_XML)


### PR DESCRIPTION
CMAKE_CXX_STANDARD 17 doesn't exist in [3.2](https://cmake.org/cmake/help/v3.2/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD), exists starting with [3.8](https://cmake.org/cmake/help/v3.8/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD).