### PR TITLE
Add readability-identifier-naming options to .clang-tidy file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,6 +39,17 @@ Checks:     '
             -readability-isolate-declaration,
             -readability-magic-numbers,
             '
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.EnumCase,            value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,        value: CamelCase  }
+  - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
+  - { key: readability-identifier-naming.MemberCase,          value: lower_case }
+  - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix, value: _          }
+  - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
+  - { key: readability-identifier-naming.UnionCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
 WarningsAsErrors: '*'
 HeaderFilterRegex: '(benchmark|src|test)/include'
 AnalyzeTemporaryDtors: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,8 +45,8 @@ CheckOptions:
   - { key: readability-identifier-naming.FunctionCase,        value: CamelCase  }
   - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
   - { key: readability-identifier-naming.MemberCase,          value: lower_case }
+  - { key: readability-identifier-naming.MemberSuffix,        value: _          }
   - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
-  - { key: readability-identifier-naming.PrivateMemberSuffix, value: _          }
   - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
   - { key: readability-identifier-naming.UnionCase,           value: CamelCase  }
   - { key: readability-identifier-naming.VariableCase,        value: lower_case }

--- a/benchmark/integration/tpcc_benchmark.cpp
+++ b/benchmark/integration/tpcc_benchmark.cpp
@@ -50,7 +50,7 @@ class TPCCBenchmark : public benchmark::Fixture {
   const int8_t num_threads_ = 4;  // defines the number of terminals (workers running txns) and warehouses for the
                                   // benchmark. Sometimes called scale factor
   const uint32_t num_precomputed_txns_per_worker_ = 100000;  // Number of txns to run per terminal (worker thread)
-  TransactionWeights txn_weights_;                            // default txn_weights. See definition for values
+  TransactionWeights txn_weights_;                           // default txn_weights. See definition for values
 
   common::WorkerPool thread_pool_{static_cast<uint32_t>(num_threads_), {}};
   common::DedicatedThreadRegistry thread_registry_;
@@ -74,7 +74,7 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithoutLogging)(benchmark::State &
 
   // Precompute all of the input arguments for every txn to be run. We want to avoid the overhead at benchmark time
   const auto precomputed_args =
-      PrecomputeArgs(&generator_, txn_weights, num_threads_, num_precomputed_txns_per_worker_);
+      PrecomputeArgs(&generator_, txn_weights_, num_threads_, num_precomputed_txns_per_worker_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -124,7 +124,7 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithoutLogging)(benchmark::State &
     uint64_t num_new_orders = 0;
     for (const auto &worker_txns : precomputed_args) {
       for (const auto &txn : worker_txns) {
-        if (txn.type == TransactionType::NewOrder) num_new_orders++;
+        if (txn.type_ == TransactionType::NewOrder) num_new_orders++;
       }
     }
     state.SetItemsProcessed(state.iterations() * num_new_orders);
@@ -148,7 +148,7 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithLogging)(benchmark::State &sta
 
   // Precompute all of the input arguments for every txn to be run. We want to avoid the overhead at benchmark time
   const auto precomputed_args =
-      PrecomputeArgs(&generator_, txn_weights, num_threads_, num_precomputed_txns_per_worker_);
+      PrecomputeArgs(&generator_, txn_weights_, num_threads_, num_precomputed_txns_per_worker_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -156,7 +156,7 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithLogging)(benchmark::State &sta
     // we need transactions, TPCC database, and GC
     log_manager_ = new storage::LogManager(LOG_FILE_NAME, num_log_buffers_, log_serialization_interval_,
                                            log_persist_interval_, log_persist_threshold_, &buffer_pool_,
-                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry));
+                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry_));
     log_manager_->Start();
     transaction::TransactionManager txn_manager(&buffer_pool_, true, log_manager_);
 
@@ -206,7 +206,7 @@ BENCHMARK_DEFINE_F(TPCCBenchmark, ScaleFactor4WithLogging)(benchmark::State &sta
     uint64_t num_new_orders = 0;
     for (const auto &worker_txns : precomputed_args) {
       for (const auto &txn : worker_txns) {
-        if (txn.type == TransactionType::NewOrder) num_new_orders++;
+        if (txn.type_ == TransactionType::NewOrder) num_new_orders++;
       }
     }
     state.SetItemsProcessed(state.iterations() * num_new_orders);

--- a/benchmark/integration/tpcc_benchmark.cpp
+++ b/benchmark/integration/tpcc_benchmark.cpp
@@ -50,10 +50,10 @@ class TPCCBenchmark : public benchmark::Fixture {
   const int8_t num_threads_ = 4;  // defines the number of terminals (workers running txns) and warehouses for the
                                   // benchmark. Sometimes called scale factor
   const uint32_t num_precomputed_txns_per_worker_ = 100000;  // Number of txns to run per terminal (worker thread)
-  TransactionWeights txn_weights;                            // default txn_weights. See definition for values
+  TransactionWeights txn_weights_;                            // default txn_weights. See definition for values
 
   common::WorkerPool thread_pool_{static_cast<uint32_t>(num_threads_), {}};
-  common::DedicatedThreadRegistry thread_registry;
+  common::DedicatedThreadRegistry thread_registry_;
 
   storage::GarbageCollectorThread *gc_thread_ = nullptr;
   const std::chrono::milliseconds gc_period_{10};

--- a/benchmark/storage/garbage_collector_benchmark.cpp
+++ b/benchmark/storage/garbage_collector_benchmark.cpp
@@ -26,11 +26,11 @@ class GarbageCollectorBenchmark : public benchmark::Fixture {
     return lag_count;
   }
 
-  const uint32_t txn_length = 5;
-  const std::vector<double> update_select_ratio = {0, 1, 0};
-  const uint32_t num_concurrent_txns = 4;
-  const uint32_t initial_table_size = 100000;
-  const uint32_t num_txns = 100000;
+  const uint32_t txn_length_ = 5;
+  const std::vector<double> update_select_ratio_ = {0, 1, 0};
+  const uint32_t num_concurrent_txns_ = 4;
+  const uint32_t initial_table_size_ = 100000;
+  const uint32_t num_txns_ = 100000;
   storage::BlockStore block_store_{1000, 1000};
   storage::RecordBufferSegmentPool buffer_pool_{1000000, 1000000};
   std::default_random_engine generator_;

--- a/benchmark/storage/garbage_collector_benchmark.cpp
+++ b/benchmark/storage/garbage_collector_benchmark.cpp
@@ -56,7 +56,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, UnlinkTime)(benchmark::State &stat
   // NOLINTNEXTLINE
   for (auto _ : state) {
     // generate our table and instantiate GC
-    LargeTransactionBenchmarkObject tested({8, 8, 8}, initial_table_size, txn_length, update_select_ratio,
+    LargeTransactionBenchmarkObject tested({8, 8, 8}, initial_table_size_, txn_length_, update_select_ratio_,
                                            &block_store_, &buffer_pool_, &generator_, true);
     gc_ = new storage::GarbageCollector(tested.GetTxnManager(), nullptr);
 
@@ -65,7 +65,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, UnlinkTime)(benchmark::State &stat
     gc_->PerformGarbageCollection();
 
     // run all txns
-    tested.SimulateOltp(num_txns, num_concurrent_txns);
+    tested.SimulateOltp(num_txns_, num_concurrent_txns_);
 
     // time just the unlinking process, verify nothing deallocated
     uint64_t elapsed_ms;
@@ -75,7 +75,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, UnlinkTime)(benchmark::State &stat
       result = gc_->PerformGarbageCollection();
     }
     EXPECT_EQ(result.first, 0);
-    EXPECT_EQ(result.second, num_txns);
+    EXPECT_EQ(result.second, num_txns_);
 
     // run another GC pass to perform deallocation, verify nothing unlinked
     result = gc_->PerformGarbageCollection();
@@ -85,7 +85,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, UnlinkTime)(benchmark::State &stat
 
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
   }
-  state.SetItemsProcessed(state.iterations() * num_txns);
+  state.SetItemsProcessed(state.iterations() * num_txns_);
 }
 
 // Create a table with 100,000 tuples, then run 100,000 txns running update statements. Then run GC and profile how long
@@ -95,7 +95,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, ReclaimTime)(benchmark::State &sta
   // NOLINTNEXTLINE
   for (auto _ : state) {
     // generate our table and instantiate GC
-    LargeTransactionBenchmarkObject tested({8, 8, 8}, initial_table_size, txn_length, update_select_ratio,
+    LargeTransactionBenchmarkObject tested({8, 8, 8}, initial_table_size_, txn_length_, update_select_ratio_,
                                            &block_store_, &buffer_pool_, &generator_, true);
     gc_ = new storage::GarbageCollector(tested.GetTxnManager(), nullptr);
 
@@ -104,7 +104,7 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, ReclaimTime)(benchmark::State &sta
     gc_->PerformGarbageCollection();
 
     // run all txns
-    tested.SimulateOltp(num_txns, num_concurrent_txns);
+    tested.SimulateOltp(num_txns_, num_concurrent_txns_);
 
     // run first pass to unlink everything, verify nothing deallocated
     std::pair<uint32_t, uint32_t> result = gc_->PerformGarbageCollection();
@@ -116,14 +116,14 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, ReclaimTime)(benchmark::State &sta
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
       result = gc_->PerformGarbageCollection();
     }
-    EXPECT_EQ(result.first, num_txns);
+    EXPECT_EQ(result.first, num_txns_);
     EXPECT_EQ(result.second, 0);
 
     delete gc_;
 
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
   }
-  state.SetItemsProcessed(state.iterations() * num_txns);
+  state.SetItemsProcessed(state.iterations() * num_txns_);
 }
 
 /**
@@ -136,18 +136,18 @@ BENCHMARK_DEFINE_F(GarbageCollectorBenchmark, HighContention)(benchmark::State &
   uint64_t lag_count = 0;
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    LargeTransactionBenchmarkObject tested({8, 8, 8}, 100, txn_length, update_select_ratio, &block_store_,
+    LargeTransactionBenchmarkObject tested({8, 8, 8}, 100, txn_length_, update_select_ratio_, &block_store_,
                                            &buffer_pool_, &generator_, true);
     StartGC(tested.GetTxnManager());
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      tested.SimulateOltp(num_txns, num_concurrent_txns);
+      tested.SimulateOltp(num_txns_, num_concurrent_txns_);
     }
     lag_count += EndGC();
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - lag_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - lag_count);
 }
 
 BENCHMARK_REGISTER_F(GarbageCollectorBenchmark, UnlinkTime)->Unit(benchmark::kMillisecond)->UseManualTime()->MinTime(1);

--- a/benchmark/storage/logging_benchmark.cpp
+++ b/benchmark/storage/logging_benchmark.cpp
@@ -46,9 +46,9 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, TPCCish)(benchmark::State &state) {
     unlink(LOG_FILE_NAME);
     log_manager_ = new storage::LogManager(LOG_FILE_NAME, num_log_buffers_, log_serialization_interval_,
                                            log_persist_interval_, log_persist_threshold_, &buffer_pool_,
-                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry));
+                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry_));
     log_manager_->Start();
-    LargeTransactionBenchmarkObject tested(attr_sizes, initial_table_size, txn_length, insert_update_select_ratio,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
                                            &block_store_, &buffer_pool_, &generator_, true, log_manager_);
     // log all of the Inserts from table creation
     log_manager_->ForceFlush();
@@ -57,7 +57,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, TPCCish)(benchmark::State &state) {
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
@@ -66,7 +66,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, TPCCish)(benchmark::State &state) {
     delete gc_thread_;
     unlink(LOG_FILE_NAME);
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 /**
@@ -83,9 +83,9 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, HighAbortRate)(benchmark::State &state) {
     // use a smaller table to make aborts more likely
     log_manager_ = new storage::LogManager(LOG_FILE_NAME, num_log_buffers_, log_serialization_interval_,
                                            log_persist_interval_, log_persist_threshold_, &buffer_pool_,
-                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry));
+                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry_));
     log_manager_->Start();
-    LargeTransactionBenchmarkObject tested(attr_sizes, 1000, txn_length, insert_update_select_ratio, &block_store_,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, 1000, txn_length, insert_update_select_ratio, &block_store_,
                                            &buffer_pool_, &generator_, true, log_manager_);
     // log all of the Inserts from table creation
     log_manager_->ForceFlush();
@@ -94,7 +94,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, HighAbortRate)(benchmark::State &state) {
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
@@ -103,7 +103,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, HighAbortRate)(benchmark::State &state) {
     delete gc_thread_;
     unlink(LOG_FILE_NAME);
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 /**
@@ -119,9 +119,9 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementInsert)(benchmark::State &st
     unlink(LOG_FILE_NAME);
     log_manager_ = new storage::LogManager(LOG_FILE_NAME, num_log_buffers_, log_serialization_interval_,
                                            log_persist_interval_, log_persist_threshold_, &buffer_pool_,
-                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry));
+                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry_));
     log_manager_->Start();
-    LargeTransactionBenchmarkObject tested(attr_sizes, 0, txn_length, insert_update_select_ratio, &block_store_,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, 0, txn_length, insert_update_select_ratio, &block_store_,
                                            &buffer_pool_, &generator_, true, log_manager_);
     // log all of the Inserts from table creation
     log_manager_->ForceFlush();
@@ -130,7 +130,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementInsert)(benchmark::State &st
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
@@ -139,7 +139,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementInsert)(benchmark::State &st
     delete gc_thread_;
     unlink(LOG_FILE_NAME);
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 /**
@@ -155,9 +155,9 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementUpdate)(benchmark::State &st
     unlink(LOG_FILE_NAME);
     log_manager_ = new storage::LogManager(LOG_FILE_NAME, num_log_buffers_, log_serialization_interval_,
                                            log_persist_interval_, log_persist_threshold_, &buffer_pool_,
-                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry));
+                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry_));
     log_manager_->Start();
-    LargeTransactionBenchmarkObject tested(attr_sizes, initial_table_size, txn_length, insert_update_select_ratio,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
                                            &block_store_, &buffer_pool_, &generator_, true, log_manager_);
     // log all of the Inserts from table creation
     log_manager_->ForceFlush();
@@ -166,7 +166,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementUpdate)(benchmark::State &st
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
@@ -175,7 +175,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementUpdate)(benchmark::State &st
     delete gc_thread_;
     unlink(LOG_FILE_NAME);
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 /**
@@ -191,9 +191,9 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementSelect)(benchmark::State &st
     unlink(LOG_FILE_NAME);
     log_manager_ = new storage::LogManager(LOG_FILE_NAME, num_log_buffers_, log_serialization_interval_,
                                            log_persist_interval_, log_persist_threshold_, &buffer_pool_,
-                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry));
+                                           common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry_));
     log_manager_->Start();
-    LargeTransactionBenchmarkObject tested(attr_sizes, initial_table_size, txn_length, insert_update_select_ratio,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
                                            &block_store_, &buffer_pool_, &generator_, true, log_manager_);
     // log all of the Inserts from table creation
     log_manager_->ForceFlush();
@@ -202,7 +202,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementSelect)(benchmark::State &st
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
       log_manager_->ForceFlush();
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
@@ -211,7 +211,7 @@ BENCHMARK_DEFINE_F(LoggingBenchmark, SingleStatementSelect)(benchmark::State &st
     delete gc_thread_;
     unlink(LOG_FILE_NAME);
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 BENCHMARK_REGISTER_F(LoggingBenchmark, TPCCish)->Unit(benchmark::kMillisecond)->UseManualTime()->MinTime(3);

--- a/benchmark/storage/logging_benchmark.cpp
+++ b/benchmark/storage/logging_benchmark.cpp
@@ -14,9 +14,9 @@ class LoggingBenchmark : public benchmark::Fixture {
  public:
   void TearDown(const benchmark::State &state) final { unlink(LOG_FILE_NAME); }
 
-  const std::vector<uint8_t> attr_sizes = {8, 8, 8, 8, 8, 8, 8, 8, 8, 8};
-  const uint32_t initial_table_size = 1000000;
-  const uint32_t num_txns = 100000;
+  const std::vector<uint8_t> attr_sizes_ = {8, 8, 8, 8, 8, 8, 8, 8, 8, 8};
+  const uint32_t initial_table_size_ = 1000000;
+  const uint32_t num_txns_ = 100000;
   storage::BlockStore block_store_{1000, 1000};
   storage::RecordBufferSegmentPool buffer_pool_{1000000, 1000000};
   std::default_random_engine generator_;
@@ -24,7 +24,7 @@ class LoggingBenchmark : public benchmark::Fixture {
   storage::LogManager *log_manager_ = nullptr;
   storage::GarbageCollectorThread *gc_thread_ = nullptr;
   const std::chrono::milliseconds gc_period_{10};
-  common::DedicatedThreadRegistry thread_registry;
+  common::DedicatedThreadRegistry thread_registry_;
 
   // Settings for log manager
   const uint64_t num_log_buffers_ = 100;

--- a/benchmark/transaction/large_transaction_benchmark.cpp
+++ b/benchmark/transaction/large_transaction_benchmark.cpp
@@ -8,9 +8,9 @@ namespace terrier {
 
 class LargeTransactionBenchmark : public benchmark::Fixture {
  public:
-  const std::vector<uint8_t> attr_sizes = {8, 8, 8, 8, 8, 8, 8, 8, 8, 8};
-  const uint32_t initial_table_size = 1000000;
-  const uint32_t num_txns = 100000;
+  const std::vector<uint8_t> attr_sizes_ = {8, 8, 8, 8, 8, 8, 8, 8, 8, 8};
+  const uint32_t initial_table_size_ = 1000000;
+  const uint32_t num_txns_ = 100000;
   storage::BlockStore block_store_{1000, 1000};
   storage::RecordBufferSegmentPool buffer_pool_{1000000, 1000000};
   std::default_random_engine generator_;

--- a/benchmark/transaction/large_transaction_benchmark.cpp
+++ b/benchmark/transaction/large_transaction_benchmark.cpp
@@ -29,18 +29,18 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, TPCCish)(benchmark::State &state) 
   const std::vector<double> insert_update_select_ratio = {0.1, 0.4, 0.5};
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    LargeTransactionBenchmarkObject tested(attr_sizes, initial_table_size, txn_length, insert_update_select_ratio,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
                                            &block_store_, &buffer_pool_, &generator_, true);
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
     delete gc_thread_;
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 /**
@@ -54,18 +54,18 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, HighAbortRate)(benchmark::State &s
   // NOLINTNEXTLINE
   for (auto _ : state) {
     // use a smaller table to make aborts more likely
-    LargeTransactionBenchmarkObject tested(attr_sizes, 1000, txn_length, insert_update_select_ratio, &block_store_,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, 1000, txn_length, insert_update_select_ratio, &block_store_,
                                            &buffer_pool_, &generator_, true);
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
     delete gc_thread_;
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 /**
@@ -79,18 +79,18 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, SingleStatementInsert)(benchmark::
   // NOLINTNEXTLINE
   for (auto _ : state) {
     // don't need any initial tuples
-    LargeTransactionBenchmarkObject tested(attr_sizes, 0, txn_length, insert_update_select_ratio, &block_store_,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, 0, txn_length, insert_update_select_ratio, &block_store_,
                                            &buffer_pool_, &generator_, true);
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
     delete gc_thread_;
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 /**
@@ -103,18 +103,18 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, SingleStatementUpdate)(benchmark::
   const std::vector<double> insert_update_select_ratio = {0, 1, 0};
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    LargeTransactionBenchmarkObject tested(attr_sizes, initial_table_size, txn_length, insert_update_select_ratio,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
                                            &block_store_, &buffer_pool_, &generator_, true);
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
     delete gc_thread_;
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 /**
@@ -127,18 +127,18 @@ BENCHMARK_DEFINE_F(LargeTransactionBenchmark, SingleStatementSelect)(benchmark::
   const std::vector<double> insert_update_select_ratio = {0, 0, 1};
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    LargeTransactionBenchmarkObject tested(attr_sizes, initial_table_size, txn_length, insert_update_select_ratio,
+    LargeTransactionBenchmarkObject tested(attr_sizes_, initial_table_size_, txn_length, insert_update_select_ratio,
                                            &block_store_, &buffer_pool_, &generator_, true);
     gc_thread_ = new storage::GarbageCollectorThread(tested.GetTxnManager(), gc_period_);
     uint64_t elapsed_ms;
     {
       common::ScopedTimer<std::chrono::milliseconds> timer(&elapsed_ms);
-      abort_count += tested.SimulateOltp(num_txns, num_concurrent_txns_);
+      abort_count += tested.SimulateOltp(num_txns_, num_concurrent_txns_);
     }
     state.SetIterationTime(static_cast<double>(elapsed_ms) / 1000.0);
     delete gc_thread_;
   }
-  state.SetItemsProcessed(state.iterations() * num_txns - abort_count);
+  state.SetItemsProcessed(state.iterations() * num_txns_ - abort_count);
 }
 
 BENCHMARK_REGISTER_F(LargeTransactionBenchmark, TPCCish)->Unit(benchmark::kMillisecond)->UseManualTime()->MinTime(3);

--- a/benchmark/util/transaction_benchmark_util.cpp
+++ b/benchmark/util/transaction_benchmark_util.cpp
@@ -30,7 +30,7 @@ void RandomWorkloadTransaction::RandomUpdate(Random *generator) {
   storage::ProjectedRowInitializer initializer =
       storage::ProjectedRowInitializer::Create(test_object_->layout_, update_col_ids);
 
-  auto *const record = txn_->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, initializer);
+  auto *const record = txn_->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, initializer);
   record->SetTupleSlot(updated);
 
   StorageTestUtil::PopulateRandomRow(record->Delta(), test_object_->layout_, 0.0, generator);
@@ -42,7 +42,7 @@ template <class Random>
 void RandomWorkloadTransaction::RandomInsert(Random *generator) {
   if (aborted_) return;
   auto *const redo =
-      txn_->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, test_object_->row_initializer_);
+      txn_->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, test_object_->row_initializer_);
   StorageTestUtil::PopulateRandomRow(redo->Delta(), test_object_->layout_, 0.0, generator);
   const storage::TupleSlot inserted = test_object_->table_.Insert(txn_, *(redo->Delta()));
   redo->SetTupleSlot(inserted);
@@ -142,7 +142,7 @@ void LargeTransactionBenchmarkObject::PopulateInitialTable(uint32_t num_tuples, 
 
   for (uint32_t i = 0; i < num_tuples; i++) {
     auto *const redo =
-        initial_txn_->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, row_initializer_);
+        initial_txn_->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, row_initializer_);
     StorageTestUtil::PopulateRandomRow(redo->Delta(), layout_, 0.0, generator);
     const storage::TupleSlot inserted = table_.Insert(initial_txn_, *(redo->Delta()));
     redo->SetTupleSlot(inserted);

--- a/build-support/bad_words.txt
+++ b/build-support/bad_words.txt
@@ -7,3 +7,4 @@
 \bcout\b
 \bprintf(
 \bstd::weak_ptr\b
+namespace .*_.* {

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -25,7 +25,7 @@ namespace terrier {
  * @return int error code from close. Informational only, no action required.
  */
 
-int terrier_close(int fd) {
+int TerrierClose(int fd) {
   // On Mac OS, close$NOCANCEL guarantees that no descriptor leak & no need to retry on failure.
   // On linux, close will do the same.
   // In short, call close/close$NOCANCEL once and consider it done. AND NEVER RETRY ON FAILURE.
@@ -41,14 +41,14 @@ int terrier_close(int fd) {
 #endif
 
   if (close_ret != 0) {
-    auto error_message = terrier_error_message();
+    auto error_message = TerrierErrorMessage();
     LOG_DEBUG("Close failed on fd: %d, errno: %d [%s]", fd, errno, error_message.c_str());
   }
 
   return close_ret;
 }
 
-std::string terrier_error_message() {
+std::string TerrierErrorMessage() {
   std::vector<char> buffer(100, '\0');
   int saved_errno = errno;
   char *error_message = nullptr;

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -8,7 +8,7 @@
 #if __APPLE__
 extern "C" {
 #include <sys/cdefs.h>
-int close$NOCANCEL(int);
+int close$NOCANCEL(int);  // NOLINT
 };
 #endif
 

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -297,7 +297,7 @@ class DatabaseCatalog {
   storage::index::Index *constraints_index_index_;
   storage::index::Index *constraints_foreigntable_index_;
 
-  transaction::Action debootstrap;
+  transaction::Action debootstrap_;
   std::atomic<uint32_t> next_oid_;
 
   const db_oid_t db_oid_;

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -200,10 +200,10 @@ class Schema {
       // If not all columns assigned OIDs, then clear the map because this is
       // a definition of a new/modified table not a catalog generated schema.
       if (columns_[i].Oid() == catalog::INVALID_COLUMN_OID) {
-        col_oid_to_offset.clear();
+        col_oid_to_offset_.clear();
         return;
       }
-      col_oid_to_offset[columns_[i].Oid()] = i;
+      col_oid_to_offset_[columns_[i].Oid()] = i;
     }
   }
 
@@ -225,8 +225,8 @@ class Schema {
    * @return description of the schema for a specific column
    */
   const Column &GetColumn(const col_oid_t col_oid) const {
-    TERRIER_ASSERT(col_oid_to_offset.count(col_oid) > 0, "col_oid does not exist in this Schema");
-    const uint32_t col_offset = col_oid_to_offset.at(col_oid);
+    TERRIER_ASSERT(col_oid_to_offset_.count(col_oid) > 0, "col_oid does not exist in this Schema");
+    const uint32_t col_offset = col_oid_to_offset_.at(col_oid);
     return columns_[col_offset];
   }
 

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -280,7 +280,7 @@ class Schema {
  private:
   friend class DatabaseCatalog;
   std::vector<Column> columns_;
-  std::unordered_map<col_oid_t, uint32_t> col_oid_to_offset;
+  std::unordered_map<col_oid_t, uint32_t> col_oid_to_offset_;
 };
 
 DEFINE_JSON_DECLARATIONS(Schema::Column);

--- a/src/include/common/container/concurrent_map.h
+++ b/src/include/common/container/concurrent_map.h
@@ -180,7 +180,7 @@ class ConcurrentMap {
    */
   ConstIterator Find(const K &key) const {
     auto it = map_.find(key);
-    if (it == map_.cend()) return CEnd();
+    if (it == map_.cend()) return cend();
     return ConstIterator(it);
   }
 
@@ -192,7 +192,7 @@ class ConcurrentMap {
    */
   Iterator Find(const K &key) {
     auto it = map_.find(key);
-    if (it == map_.end()) return End();
+    if (it == map_.end()) return end();
     return Iterator(it);
   }
 
@@ -206,22 +206,22 @@ class ConcurrentMap {
   /**
    * @return const iterator to the first element
    */
-  ConstIterator CBegin() const { return ConstIterator(map_.cbegin()); }
+  ConstIterator cbegin() const { return ConstIterator(map_.cbegin()); }
 
   /**
    * @return Iterator to the first element
    */
-  Iterator Begin() { return Iterator(map_.begin()); }
+  Iterator begin() { return Iterator(map_.begin()); }
 
   /**
    * @return const iterator to the element following the last element
    */
-  ConstIterator CEnd() const { return ConstIterator(map_.cend()); }
+  ConstIterator cend() const { return ConstIterator(map_.cend()); }
 
   /**
    * @return Iterator to the element following the last element
    */
-  Iterator End() { return Iterator(map_.end()); }
+  Iterator end() { return Iterator(map_.end()); }
 
  private:
   tbb::concurrent_unordered_map<TEMPLATE_ARGS> map_;

--- a/src/include/common/container/concurrent_vector.h
+++ b/src/include/common/container/concurrent_vector.h
@@ -117,13 +117,13 @@ class ConcurrentVector {
    * Returns an iterator pointing to the first element in the vector.
    * @return an iterator pointing to the first element in the vector.
    */
-  Iterator Begin() { return Iterator(vector_.begin()); }
+  Iterator begin() { return Iterator(vector_.begin()); }
 
   /**
    * Returns an iterator pointing to the last element in the vector.
    * @return an iterator pointing to the last element in the vector.
    */
-  Iterator End() { return Iterator(vector_.end()); }
+  Iterator end() { return Iterator(vector_.end()); }
 
  private:
   tbb::concurrent_vector<T, Alloc> vector_;

--- a/src/include/common/container/concurrent_vector.h
+++ b/src/include/common/container/concurrent_vector.h
@@ -117,13 +117,13 @@ class ConcurrentVector {
    * Returns an iterator pointing to the first element in the vector.
    * @return an iterator pointing to the first element in the vector.
    */
-  Iterator begin() { return Iterator(vector_.begin()); }
+  Iterator begin() { return Iterator(vector_.begin()); }  // NOLINT for STL name compability
 
   /**
    * Returns an iterator pointing to the last element in the vector.
    * @return an iterator pointing to the last element in the vector.
    */
-  Iterator end() { return Iterator(vector_.end()); }
+  Iterator end() { return Iterator(vector_.end()); }  // NOLINT for STL name compability
 
  private:
   tbb::concurrent_vector<T, Alloc> vector_;

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -43,9 +43,9 @@ class Exception : public std::runtime_error {
    * Allows type and source location of the exception to be recorded in the log at the catch point.
    */
   friend std::ostream &operator<<(std::ostream &out, const Exception &ex) {
-    out << ex.get_type() << " exception:";
-    out << ex.get_file() << ":";
-    out << ex.get_line() << ":";
+    out << ex.GetType() << " exception:";
+    out << ex.GetFile() << ":";
+    out << ex.GetLine() << ":";
     out << ex.what();
     return out;
   }

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -53,7 +53,7 @@ class Exception : public std::runtime_error {
   /**
    * @return the exception type
    */
-  const char *get_type() const {
+  const char *GetType() const {
     switch (type_) {
       case ExceptionType::NOT_IMPLEMENTED:
         return "Not Implemented";
@@ -73,12 +73,12 @@ class Exception : public std::runtime_error {
   /**
    * @return the file that threw the exception
    */
-  const char *get_file() const { return file_; }
+  const char *GetFile() const { return file_; }
 
   /**
    * @return the line number that threw the exception
    */
-  int get_line() const { return line_; }
+  int GetLine() const { return line_; }
 
  protected:
   /**

--- a/src/include/common/hash_util.h
+++ b/src/include/common/hash_util.h
@@ -13,7 +13,7 @@ using hash_t = uint64_t;
  */
 class HashUtil {
  private:
-  static const hash_t prime_factor = 10000019;
+  static const hash_t PRIME_FACTOR = 10000019;
 
  public:
   // Static utility class
@@ -71,7 +71,7 @@ class HashUtil {
    * @return sum of two hashes
    */
   static hash_t SumHashes(const hash_t l, const hash_t r) {
-    return (l % prime_factor + r % prime_factor) % prime_factor;
+    return (l % PRIME_FACTOR + r % PRIME_FACTOR) % PRIME_FACTOR;
   }
 
   /**

--- a/src/include/common/managed_pointer.h
+++ b/src/include/common/managed_pointer.h
@@ -51,7 +51,7 @@ class ManagedPointer {
   /**
    * @return the underlying pointer
    */
-  Underlying *get() const { return underlying_; }
+  Underlying *Get() const { return underlying_; }
 
   /**
    * @return True if it is not a nullptr, false otherwise

--- a/src/include/common/strong_typedef.h
+++ b/src/include/common/strong_typedef.h
@@ -259,14 +259,16 @@ struct atomic<terrier::common::StrongTypeAlias<Tag, IntType>> {
    * Checks if the atomic object is lock-free.
    * @return true if the atomic operations on the objects of this type are lock-free, false otherwise.
    */
-  bool is_lock_free() const noexcept { return underlying_.is_lock_free(); }
+  bool is_lock_free() const noexcept {  // NOLINT match underlying API
+    return underlying_.is_lock_free();
+  }
 
   /**
    * Atomically replaces the current value with desired. Memory is affected according to the value of order.
    * @param desired	the value to store into the atomic variable.
    * @param order memory order constraints to enforce.
    */
-  void store(t desired, memory_order order = memory_order_seq_cst) volatile noexcept {
+  void store(t desired, memory_order order = memory_order_seq_cst) volatile noexcept {  // NOLINT match underlying API
     underlying_.store(!desired, order);
   }
 
@@ -276,7 +278,9 @@ struct atomic<terrier::common::StrongTypeAlias<Tag, IntType>> {
    * @param order memory order constraints to enforce.
    * @return The current value of the atomic variable.
    */
-  t load(memory_order order = memory_order_seq_cst) const volatile noexcept { return t(underlying_.load(order)); }
+  t load(memory_order order = memory_order_seq_cst) const volatile noexcept {  // NOLINT match underlying API
+    return t(underlying_.load(order));
+  }
 
   /**
    * Atomically replaces the underlying value with desired. The operation is read-modify-write operation.
@@ -285,7 +289,7 @@ struct atomic<terrier::common::StrongTypeAlias<Tag, IntType>> {
    * @param order memory order constraints to enforce.
    * @return The value of the atomic variable before the call.
    */
-  t exchange(t desired, memory_order order = memory_order_seq_cst) volatile noexcept {
+  t exchange(t desired, memory_order order = memory_order_seq_cst) volatile noexcept {  // NOLINT match underlying API
     return t(underlying_.exchange(!desired, order));
   }
 

--- a/src/include/common/utility.h
+++ b/src/include/common/utility.h
@@ -3,7 +3,7 @@
 
 namespace terrier {
 
-int terrier_close(int fd);
+int TerrierClose(int fd);
 
-std::string terrier_error_message();
+std::string TerrierErrorMessage();
 }  // namespace terrier

--- a/src/include/di/di_help.h
+++ b/src/include/di/di_help.h
@@ -54,13 +54,13 @@ using namespace boost::di;  // NOLINT
  * @tparam T the type to test
  */
 template <class T>
-struct named : policies::detail::type_op {
+struct named : policies::detail::type_op {  // NOLINT
   /**
    * see boost::di doc https://boost-experimental.github.io/di/user_guide/index.html#policies
    * @tparam TArg
    */
   template <class TArg>
-  struct apply : aux::integral_constant<bool, !aux::is_same<no_name, typename TArg::name>::value> {};
+  struct apply : aux::integral_constant<bool, !aux::is_same<no_name, typename TArg::name>::value> {};  // NOLINT
 };
 
 /**
@@ -75,8 +75,8 @@ class StrictBindingPolicy : public di::config {
    * @param ... vararg input
    * @return strict binding policy
    */
-  static auto policies(...) noexcept {
-    using namespace policies;  // NOLINT
+  static auto policies(...) noexcept {  // NOLINT
+    using namespace policies;           // NOLINT
     return make_policies(constructible(is_bound<_>{}));
   }
 };
@@ -91,7 +91,7 @@ class TestBindingPolicy : public config {
    * @param ... vararg input
    * @return strict binding policy
    */
-  static auto policies(...) noexcept {
+  static auto policies(...) noexcept {    // NOLINT
     using namespace policies;             // NOLINT
     using namespace policies::operators;  // NOLINT
     // Unnamed unbound variables are most likely not
@@ -135,7 +135,7 @@ class TerrierWrapper {
   }
 
  private:
-  TExpected *wrapped;
+  TExpected *wrapped;  // NOLINT
 };
 
 /**
@@ -155,7 +155,7 @@ class TerrierSharedModule {
    * @tparam TGiven
    */
   template <class TExpected, class TGiven>
-  class scope {
+  class scope {  // NOLINT
    public:
     // TODO(Tianyu): Not sure if this is relevant as we prohibit injection of non-const references.
     // This is the referrable flag used for boost::di's singleton scope.
@@ -170,7 +170,7 @@ class TerrierSharedModule {
      * @return see https://boost-experimental.github.io/di/user_guide/index.html#scopes
      */
     template <class, class, class TProvider>
-    static TerrierWrapper<TExpected, TGiven> try_create(const TProvider &);
+    static TerrierWrapper<TExpected, TGiven> try_create(const TProvider &);  // NOLINT
 
     /**
      * @tparam TProvider provider type
@@ -178,7 +178,7 @@ class TerrierSharedModule {
      * @return see https://boost-experimental.github.io/di/user_guide/index.html#scopes
      */
     template <class, class, class TProvider>
-    TerrierWrapper<TExpected, TGiven> create(const TProvider &provider) {
+    TerrierWrapper<TExpected, TGiven> create(const TProvider &provider) {  // NOLINT
       if (object_ == nullptr) object_ = std::unique_ptr<TGiven>(provider.get());
       return object_.get();
     }
@@ -209,7 +209,7 @@ class TerrierSingleton {
    * @tparam TGiven
    */
   template <class TExpected, class TGiven>
-  class scope {
+  class scope {  // NOLINT
    public:
     // TODO(Tianyu): Not sure if this is relevant as we prohibit injection of non-const references.
     // This is the referrable flag used for boost::di's singleton scope.
@@ -224,7 +224,7 @@ class TerrierSingleton {
      * @return see https://boost-experimental.github.io/di/user_guide/index.html#scopes
      */
     template <class, class, class TProvider>
-    static TerrierWrapper<TExpected, TGiven> try_create(const TProvider &);
+    static TerrierWrapper<TExpected, TGiven> try_create(const TProvider &);  // NOLINT
 
     /**
      * @tparam TProvider provider type
@@ -232,7 +232,7 @@ class TerrierSingleton {
      * @return see https://boost-experimental.github.io/di/user_guide/index.html#scopes
      */
     template <class, class, class TProvider>
-    TerrierWrapper<TExpected, TGiven> create(const TProvider &provider) {
+    TerrierWrapper<TExpected, TGiven> create(const TProvider &provider) {  // NOLINT
       static auto object(provider.get(type_traits::stack{}));
       return &object;
     }
@@ -253,7 +253,7 @@ class DisabledModule {
    * @tparam TGiven
    */
   template <class TExpected, class TGiven>
-  class scope {
+  class scope {  // NOLINT
     /**
      * Custom wrapper that specifically allows implicit casting to terrier-approved types from
      * nullptr. We allow ManagedPointers, raw pointers.
@@ -288,7 +288,7 @@ class DisabledModule {
      * @return see boost::di doc
      */
     template <class, class, class TProvider>
-    static TerrierDisabledWrapper try_create(const TProvider &);
+    static TerrierDisabledWrapper try_create(const TProvider &);  // NOLINT
 
     /**
      * @tparam TProvider provider type
@@ -296,7 +296,7 @@ class DisabledModule {
      * @return see boost::di doc
      */
     template <class, class, class TProvider>
-    TerrierDisabledWrapper create(const TProvider &provider) {
+    TerrierDisabledWrapper create(const TProvider &provider) {  // NOLINT
       return {};
     }
   };

--- a/src/include/loggers/catalog_logger.h
+++ b/src/include/loggers/catalog_logger.h
@@ -8,7 +8,7 @@
 namespace terrier::catalog {
 extern std::shared_ptr<spdlog::logger> catalog_logger;
 
-void init_catalog_logger();
+void InitCatalogLogger();
 }  // namespace terrier::catalog
 
 #define CATALOG_LOG_TRACE(...) ::terrier::catalog::catalog_logger->trace(__VA_ARGS__);

--- a/src/include/loggers/index_logger.h
+++ b/src/include/loggers/index_logger.h
@@ -8,7 +8,7 @@
 namespace terrier::storage {
 extern std::shared_ptr<spdlog::logger> index_logger;
 
-void init_index_logger();
+void InitIndexLogger();
 }  // namespace terrier::storage
 
 #define INDEX_LOG_TRACE(...) ::terrier::storage::index_logger->trace(__VA_ARGS__);

--- a/src/include/loggers/loggers_util.h
+++ b/src/include/loggers/loggers_util.h
@@ -26,18 +26,18 @@ class LoggersUtil {
    */
   static void Initialize(const bool testing) {
     try {
-      init_main_logger();
+      InitMainLogger();
       // initialize namespace specific loggers
-      storage::init_index_logger();
-      storage::init_storage_logger();
-      transaction::init_transaction_logger();
-      catalog::init_catalog_logger();
-      settings::init_settings_logger();
-      parser::init_parser_logger();
-      network::init_network_logger();
+      storage::InitIndexLogger();
+      storage::InitStorageLogger();
+      transaction::InitTransactionLogger();
+      catalog::InitCatalogLogger();
+      settings::InitSettingsLogger();
+      parser::InitParserLogger();
+      network::InitNetworkLogger();
 
       if (testing) {
-        init_test_logger();
+        InitTestLogger();
       }
 
       // Flush all *registered* loggers using a worker thread. Registered loggers must be thread safe for this to work

--- a/src/include/loggers/main_logger.h
+++ b/src/include/loggers/main_logger.h
@@ -12,7 +12,7 @@
 extern std::shared_ptr<spdlog::sinks::stdout_sink_mt> default_sink;
 extern std::shared_ptr<spdlog::logger> main_logger;
 
-void init_main_logger();
+void InitMainLogger();
 
 #define LOG_TRACE(...) ::main_logger->trace(__VA_ARGS__);
 

--- a/src/include/loggers/network_logger.h
+++ b/src/include/loggers/network_logger.h
@@ -8,7 +8,7 @@
 namespace terrier::network {
 extern std::shared_ptr<spdlog::logger> network_logger;
 
-void init_network_logger();
+void InitNetworkLogger();
 }  // namespace terrier::network
 
 #define NETWORK_LOG_TRACE(...) ::terrier::network::network_logger->trace(__VA_ARGS__);

--- a/src/include/loggers/parser_logger.h
+++ b/src/include/loggers/parser_logger.h
@@ -8,7 +8,7 @@
 namespace terrier::parser {
 extern std::shared_ptr<spdlog::logger> parser_logger;
 
-void init_parser_logger();
+void InitParserLogger();
 }  // namespace terrier::parser
 
 #define PARSER_LOG_TRACE(...) ::terrier::parser::parser_logger->trace(__VA_ARGS__);

--- a/src/include/loggers/settings_logger.h
+++ b/src/include/loggers/settings_logger.h
@@ -8,7 +8,7 @@
 namespace terrier::settings {
 extern std::shared_ptr<spdlog::logger> settings_logger;
 
-void init_settings_logger();
+void InitSettingsLogger();
 }  // namespace terrier::settings
 
 #define SETTINGS_LOG_TRACE(...) ::terrier::settings::settings_logger->trace(__VA_ARGS__);

--- a/src/include/loggers/storage_logger.h
+++ b/src/include/loggers/storage_logger.h
@@ -8,7 +8,7 @@
 namespace terrier::storage {
 extern std::shared_ptr<spdlog::logger> storage_logger;
 
-void init_storage_logger();
+void InitStorageLogger();
 }  // namespace terrier::storage
 
 #define STORAGE_LOG_TRACE(...) ::terrier::storage::storage_logger->trace(__VA_ARGS__);

--- a/src/include/loggers/test_logger.h
+++ b/src/include/loggers/test_logger.h
@@ -8,7 +8,7 @@
 namespace terrier {
 extern std::shared_ptr<spdlog::logger> test_logger;
 
-void init_test_logger();
+void InitTestLogger();
 }  // namespace terrier
 
 #define TEST_LOG_TRACE(...) ::terrier::test_logger->trace(__VA_ARGS__);

--- a/src/include/loggers/transaction_logger.h
+++ b/src/include/loggers/transaction_logger.h
@@ -8,7 +8,7 @@
 namespace terrier::transaction {
 extern std::shared_ptr<spdlog::logger> transaction_logger;
 
-void init_transaction_logger();
+void InitTransactionLogger();
 }  // namespace terrier::transaction
 
 #define TXN_LOG_TRACE(...) ::terrier::transaction::transaction_logger->trace(__VA_ARGS__);

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -103,7 +103,7 @@ class DBMain {
   network::ProtocolInterpreter::Provider *provider_;
   common::DedicatedThreadRegistry *thread_registry_;
 
-  bool running = false;
+  bool running_ = false;
 
   /**
    * Cleans up and exit.

--- a/src/include/network/connection_context.h
+++ b/src/include/network/connection_context.h
@@ -16,12 +16,12 @@ struct ConnectionContext {
   /**
    * The statements in this connection
    */
-  std::unordered_map<std::string, trafficcop::Statement> statements;
+  std::unordered_map<std::string, trafficcop::Statement> statements_;
 
   /**
    * The portals in this connection
    */
-  std::unordered_map<std::string, trafficcop::Portal> portals;
+  std::unordered_map<std::string, trafficcop::Portal> portals_;
 
   /**
    * Cleans up this ConnectionContext.

--- a/src/include/network/connection_context.h
+++ b/src/include/network/connection_context.h
@@ -29,10 +29,10 @@ struct ConnectionContext {
    */
   void Reset() {
     // Cleans up all the sqlite statements in this connection
-    for (auto pair : statements) pair.second.Finalize();
+    for (auto pair : statements_) pair.second.Finalize();
 
-    statements.clear();
-    portals.clear();
+    statements_.clear();
+    portals_.clear();
   }
 };
 

--- a/src/include/network/connection_handle.h
+++ b/src/include/network/connection_handle.h
@@ -213,7 +213,7 @@ class ConnectionHandle {
      * behavior and the
      * next state it should go to.
      */
-    static transition_result Delta_(ConnState state, Transition transition);
+    static transition_result Delta(ConnState state, Transition transition);
     ConnState current_state_ = ConnState::READ;
   };
 

--- a/src/include/network/network_io_wrapper.h
+++ b/src/include/network/network_io_wrapper.h
@@ -77,7 +77,7 @@ class NetworkIoWrapper {
    * @return The next transition for this client's state machine
    */
   Transition Close() {
-    terrier_close(sock_fd_);
+    TerrierClose(sock_fd_);
     return Transition::PROCEED;
   }
 

--- a/src/include/network/postgres/postgres_protocol_utils.h
+++ b/src/include/network/postgres/postgres_protocol_utils.h
@@ -19,7 +19,7 @@ namespace terrier::network {
   * Hardcoded server parameter values to send to the client
   */
   const std::unordered_map<std::string, std::string>
-    parameter_status_map = {
+    PARAMETER_STATUS_MAP = {
       {"application_name", "psql"},
       {"client_encoding", "UTF8"},
       {"DateStyle", "ISO, MDY"},
@@ -287,7 +287,7 @@ class PostgresPacketWriter {
   void WriteStartupResponse() {
     BeginPacket(NetworkMessageType::AUTHENTICATION_REQUEST).AppendValue<int32_t>(0).EndPacket();
 
-    for (auto &entry : parameter_status_map)
+    for (auto &entry : PARAMETER_STATUS_MAP)
       BeginPacket(NetworkMessageType::PARAMETER_STATUS)
           .AppendString(entry.first)
           .AppendString(entry.second)
@@ -430,16 +430,16 @@ class PostgresPacketWriter {
     }
     writer.AppendValue(static_cast<int16_t>(paramVals.size()));
 
-    for (auto paramVal : paramVals) {
-      if (paramVal == nullptr) {
+    for (auto param_val : paramVals) {
+      if (param_val == nullptr) {
         // NULL value
         writer.AppendValue(static_cast<int32_t>(-1));
         continue;
       }
 
-      auto size = static_cast<int32_t>(paramVal->size());
+      auto size = static_cast<int32_t>(param_val->size());
       writer.AppendValue(size);
-      writer.AppendRaw(paramVal->data(), size);
+      writer.AppendRaw(param_val->data(), size);
     }
 
     writer.AppendValue(static_cast<int16_t>(resultFormatCodes.size()));

--- a/src/include/optimizer/logical_operators.h
+++ b/src/include/optimizer/logical_operators.h
@@ -43,7 +43,7 @@ class LogicalGet : public OperatorNode<LogicalGet> {
    * @param is_for_update whether the scan is used for update
    * @return
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid, std::vector<AnnotatedExpression> predicates,
                        std::string table_alias, bool is_for_update);
 
@@ -126,7 +126,7 @@ class LogicalExternalFileGet : public OperatorNode<LogicalExternalFileGet> {
    * @param escape character used for escape sequences
    * @return an LogicalExternalFileGet operator
    */
-  static Operator make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
+  static Operator Make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
                        char escape);
 
   bool operator==(const BaseOperatorNode &r) override;
@@ -194,7 +194,7 @@ class LogicalQueryDerivedGet : public OperatorNode<LogicalQueryDerivedGet> {
    * @param alias_to_expr_map map from table aliases to expressions of those tables
    * @return a LogicalQueryDerivedGet operator
    */
-  static Operator make(
+  static Operator Make(
       std::string table_alias,
       std::unordered_map<std::string, common::ManagedPointer<parser::AbstractExpression>> &&alias_to_expr_map);
 
@@ -235,7 +235,7 @@ class LogicalFilter : public OperatorNode<LogicalFilter> {
    * @param predicates The list of predicates used to perform the scan
    * @return a LogicalFilter operator
    */
-  static Operator make(std::vector<AnnotatedExpression> &&predicates);
+  static Operator Make(std::vector<AnnotatedExpression> &&predicates);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -264,7 +264,7 @@ class LogicalProjection : public OperatorNode<LogicalProjection> {
    * @param expressions list of AbstractExpressions in the projection list.
    * @return a LogicalProjection operator
    */
-  static Operator make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&expressions);
+  static Operator Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&expressions);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -290,13 +290,13 @@ class LogicalDependentJoin : public OperatorNode<LogicalDependentJoin> {
   /**
    * @return a DependentJoin operator
    */
-  static Operator make();
+  static Operator Make();
 
   /**
    * @param conditions condition of the join
    * @return a DependentJoin operator
    */
-  static Operator make(std::vector<AnnotatedExpression> &&conditions);
+  static Operator Make(std::vector<AnnotatedExpression> &&conditions);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -322,13 +322,13 @@ class LogicalMarkJoin : public OperatorNode<LogicalMarkJoin> {
   /**
    * @return a MarkJoin operator
    */
-  static Operator make();
+  static Operator Make();
 
   /**
    * @param conditions conditions of the join
    * @return a MarkJoin operator
    */
-  static Operator make(std::vector<AnnotatedExpression> &&conditions);
+  static Operator Make(std::vector<AnnotatedExpression> &&conditions);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -354,13 +354,13 @@ class LogicalSingleJoin : public OperatorNode<LogicalSingleJoin> {
   /**
    * @return a SingleJoin operator
    */
-  static Operator make();
+  static Operator Make();
 
   /**
    * @param conditions conditions of the join
    * @return a SingleJoin operator
    */
-  static Operator make(std::vector<AnnotatedExpression> &&conditions);
+  static Operator Make(std::vector<AnnotatedExpression> &&conditions);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -386,13 +386,13 @@ class LogicalInnerJoin : public OperatorNode<LogicalInnerJoin> {
   /**
    * @return an InnerJoin operator
    */
-  static Operator make();
+  static Operator Make();
 
   /**
    * @param conditions conditions of the join
    * @return an InnerJoin operator
    */
-  static Operator make(std::vector<AnnotatedExpression> &&conditions);
+  static Operator Make(std::vector<AnnotatedExpression> &&conditions);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -419,7 +419,7 @@ class LogicalLeftJoin : public OperatorNode<LogicalLeftJoin> {
    * @param join_predicate condition of the join
    * @return a LeftJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -446,7 +446,7 @@ class LogicalRightJoin : public OperatorNode<LogicalRightJoin> {
    * @param join_predicate condition of the join
    * @return a RightJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -473,7 +473,7 @@ class LogicalOuterJoin : public OperatorNode<LogicalOuterJoin> {
    * @param join_predicate condition of the join
    * @return an OuterJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -500,7 +500,7 @@ class LogicalSemiJoin : public OperatorNode<LogicalSemiJoin> {
    * @param join_predicate condition of the join
    * @return a SemiJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -526,20 +526,20 @@ class LogicalAggregateAndGroupBy : public OperatorNode<LogicalAggregateAndGroupB
   /**
    * @return a GroupBy operator
    */
-  static Operator make();
+  static Operator Make();
 
   /**
    * @param columns columns to group by
    * @return a GroupBy operator
    */
-  static Operator make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns);
+  static Operator Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns);
 
   /**
    * @param columns columns to group by
    * @param having HAVING clause
    * @return a GroupBy operator
    */
-  static Operator make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
+  static Operator Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
                        std::vector<AnnotatedExpression> &&having);
 
   bool operator==(const BaseOperatorNode &r) override;
@@ -581,7 +581,7 @@ class LogicalInsert : public OperatorNode<LogicalInsert> {
    * @param values list of expressions that provide the values to insert into columns
    * @return
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid, std::vector<catalog::col_oid_t> &&columns,
                        std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> &&values);
 
@@ -654,7 +654,7 @@ class LogicalInsertSelect : public OperatorNode<LogicalInsertSelect> {
    * @param table_oid OID of the table
    * @return
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid);
 
   bool operator==(const BaseOperatorNode &r) override;
@@ -702,7 +702,7 @@ class LogicalDistinct : public OperatorNode<LogicalDistinct> {
    * It doesn't need to store any data. It is just a placeholder
    * @return
    */
-  static Operator make();
+  static Operator Make();
 
   bool operator==(const BaseOperatorNode &r) override;
   common::hash_t Hash() const override;
@@ -721,7 +721,7 @@ class LogicalLimit : public OperatorNode<LogicalLimit> {
    * @param sort_directions inlined sort directions (can be empty)
    * @return
    */
-  static Operator make(size_t offset, size_t limit,
+  static Operator Make(size_t offset, size_t limit,
                        std::vector<common::ManagedPointer<parser::AbstractExpression>> &&sort_exprs,
                        std::vector<planner::OrderByOrderingType> &&sort_directions);
 
@@ -786,7 +786,7 @@ class LogicalDelete : public OperatorNode<LogicalDelete> {
    * @param table_oid OID of the table
    * @return
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid);
 
   bool operator==(const BaseOperatorNode &r) override;
@@ -836,7 +836,7 @@ class LogicalUpdate : public OperatorNode<LogicalUpdate> {
    * @param updates the update clauses from the SET portion of the query
    * @return
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid,
                        std::vector<common::ManagedPointer<parser::UpdateClause>> &&updates);
 
@@ -898,7 +898,7 @@ class LogicalExportExternalFile : public OperatorNode<LogicalExportExternalFile>
    * @param escape the character to use to escape characters in values
    * @return
    */
-  static Operator make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
+  static Operator Make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
                        char escape);
 
   bool operator==(const BaseOperatorNode &r) override;

--- a/src/include/optimizer/operator_node.h
+++ b/src/include/optimizer/operator_node.h
@@ -93,12 +93,12 @@ class OperatorNode : public BaseOperatorNode {
   /**
    * @return string name of the underlying operator
    */
-  std::string GetName() const override { return std::string(name_); }
+  std::string GetName() const override { return std::string(name); }
 
   /**
    * @return type of the underlying operator
    */
-  OpType GetType() const override { return type_; }
+  OpType GetType() const override { return type; }
 
   /**
    * @return whether the underlying operator is logical
@@ -114,12 +114,12 @@ class OperatorNode : public BaseOperatorNode {
   /**
    * Name of the operator
    */
-  static const char *name_;
+  static const char *name;
 
   /**
    * Type of the operator
    */
-  static OpType type_;
+  static OpType type;
 };
 
 /**

--- a/src/include/optimizer/operator_node.h
+++ b/src/include/optimizer/operator_node.h
@@ -93,12 +93,12 @@ class OperatorNode : public BaseOperatorNode {
   /**
    * @return string name of the underlying operator
    */
-  std::string GetName() const override { return std::string(name); }
+  std::string GetName() const override { return std::string(name_); }
 
   /**
    * @return type of the underlying operator
    */
-  OpType GetType() const override { return type; }
+  OpType GetType() const override { return type_; }
 
   /**
    * @return whether the underlying operator is logical
@@ -114,12 +114,12 @@ class OperatorNode : public BaseOperatorNode {
   /**
    * Name of the operator
    */
-  static const char *name;
+  static const char *name_;
 
   /**
    * Type of the operator
    */
-  static OpType type;
+  static OpType type_;
 };
 
 /**

--- a/src/include/optimizer/physical_operators.h
+++ b/src/include/optimizer/physical_operators.h
@@ -37,7 +37,7 @@ class TableFreeScan : public OperatorNode<TableFreeScan> {
   /**
    * @return a TableFreeScan operator
    */
-  static Operator make();
+  static Operator Make();
 
   bool operator==(const BaseOperatorNode &r) override;
   common::hash_t Hash() const override;
@@ -57,7 +57,7 @@ class SeqScan : public OperatorNode<SeqScan> {
    * @param is_for_update whether the scan is used for update
    * @return a SeqScan operator
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid, std::vector<AnnotatedExpression> &&predicates,
                        std::string table_alias, bool is_for_update);
 
@@ -144,7 +144,7 @@ class IndexScan : public OperatorNode<IndexScan> {
    * @param value_list values to be scanned
    * @return an IndexScan operator
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::index_oid_t index_oid, std::vector<AnnotatedExpression> &&predicates,
                        std::string table_alias, bool is_for_update,
                        std::vector<catalog::col_oid_t> &&key_column_oid_list,
@@ -260,7 +260,7 @@ class ExternalFileScan : public OperatorNode<ExternalFileScan> {
    * @param escape character used for escape sequences
    * @return an ExternalFileScan operator
    */
-  static Operator make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
+  static Operator Make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
                        char escape);
 
   bool operator==(const BaseOperatorNode &r) override;
@@ -329,7 +329,7 @@ class QueryDerivedScan : public OperatorNode<QueryDerivedScan> {
    * @param alias_to_expr_map map from table aliases to expressions of those tables
    * @return a QueryDerivedScan operator
    */
-  static Operator make(
+  static Operator Make(
       std::string table_alias,
       std::unordered_map<std::string, common::ManagedPointer<parser::AbstractExpression>> &&alias_to_expr_map);
 
@@ -369,7 +369,7 @@ class OrderBy : public OperatorNode<OrderBy> {
   /**
    * @return an OrderBy operator
    */
-  static Operator make();
+  static Operator Make();
 
   bool operator==(const BaseOperatorNode &r) override;
   common::hash_t Hash() const override;
@@ -387,7 +387,7 @@ class Limit : public OperatorNode<Limit> {
    * @param sort_directions sorting order
    * @return a Limit operator
    */
-  static Operator make(size_t offset, size_t limit,
+  static Operator Make(size_t offset, size_t limit,
                        std::vector<common::ManagedPointer<parser::AbstractExpression>> &&sort_columns,
                        std::vector<planner::OrderByOrderingType> &&sort_directions);
 
@@ -456,7 +456,7 @@ class InnerNLJoin : public OperatorNode<InnerNLJoin> {
    * @param right_keys right keys to join
    * @return an InnerNLJoin operator
    */
-  static Operator make(std::vector<AnnotatedExpression> &&join_predicates,
+  static Operator Make(std::vector<AnnotatedExpression> &&join_predicates,
                        std::vector<common::ManagedPointer<parser::AbstractExpression>> &&left_keys,
                        std::vector<common::ManagedPointer<parser::AbstractExpression>> &&right_keys);
 
@@ -505,7 +505,7 @@ class LeftNLJoin : public OperatorNode<LeftNLJoin> {
    * @param join_predicate predicate for join
    * @return a LeftNLJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -532,7 +532,7 @@ class RightNLJoin : public OperatorNode<RightNLJoin> {
    * @param join_predicate predicate for join
    * @return a RightNLJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -559,7 +559,7 @@ class OuterNLJoin : public OperatorNode<OuterNLJoin> {
    * @param join_predicate predicate for join
    * @return a OuterNLJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -588,7 +588,7 @@ class InnerHashJoin : public OperatorNode<InnerHashJoin> {
    * @param right_keys right keys to join
    * @return an IneerNLJoin operator
    */
-  static Operator make(std::vector<AnnotatedExpression> &&join_predicates,
+  static Operator Make(std::vector<AnnotatedExpression> &&join_predicates,
                        std::vector<common::ManagedPointer<parser::AbstractExpression>> &&left_keys,
                        std::vector<common::ManagedPointer<parser::AbstractExpression>> &&right_keys);
 
@@ -637,7 +637,7 @@ class LeftHashJoin : public OperatorNode<LeftHashJoin> {
    * @param join_predicate predicate for join
    * @return a LeftHashJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -664,7 +664,7 @@ class RightHashJoin : public OperatorNode<RightHashJoin> {
    * @param join_predicate predicate for join
    * @return a RightHashJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -691,7 +691,7 @@ class OuterHashJoin : public OperatorNode<OuterHashJoin> {
    * @param join_predicate predicate for join
    * @return a OuterHashJoin operator
    */
-  static Operator make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
+  static Operator Make(common::ManagedPointer<parser::AbstractExpression> join_predicate);
 
   bool operator==(const BaseOperatorNode &r) override;
 
@@ -722,7 +722,7 @@ class Insert : public OperatorNode<Insert> {
    * @param values expressions of values to insert
    * @return an Insert operator
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid, std::vector<catalog::col_oid_t> &&columns,
                        std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> &&values);
 
@@ -794,7 +794,7 @@ class InsertSelect : public OperatorNode<InsertSelect> {
    * @param table_oid OID of the table
    * @return an InsertSelect operator
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid);
 
   bool operator==(const BaseOperatorNode &r) override;
@@ -844,7 +844,7 @@ class Delete : public OperatorNode<Delete> {
    * @param delete_condition expression of delete condition
    * @return an InsertSelect operator
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid,
                        common::ManagedPointer<parser::AbstractExpression> delete_condition);
 
@@ -906,7 +906,7 @@ class ExportExternalFile : public OperatorNode<ExportExternalFile> {
    * @param escape character used for escape sequences
    * @return an ExportExternalFile operator
    */
-  static Operator make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
+  static Operator Make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
                        char escape);
 
   bool operator==(const BaseOperatorNode &r) override;
@@ -977,7 +977,7 @@ class Update : public OperatorNode<Update> {
    * @param updates update clause
    * @return an Update operator
    */
-  static Operator make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+  static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid,
                        std::vector<common::ManagedPointer<parser::UpdateClause>> &&updates);
 
@@ -1036,7 +1036,7 @@ class HashGroupBy : public OperatorNode<HashGroupBy> {
    * @param having expression of HAVING clause
    * @return a HashGroupBy operator
    */
-  static Operator make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
+  static Operator Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
                        std::vector<AnnotatedExpression> &&having);
 
   bool operator==(const BaseOperatorNode &r) override;
@@ -1075,7 +1075,7 @@ class SortGroupBy : public OperatorNode<SortGroupBy> {
    * @param having HAVING clause
    * @return a SortGroupBy operator
    */
-  static Operator make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
+  static Operator Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
                        std::vector<AnnotatedExpression> &&having);
 
   bool operator==(const BaseOperatorNode &r) override;
@@ -1112,7 +1112,7 @@ class Aggregate : public OperatorNode<Aggregate> {
   /**
    * @return an Aggregate operator
    */
-  static Operator make();
+  static Operator Make();
 
   bool operator==(const BaseOperatorNode &r) override;
   common::hash_t Hash() const override;
@@ -1126,7 +1126,7 @@ class Distinct : public OperatorNode<Distinct> {
   /**
    * @return a distinct operator
    */
-  static Operator make();
+  static Operator Make();
 
   bool operator==(const BaseOperatorNode &r) override;
   common::hash_t Hash() const override;

--- a/src/include/parser/expression/case_expression.h
+++ b/src/include/parser/expression/case_expression.h
@@ -20,11 +20,11 @@ class CaseExpression : public AbstractExpression {
     /**
      * The condition to be checked for this case expression.
      */
-    std::shared_ptr<AbstractExpression> condition;
+    std::shared_ptr<AbstractExpression> condition_;
     /**
      * The value that this expression should have if the corresponding condition is true.
      */
-    std::shared_ptr<AbstractExpression> then;
+    std::shared_ptr<AbstractExpression> then_;
 
     /**
      * Equality check

--- a/src/include/parser/expression/case_expression.h
+++ b/src/include/parser/expression/case_expression.h
@@ -31,7 +31,7 @@ class CaseExpression : public AbstractExpression {
      * @param rhs the other WhenClause to compare to
      * @return if the two are equal
      */
-    bool operator==(const WhenClause &rhs) const { return *condition == *rhs.condition && *then == *rhs.then; }
+    bool operator==(const WhenClause &rhs) const { return *condition_ == *rhs.condition_ && *then_ == *rhs.then_; }
 
     /**
      * Inequality check
@@ -46,8 +46,8 @@ class CaseExpression : public AbstractExpression {
      */
     nlohmann::json ToJson() const {
       nlohmann::json j;
-      j["condition"] = condition;
-      j["then"] = then;
+      j["condition"] = condition_;
+      j["then"] = then_;
       return j;
     }
 
@@ -56,8 +56,8 @@ class CaseExpression : public AbstractExpression {
      * @param j json to deserialize
      */
     void FromJson(const nlohmann::json &j) {
-      condition = DeserializeExpression(j.at("condition"));
-      then = DeserializeExpression(j.at("then"));
+      condition_ = DeserializeExpression(j.at("condition"));
+      then_ = DeserializeExpression(j.at("then"));
     }
   };
 
@@ -81,8 +81,8 @@ class CaseExpression : public AbstractExpression {
   common::hash_t Hash() const override {
     common::hash_t hash = AbstractExpression::Hash();
     for (auto &clause : when_clauses_) {
-      hash = common::HashUtil::CombineHashes(hash, clause.condition->Hash());
-      hash = common::HashUtil::CombineHashes(hash, clause.then->Hash());
+      hash = common::HashUtil::CombineHashes(hash, clause.condition_->Hash());
+      hash = common::HashUtil::CombineHashes(hash, clause.then_->Hash());
     }
     if (default_expr_ != nullptr) {
       hash = common::HashUtil::CombineHashes(hash, default_expr_->Hash());
@@ -119,7 +119,7 @@ class CaseExpression : public AbstractExpression {
    */
   std::shared_ptr<AbstractExpression> GetWhenClauseCondition(size_t index) const {
     TERRIER_ASSERT(index < when_clauses_.size(), "Index must be in bounds.");
-    return when_clauses_[index].condition;
+    return when_clauses_[index].condition_;
   }
 
   /**
@@ -128,7 +128,7 @@ class CaseExpression : public AbstractExpression {
    */
   std::shared_ptr<AbstractExpression> GetWhenClauseResult(size_t index) const {
     TERRIER_ASSERT(index < when_clauses_.size(), "Index must be in bounds.");
-    return when_clauses_[index].then;
+    return when_clauses_[index].then_;
   }
 
   /**

--- a/src/include/parser/nodes.h
+++ b/src/include/parser/nodes.h
@@ -5,13 +5,13 @@
 /**
  * A value parsenode as produced by the Postgres parser
  */
-using value = struct value {
-  NodeTag type; /**< tag appropriately (eg. T_String) */
+using value = struct Value {
+  NodeTag type_; /**< tag appropriately (eg. T_String) */
   /**
    * value, as specified via tag
    */
   union ValUnion {
-    int32_t ival; /**< A machine integer */
-    char *str;    /**< string */
-  } val;          /**< value */
+    int32_t ival_; /**< A machine integer */
+    char *str_;    /**< string */
+  } val_;          /**< value */
 };

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -96,10 +96,10 @@ using SubLink = struct SubLink {
   Expr xpr_;
   SubLinkType sub_link_type_; /* see above */
   int sub_link_id_;           /* ID (1..n); 0 if not MULTIEXPR */
-  Node *testexpr_;          /* outer-query test for ALL/ANY/ROWCOMPARE */
-  List *oper_name_;          /* originally specified operator name */
-  Node *subselect_;         /* subselect as Query* or raw parsetree */
-  int location_;            /* token location, or -1 if unknown */
+  Node *testexpr_;            /* outer-query test for ALL/ANY/ROWCOMPARE */
+  List *oper_name_;           /* originally specified operator name */
+  Node *subselect_;           /* subselect as Query* or raw parsetree */
+  int location_;              /* token location, or -1 if unknown */
 };
 
 using BoolExpr = struct BoolExpr {
@@ -148,14 +148,14 @@ using NullTest = struct NullTest {
 
 using JoinExpr = struct JoinExpr {
   NodeTag type_;
-  JoinType jointype_; /* type of join */
+  JoinType jointype_;  /* type of join */
   bool is_natural_;    /* Natural join? Will need to shape table */
-  Node *larg_;        /* left subtree */
-  Node *rarg_;        /* right subtree */
+  Node *larg_;         /* left subtree */
+  Node *rarg_;         /* right subtree */
   List *using_clause_; /* USING clause, if any (list of String) */
-  Node *quals_;       /* qualifiers on join, if any */
-  Alias *alias_;      /* user-written alias clause, if any */
-  int rtindex_;       /* RT index assigned for join, or 0 */
+  Node *quals_;        /* qualifiers on join, if any */
+  Alias *alias_;       /* user-written alias clause, if any */
+  int rtindex_;        /* RT index assigned for join, or 0 */
 };
 
 using CaseExpr = struct CaseExpr {
@@ -184,9 +184,9 @@ using RangeSubselect = struct RangeSubselect {
 
 using RangeVar = struct RangeVar {
   NodeTag type_;
-  char *catalogname_; /* the catalog (database) name, or NULL */
-  char *schemaname_;  /* the schema name, or NULL */
-  char *relname_;     /* the relation/sequence name */
+  char *catalogname_;  /* the catalog (database) name, or NULL */
+  char *schemaname_;   /* the schema name, or NULL */
+  char *relname_;      /* the relation/sequence name */
   InhOption inh_opt_;  // expand rel by inheritance?
   // recursively act on children?
   char relpersistence_; /* see RELPERSISTENCE_* in pg_class.h */
@@ -211,11 +211,11 @@ using OnCommitAction = enum OnCommitAction {
 using IntoClause = struct IntoClause {
   NodeTag type_;
 
-  RangeVar *rel_;           /* target relation name */
+  RangeVar *rel_;            /* target relation name */
   List *col_names_;          /* column names to assign, or NIL */
-  List *options_;           /* options from WITH clause */
+  List *options_;            /* options from WITH clause */
   OnCommitAction on_commit_; /* what do we do at COMMIT? */
-  char *table_space_name_;    /* table space to use, or NULL */
+  char *table_space_name_;   /* table space to use, or NULL */
   Node *view_query_;         /* materialized view's SELECT query */
   bool skip_data_;           /* true for WITH NO DATA */
 };
@@ -234,7 +234,7 @@ using SortBy = struct SortBy {
   Node *node_;               /* expression to sort on */
   SortByDir sortby_dir_;     /* ASC/DESC/USING/default */
   SortByNulls sortby_nulls_; /* NULLS FIRST/LAST */
-  List *use_op_;              /* name of op to use, if SORTBY_USING */
+  List *use_op_;             /* name of op to use, if SORTBY_USING */
   int location_;             /* operator location, or -1 if none/unknown */
 };
 
@@ -242,27 +242,27 @@ using InferClause = struct InferClause {
   NodeTag type_;
   List *index_elems_;  /* IndexElems to infer unique index */
   Node *where_clause_; /* qualification (partial-index predicate) */
-  char *conname_;     /* Constraint name, or NULL if unnamed */
-  int location_;      /* token location, or -1 if unknown */
+  char *conname_;      /* Constraint name, or NULL if unnamed */
+  int location_;       /* token location, or -1 if unknown */
 };
 
 using OnConflictClause = struct OnConflictClause {
   NodeTag type_;
   OnConflictAction action_; /* DO NOTHING or UPDATE? */
   InferClause *infer_;      /* Optional index inference clause */
-  List *target_list_;        /* the target list (of ResTarget) */
-  Node *where_clause_;       /* qualifications */
+  List *target_list_;       /* the target list (of ResTarget) */
+  Node *where_clause_;      /* qualifications */
   int location_;            /* token location, or -1 if unknown */
 };
 
 using InsertStmt = struct InsertStmt {
   NodeTag type_;
-  RangeVar *relation_;                 /* relation to insert into */
-  List *cols_;                         /* optional: names of the target columns */
-  Node *select_stmt_;                   /* the source SELECT/VALUES, or NULL */
+  RangeVar *relation_;                   /* relation to insert into */
+  List *cols_;                           /* optional: names of the target columns */
+  Node *select_stmt_;                    /* the source SELECT/VALUES, or NULL */
   OnConflictClause *on_conflict_clause_; /* ON CONFLICT clause */
-  List *returning_list_;                /* list of expressions to return */
-  WithClause *with_clause_;             /* WITH clause */
+  List *returning_list_;                 /* list of expressions to return */
+  WithClause *with_clause_;              /* WITH clause */
 };
 
 using SelectStmt = struct SelectStmt {
@@ -326,14 +326,14 @@ using ExplainStmt = struct ExplainStmt {
 
 using TypeName = struct TypeName {
   NodeTag type_;
-  List *names_;       /* qualified name (list of Value strings) */
+  List *names_;        /* qualified name (list of Value strings) */
   Oid type_oid_;       /* type identified by OID */
-  bool setof_;        /* is a set? */
-  bool pct_type_;     /* %TYPE specified? */
-  List *typmods_;     /* type modifier expression(s) */
-  int typemod_;       /* prespecified type modifier */
+  bool setof_;         /* is a set? */
+  bool pct_type_;      /* %TYPE specified? */
+  List *typmods_;      /* type modifier expression(s) */
+  int typemod_;        /* prespecified type modifier */
   List *array_bounds_; /* array bounds */
-  int location_;      /* token location, or -1 if unknown */
+  int location_;       /* token location, or -1 if unknown */
 };
 
 using IndexElem = struct IndexElem {
@@ -349,25 +349,25 @@ using IndexElem = struct IndexElem {
 
 using IndexStmt = struct IndexStmt {
   NodeTag type_;
-  char *idxname_;        /* name of new index, or NULL for default */
-  RangeVar *relation_;   /* relation to build index on */
-  char *access_method_;   /* name of access method (eg. btree) */
-  char *table_space_;     /* tablespace, or NULL for default */
-  List *index_params_;    /* columns to index: a list of IndexElem */
-  List *options_;        /* WITH clause options: a list of DefElem */
-  Node *where_clause_;    /* qualification (partial-index predicate) */
+  char *idxname_;          /* name of new index, or NULL for default */
+  RangeVar *relation_;     /* relation to build index on */
+  char *access_method_;    /* name of access method (eg. btree) */
+  char *table_space_;      /* tablespace, or NULL for default */
+  List *index_params_;     /* columns to index: a list of IndexElem */
+  List *options_;          /* WITH clause options: a list of DefElem */
+  Node *where_clause_;     /* qualification (partial-index predicate) */
   List *exclude_op_names_; /* exclusion operator names, or NIL if none */
-  char *idxcomment_;     /* comment to apply to index, or NULL */
-  Oid index_oid_;         /* OID of an existing index, if any */
-  Oid old_node_;          /* relfilenode of existing storage, if any */
-  bool unique_;          /* is index unique? */
-  bool primary_;         /* is index a primary key? */
-  bool isconstraint_;    /* is it for a pkey/unique constraint? */
-  bool deferrable_;      /* is the constraint DEFERRABLE? */
-  bool initdeferred_;    /* is the constraint INITIALLY DEFERRED? */
-  bool transformed_;     /* true when transformIndexStmt is finished */
-  bool concurrent_;      /* should this be a concurrent index build? */
-  bool if_not_exists_;   /* just do nothing if index already exists? */
+  char *idxcomment_;       /* comment to apply to index, or NULL */
+  Oid index_oid_;          /* OID of an existing index, if any */
+  Oid old_node_;           /* relfilenode of existing storage, if any */
+  bool unique_;            /* is index unique? */
+  bool primary_;           /* is index a primary key? */
+  bool isconstraint_;      /* is it for a pkey/unique constraint? */
+  bool deferrable_;        /* is the constraint DEFERRABLE? */
+  bool initdeferred_;      /* is the constraint INITIALLY DEFERRED? */
+  bool transformed_;       /* true when transformIndexStmt is finished */
+  bool concurrent_;        /* should this be a concurrent index build? */
+  bool if_not_exists_;     /* just do nothing if index already exists? */
 };
 
 using CreateTrigStmt = struct CreateTrigStmt {
@@ -382,7 +382,7 @@ using CreateTrigStmt = struct CreateTrigStmt {
   /* events uses the TRIGGER_TYPE bits defined in catalog/pg_trigger.h */
   int16_t events_;    /* "OR" of INSERT/UPDATE/DELETE/TRUNCATE */
   List *columns_;     /* column names, or NIL for all columns */
-  Node *when_clause_;  /* qual expression, or NULL if none */
+  Node *when_clause_; /* qual expression, or NULL if none */
   bool isconstraint_; /* This is a constraint trigger */
   /* The remaining fields are only used for constraint triggers */
   bool deferrable_;     /* [NOT] DEFERRABLE */
@@ -393,7 +393,7 @@ using CreateTrigStmt = struct CreateTrigStmt {
 using ColumnDef = struct ColumnDef {
   NodeTag type_;
   char *colname_;        /* name of column */
-  TypeName *type_name_;   /* type of column */
+  TypeName *type_name_;  /* type of column */
   int inhcount_;         /* number of times column is inherited */
   bool is_local_;        /* column has local (non-inherited) def'n */
   bool is_not_null_;     /* NOT NULL constraint specified? */
@@ -401,8 +401,8 @@ using ColumnDef = struct ColumnDef {
   char storage_;         /* attstorage setting, or 0 for default */
   Node *raw_default_;    /* default value (untransformed parse tree) */
   Node *cooked_default_; /* default value (transformed expr tree) */
-  Node *coll_clause_;     /* untransformed COLLATE spec, if any */
-  Oid coll_oid_;          /* collation OID (InvalidOid if not set) */
+  Node *coll_clause_;    /* untransformed COLLATE spec, if any */
+  Oid coll_oid_;         /* collation OID (InvalidOid if not set) */
   List *constraints_;    /* other constraints on column */
   List *fdwoptions_;     /* per-column FDW options */
   int location_;         /* parse location, or -1 if none/unknown */
@@ -410,11 +410,11 @@ using ColumnDef = struct ColumnDef {
 
 using CreateStmt = struct CreateStmt {
   NodeTag type_;
-  RangeVar *relation_;  /* relation to create */
+  RangeVar *relation_;   /* relation to create */
   List *table_elts_;     /* column definitions (list of ColumnDef) */
   List *inh_relations_;  // relations to inherit from (list of
   // inhRelation)
-  TypeName *of_typename_;    /* OF typename */
+  TypeName *of_typename_;   /* OF typename */
   List *constraints_;       /* constraints (list of Constraint nodes) */
   List *options_;           /* options from WITH clause */
   OnCommitAction oncommit_; /* what do we do at COMMIT? */
@@ -495,7 +495,7 @@ using Constraint = struct Constraint {
 
 using DeleteStmt = struct DeleteStmt {
   NodeTag type_;
-  RangeVar *relation_;     /* relation to delete from */
+  RangeVar *relation_;      /* relation to delete from */
   List *using_clause_;      /* optional using clause for more tables */
   Node *where_clause_;      /* qualifications */
   List *returning_list_;    /* list of expressions to return */
@@ -524,21 +524,21 @@ using A_Const = struct AConst {
 
 using TypeCast = struct TypeCast {
   NodeTag type_;
-  Node *arg_;          /* the expression being casted */
+  Node *arg_;           /* the expression being casted */
   TypeName *type_name_; /* the target type */
-  int location_;       /* token location, or -1 if unknown */
+  int location_;        /* token location, or -1 if unknown */
 };
 
 using WindowDef = struct WindowDef {
   NodeTag type_;
-  char *name_;            /* window's own name */
-  char *refname_;         /* referenced window name, if any */
+  char *name_;             /* window's own name */
+  char *refname_;          /* referenced window name, if any */
   List *partition_clause_; /* PARTITION BY expression list */
   List *order_clause_;     /* ORDER BY (list of SortBy) */
   int frame_options_;      /* frame_clause options, see below */
   Node *start_offset_;     /* expression for starting bound, if any */
   Node *end_offset_;       /* expression for ending bound, if any */
-  int location_;          /* parse location, or -1 if none/unknown */
+  int location_;           /* parse location, or -1 if none/unknown */
 };
 
 using FuncCall = struct FuncCall {
@@ -557,7 +557,7 @@ using FuncCall = struct FuncCall {
 
 using UpdateStmt = struct UpdateStmt {
   NodeTag type_;
-  RangeVar *relation_;     /* relation to update */
+  RangeVar *relation_;      /* relation to update */
   List *target_list_;       /* the target list (of ResTarget) */
   Node *where_clause_;      /* qualifications */
   List *from_clause_;       /* optional from clause for more tables */
@@ -638,12 +638,12 @@ using DropBehaviour = enum DropBehavior {
 
 using DropStmt = struct DropStmt {
   NodeTag type_;
-  List *objects_;         /* list of sublists of names (as Values) */
-  List *arguments_;       /* list of sublists of arguments (as Values) */
+  List *objects_;          /* list of sublists of names (as Values) */
+  List *arguments_;        /* list of sublists of arguments (as Values) */
   ObjectType remove_type_; /* object type */
-  DropBehavior behavior_; /* RESTRICT or CASCADE behavior */
-  bool missing_ok_;       /* skip error if object is missing? */
-  bool concurrent_;       /* drop index concurrently? */
+  DropBehavior behavior_;  /* RESTRICT or CASCADE behavior */
+  bool missing_ok_;        /* skip error if object is missing? */
+  bool concurrent_;        /* drop index concurrently? */
 };
 
 using DropDatabaseStmt = struct DropDatabaseStmt {
@@ -710,7 +710,7 @@ using CreateSchemaStmt = struct CreateSchemaStmt {
   NodeTag type_;
   char *schemaname_;   /* the name of the schema to create */
   Node *authrole_;     /* the owner of the created schema */
-  List *schema_elts_;   /* schema components (list of parsenodes) */
+  List *schema_elts_;  /* schema components (list of parsenodes) */
   bool if_not_exists_; /* just do nothing if schema already exists? */
 };
 
@@ -732,11 +732,11 @@ using ViewCheckOption = enum ViewCheckOption { NO_CHECK_OPTION, LOCAL_CHECK_OPTI
 
 using ViewStmt = struct ViewStmt {
   NodeTag type_;
-  RangeVar *view_;                  /* the view to be created */
-  List *aliases_;                   /* target column names */
-  Node *query_;                     /* the SELECT query */
-  bool replace_;                    /* replace an existing view? */
-  List *options_;                   /* options from WITH clause */
+  RangeVar *view_;                    /* the view to be created */
+  List *aliases_;                     /* target column names */
+  Node *query_;                       /* the SELECT query */
+  bool replace_;                      /* replace an existing view? */
+  List *options_;                     /* options from WITH clause */
   ViewCheckOption with_check_option_; /* WITH CHECK OPTION */
 };
 
@@ -789,11 +789,11 @@ using VariableShowStmt = struct VariableShowStmt {
 
 using CreateFunctionStmt = struct CreateFunctionStmt {
   NodeTag type_;
-  bool replace_;         /* T => replace if already exists */
-  List *funcname_;       /* qualified name of function to create */
-  List *parameters_;     /* a list of FunctionParameter */
+  bool replace_;          /* T => replace if already exists */
+  List *funcname_;        /* qualified name of function to create */
+  List *parameters_;      /* a list of FunctionParameter */
   TypeName *return_type_; /* the return type */
-  List *options_;        /* a list of DefElem */
+  List *options_;         /* a list of DefElem */
   List *with_clause_;     /* a list of DefElem */
 };
 
@@ -809,7 +809,7 @@ using FunctionParameterMode = enum FunctionParameterMode {
 using FunctionParameter = struct FunctionParameter {
   NodeTag type_;
   char *name_;                 /* parameter name, or NULL if not given */
-  TypeName *arg_type_;          /* TypeName for parameter type */
+  TypeName *arg_type_;         /* TypeName for parameter type */
   FunctionParameterMode mode_; /* IN/OUT/etc */
   Node *defexpr_;              /* raw default expr, or NULL if not given */
 };

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -15,9 +15,9 @@
 using SetOperation = enum SetOperation { SETOP_NONE = 0, SETOP_UNION, SETOP_INTERSECT, SETOP_EXCEPT };
 
 using Alias = struct Alias {
-  NodeTag type;
-  char *aliasname; /* aliased rel name (never qualified) */
-  List *colnames;  /* optional list of column aliases */
+  NodeTag type_;
+  char *aliasname_; /* aliased rel name (never qualified) */
+  List *colnames_;  /* optional list of column aliases */
 };
 
 using InhOption = enum InhOption {
@@ -28,7 +28,7 @@ using InhOption = enum InhOption {
 
 using BoolExprType = enum BoolExprType { AND_EXPR, OR_EXPR, NOT_EXPR };
 
-using Expr = struct Expr { NodeTag type; };
+using Expr = struct Expr { NodeTag type_; };
 
 /*
  * SubLink
@@ -93,23 +93,23 @@ using SubLinkType = enum SubLinkType {
 };
 
 using SubLink = struct SubLink {
-  Expr xpr;
-  SubLinkType subLinkType; /* see above */
-  int subLinkId;           /* ID (1..n); 0 if not MULTIEXPR */
-  Node *testexpr;          /* outer-query test for ALL/ANY/ROWCOMPARE */
-  List *operName;          /* originally specified operator name */
-  Node *subselect;         /* subselect as Query* or raw parsetree */
-  int location;            /* token location, or -1 if unknown */
+  Expr xpr_;
+  SubLinkType sub_link_type_; /* see above */
+  int sub_link_id_;           /* ID (1..n); 0 if not MULTIEXPR */
+  Node *testexpr_;          /* outer-query test for ALL/ANY/ROWCOMPARE */
+  List *oper_name_;          /* originally specified operator name */
+  Node *subselect_;         /* subselect as Query* or raw parsetree */
+  int location_;            /* token location, or -1 if unknown */
 };
 
 using BoolExpr = struct BoolExpr {
-  Expr xpr;
-  BoolExprType boolop;
-  List *args;   /* arguments to this expression */
-  int location; /* token location, or -1 if unknown */
+  Expr xpr_;
+  BoolExprType boolop_;
+  List *args_;   /* arguments to this expression */
+  int location_; /* token location, or -1 if unknown */
 };
 
-using A_Expr_Kind = enum A_Expr_Kind {
+using A_Expr_Kind = enum AExprKind {
   AEXPR_OP,              /* normal operator */
   AEXPR_OP_ANY,          /* scalar op ANY (array) */
   AEXPR_OP_ALL,          /* scalar op ALL (array) */
@@ -127,78 +127,78 @@ using A_Expr_Kind = enum A_Expr_Kind {
   AEXPR_PAREN            /* nameless dummy node for parentheses */
 };
 
-using A_Expr = struct A_Expr {
-  NodeTag type;
-  A_Expr_Kind kind; /* see above */
-  List *name;       /* possibly-qualified name of operator */
-  Node *lexpr;      /* left argument, or NULL if none */
-  Node *rexpr;      /* right argument, or NULL if none */
-  int location;     /* token location, or -1 if unknown */
+using A_Expr = struct AExpr {
+  NodeTag type_;
+  A_Expr_Kind kind_; /* see above */
+  List *name_;       /* possibly-qualified name of operator */
+  Node *lexpr_;      /* left argument, or NULL if none */
+  Node *rexpr_;      /* right argument, or NULL if none */
+  int location_;     /* token location, or -1 if unknown */
 };
 
 using NullTestType = enum NullTestType { IS_NULL, IS_NOT_NULL };
 
 using NullTest = struct NullTest {
-  Expr xpr;
-  Expr *arg;                 /* input expression */
-  NullTestType nulltesttype; /* IS NULL, IS NOT NULL */
-  bool argisrow;             /* T if input is of a composite type */
-  int location;              /* token location, or -1 if unknown */
+  Expr xpr_;
+  Expr *arg_;                 /* input expression */
+  NullTestType nulltesttype_; /* IS NULL, IS NOT NULL */
+  bool argisrow_;             /* T if input is of a composite type */
+  int location_;              /* token location, or -1 if unknown */
 };
 
 using JoinExpr = struct JoinExpr {
-  NodeTag type;
-  JoinType jointype; /* type of join */
-  bool isNatural;    /* Natural join? Will need to shape table */
-  Node *larg;        /* left subtree */
-  Node *rarg;        /* right subtree */
-  List *usingClause; /* USING clause, if any (list of String) */
-  Node *quals;       /* qualifiers on join, if any */
-  Alias *alias;      /* user-written alias clause, if any */
-  int rtindex;       /* RT index assigned for join, or 0 */
+  NodeTag type_;
+  JoinType jointype_; /* type of join */
+  bool is_natural_;    /* Natural join? Will need to shape table */
+  Node *larg_;        /* left subtree */
+  Node *rarg_;        /* right subtree */
+  List *using_clause_; /* USING clause, if any (list of String) */
+  Node *quals_;       /* qualifiers on join, if any */
+  Alias *alias_;      /* user-written alias clause, if any */
+  int rtindex_;       /* RT index assigned for join, or 0 */
 };
 
 using CaseExpr = struct CaseExpr {
-  Expr xpr;
-  Oid casetype;    /* type of expression result */
-  Oid casecollid;  /* OID of collation, or InvalidOid if none */
-  Expr *arg;       /* implicit equality comparison argument */
-  List *args;      /* the arguments (list of WHEN clauses) */
-  Expr *defresult; /* the default result (ELSE clause) */
-  int location;    /* token location, or -1 if unknown */
+  Expr xpr_;
+  Oid casetype_;    /* type of expression result */
+  Oid casecollid_;  /* OID of collation, or InvalidOid if none */
+  Expr *arg_;       /* implicit equality comparison argument */
+  List *args_;      /* the arguments (list of WHEN clauses) */
+  Expr *defresult_; /* the default result (ELSE clause) */
+  int location_;    /* token location, or -1 if unknown */
 };
 
 using CaseWhen = struct CaseWhen {
-  Expr xpr;
-  Expr *expr;   /* condition expression */
-  Expr *result; /* substitution result */
-  int location; /* token location, or -1 if unknown */
+  Expr xpr_;
+  Expr *expr_;   /* condition expression */
+  Expr *result_; /* substitution result */
+  int location_; /* token location, or -1 if unknown */
 };
 
 using RangeSubselect = struct RangeSubselect {
-  NodeTag type;
-  bool lateral;   /* does it have LATERAL prefix? */
-  Node *subquery; /* the untransformed sub-select clause */
-  Alias *alias;   /* table alias & optional column aliases */
+  NodeTag type_;
+  bool lateral_;   /* does it have LATERAL prefix? */
+  Node *subquery_; /* the untransformed sub-select clause */
+  Alias *alias_;   /* table alias & optional column aliases */
 };
 
 using RangeVar = struct RangeVar {
-  NodeTag type;
-  char *catalogname; /* the catalog (database) name, or NULL */
-  char *schemaname;  /* the schema name, or NULL */
-  char *relname;     /* the relation/sequence name */
-  InhOption inhOpt;  // expand rel by inheritance?
+  NodeTag type_;
+  char *catalogname_; /* the catalog (database) name, or NULL */
+  char *schemaname_;  /* the schema name, or NULL */
+  char *relname_;     /* the relation/sequence name */
+  InhOption inh_opt_;  // expand rel by inheritance?
   // recursively act on children?
-  char relpersistence; /* see RELPERSISTENCE_* in pg_class.h */
-  Alias *alias;        /* table alias & optional column aliases */
-  int location;        /* token location, or -1 if unknown */
+  char relpersistence_; /* see RELPERSISTENCE_* in pg_class.h */
+  Alias *alias_;        /* table alias & optional column aliases */
+  int location_;        /* token location, or -1 if unknown */
 };
 
 using WithClause = struct WithClause {
-  NodeTag type;
-  List *ctes;     /* list of CommonTableExprs */
-  bool recursive; /* true = WITH RECURSIVE */
-  int location;   /* token location, or -1 if unknown */
+  NodeTag type_;
+  List *ctes_;     /* list of CommonTableExprs */
+  bool recursive_; /* true = WITH RECURSIVE */
+  int location_;   /* token location, or -1 if unknown */
 };
 
 using OnCommitAction = enum OnCommitAction {
@@ -209,15 +209,15 @@ using OnCommitAction = enum OnCommitAction {
 };
 
 using IntoClause = struct IntoClause {
-  NodeTag type;
+  NodeTag type_;
 
-  RangeVar *rel;           /* target relation name */
-  List *colNames;          /* column names to assign, or NIL */
-  List *options;           /* options from WITH clause */
-  OnCommitAction onCommit; /* what do we do at COMMIT? */
-  char *tableSpaceName;    /* table space to use, or NULL */
-  Node *viewQuery;         /* materialized view's SELECT query */
-  bool skipData;           /* true for WITH NO DATA */
+  RangeVar *rel_;           /* target relation name */
+  List *col_names_;          /* column names to assign, or NIL */
+  List *options_;           /* options from WITH clause */
+  OnCommitAction on_commit_; /* what do we do at COMMIT? */
+  char *table_space_name_;    /* table space to use, or NULL */
+  Node *view_query_;         /* materialized view's SELECT query */
+  bool skip_data_;           /* true for WITH NO DATA */
 };
 
 using SortByDir = enum SortByDir {
@@ -230,56 +230,56 @@ using SortByDir = enum SortByDir {
 using SortByNulls = enum SortByNulls { SORTBY_NULLS_DEFAULT, SORTBY_NULLS_FIRST, SORTBY_NULLS_LAST };
 
 using SortBy = struct SortBy {
-  NodeTag type;
-  Node *node;               /* expression to sort on */
-  SortByDir sortby_dir;     /* ASC/DESC/USING/default */
-  SortByNulls sortby_nulls; /* NULLS FIRST/LAST */
-  List *useOp;              /* name of op to use, if SORTBY_USING */
-  int location;             /* operator location, or -1 if none/unknown */
+  NodeTag type_;
+  Node *node_;               /* expression to sort on */
+  SortByDir sortby_dir_;     /* ASC/DESC/USING/default */
+  SortByNulls sortby_nulls_; /* NULLS FIRST/LAST */
+  List *use_op_;              /* name of op to use, if SORTBY_USING */
+  int location_;             /* operator location, or -1 if none/unknown */
 };
 
 using InferClause = struct InferClause {
-  NodeTag type;
-  List *indexElems;  /* IndexElems to infer unique index */
-  Node *whereClause; /* qualification (partial-index predicate) */
-  char *conname;     /* Constraint name, or NULL if unnamed */
-  int location;      /* token location, or -1 if unknown */
+  NodeTag type_;
+  List *index_elems_;  /* IndexElems to infer unique index */
+  Node *where_clause_; /* qualification (partial-index predicate) */
+  char *conname_;     /* Constraint name, or NULL if unnamed */
+  int location_;      /* token location, or -1 if unknown */
 };
 
 using OnConflictClause = struct OnConflictClause {
-  NodeTag type;
-  OnConflictAction action; /* DO NOTHING or UPDATE? */
-  InferClause *infer;      /* Optional index inference clause */
-  List *targetList;        /* the target list (of ResTarget) */
-  Node *whereClause;       /* qualifications */
-  int location;            /* token location, or -1 if unknown */
+  NodeTag type_;
+  OnConflictAction action_; /* DO NOTHING or UPDATE? */
+  InferClause *infer_;      /* Optional index inference clause */
+  List *target_list_;        /* the target list (of ResTarget) */
+  Node *where_clause_;       /* qualifications */
+  int location_;            /* token location, or -1 if unknown */
 };
 
 using InsertStmt = struct InsertStmt {
-  NodeTag type;
-  RangeVar *relation;                 /* relation to insert into */
-  List *cols;                         /* optional: names of the target columns */
-  Node *selectStmt;                   /* the source SELECT/VALUES, or NULL */
-  OnConflictClause *onConflictClause; /* ON CONFLICT clause */
-  List *returningList;                /* list of expressions to return */
-  WithClause *withClause;             /* WITH clause */
+  NodeTag type_;
+  RangeVar *relation_;                 /* relation to insert into */
+  List *cols_;                         /* optional: names of the target columns */
+  Node *select_stmt_;                   /* the source SELECT/VALUES, or NULL */
+  OnConflictClause *on_conflict_clause_; /* ON CONFLICT clause */
+  List *returning_list_;                /* list of expressions to return */
+  WithClause *with_clause_;             /* WITH clause */
 };
 
 using SelectStmt = struct SelectStmt {
-  NodeTag type;
+  NodeTag type_;
 
   /*
    * These fields are used only in "leaf" SelectStmts.
    */
-  List *distinctClause;  // NULL, list of DISTINCT ON exprs, or
+  List *distinct_clause_;  // NULL, list of DISTINCT ON exprs, or
   // lcons(NIL,NIL) for all (SELECT DISTINCT)
-  IntoClause *intoClause; /* target for SELECT INTO */
-  List *targetList;       /* the target list (of ResTarget) */
-  List *fromClause;       /* the FROM clause */
-  Node *whereClause;      /* WHERE qualification */
-  List *groupClause;      /* GROUP BY clauses */
-  Node *havingClause;     /* HAVING conditional-expression */
-  List *windowClause;     /* WINDOW window_name AS (...), ... */
+  IntoClause *into_clause_; /* target for SELECT INTO */
+  List *target_list_;       /* the target list (of ResTarget) */
+  List *from_clause_;       /* the FROM clause */
+  Node *where_clause_;      /* WHERE qualification */
+  List *group_clause_;      /* GROUP BY clauses */
+  Node *having_clause_;     /* HAVING conditional-expression */
+  List *window_clause_;     /* WINDOW window_name AS (...), ... */
 
   /*
    * In a "leaf" node representing a VALUES list, the above fields are all
@@ -289,25 +289,25 @@ using SelectStmt = struct SelectStmt {
    * node), regardless of the context of the VALUES list. It's up to parse
    * analysis to reject that where not valid.
    */
-  List *valuesLists; /* untransformed list of expression lists */
+  List *values_lists_; /* untransformed list of expression lists */
 
   /*
    * These fields are used in both "leaf" SelectStmts and upper-level
    * SelectStmts.
    */
-  List *sortClause;       /* sort clause (a list of SortBy's) */
-  Node *limitOffset;      /* # of result tuples to skip */
-  Node *limitCount;       /* # of result tuples to return */
-  List *lockingClause;    /* FOR UPDATE (list of LockingClause's) */
-  WithClause *withClause; /* WITH clause */
+  List *sort_clause_;       /* sort clause (a list of SortBy's) */
+  Node *limit_offset_;      /* # of result tuples to skip */
+  Node *limit_count_;       /* # of result tuples to return */
+  List *locking_clause_;    /* FOR UPDATE (list of LockingClause's) */
+  WithClause *with_clause_; /* WITH clause */
 
   /*
    * These fields are used only in upper-level SelectStmts.
    */
-  SetOperation op;         /* type of set op */
-  bool all;                /* ALL specified? */
-  struct SelectStmt *larg; /* left child */
-  struct SelectStmt *rarg; /* right child */
+  SetOperation op_;         /* type of set op */
+  bool all_;                /* ALL specified? */
+  struct SelectStmt *larg_; /* left child */
+  struct SelectStmt *rarg_; /* right child */
   /* Eventually add fields for CORRESPONDING spec here */
 };
 
@@ -319,107 +319,107 @@ using SelectStmt = struct SelectStmt {
  * of the query are always postponed until execution.
  */
 using ExplainStmt = struct ExplainStmt {
-  NodeTag type;
-  Node *query;   /* the query (see comments above) */
-  List *options; /* list of DefElem nodes */
+  NodeTag type_;
+  Node *query_;   /* the query (see comments above) */
+  List *options_; /* list of DefElem nodes */
 };
 
 using TypeName = struct TypeName {
-  NodeTag type;
-  List *names;       /* qualified name (list of Value strings) */
-  Oid typeOid;       /* type identified by OID */
-  bool setof;        /* is a set? */
-  bool pct_type;     /* %TYPE specified? */
-  List *typmods;     /* type modifier expression(s) */
-  int typemod;       /* prespecified type modifier */
-  List *arrayBounds; /* array bounds */
-  int location;      /* token location, or -1 if unknown */
+  NodeTag type_;
+  List *names_;       /* qualified name (list of Value strings) */
+  Oid type_oid_;       /* type identified by OID */
+  bool setof_;        /* is a set? */
+  bool pct_type_;     /* %TYPE specified? */
+  List *typmods_;     /* type modifier expression(s) */
+  int typemod_;       /* prespecified type modifier */
+  List *array_bounds_; /* array bounds */
+  int location_;      /* token location, or -1 if unknown */
 };
 
 using IndexElem = struct IndexElem {
-  NodeTag type;
-  char *name;                 /* name of attribute to index, or NULL */
-  Node *expr;                 /* expression to index, or NULL */
-  char *indexcolname;         /* name for index column; NULL = default */
-  List *collation;            /* name of collation; NIL = default */
-  List *opclass;              /* name of desired opclass; NIL = default */
-  SortByDir ordering;         /* ASC/DESC/default */
-  SortByNulls nulls_ordering; /* FIRST/LAST/default */
+  NodeTag type_;
+  char *name_;                 /* name of attribute to index, or NULL */
+  Node *expr_;                 /* expression to index, or NULL */
+  char *indexcolname_;         /* name for index column; NULL = default */
+  List *collation_;            /* name of collation; NIL = default */
+  List *opclass_;              /* name of desired opclass; NIL = default */
+  SortByDir ordering_;         /* ASC/DESC/default */
+  SortByNulls nulls_ordering_; /* FIRST/LAST/default */
 };
 
 using IndexStmt = struct IndexStmt {
-  NodeTag type;
-  char *idxname;        /* name of new index, or NULL for default */
-  RangeVar *relation;   /* relation to build index on */
-  char *accessMethod;   /* name of access method (eg. btree) */
-  char *tableSpace;     /* tablespace, or NULL for default */
-  List *indexParams;    /* columns to index: a list of IndexElem */
-  List *options;        /* WITH clause options: a list of DefElem */
-  Node *whereClause;    /* qualification (partial-index predicate) */
-  List *excludeOpNames; /* exclusion operator names, or NIL if none */
-  char *idxcomment;     /* comment to apply to index, or NULL */
-  Oid indexOid;         /* OID of an existing index, if any */
-  Oid oldNode;          /* relfilenode of existing storage, if any */
-  bool unique;          /* is index unique? */
-  bool primary;         /* is index a primary key? */
-  bool isconstraint;    /* is it for a pkey/unique constraint? */
-  bool deferrable;      /* is the constraint DEFERRABLE? */
-  bool initdeferred;    /* is the constraint INITIALLY DEFERRED? */
-  bool transformed;     /* true when transformIndexStmt is finished */
-  bool concurrent;      /* should this be a concurrent index build? */
-  bool if_not_exists;   /* just do nothing if index already exists? */
+  NodeTag type_;
+  char *idxname_;        /* name of new index, or NULL for default */
+  RangeVar *relation_;   /* relation to build index on */
+  char *access_method_;   /* name of access method (eg. btree) */
+  char *table_space_;     /* tablespace, or NULL for default */
+  List *index_params_;    /* columns to index: a list of IndexElem */
+  List *options_;        /* WITH clause options: a list of DefElem */
+  Node *where_clause_;    /* qualification (partial-index predicate) */
+  List *exclude_op_names_; /* exclusion operator names, or NIL if none */
+  char *idxcomment_;     /* comment to apply to index, or NULL */
+  Oid index_oid_;         /* OID of an existing index, if any */
+  Oid old_node_;          /* relfilenode of existing storage, if any */
+  bool unique_;          /* is index unique? */
+  bool primary_;         /* is index a primary key? */
+  bool isconstraint_;    /* is it for a pkey/unique constraint? */
+  bool deferrable_;      /* is the constraint DEFERRABLE? */
+  bool initdeferred_;    /* is the constraint INITIALLY DEFERRED? */
+  bool transformed_;     /* true when transformIndexStmt is finished */
+  bool concurrent_;      /* should this be a concurrent index build? */
+  bool if_not_exists_;   /* just do nothing if index already exists? */
 };
 
 using CreateTrigStmt = struct CreateTrigStmt {
-  NodeTag type;
-  char *trigname;     /* TRIGGER's name */
-  RangeVar *relation; /* relation trigger is on */
-  List *funcname;     /* qual. name of function to call */
-  List *args;         /* list of (T_String) Values or NIL */
-  bool row;           /* ROW/STATEMENT */
+  NodeTag type_;
+  char *trigname_;     /* TRIGGER's name */
+  RangeVar *relation_; /* relation trigger is on */
+  List *funcname_;     /* qual. name of function to call */
+  List *args_;         /* list of (T_String) Values or NIL */
+  bool row_;           /* ROW/STATEMENT */
   /* timing uses the TRIGGER_TYPE bits defined in catalog/pg_trigger.h */
-  int16_t timing; /* BEFORE, AFTER, or INSTEAD */
+  int16_t timing_; /* BEFORE, AFTER, or INSTEAD */
   /* events uses the TRIGGER_TYPE bits defined in catalog/pg_trigger.h */
-  int16_t events;    /* "OR" of INSERT/UPDATE/DELETE/TRUNCATE */
-  List *columns;     /* column names, or NIL for all columns */
-  Node *whenClause;  /* qual expression, or NULL if none */
-  bool isconstraint; /* This is a constraint trigger */
+  int16_t events_;    /* "OR" of INSERT/UPDATE/DELETE/TRUNCATE */
+  List *columns_;     /* column names, or NIL for all columns */
+  Node *when_clause_;  /* qual expression, or NULL if none */
+  bool isconstraint_; /* This is a constraint trigger */
   /* The remaining fields are only used for constraint triggers */
-  bool deferrable;     /* [NOT] DEFERRABLE */
-  bool initdeferred;   /* INITIALLY {DEFERRED|IMMEDIATE} */
-  RangeVar *constrrel; /* opposite relation, if RI trigger */
+  bool deferrable_;     /* [NOT] DEFERRABLE */
+  bool initdeferred_;   /* INITIALLY {DEFERRED|IMMEDIATE} */
+  RangeVar *constrrel_; /* opposite relation, if RI trigger */
 };
 
 using ColumnDef = struct ColumnDef {
-  NodeTag type;
-  char *colname;        /* name of column */
-  TypeName *typeName;   /* type of column */
-  int inhcount;         /* number of times column is inherited */
-  bool is_local;        /* column has local (non-inherited) def'n */
-  bool is_not_null;     /* NOT NULL constraint specified? */
-  bool is_from_type;    /* column definition came from table type */
-  char storage;         /* attstorage setting, or 0 for default */
-  Node *raw_default;    /* default value (untransformed parse tree) */
-  Node *cooked_default; /* default value (transformed expr tree) */
-  Node *collClause;     /* untransformed COLLATE spec, if any */
-  Oid collOid;          /* collation OID (InvalidOid if not set) */
-  List *constraints;    /* other constraints on column */
-  List *fdwoptions;     /* per-column FDW options */
-  int location;         /* parse location, or -1 if none/unknown */
+  NodeTag type_;
+  char *colname_;        /* name of column */
+  TypeName *type_name_;   /* type of column */
+  int inhcount_;         /* number of times column is inherited */
+  bool is_local_;        /* column has local (non-inherited) def'n */
+  bool is_not_null_;     /* NOT NULL constraint specified? */
+  bool is_from_type_;    /* column definition came from table type */
+  char storage_;         /* attstorage setting, or 0 for default */
+  Node *raw_default_;    /* default value (untransformed parse tree) */
+  Node *cooked_default_; /* default value (transformed expr tree) */
+  Node *coll_clause_;     /* untransformed COLLATE spec, if any */
+  Oid coll_oid_;          /* collation OID (InvalidOid if not set) */
+  List *constraints_;    /* other constraints on column */
+  List *fdwoptions_;     /* per-column FDW options */
+  int location_;         /* parse location, or -1 if none/unknown */
 };
 
 using CreateStmt = struct CreateStmt {
-  NodeTag type;
-  RangeVar *relation;  /* relation to create */
-  List *tableElts;     /* column definitions (list of ColumnDef) */
-  List *inhRelations;  // relations to inherit from (list of
+  NodeTag type_;
+  RangeVar *relation_;  /* relation to create */
+  List *table_elts_;     /* column definitions (list of ColumnDef) */
+  List *inh_relations_;  // relations to inherit from (list of
   // inhRelation)
-  TypeName *ofTypename;    /* OF typename */
-  List *constraints;       /* constraints (list of Constraint nodes) */
-  List *options;           /* options from WITH clause */
-  OnCommitAction oncommit; /* what do we do at COMMIT? */
-  char *tablespacename;    /* table space to use, or NULL */
-  bool if_not_exists;      /* just do nothing if it already exists? */
+  TypeName *of_typename_;    /* OF typename */
+  List *constraints_;       /* constraints (list of Constraint nodes) */
+  List *options_;           /* options from WITH clause */
+  OnCommitAction oncommit_; /* what do we do at COMMIT? */
+  char *tablespacename_;    /* table space to use, or NULL */
+  bool if_not_exists_;      /* just do nothing if it already exists? */
 };
 
 using ConstrType = enum ConstrType /* types of constraints */
@@ -450,119 +450,119 @@ using ConstrType = enum ConstrType /* types of constraints */
 #define FKCONSTR_MATCH_SIMPLE 's'
 
 using Constraint = struct Constraint {
-  NodeTag type;
-  ConstrType contype; /* see above */
+  NodeTag type_;
+  ConstrType contype_; /* see above */
 
   /* Fields used for most/all constraint types: */
-  char *conname;     /* Constraint name, or NULL if unnamed */
-  bool deferrable;   /* DEFERRABLE? */
-  bool initdeferred; /* INITIALLY DEFERRED? */
-  int location;      /* token location, or -1 if unknown */
+  char *conname_;     /* Constraint name, or NULL if unnamed */
+  bool deferrable_;   /* DEFERRABLE? */
+  bool initdeferred_; /* INITIALLY DEFERRED? */
+  int location_;      /* token location, or -1 if unknown */
 
   /* Fields used for constraints with expressions (CHECK and DEFAULT): */
-  bool is_no_inherit; /* is constraint non-inheritable? */
-  Node *raw_expr;     /* expr, as untransformed parse tree */
-  char *cooked_expr;  /* expr, as nodeToString representation */
+  bool is_no_inherit_; /* is constraint non-inheritable? */
+  Node *raw_expr_;     /* expr, as untransformed parse tree */
+  char *cooked_expr_;  /* expr, as nodeToString representation */
 
   /* Fields used for unique constraints (UNIQUE and PRIMARY KEY): */
-  List *keys; /* String nodes naming referenced column(s) */
+  List *keys_; /* String nodes naming referenced column(s) */
 
   /* Fields used for EXCLUSION constraints: */
-  List *exclusions; /* list of (IndexElem, operator name) pairs */
+  List *exclusions_; /* list of (IndexElem, operator name) pairs */
 
   /* Fields used for index constraints (UNIQUE, PRIMARY KEY, EXCLUSION): */
-  List *options;    /* options from WITH clause */
-  char *indexname;  /* existing index to use; otherwise NULL */
-  char *indexspace; /* index tablespace; NULL for default */
+  List *options_;    /* options from WITH clause */
+  char *indexname_;  /* existing index to use; otherwise NULL */
+  char *indexspace_; /* index tablespace; NULL for default */
   /* These could be, but currently are not, used for UNIQUE/PKEY: */
-  char *access_method; /* index access method; NULL for default */
-  Node *where_clause;  /* partial index predicate */
+  char *access_method_; /* index access method; NULL for default */
+  Node *where_clause_;  /* partial index predicate */
 
   /* Fields used for FOREIGN KEY constraints: */
-  RangeVar *pktable;   /* Primary key table */
-  List *fk_attrs;      /* Attributes of foreign key */
-  List *pk_attrs;      /* Corresponding attrs in PK table */
-  char fk_matchtype;   /* FULL, PARTIAL, SIMPLE */
-  char fk_upd_action;  /* ON UPDATE action */
-  char fk_del_action;  /* ON DELETE action */
-  List *old_conpfeqop; /* pg_constraint.conpfeqop of my former self */
-  Oid old_pktable_oid; /* pg_constraint.confrelid of my former self */
+  RangeVar *pktable_;   /* Primary key table */
+  List *fk_attrs_;      /* Attributes of foreign key */
+  List *pk_attrs_;      /* Corresponding attrs in PK table */
+  char fk_matchtype_;   /* FULL, PARTIAL, SIMPLE */
+  char fk_upd_action_;  /* ON UPDATE action */
+  char fk_del_action_;  /* ON DELETE action */
+  List *old_conpfeqop_; /* pg_constraint.conpfeqop of my former self */
+  Oid old_pktable_oid_; /* pg_constraint.confrelid of my former self */
 
   /* Fields used for constraints that allow a NOT VALID specification */
-  bool skip_validation; /* skip validation of existing rows? */
-  bool initially_valid; /* mark the new constraint as valid? */
+  bool skip_validation_; /* skip validation of existing rows? */
+  bool initially_valid_; /* mark the new constraint as valid? */
 };
 
 using DeleteStmt = struct DeleteStmt {
-  NodeTag type;
-  RangeVar *relation;     /* relation to delete from */
-  List *usingClause;      /* optional using clause for more tables */
-  Node *whereClause;      /* qualifications */
-  List *returningList;    /* list of expressions to return */
-  WithClause *withClause; /* WITH clause */
+  NodeTag type_;
+  RangeVar *relation_;     /* relation to delete from */
+  List *using_clause_;      /* optional using clause for more tables */
+  Node *where_clause_;      /* qualifications */
+  List *returning_list_;    /* list of expressions to return */
+  WithClause *with_clause_; /* WITH clause */
 };
 
 using ResTarget = struct ResTarget {
-  NodeTag type;
-  char *name;        /* column name or NULL */
-  List *indirection; /* subscripts, field names, and '*', or NIL */
-  Node *val;         /* the value expression to compute or assign */
-  int location;      /* token location, or -1 if unknown */
+  NodeTag type_;
+  char *name_;        /* column name or NULL */
+  List *indirection_; /* subscripts, field names, and '*', or NIL */
+  Node *val_;         /* the value expression to compute or assign */
+  int location_;      /* token location, or -1 if unknown */
 };
 
 using ColumnRef = struct ColumnRef {
-  NodeTag type;
-  List *fields; /* field names (Value strings) or A_Star */
-  int location; /* token location, or -1 if unknown */
+  NodeTag type_;
+  List *fields_; /* field names (Value strings) or A_Star */
+  int location_; /* token location, or -1 if unknown */
 };
 
-using A_Const = struct A_Const {
-  NodeTag type;
-  value val;    /* value (includes type info, see value.h) */
-  int location; /* token location, or -1 if unknown */
+using A_Const = struct AConst {
+  NodeTag type_;
+  value val_;    /* value (includes type info, see value.h) */
+  int location_; /* token location, or -1 if unknown */
 };
 
 using TypeCast = struct TypeCast {
-  NodeTag type;
-  Node *arg;          /* the expression being casted */
-  TypeName *typeName; /* the target type */
-  int location;       /* token location, or -1 if unknown */
+  NodeTag type_;
+  Node *arg_;          /* the expression being casted */
+  TypeName *type_name_; /* the target type */
+  int location_;       /* token location, or -1 if unknown */
 };
 
 using WindowDef = struct WindowDef {
-  NodeTag type;
-  char *name;            /* window's own name */
-  char *refname;         /* referenced window name, if any */
-  List *partitionClause; /* PARTITION BY expression list */
-  List *orderClause;     /* ORDER BY (list of SortBy) */
-  int frameOptions;      /* frame_clause options, see below */
-  Node *startOffset;     /* expression for starting bound, if any */
-  Node *endOffset;       /* expression for ending bound, if any */
-  int location;          /* parse location, or -1 if none/unknown */
+  NodeTag type_;
+  char *name_;            /* window's own name */
+  char *refname_;         /* referenced window name, if any */
+  List *partition_clause_; /* PARTITION BY expression list */
+  List *order_clause_;     /* ORDER BY (list of SortBy) */
+  int frame_options_;      /* frame_clause options, see below */
+  Node *start_offset_;     /* expression for starting bound, if any */
+  Node *end_offset_;       /* expression for ending bound, if any */
+  int location_;          /* parse location, or -1 if none/unknown */
 };
 
 using FuncCall = struct FuncCall {
-  NodeTag type;
-  List *funcname;         /* qualified name of function */
-  List *args;             /* the arguments (list of exprs) */
-  List *agg_order;        /* ORDER BY (list of SortBy) */
-  Node *agg_filter;       /* FILTER clause, if any */
-  bool agg_within_group;  /* ORDER BY appeared in WITHIN GROUP */
-  bool agg_star;          /* argument was really '*' */
-  bool agg_distinct;      /* arguments were labeled DISTINCT */
-  bool func_variadic;     /* last argument was labeled VARIADIC */
-  struct WindowDef *over; /* OVER clause, if any */
-  int location;           /* token location, or -1 if unknown */
+  NodeTag type_;
+  List *funcname_;         /* qualified name of function */
+  List *args_;             /* the arguments (list of exprs) */
+  List *agg_order_;        /* ORDER BY (list of SortBy) */
+  Node *agg_filter_;       /* FILTER clause, if any */
+  bool agg_within_group_;  /* ORDER BY appeared in WITHIN GROUP */
+  bool agg_star_;          /* argument was really '*' */
+  bool agg_distinct_;      /* arguments were labeled DISTINCT */
+  bool func_variadic_;     /* last argument was labeled VARIADIC */
+  struct WindowDef *over_; /* OVER clause, if any */
+  int location_;           /* token location, or -1 if unknown */
 };
 
 using UpdateStmt = struct UpdateStmt {
-  NodeTag type;
-  RangeVar *relation;     /* relation to update */
-  List *targetList;       /* the target list (of ResTarget) */
-  Node *whereClause;      /* qualifications */
-  List *fromClause;       /* optional from clause for more tables */
-  List *returningList;    /* list of expressions to return */
-  WithClause *withClause; /* WITH clause */
+  NodeTag type_;
+  RangeVar *relation_;     /* relation to update */
+  List *target_list_;       /* the target list (of ResTarget) */
+  Node *where_clause_;      /* qualifications */
+  List *from_clause_;       /* optional from clause for more tables */
+  List *returning_list_;    /* list of expressions to return */
+  WithClause *with_clause_; /* WITH clause */
 };
 
 using TransactionStmtKind = enum TransactionStmtKind {
@@ -579,10 +579,10 @@ using TransactionStmtKind = enum TransactionStmtKind {
 };
 
 using TransactionStmt = struct TransactionStmt {
-  NodeTag type;
-  TransactionStmtKind kind; /* see above */
-  List *options;            /* for BEGIN/START and savepoint commands */
-  char *gid;                /* for two-phase-commit related commands */
+  NodeTag type_;
+  TransactionStmtKind kind_; /* see above */
+  List *options_;            /* for BEGIN/START and savepoint commands */
+  char *gid_;                /* for two-phase-commit related commands */
 };
 
 using ObjectType = enum ObjectType {
@@ -637,39 +637,39 @@ using DropBehaviour = enum DropBehavior {
 };
 
 using DropStmt = struct DropStmt {
-  NodeTag type;
-  List *objects;         /* list of sublists of names (as Values) */
-  List *arguments;       /* list of sublists of arguments (as Values) */
-  ObjectType removeType; /* object type */
-  DropBehavior behavior; /* RESTRICT or CASCADE behavior */
-  bool missing_ok;       /* skip error if object is missing? */
-  bool concurrent;       /* drop index concurrently? */
+  NodeTag type_;
+  List *objects_;         /* list of sublists of names (as Values) */
+  List *arguments_;       /* list of sublists of arguments (as Values) */
+  ObjectType remove_type_; /* object type */
+  DropBehavior behavior_; /* RESTRICT or CASCADE behavior */
+  bool missing_ok_;       /* skip error if object is missing? */
+  bool concurrent_;       /* drop index concurrently? */
 };
 
 using DropDatabaseStmt = struct DropDatabaseStmt {
-  NodeTag type;
-  char *dbname;    /* name of database to drop */
-  bool missing_ok; /* skip error if object is missing? */
+  NodeTag type_;
+  char *dbname_;    /* name of database to drop */
+  bool missing_ok_; /* skip error if object is missing? */
 };
 
 using TruncateStmt = struct TruncateStmt {
-  NodeTag type;
-  List *relations;       /* relations (RangeVars) to be truncated */
-  bool restart_seqs;     /* restart owned sequences? */
-  DropBehavior behavior; /* RESTRICT or CASCADE behavior */
+  NodeTag type_;
+  List *relations_;       /* relations (RangeVars) to be truncated */
+  bool restart_seqs_;     /* restart owned sequences? */
+  DropBehavior behavior_; /* RESTRICT or CASCADE behavior */
 };
 
 using ExecuteStmt = struct ExecuteStmt {
-  NodeTag type;
-  char *name;   /* The name of the plan to execute */
-  List *params; /* Values to assign to parameters */
+  NodeTag type_;
+  char *name_;   /* The name of the plan to execute */
+  List *params_; /* Values to assign to parameters */
 };
 
 using PrepareStmt = struct PrepareStmt {
-  NodeTag type;
-  char *name;     /* Name of plan, arbitrary */
-  List *argtypes; /* Types of parameters (List of TypeName) */
-  Node *query;    /* The query itself (as a raw parsetree) */
+  NodeTag type_;
+  char *name_;     /* Name of plan, arbitrary */
+  List *argtypes_; /* Types of parameters (List of TypeName) */
+  Node *query_;    /* The query itself (as a raw parsetree) */
 };
 
 using DefElemAction = enum DefElemAction {
@@ -680,38 +680,38 @@ using DefElemAction = enum DefElemAction {
 };
 
 using DefElem = struct DefElem {
-  NodeTag type;
-  char *defnamespace; /* NULL if unqualified name */
-  char *defname;
-  Node *arg;               /* a (Value *) or a (TypeName *) */
-  DefElemAction defaction; /* unspecified action, or SET/ADD/DROP */
-  int location;            /* parse location, or -1 if none/unknown */
+  NodeTag type_;
+  char *defnamespace_; /* NULL if unqualified name */
+  char *defname_;
+  Node *arg_;               /* a (Value *) or a (TypeName *) */
+  DefElemAction defaction_; /* unspecified action, or SET/ADD/DROP */
+  int location_;            /* parse location, or -1 if none/unknown */
 };
 
 using CopyStmt = struct CopyStmt {
-  NodeTag type;
-  RangeVar *relation; /* the relation to copy */
-  Node *query;        /* the SELECT query to copy */
-  List *attlist;      // List of column names (as Strings), or NIL
+  NodeTag type_;
+  RangeVar *relation_; /* the relation to copy */
+  Node *query_;        /* the SELECT query to copy */
+  List *attlist_;      // List of column names (as Strings), or NIL
   // for all columns
-  bool is_from;    /* TO or FROM */
-  bool is_program; /* is 'filename' a program to popen? */
-  char *filename;  /* filename, or NULL for STDIN/STDOUT */
-  List *options;   /* List of DefElem nodes */
+  bool is_from_;    /* TO or FROM */
+  bool is_program_; /* is 'filename' a program to popen? */
+  char *filename_;  /* filename, or NULL for STDIN/STDOUT */
+  List *options_;   /* List of DefElem nodes */
 };
 
 using CreateDatabaseStmt = struct CreateDatabaseStmt {
-  NodeTag type;
-  char *dbname;  /* name of database to create */
-  List *options; /* List of DefElem nodes */
+  NodeTag type_;
+  char *dbname_;  /* name of database to create */
+  List *options_; /* List of DefElem nodes */
 };
 
 using CreateSchemaStmt = struct CreateSchemaStmt {
-  NodeTag type;
-  char *schemaname;   /* the name of the schema to create */
-  Node *authrole;     /* the owner of the created schema */
-  List *schemaElts;   /* schema components (list of parsenodes) */
-  bool if_not_exists; /* just do nothing if schema already exists? */
+  NodeTag type_;
+  char *schemaname_;   /* the name of the schema to create */
+  Node *authrole_;     /* the owner of the created schema */
+  List *schema_elts_;   /* schema components (list of parsenodes) */
+  bool if_not_exists_; /* just do nothing if schema already exists? */
 };
 
 using RoleSpecType = enum RoleSpecType {
@@ -722,28 +722,28 @@ using RoleSpecType = enum RoleSpecType {
 };
 
 using RoleSpec = struct RoleSpec {
-  NodeTag type;
-  RoleSpecType roletype; /* Type of this rolespec */
-  char *rolename;        /* filled only for ROLESPEC_CSTRING */
-  int location;          /* token location, or -1 if unknown */
+  NodeTag type_;
+  RoleSpecType roletype_; /* Type of this rolespec */
+  char *rolename_;        /* filled only for ROLESPEC_CSTRING */
+  int location_;          /* token location, or -1 if unknown */
 };
 
 using ViewCheckOption = enum ViewCheckOption { NO_CHECK_OPTION, LOCAL_CHECK_OPTION, CASCADED_CHECK_OPTION };
 
 using ViewStmt = struct ViewStmt {
-  NodeTag type;
-  RangeVar *view;                  /* the view to be created */
-  List *aliases;                   /* target column names */
-  Node *query;                     /* the SELECT query */
-  bool replace;                    /* replace an existing view? */
-  List *options;                   /* options from WITH clause */
-  ViewCheckOption withCheckOption; /* WITH CHECK OPTION */
+  NodeTag type_;
+  RangeVar *view_;                  /* the view to be created */
+  List *aliases_;                   /* target column names */
+  Node *query_;                     /* the SELECT query */
+  bool replace_;                    /* replace an existing view? */
+  List *options_;                   /* options from WITH clause */
+  ViewCheckOption with_check_option_; /* WITH CHECK OPTION */
 };
 
 using ParamRef = struct ParamRef {
-  NodeTag type;
-  int number;   /* the number of the parameter */
-  int location; /* token location, or -1 if unknown */
+  NodeTag type_;
+  int number_;   /* the number of the parameter */
+  int location_; /* token location, or -1 if unknown */
 };
 
 using VacuumOption = enum VacuumOption {
@@ -757,10 +757,10 @@ using VacuumOption = enum VacuumOption {
 };
 
 using VacuumStmt = struct VacuumStmt {
-  NodeTag type;
-  int options;        /* OR of VacuumOption flags */
-  RangeVar *relation; /* single table to process, or NULL */
-  List *va_cols;      /* list of column names, or NIL for all */
+  NodeTag type_;
+  int options_;        /* OR of VacuumOption flags */
+  RangeVar *relation_; /* single table to process, or NULL */
+  List *va_cols_;      /* list of column names, or NIL for all */
 };
 
 enum VariableSetKind {
@@ -773,28 +773,28 @@ enum VariableSetKind {
 };
 
 using VariableSetStmt = struct VariableSetStmt {
-  NodeTag type;
-  VariableSetKind kind;
-  char *name;    /* variable to be set */
-  List *args;    /* List of A_Const nodes */
-  bool is_local; /* SET LOCAL? */
+  NodeTag type_;
+  VariableSetKind kind_;
+  char *name_;    /* variable to be set */
+  List *args_;    /* List of A_Const nodes */
+  bool is_local_; /* SET LOCAL? */
 };
 
 using VariableShowStmt = struct VariableShowStmt {
-  NodeTag type;
-  char *name;
+  NodeTag type_;
+  char *name_;
 };
 
 /// **********  For UDFs *********** ///
 
 using CreateFunctionStmt = struct CreateFunctionStmt {
-  NodeTag type;
-  bool replace;         /* T => replace if already exists */
-  List *funcname;       /* qualified name of function to create */
-  List *parameters;     /* a list of FunctionParameter */
-  TypeName *returnType; /* the return type */
-  List *options;        /* a list of DefElem */
-  List *withClause;     /* a list of DefElem */
+  NodeTag type_;
+  bool replace_;         /* T => replace if already exists */
+  List *funcname_;       /* qualified name of function to create */
+  List *parameters_;     /* a list of FunctionParameter */
+  TypeName *return_type_; /* the return type */
+  List *options_;        /* a list of DefElem */
+  List *with_clause_;     /* a list of DefElem */
 };
 
 using FunctionParameterMode = enum FunctionParameterMode {
@@ -807,9 +807,9 @@ using FunctionParameterMode = enum FunctionParameterMode {
 };
 
 using FunctionParameter = struct FunctionParameter {
-  NodeTag type;
-  char *name;                 /* parameter name, or NULL if not given */
-  TypeName *argType;          /* TypeName for parameter type */
-  FunctionParameterMode mode; /* IN/OUT/etc */
-  Node *defexpr;              /* raw default expr, or NULL if not given */
+  NodeTag type_;
+  char *name_;                 /* parameter name, or NULL if not given */
+  TypeName *arg_type_;          /* TypeName for parameter type */
+  FunctionParameterMode mode_; /* IN/OUT/etc */
+  Node *defexpr_;              /* raw default expr, or NULL if not given */
 };

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -132,8 +132,8 @@ class PostgresParser {
 
   // CREATE helpers
   using ColumnDefTransResult = struct {
-    std::unique_ptr<ColumnDefinition> col;
-    std::vector<std::shared_ptr<ColumnDefinition>> fks;
+    std::unique_ptr<ColumnDefinition> col_;
+    std::vector<std::shared_ptr<ColumnDefinition>> fks_;
   };
   static ColumnDefTransResult ColumnDefTransform(ColumnDef *root);
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -151,7 +151,7 @@ class DataTable {
   /**
    * @return the first tuple slot contained in the data table
    */
-  SlotIterator begin() const {
+  SlotIterator Begin() const {
     common::SpinLatch::ScopedSpinLatch guard(&blocks_latch_);
     return {this, blocks_.begin(), 0};
   }
@@ -163,7 +163,7 @@ class DataTable {
    *
    * @return one past the last tuple slot contained in the data table.
    */
-  SlotIterator end() const;
+  SlotIterator End() const;
 
   /**
    * Update the tuple according to the redo buffer given, and update the version chain to link to an

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -151,7 +151,7 @@ class DataTable {
   /**
    * @return the first tuple slot contained in the data table
    */
-  SlotIterator Begin() const {
+  SlotIterator begin() const {  // NOLINT for STL name compability
     common::SpinLatch::ScopedSpinLatch guard(&blocks_latch_);
     return {this, blocks_.begin(), 0};
   }
@@ -163,7 +163,7 @@ class DataTable {
    *
    * @return one past the last tuple slot contained in the data table.
    */
-  SlotIterator End() const;
+  SlotIterator end() const;  // NOLINT for STL name compability
 
   /**
    * Update the tuple according to the redo buffer given, and update the version chain to link to an

--- a/src/include/storage/index/compact_ints_key.h
+++ b/src/include/storage/index/compact_ints_key.h
@@ -43,9 +43,9 @@ class CompactIntsKey {
   /**
    * key size in bytes, exposed for hasher and comparators
    */
-  static constexpr size_t key_size_byte = KeySize * sizeof(uint64_t);
+  static constexpr size_t KEY_SIZE_BYTE = KeySize * sizeof(uint64_t);
   static_assert(KeySize > 0 && KeySize <= INTSKEY_MAX_SLOTS);  // size must be no greater than 256-bits
-  static_assert(key_size_byte % sizeof(uintptr_t) == 0);       // size must be multiple of 8 bytes
+  static_assert(KEY_SIZE_BYTE % sizeof(uintptr_t) == 0);       // size must be multiple of 8 bytes
 
   /**
    * @return underlying byte array, exposed for hasher and comparators
@@ -67,16 +67,16 @@ class CompactIntsKey {
                    "attr_sizes and attr_offsets must be equal in size.");
     TERRIER_ASSERT(!attr_sizes.empty(), "attr_sizes has too few values.");
 
-    std::memset(key_data_, 0, key_size_byte);
+    std::memset(key_data_, 0, KEY_SIZE_BYTE);
 
     for (uint8_t i = 0; i < from.NumColumns(); i++) {
-      TERRIER_ASSERT(compact_ints_offsets[i] + attr_sizes[i] <= key_size_byte, "out of bounds");
+      TERRIER_ASSERT(compact_ints_offsets[i] + attr_sizes[i] <= KEY_SIZE_BYTE, "out of bounds");
       CopyAttrFromProjection(from, static_cast<uint16_t>(from.ColumnIds()[i]), attr_sizes[i], compact_ints_offsets[i]);
     }
   }
 
  private:
-  byte key_data_[key_size_byte];
+  byte key_data_[KEY_SIZE_BYTE];
 
   void CopyAttrFromProjection(const storage::ProjectedRow &from, const uint16_t projection_list_offset,
                               const uint8_t attr_size, const uint8_t compact_ints_offset) {
@@ -238,7 +238,7 @@ class CompactIntsKey {
     // so we must use automatic type inference
     const auto big_endian = ToBigEndian(data);
 
-    TERRIER_ASSERT(offset + sizeof(IntType) <= key_size_byte, "Out of bounds access on key_data_.");
+    TERRIER_ASSERT(offset + sizeof(IntType) <= KEY_SIZE_BYTE, "Out of bounds access on key_data_.");
 
     // This will almost always be optimized into single move
     std::memcpy(key_data_ + offset, &big_endian, sizeof(IntType));
@@ -287,7 +287,7 @@ struct hash<terrier::storage::index::CompactIntsKey<KeySize>> {
    */
   size_t operator()(const terrier::storage::index::CompactIntsKey<KeySize> &key) const {
     const auto *const ptr = key.KeyData();
-    return terrier::common::HashUtil::HashBytes(ptr, terrier::storage::index::CompactIntsKey<KeySize>::key_size_byte);
+    return terrier::common::HashUtil::HashBytes(ptr, terrier::storage::index::CompactIntsKey<KeySize>::KEY_SIZE_BYTE);
   }
 };
 
@@ -305,7 +305,7 @@ struct equal_to<terrier::storage::index::CompactIntsKey<KeySize>> {
    */
   bool operator()(const terrier::storage::index::CompactIntsKey<KeySize> &lhs,
                   const terrier::storage::index::CompactIntsKey<KeySize> &rhs) const {
-    return std::memcmp(lhs.KeyData(), rhs.KeyData(), terrier::storage::index::CompactIntsKey<KeySize>::key_size_byte) ==
+    return std::memcmp(lhs.KeyData(), rhs.KeyData(), terrier::storage::index::CompactIntsKey<KeySize>::KEY_SIZE_BYTE) ==
            0;
   }
 };
@@ -324,7 +324,7 @@ struct less<terrier::storage::index::CompactIntsKey<KeySize>> {
    */
   bool operator()(const terrier::storage::index::CompactIntsKey<KeySize> &lhs,
                   const terrier::storage::index::CompactIntsKey<KeySize> &rhs) const {
-    return std::memcmp(lhs.KeyData(), rhs.KeyData(), terrier::storage::index::CompactIntsKey<KeySize>::key_size_byte) <
+    return std::memcmp(lhs.KeyData(), rhs.KeyData(), terrier::storage::index::CompactIntsKey<KeySize>::KEY_SIZE_BYTE) <
            0;
   }
 };

--- a/src/include/storage/index/generic_key.h
+++ b/src/include/storage/index/generic_key.h
@@ -27,7 +27,7 @@ class GenericKey {
   /**
    * key size in bytes, exposed for hasher and comparators
    */
-  static constexpr size_t key_size_byte = KeySize;
+  static constexpr size_t KEY_SIZE_BYTE = KeySize;
   static_assert(KeySize > 0 && KeySize <= GENERICKEY_MAX_SIZE);  // size must be no greater than 256-bits
 
   /**
@@ -39,7 +39,7 @@ class GenericKey {
     TERRIER_ASSERT(from.NumColumns() == metadata.GetSchema().GetColumns().size(),
                    "ProjectedRow should have the same number of columns at the original key schema.");
     metadata_ = &metadata;
-    std::memset(key_data_, 0, key_size_byte);
+    std::memset(key_data_, 0, KEY_SIZE_BYTE);
 
     if (metadata.MustInlineVarlen()) {
       const auto &key_schema = metadata.GetSchema();
@@ -68,7 +68,7 @@ class GenericKey {
             const auto varlen_size = varlen.Size();
             *reinterpret_cast<uint32_t *const>(to_attr) = varlen_size;
             TERRIER_ASSERT(reinterpret_cast<uintptr_t>(to_attr) + sizeof(uint32_t) + varlen_size <=
-                               reinterpret_cast<uintptr_t>(this) + key_size_byte,
+                               reinterpret_cast<uintptr_t>(this) + KEY_SIZE_BYTE,
                            "ProjectedRow will access out of bounds.");
             std::memcpy(to_attr + sizeof(uint32_t), varlen.Content(), varlen_size);
           }
@@ -76,7 +76,7 @@ class GenericKey {
       }
     } else {
       TERRIER_ASSERT(reinterpret_cast<uintptr_t>(GetProjectedRow()) + from.Size() <=
-                         reinterpret_cast<uintptr_t>(this) + key_size_byte,
+                         reinterpret_cast<uintptr_t>(this) + KEY_SIZE_BYTE,
                      "ProjectedRow will access out of bounds.");
       std::memcpy(GetProjectedRow(), &from, from.Size());
     }
@@ -89,7 +89,7 @@ class GenericKey {
     const auto *pr = reinterpret_cast<const ProjectedRow *>(StorageUtil::AlignedPtr(sizeof(uint64_t), key_data_));
     TERRIER_ASSERT(reinterpret_cast<uintptr_t>(pr) % sizeof(uint64_t) == 0,
                    "ProjectedRow must be aligned to 8 bytes for atomicity guarantees.");
-    TERRIER_ASSERT(reinterpret_cast<uintptr_t>(pr) + pr->Size() <= reinterpret_cast<uintptr_t>(this) + key_size_byte,
+    TERRIER_ASSERT(reinterpret_cast<uintptr_t>(pr) + pr->Size() <= reinterpret_cast<uintptr_t>(this) + KEY_SIZE_BYTE,
                    "ProjectedRow will access out of bounds.");
     return pr;
   }
@@ -197,12 +197,12 @@ class GenericKey {
     auto *pr = reinterpret_cast<ProjectedRow *>(StorageUtil::AlignedPtr(sizeof(uint64_t), key_data_));
     TERRIER_ASSERT(reinterpret_cast<uintptr_t>(pr) % sizeof(uint64_t) == 0,
                    "ProjectedRow must be aligned to 8 bytes for atomicity guarantees.");
-    TERRIER_ASSERT(reinterpret_cast<uintptr_t>(pr) + pr->Size() < reinterpret_cast<uintptr_t>(this) + key_size_byte,
+    TERRIER_ASSERT(reinterpret_cast<uintptr_t>(pr) + pr->Size() < reinterpret_cast<uintptr_t>(this) + KEY_SIZE_BYTE,
                    "ProjectedRow will access out of bounds.");
     return pr;
   }
 
-  byte key_data_[key_size_byte];
+  byte key_data_[KEY_SIZE_BYTE];
   const IndexMetadata *metadata_ = nullptr;
 };
 

--- a/src/include/storage/record_buffer.h
+++ b/src/include/storage/record_buffer.h
@@ -137,12 +137,12 @@ class IterableBufferSegment {
   /**
    * @return iterator to the first element
    */
-  Iterator begin() { return {segment_, 0}; }
+  Iterator Begin() { return {segment_, 0}; }
 
   /**
    * @return iterator to the second element
    */
-  Iterator end() { return {segment_, segment_->size_}; }
+  Iterator End() { return {segment_, segment_->size_}; }
 
  private:
   RecordBufferSegment *segment_;
@@ -285,12 +285,12 @@ class UndoBuffer {
   /**
    * @return Iterator to the first element
    */
-  Iterator begin() { return {buffers_.begin(), 0}; }
+  Iterator Begin() { return {buffers_.begin(), 0}; }
 
   /**
    * @return Iterator to the element following the last element
    */
-  Iterator end() { return {buffers_.end(), 0}; }
+  Iterator End() { return {buffers_.end(), 0}; }
 
   /**
    * @return true if UndoBuffer contains no UndoRecords, false otherwise

--- a/src/include/storage/record_buffer.h
+++ b/src/include/storage/record_buffer.h
@@ -137,12 +137,12 @@ class IterableBufferSegment {
   /**
    * @return iterator to the first element
    */
-  Iterator Begin() { return {segment_, 0}; }
+  Iterator begin() { return {segment_, 0}; }  // NOLINT for STL name compability
 
   /**
    * @return iterator to the second element
    */
-  Iterator End() { return {segment_, segment_->size_}; }
+  Iterator end() { return {segment_, segment_->size_}; }  // NOLINT for STL name compability
 
  private:
   RecordBufferSegment *segment_;
@@ -285,12 +285,12 @@ class UndoBuffer {
   /**
    * @return Iterator to the first element
    */
-  Iterator Begin() { return {buffers_.begin(), 0}; }
+  Iterator begin() { return {buffers_.begin(), 0}; }  // NOLINT for STL name compability
 
   /**
    * @return Iterator to the element following the last element
    */
-  Iterator End() { return {buffers_.end(), 0}; }
+  Iterator end() { return {buffers_.end(), 0}; }  // NOLINT for STL name compability
 
   /**
    * @return true if UndoBuffer contains no UndoRecords, false otherwise

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -26,9 +26,9 @@ class SqlTable {
    * this layer, consider alternatives.
    */
   struct DataTableVersion {
-    DataTable *data_table;
-    BlockLayout layout;
-    ColumnMap column_map;
+    DataTable *data_table_;
+    BlockLayout layout_;
+    ColumnMap column_map_;
   };
 
  public:
@@ -145,12 +145,12 @@ class SqlTable {
   /**
    * @return the first tuple slot contained in the underlying DataTable
    */
-  DataTable::SlotIterator begin() const { return table_.data_table->begin(); }
+  DataTable::SlotIterator Begin() const { return table_.data_table->begin(); }
 
   /**
    * @return one past the last tuple slot contained in the underlying DataTable
    */
-  DataTable::SlotIterator end() const { return table_.data_table->end(); }
+  DataTable::SlotIterator End() const { return table_.data_table->end(); }
 
   /**
    * Generates an ProjectedColumnsInitializer for the execution layer to use. This performs the translation from col_oid

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -44,7 +44,7 @@ class SqlTable {
   /**
    * Destructs a SqlTable, frees all its members.
    */
-  ~SqlTable() { delete table_.data_table; }
+  ~SqlTable() { delete table_.data_table_; }
 
   /**
    * Materializes a single tuple from the given slot, as visible at the timestamp of the calling txn.
@@ -55,7 +55,7 @@ class SqlTable {
    * @return true if tuple is visible to this txn and ProjectedRow has been populated, false otherwise
    */
   bool Select(transaction::TransactionContext *const txn, const TupleSlot slot, ProjectedRow *const out_buffer) const {
-    return table_.data_table->Select(txn, slot, out_buffer);
+    return table_.data_table_->Select(txn, slot, out_buffer);
   }
 
   /**
@@ -73,7 +73,7 @@ class SqlTable {
                                ->LogRecord::GetUnderlyingRecordBodyAs<RedoRecord>(),
                    "This RedoRecord is not the most recent entry in the txn's RedoBuffer. Was StageWrite called "
                    "immediately before?");
-    const auto result = table_.data_table->Update(txn, redo->GetTupleSlot(), *(redo->Delta()));
+    const auto result = table_.data_table_->Update(txn, redo->GetTupleSlot(), *(redo->Delta()));
     if (!result) {
       // For MVCC correctness, this txn must now abort for the GC to clean up the version chain in the DataTable
       // correctly.
@@ -96,7 +96,7 @@ class SqlTable {
                                ->LogRecord::GetUnderlyingRecordBodyAs<RedoRecord>(),
                    "This RedoRecord is not the most recent entry in the txn's RedoBuffer. Was StageWrite called "
                    "immediately before?");
-    const auto slot = table_.data_table->Insert(txn, *(redo->Delta()));
+    const auto slot = table_.data_table_->Insert(txn, *(redo->Delta()));
     redo->SetTupleSlot(slot);
     return slot;
   }
@@ -116,7 +116,7 @@ class SqlTable {
                 ->GetTupleSlot() == slot,
         "This Delete is not the most recent entry in the txn's RedoBuffer. Was StageDelete called immediately before?");
 
-    const auto result = table_.data_table->Delete(txn, slot);
+    const auto result = table_.data_table_->Delete(txn, slot);
     if (!result) {
       // For MVCC correctness, this txn must now abort for the GC to clean up the version chain in the DataTable
       // correctly.
@@ -139,18 +139,18 @@ class SqlTable {
    */
   void Scan(transaction::TransactionContext *const txn, DataTable::SlotIterator *const start_pos,
             ProjectedColumns *const out_buffer) const {
-    return table_.data_table->Scan(txn, start_pos, out_buffer);
+    return table_.data_table_->Scan(txn, start_pos, out_buffer);
   }
 
   /**
    * @return the first tuple slot contained in the underlying DataTable
    */
-  DataTable::SlotIterator Begin() const { return table_.data_table->begin(); }
+  DataTable::SlotIterator begin() const { return table_.data_table_->begin(); }  // NOLINT for STL name compability
 
   /**
    * @return one past the last tuple slot contained in the underlying DataTable
    */
-  DataTable::SlotIterator End() const { return table_.data_table->end(); }
+  DataTable::SlotIterator end() const { return table_.data_table_->end(); }  // NOLINT for STL name compability
 
   /**
    * Generates an ProjectedColumnsInitializer for the execution layer to use. This performs the translation from col_oid
@@ -167,7 +167,7 @@ class SqlTable {
     auto col_ids = ColIdsForOids(col_oids);
     TERRIER_ASSERT(col_ids.size() == col_oids.size(),
                    "Projection should be the same number of columns as requested col_oids.");
-    return ProjectedColumnsInitializer(table_.layout, col_ids, max_tuples);
+    return ProjectedColumnsInitializer(table_.layout_, col_ids, max_tuples);
   }
 
   /**
@@ -183,7 +183,7 @@ class SqlTable {
     auto col_ids = ColIdsForOids(col_oids);
     TERRIER_ASSERT(col_ids.size() == col_oids.size(),
                    "Projection should be the same number of columns as requested col_oids.");
-    return ProjectedRowInitializer::Create(table_.layout, col_ids);
+    return ProjectedRowInitializer::Create(table_.layout_, col_ids);
   }
 
   /**

--- a/src/include/traffic_cop/portal.h
+++ b/src/include/traffic_cop/portal.h
@@ -20,7 +20,7 @@ struct Portal {
    * The sequence of parameter values
    */
   // Since TransientValue forbids copying, using a pointer is more convenient
-  std::shared_ptr<std::vector<type::TransientValue>> params;
+  std::shared_ptr<std::vector<type::TransientValue>> params_;
 };
 
 }  // namespace terrier::trafficcop

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -28,7 +28,7 @@ class TrafficCop {
   SqliteEngine *GetExecutionEngine() { return &sqlite_engine; }
 
  private:
-  SqliteEngine sqlite_engine;
+  SqliteEngine sqlite_engine_;
 };
 
 }  // namespace terrier::trafficcop

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -25,7 +25,7 @@ class TrafficCop {
    * Returns the execution engine.
    * @return the execution engine.
    */
-  SqliteEngine *GetExecutionEngine() { return &sqlite_engine; }
+  SqliteEngine *GetExecutionEngine() { return &sqlite_engine_; }
 
  private:
   SqliteEngine sqlite_engine_;

--- a/src/loggers/catalog_logger.cpp
+++ b/src/loggers/catalog_logger.cpp
@@ -6,7 +6,7 @@ namespace terrier::catalog {
 
 std::shared_ptr<spdlog::logger> catalog_logger;
 
-void init_catalog_logger() {
+void InitCatalogLogger() {
   catalog_logger = std::make_shared<spdlog::logger>("catalog_logger", ::default_sink);
   spdlog::register_logger(catalog_logger);
   catalog_logger->set_level(spdlog::level::trace);

--- a/src/loggers/index_logger.cpp
+++ b/src/loggers/index_logger.cpp
@@ -6,7 +6,7 @@ namespace terrier::storage {
 
 std::shared_ptr<spdlog::logger> index_logger;
 
-void init_index_logger() {
+void InitIndexLogger() {
   index_logger = std::make_shared<spdlog::logger>("index_logger", ::default_sink);
   spdlog::register_logger(index_logger);
 }

--- a/src/loggers/main_logger.cpp
+++ b/src/loggers/main_logger.cpp
@@ -4,7 +4,7 @@
 std::shared_ptr<spdlog::sinks::stdout_sink_mt> default_sink;
 std::shared_ptr<spdlog::logger> main_logger;
 
-void init_main_logger() {
+void InitMainLogger() {
   // create the default, shared sink
   default_sink = std::make_shared<spdlog::sinks::stdout_sink_mt>();
 

--- a/src/loggers/network_logger.cpp
+++ b/src/loggers/network_logger.cpp
@@ -7,7 +7,7 @@ namespace terrier::network {
 
 std::shared_ptr<spdlog::logger> network_logger;
 
-void init_network_logger() {
+void InitNetworkLogger() {
   network_logger = std::make_shared<spdlog::logger>("network_logger", ::default_sink);
   spdlog::register_logger(network_logger);
 }

--- a/src/loggers/parser_logger.cpp
+++ b/src/loggers/parser_logger.cpp
@@ -6,7 +6,7 @@ namespace terrier::parser {
 
 std::shared_ptr<spdlog::logger> parser_logger;
 
-void init_parser_logger() {
+void InitParserLogger() {
   parser_logger = std::make_shared<spdlog::logger>("parser_logger", ::default_sink);
   spdlog::register_logger(parser_logger);
 }

--- a/src/loggers/settings_logger.cpp
+++ b/src/loggers/settings_logger.cpp
@@ -6,7 +6,7 @@ namespace terrier::settings {
 
 std::shared_ptr<spdlog::logger> settings_logger;
 
-void init_settings_logger() {
+void InitSettingsLogger() {
   settings_logger = std::make_shared<spdlog::logger>("settings_logger", ::default_sink);
   spdlog::register_logger(settings_logger);
   settings_logger->set_level(spdlog::level::trace);

--- a/src/loggers/storage_logger.cpp
+++ b/src/loggers/storage_logger.cpp
@@ -6,7 +6,7 @@ namespace terrier::storage {
 
 std::shared_ptr<spdlog::logger> storage_logger;
 
-void init_storage_logger() {
+void InitStorageLogger() {
   storage_logger = std::make_shared<spdlog::logger>("storage_logger", ::default_sink);
   spdlog::register_logger(storage_logger);
 }

--- a/src/loggers/test_logger.cpp
+++ b/src/loggers/test_logger.cpp
@@ -6,7 +6,7 @@ namespace terrier {
 
 std::shared_ptr<spdlog::logger> test_logger;
 
-void init_test_logger() {
+void InitTestLogger() {
   test_logger = std::make_shared<spdlog::logger>("test_logger", ::default_sink);
   spdlog::register_logger(test_logger);
 }

--- a/src/loggers/transaction_logger.cpp
+++ b/src/loggers/transaction_logger.cpp
@@ -6,7 +6,7 @@ namespace terrier::transaction {
 
 std::shared_ptr<spdlog::logger> transaction_logger;
 
-void init_transaction_logger() {
+void InitTransactionLogger() {
   transaction_logger = std::make_shared<spdlog::logger>("transaction_logger", ::default_sink);
   spdlog::register_logger(transaction_logger);
 }

--- a/src/main/db_main.cpp
+++ b/src/main/db_main.cpp
@@ -60,7 +60,7 @@ DBMain::DBMain(std::unordered_map<settings::Param, settings::ParamInfo> &&param_
 }
 
 void DBMain::Run() {
-  running = true;
+  running_ = true;
   server_->SetPort(static_cast<int16_t>(
       type::TransientValuePeeker::PeekInteger(param_map_.find(settings::Param::port)->second.value_)));
   server_->RunServer();
@@ -75,7 +75,7 @@ void DBMain::Run() {
 }
 
 void DBMain::ForceShutdown() {
-  if (running) {
+  if (running_) {
     server_->StopServer();
   }
   CleanUp();

--- a/src/network/connection_handle.cpp
+++ b/src/network/connection_handle.cpp
@@ -44,7 +44,7 @@
 // undefined state or transition on said state will throw a runtime error.
 
 #define DEF_TRANSITION_GRAPH                                                                                        \
-  ConnectionHandle::StateMachine::transition_result ConnectionHandle::StateMachine::Delta_(ConnState state,         \
+  ConnectionHandle::StateMachine::transition_result ConnectionHandle::StateMachine::Delta(ConnState state,         \
                                                                                            Transition transition) { \
     switch (state) {
 #define DEFINE_STATE(s) \
@@ -147,7 +147,7 @@ END_DEF
     void ConnectionHandle::StateMachine::Accept(Transition action, ConnectionHandle &connection) {
   Transition next = action;
   while (next != Transition::NONE) {
-    transition_result result = Delta_(current_state_, next);
+    transition_result result = Delta(current_state_, next);
     current_state_ = result.first;
     try {
       next = result.second(connection);

--- a/src/network/terrier_server.cpp
+++ b/src/network/terrier_server.cpp
@@ -76,7 +76,7 @@ void TerrierServer::StopServer() {
   const bool result UNUSED_ATTRIBUTE =
       thread_registry_->StopTask(this, dispatcher_task_.CastManagedPointerTo<common::DedicatedThreadTask>());
   TERRIER_ASSERT(result, "Failed to stop ConnectionDispatcherTask.");
-  terrier_close(listen_fd_);
+  TerrierClose(listen_fd_);
   NETWORK_LOG_INFO("Server Closed");
 
   // Clear the running_ flag for any waiting threads and wake up them up with the condition variable

--- a/src/network/terrier_server.cpp
+++ b/src/network/terrier_server.cpp
@@ -59,7 +59,7 @@ void TerrierServer::RunServer() {
   listen(listen_fd_, conn_backlog);
 
   dispatcher_task_ = thread_registry_->RegisterDedicatedThread<ConnectionDispatcherTask>(
-      this /* requester */, max_connections_, listen_fd_, this, common::ManagedPointer(provider_.get()),
+      this /* requester */, max_connections_, listen_fd_, this, common::ManagedPointer(provider_.Get()),
       connection_handle_factory_, thread_registry_);
 
   NETWORK_LOG_INFO("Listening on port {0}", port_);

--- a/src/optimizer/logical_operators.cpp
+++ b/src/optimizer/logical_operators.cpp
@@ -691,100 +691,100 @@ void OperatorNode<T>::Accept(OperatorVisitor *v) const {
 
 //===--------------------------------------------------------------------===//
 template <>
-const char *OperatorNode<LogicalGet>::name_ = "LogicalGet";
+const char *OperatorNode<LogicalGet>::name = "LogicalGet";
 template <>
-const char *OperatorNode<LogicalExternalFileGet>::name_ = "LogicalExternalFileGet";
+const char *OperatorNode<LogicalExternalFileGet>::name = "LogicalExternalFileGet";
 template <>
-const char *OperatorNode<LogicalQueryDerivedGet>::name_ = "LogicalQueryDerivedGet";
+const char *OperatorNode<LogicalQueryDerivedGet>::name = "LogicalQueryDerivedGet";
 template <>
-const char *OperatorNode<LogicalFilter>::name_ = "LogicalFilter";
+const char *OperatorNode<LogicalFilter>::name = "LogicalFilter";
 template <>
-const char *OperatorNode<LogicalProjection>::name_ = "LogicalProjection";
+const char *OperatorNode<LogicalProjection>::name = "LogicalProjection";
 template <>
-const char *OperatorNode<LogicalMarkJoin>::name_ = "LogicalMarkJoin";
+const char *OperatorNode<LogicalMarkJoin>::name = "LogicalMarkJoin";
 template <>
-const char *OperatorNode<LogicalSingleJoin>::name_ = "LogicalSingleJoin";
+const char *OperatorNode<LogicalSingleJoin>::name = "LogicalSingleJoin";
 template <>
-const char *OperatorNode<LogicalDependentJoin>::name_ = "LogicalDependentJoin";
+const char *OperatorNode<LogicalDependentJoin>::name = "LogicalDependentJoin";
 template <>
-const char *OperatorNode<LogicalInnerJoin>::name_ = "LogicalInnerJoin";
+const char *OperatorNode<LogicalInnerJoin>::name = "LogicalInnerJoin";
 template <>
-const char *OperatorNode<LogicalLeftJoin>::name_ = "LogicalLeftJoin";
+const char *OperatorNode<LogicalLeftJoin>::name = "LogicalLeftJoin";
 template <>
-const char *OperatorNode<LogicalRightJoin>::name_ = "LogicalRightJoin";
+const char *OperatorNode<LogicalRightJoin>::name = "LogicalRightJoin";
 template <>
-const char *OperatorNode<LogicalOuterJoin>::name_ = "LogicalOuterJoin";
+const char *OperatorNode<LogicalOuterJoin>::name = "LogicalOuterJoin";
 template <>
-const char *OperatorNode<LogicalSemiJoin>::name_ = "LogicalSemiJoin";
+const char *OperatorNode<LogicalSemiJoin>::name = "LogicalSemiJoin";
 template <>
-const char *OperatorNode<LogicalAggregateAndGroupBy>::name_ = "LogicalAggregateAndGroupBy";
+const char *OperatorNode<LogicalAggregateAndGroupBy>::name = "LogicalAggregateAndGroupBy";
 template <>
-const char *OperatorNode<LogicalInsert>::name_ = "LogicalInsert";
+const char *OperatorNode<LogicalInsert>::name = "LogicalInsert";
 template <>
-const char *OperatorNode<LogicalInsertSelect>::name_ = "LogicalInsertSelect";
+const char *OperatorNode<LogicalInsertSelect>::name = "LogicalInsertSelect";
 template <>
-const char *OperatorNode<LogicalUpdate>::name_ = "LogicalUpdate";
+const char *OperatorNode<LogicalUpdate>::name = "LogicalUpdate";
 template <>
-const char *OperatorNode<LogicalDelete>::name_ = "LogicalDelete";
+const char *OperatorNode<LogicalDelete>::name = "LogicalDelete";
 template <>
-const char *OperatorNode<LogicalLimit>::name_ = "LogicalLimit";
+const char *OperatorNode<LogicalLimit>::name = "LogicalLimit";
 template <>
-const char *OperatorNode<LogicalDistinct>::name_ = "LogicalDistinct";
+const char *OperatorNode<LogicalDistinct>::name = "LogicalDistinct";
 template <>
-const char *OperatorNode<LogicalExportExternalFile>::name_ = "LogicalExportExternalFile";
+const char *OperatorNode<LogicalExportExternalFile>::name = "LogicalExportExternalFile";
 
 //===--------------------------------------------------------------------===//
 template <>
-OpType OperatorNode<LogicalGet>::type_ = OpType::LOGICALGET;
+OpType OperatorNode<LogicalGet>::type = OpType::LOGICALGET;
 template <>
-OpType OperatorNode<LogicalExternalFileGet>::type_ = OpType::LOGICALEXTERNALFILEGET;
+OpType OperatorNode<LogicalExternalFileGet>::type = OpType::LOGICALEXTERNALFILEGET;
 template <>
-OpType OperatorNode<LogicalQueryDerivedGet>::type_ = OpType::LOGICALQUERYDERIVEDGET;
+OpType OperatorNode<LogicalQueryDerivedGet>::type = OpType::LOGICALQUERYDERIVEDGET;
 template <>
-OpType OperatorNode<LogicalFilter>::type_ = OpType::LOGICALFILTER;
+OpType OperatorNode<LogicalFilter>::type = OpType::LOGICALFILTER;
 template <>
-OpType OperatorNode<LogicalProjection>::type_ = OpType::LOGICALPROJECTION;
+OpType OperatorNode<LogicalProjection>::type = OpType::LOGICALPROJECTION;
 template <>
-OpType OperatorNode<LogicalMarkJoin>::type_ = OpType::LOGICALMARKJOIN;
+OpType OperatorNode<LogicalMarkJoin>::type = OpType::LOGICALMARKJOIN;
 template <>
-OpType OperatorNode<LogicalSingleJoin>::type_ = OpType::LOGICALSINGLEJOIN;
+OpType OperatorNode<LogicalSingleJoin>::type = OpType::LOGICALSINGLEJOIN;
 template <>
-OpType OperatorNode<LogicalDependentJoin>::type_ = OpType::LOGICALDEPENDENTJOIN;
+OpType OperatorNode<LogicalDependentJoin>::type = OpType::LOGICALDEPENDENTJOIN;
 template <>
-OpType OperatorNode<LogicalInnerJoin>::type_ = OpType::LOGICALINNERJOIN;
+OpType OperatorNode<LogicalInnerJoin>::type = OpType::LOGICALINNERJOIN;
 template <>
-OpType OperatorNode<LogicalLeftJoin>::type_ = OpType::LOGICALLEFTJOIN;
+OpType OperatorNode<LogicalLeftJoin>::type = OpType::LOGICALLEFTJOIN;
 template <>
-OpType OperatorNode<LogicalRightJoin>::type_ = OpType::LOGICALRIGHTJOIN;
+OpType OperatorNode<LogicalRightJoin>::type = OpType::LOGICALRIGHTJOIN;
 template <>
-OpType OperatorNode<LogicalOuterJoin>::type_ = OpType::LOGICALOUTERJOIN;
+OpType OperatorNode<LogicalOuterJoin>::type = OpType::LOGICALOUTERJOIN;
 template <>
-OpType OperatorNode<LogicalSemiJoin>::type_ = OpType::LOGICALSEMIJOIN;
+OpType OperatorNode<LogicalSemiJoin>::type = OpType::LOGICALSEMIJOIN;
 template <>
-OpType OperatorNode<LogicalAggregateAndGroupBy>::type_ = OpType::LOGICALAGGREGATEANDGROUPBY;
+OpType OperatorNode<LogicalAggregateAndGroupBy>::type = OpType::LOGICALAGGREGATEANDGROUPBY;
 template <>
-OpType OperatorNode<LogicalInsert>::type_ = OpType::LOGICALINSERT;
+OpType OperatorNode<LogicalInsert>::type = OpType::LOGICALINSERT;
 template <>
-OpType OperatorNode<LogicalInsertSelect>::type_ = OpType::LOGICALINSERTSELECT;
+OpType OperatorNode<LogicalInsertSelect>::type = OpType::LOGICALINSERTSELECT;
 template <>
-OpType OperatorNode<LogicalUpdate>::type_ = OpType::LOGICALUPDATE;
+OpType OperatorNode<LogicalUpdate>::type = OpType::LOGICALUPDATE;
 template <>
-OpType OperatorNode<LogicalDelete>::type_ = OpType::LOGICALDELETE;
+OpType OperatorNode<LogicalDelete>::type = OpType::LOGICALDELETE;
 template <>
-OpType OperatorNode<LogicalDistinct>::type_ = OpType::LOGICALDISTINCT;
+OpType OperatorNode<LogicalDistinct>::type = OpType::LOGICALDISTINCT;
 template <>
-OpType OperatorNode<LogicalLimit>::type_ = OpType::LOGICALLIMIT;
+OpType OperatorNode<LogicalLimit>::type = OpType::LOGICALLIMIT;
 template <>
-OpType OperatorNode<LogicalExportExternalFile>::type_ = OpType::LOGICALEXPORTEXTERNALFILE;
+OpType OperatorNode<LogicalExportExternalFile>::type = OpType::LOGICALEXPORTEXTERNALFILE;
 
 template <typename T>
 bool OperatorNode<T>::IsLogical() const {
-  return type_ < OpType::LOGICALPHYSICALDELIMITER;
+  return type < OpType::LOGICALPHYSICALDELIMITER;
 }
 
 template <typename T>
 bool OperatorNode<T>::IsPhysical() const {
-  return type_ > OpType::LOGICALPHYSICALDELIMITER;
+  return type > OpType::LOGICALPHYSICALDELIMITER;
 }
 
 }  // namespace terrier::optimizer

--- a/src/optimizer/logical_operators.cpp
+++ b/src/optimizer/logical_operators.cpp
@@ -12,7 +12,7 @@ namespace terrier::optimizer {
 //===--------------------------------------------------------------------===//
 // Logical Get
 //===--------------------------------------------------------------------===//
-Operator LogicalGet::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator LogicalGet::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                           catalog::table_oid_t table_oid, std::vector<AnnotatedExpression> predicates,
                           std::string table_alias, bool is_for_update) {
   auto *get = new LogicalGet;
@@ -54,7 +54,7 @@ bool LogicalGet::operator==(const BaseOperatorNode &r) {
 // External file get
 //===--------------------------------------------------------------------===//
 
-Operator LogicalExternalFileGet::make(parser::ExternalFileFormat format, std::string file_name, char delimiter,
+Operator LogicalExternalFileGet::Make(parser::ExternalFileFormat format, std::string file_name, char delimiter,
                                       char quote, char escape) {
   auto *get = new LogicalExternalFileGet();
   get->format_ = format;
@@ -85,7 +85,7 @@ common::hash_t LogicalExternalFileGet::Hash() const {
 //===--------------------------------------------------------------------===//
 // Query derived get
 //===--------------------------------------------------------------------===//
-Operator LogicalQueryDerivedGet::make(
+Operator LogicalQueryDerivedGet::Make(
     std::string table_alias,
     std::unordered_map<std::string, common::ManagedPointer<parser::AbstractExpression>> &&alias_to_expr_map) {
   auto *get = new LogicalQueryDerivedGet;
@@ -115,7 +115,7 @@ common::hash_t LogicalQueryDerivedGet::Hash() const {
 // LogicalFilter
 //===--------------------------------------------------------------------===//
 
-Operator LogicalFilter::make(std::vector<AnnotatedExpression> &&predicates) {
+Operator LogicalFilter::Make(std::vector<AnnotatedExpression> &&predicates) {
   auto *op = new LogicalFilter;
   op->predicates_ = std::move(predicates);
   return Operator(op);
@@ -149,7 +149,7 @@ common::hash_t LogicalFilter::Hash() const {
 // LogicalProjection
 //===--------------------------------------------------------------------===//
 
-Operator LogicalProjection::make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&expressions) {
+Operator LogicalProjection::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&expressions) {
   auto *op = new LogicalProjection;
   op->expressions_ = std::move(expressions);
   return Operator(op);
@@ -174,7 +174,7 @@ common::hash_t LogicalProjection::Hash() const {
 // LogicalInsert
 //===--------------------------------------------------------------------===//
 
-Operator LogicalInsert::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator LogicalInsert::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                              catalog::table_oid_t table_oid, std::vector<catalog::col_oid_t> &&columns,
                              std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> &&values) {
 #ifndef NDEBUG
@@ -224,7 +224,7 @@ bool LogicalInsert::operator==(const BaseOperatorNode &r) {
 // LogicalInsertSelect
 //===--------------------------------------------------------------------===//
 
-Operator LogicalInsertSelect::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator LogicalInsertSelect::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                                    catalog::table_oid_t table_oid) {
   auto *op = new LogicalInsertSelect;
   op->database_oid_ = database_oid;
@@ -254,7 +254,7 @@ bool LogicalInsertSelect::operator==(const BaseOperatorNode &r) {
 // LogicalDistinct
 //===--------------------------------------------------------------------===//
 
-Operator LogicalDistinct::make() {
+Operator LogicalDistinct::Make() {
   auto *op = new LogicalDistinct;
   // We don't have anything that we need to store, so we're just going
   // to throw this mofo out to the world as is...
@@ -276,7 +276,7 @@ common::hash_t LogicalDistinct::Hash() const {
 // LogicalLimit
 //===--------------------------------------------------------------------===//
 
-Operator LogicalLimit::make(size_t offset, size_t limit,
+Operator LogicalLimit::Make(size_t offset, size_t limit,
                             std::vector<common::ManagedPointer<parser::AbstractExpression>> &&sort_exprs,
                             std::vector<planner::OrderByOrderingType> &&sort_directions) {
   TERRIER_ASSERT(sort_exprs.size() == sort_directions.size(), "Mismatched ORDER BY expressions + directions");
@@ -311,7 +311,7 @@ common::hash_t LogicalLimit::Hash() const {
 // LogicalDelete
 //===--------------------------------------------------------------------===//
 
-Operator LogicalDelete::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator LogicalDelete::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                              catalog::table_oid_t table_oid) {
   auto *op = new LogicalDelete;
   op->database_oid_ = database_oid;
@@ -341,7 +341,7 @@ bool LogicalDelete::operator==(const BaseOperatorNode &r) {
 // LogicalUpdate
 //===--------------------------------------------------------------------===//
 
-Operator LogicalUpdate::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator LogicalUpdate::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                              catalog::table_oid_t table_oid,
                              std::vector<common::ManagedPointer<parser::UpdateClause>> &&updates) {
   auto *op = new LogicalUpdate;
@@ -375,7 +375,7 @@ bool LogicalUpdate::operator==(const BaseOperatorNode &r) {
 // LogicalExportExternalFile
 //===--------------------------------------------------------------------===//
 
-Operator LogicalExportExternalFile::make(parser::ExternalFileFormat format, std::string file_name, char delimiter,
+Operator LogicalExportExternalFile::Make(parser::ExternalFileFormat format, std::string file_name, char delimiter,
                                          char quote, char escape) {
   auto *op = new LogicalExportExternalFile;
   op->format_ = format;
@@ -410,13 +410,13 @@ bool LogicalExportExternalFile::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // Logical Dependent Join
 //===--------------------------------------------------------------------===//
-Operator LogicalDependentJoin::make() {
+Operator LogicalDependentJoin::Make() {
   auto *join = new LogicalDependentJoin;
   join->join_predicates_ = {};
   return Operator(join);
 }
 
-Operator LogicalDependentJoin::make(std::vector<AnnotatedExpression> &&conditions) {
+Operator LogicalDependentJoin::Make(std::vector<AnnotatedExpression> &&conditions) {
   auto *join = new LogicalDependentJoin;
   join->join_predicates_ = std::move(conditions);
   return Operator(join);
@@ -443,13 +443,13 @@ common::hash_t LogicalDependentJoin::Hash() const {
 //===--------------------------------------------------------------------===//
 // MarkJoin
 //===--------------------------------------------------------------------===//
-Operator LogicalMarkJoin::make() {
+Operator LogicalMarkJoin::Make() {
   auto *join = new LogicalMarkJoin;
   join->join_predicates_ = {};
   return Operator(join);
 }
 
-Operator LogicalMarkJoin::make(std::vector<AnnotatedExpression> &&conditions) {
+Operator LogicalMarkJoin::Make(std::vector<AnnotatedExpression> &&conditions) {
   auto *join = new LogicalMarkJoin;
   join->join_predicates_ = std::move(conditions);
   return Operator(join);
@@ -476,13 +476,13 @@ bool LogicalMarkJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // SingleJoin
 //===--------------------------------------------------------------------===//
-Operator LogicalSingleJoin::make() {
+Operator LogicalSingleJoin::Make() {
   auto *join = new LogicalSingleJoin;
   join->join_predicates_ = {};
   return Operator(join);
 }
 
-Operator LogicalSingleJoin::make(std::vector<AnnotatedExpression> &&conditions) {
+Operator LogicalSingleJoin::Make(std::vector<AnnotatedExpression> &&conditions) {
   auto *join = new LogicalSingleJoin;
   join->join_predicates_ = std::move(conditions);
   return Operator(join);
@@ -509,13 +509,13 @@ bool LogicalSingleJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // InnerJoin
 //===--------------------------------------------------------------------===//
-Operator LogicalInnerJoin::make() {
+Operator LogicalInnerJoin::Make() {
   auto *join = new LogicalInnerJoin;
   join->join_predicates_ = {};
   return Operator(join);
 }
 
-Operator LogicalInnerJoin::make(std::vector<AnnotatedExpression> &&conditions) {
+Operator LogicalInnerJoin::Make(std::vector<AnnotatedExpression> &&conditions) {
   auto *join = new LogicalInnerJoin;
   join->join_predicates_ = std::move(conditions);
   return Operator(join);
@@ -542,7 +542,7 @@ bool LogicalInnerJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // LeftJoin
 //===--------------------------------------------------------------------===//
-Operator LogicalLeftJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator LogicalLeftJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new LogicalLeftJoin();
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -563,7 +563,7 @@ bool LogicalLeftJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // RightJoin
 //===--------------------------------------------------------------------===//
-Operator LogicalRightJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator LogicalRightJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new LogicalRightJoin();
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -584,7 +584,7 @@ bool LogicalRightJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // OuterJoin
 //===--------------------------------------------------------------------===//
-Operator LogicalOuterJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator LogicalOuterJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new LogicalOuterJoin;
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -605,7 +605,7 @@ bool LogicalOuterJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // SemiJoin
 //===--------------------------------------------------------------------===//
-Operator LogicalSemiJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator LogicalSemiJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new LogicalSemiJoin;
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -626,21 +626,21 @@ bool LogicalSemiJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // Aggregate
 //===--------------------------------------------------------------------===//
-Operator LogicalAggregateAndGroupBy::make() {
+Operator LogicalAggregateAndGroupBy::Make() {
   auto *group_by = new LogicalAggregateAndGroupBy;
   group_by->columns_ = {};
   group_by->having_ = {};
   return Operator(group_by);
 }
 
-Operator LogicalAggregateAndGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns) {
+Operator LogicalAggregateAndGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns) {
   auto *group_by = new LogicalAggregateAndGroupBy;
   group_by->columns_ = std::move(columns);
   group_by->having_ = {};
   return Operator(group_by);
 }
 
-Operator LogicalAggregateAndGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
+Operator LogicalAggregateAndGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
                                           std::vector<AnnotatedExpression> &&having) {
   auto *group_by = new LogicalAggregateAndGroupBy;
   group_by->columns_ = std::move(columns);

--- a/src/optimizer/physical_operators.cpp
+++ b/src/optimizer/physical_operators.cpp
@@ -13,7 +13,7 @@ namespace terrier::optimizer {
 //===--------------------------------------------------------------------===//
 // TableFreeScan
 //===--------------------------------------------------------------------===//
-Operator TableFreeScan::make() {
+Operator TableFreeScan::Make() {
   auto *table_free_scan = new TableFreeScan;
   return Operator(table_free_scan);
 }
@@ -32,7 +32,7 @@ common::hash_t TableFreeScan::Hash() const {
 //===--------------------------------------------------------------------===//
 // SeqScan
 //===--------------------------------------------------------------------===//
-Operator SeqScan::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator SeqScan::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                        catalog::table_oid_t table_oid, std::vector<AnnotatedExpression> &&predicates,
                        std::string table_alias, bool is_for_update) {
   auto *scan = new SeqScan;
@@ -73,7 +73,7 @@ common::hash_t SeqScan::Hash() const {
 //===--------------------------------------------------------------------===//
 // IndexScan
 //===--------------------------------------------------------------------===//
-Operator IndexScan::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator IndexScan::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                          catalog::index_oid_t index_oid, std::vector<AnnotatedExpression> &&predicates,
                          std::string table_alias, bool is_for_update,
                          std::vector<catalog::col_oid_t> &&key_column_oid_list,
@@ -137,7 +137,7 @@ common::hash_t IndexScan::Hash() const {
 //===--------------------------------------------------------------------===//
 // External file scan
 //===--------------------------------------------------------------------===//
-Operator ExternalFileScan::make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
+Operator ExternalFileScan::Make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
                                 char escape) {
   auto *get = new ExternalFileScan();
   get->format_ = format;
@@ -168,7 +168,7 @@ common::hash_t ExternalFileScan::Hash() const {
 //===--------------------------------------------------------------------===//
 // Query derived scan
 //===--------------------------------------------------------------------===//
-Operator QueryDerivedScan::make(
+Operator QueryDerivedScan::Make(
     std::string table_alias,
     std::unordered_map<std::string, common::ManagedPointer<parser::AbstractExpression>> &&alias_to_expr_map) {
   auto *get = new QueryDerivedScan;
@@ -198,7 +198,7 @@ common::hash_t QueryDerivedScan::Hash() const {
 //===--------------------------------------------------------------------===//
 // OrderBy
 //===--------------------------------------------------------------------===//
-Operator OrderBy::make() {
+Operator OrderBy::Make() {
   auto *order_by = new OrderBy;
 
   return Operator(order_by);
@@ -218,7 +218,7 @@ common::hash_t OrderBy::Hash() const {
 //===--------------------------------------------------------------------===//
 // PhysicalLimit
 //===--------------------------------------------------------------------===//
-Operator Limit::make(size_t offset, size_t limit,
+Operator Limit::Make(size_t offset, size_t limit,
                      std::vector<common::ManagedPointer<parser::AbstractExpression>> &&sort_columns,
                      std::vector<planner::OrderByOrderingType> &&sort_directions) {
   auto *limit_op = new Limit;
@@ -251,7 +251,7 @@ common::hash_t Limit::Hash() const {
 //===--------------------------------------------------------------------===//
 // InnerNLJoin
 //===--------------------------------------------------------------------===//
-Operator InnerNLJoin::make(std::vector<AnnotatedExpression> &&join_predicates,
+Operator InnerNLJoin::Make(std::vector<AnnotatedExpression> &&join_predicates,
                            std::vector<common::ManagedPointer<parser::AbstractExpression>> &&left_keys,
                            std::vector<common::ManagedPointer<parser::AbstractExpression>> &&right_keys) {
   auto *join = new InnerNLJoin();
@@ -295,7 +295,7 @@ bool InnerNLJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // LeftNLJoin
 //===--------------------------------------------------------------------===//
-Operator LeftNLJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator LeftNLJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new LeftNLJoin();
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -315,7 +315,7 @@ bool LeftNLJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // RightNLJoin
 //===--------------------------------------------------------------------===//
-Operator RightNLJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator RightNLJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new RightNLJoin();
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -336,7 +336,7 @@ bool RightNLJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // OuterNLJoin
 //===--------------------------------------------------------------------===//
-Operator OuterNLJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator OuterNLJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new OuterNLJoin();
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -357,7 +357,7 @@ bool OuterNLJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // InnerHashJoin
 //===--------------------------------------------------------------------===//
-Operator InnerHashJoin::make(std::vector<AnnotatedExpression> &&join_predicates,
+Operator InnerHashJoin::Make(std::vector<AnnotatedExpression> &&join_predicates,
                              std::vector<common::ManagedPointer<parser::AbstractExpression>> &&left_keys,
                              std::vector<common::ManagedPointer<parser::AbstractExpression>> &&right_keys) {
   auto *join = new InnerHashJoin();
@@ -400,7 +400,7 @@ bool InnerHashJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // LeftHashJoin
 //===--------------------------------------------------------------------===//
-Operator LeftHashJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator LeftHashJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new LeftHashJoin();
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -421,7 +421,7 @@ bool LeftHashJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // RightHashJoin
 //===--------------------------------------------------------------------===//
-Operator RightHashJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator RightHashJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new RightHashJoin();
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -442,7 +442,7 @@ bool RightHashJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // OuterHashJoin
 //===--------------------------------------------------------------------===//
-Operator OuterHashJoin::make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
+Operator OuterHashJoin::Make(common::ManagedPointer<parser::AbstractExpression> join_predicate) {
   auto *join = new OuterHashJoin();
   join->join_predicate_ = join_predicate;
   return Operator(join);
@@ -463,7 +463,7 @@ bool OuterHashJoin::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // Insert
 //===--------------------------------------------------------------------===//
-Operator Insert::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator Insert::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                       catalog::table_oid_t table_oid, std::vector<catalog::col_oid_t> &&columns,
                       std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> &&values) {
 #ifndef NDEBUG
@@ -512,7 +512,7 @@ bool Insert::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // InsertSelect
 //===--------------------------------------------------------------------===//
-Operator InsertSelect::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator InsertSelect::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                             catalog::table_oid_t table_oid) {
   auto *insert_op = new InsertSelect;
   insert_op->database_oid_ = database_oid;
@@ -541,7 +541,7 @@ bool InsertSelect::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // Delete
 //===--------------------------------------------------------------------===//
-Operator Delete::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator Delete::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                       catalog::table_oid_t table_oid,
                       common::ManagedPointer<parser::AbstractExpression> delete_condition) {
   auto *delete_op = new Delete;
@@ -573,7 +573,7 @@ bool Delete::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // Update
 //===--------------------------------------------------------------------===//
-Operator Update::make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
+Operator Update::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
                       catalog::table_oid_t table_oid,
                       std::vector<common::ManagedPointer<parser::UpdateClause>> &&updates) {
   auto *op = new Update;
@@ -606,7 +606,7 @@ bool Update::operator==(const BaseOperatorNode &r) {
 //===--------------------------------------------------------------------===//
 // ExportExternalFile
 //===--------------------------------------------------------------------===//
-Operator ExportExternalFile::make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
+Operator ExportExternalFile::Make(parser::ExternalFileFormat format, std::string file_name, char delimiter, char quote,
                                   char escape) {
   auto *export_op = new ExportExternalFile();
   export_op->format_ = format;
@@ -637,7 +637,7 @@ common::hash_t ExportExternalFile::Hash() const {
 //===--------------------------------------------------------------------===//
 // HashGroupBy
 //===--------------------------------------------------------------------===//
-Operator HashGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
+Operator HashGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
                            std::vector<AnnotatedExpression> &&having) {
   auto *agg = new HashGroupBy;
   agg->columns_ = std::move(columns);
@@ -674,7 +674,7 @@ common::hash_t HashGroupBy::Hash() const {
 //===--------------------------------------------------------------------===//
 // SortGroupBy
 //===--------------------------------------------------------------------===//
-Operator SortGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
+Operator SortGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>> &&columns,
                            std::vector<AnnotatedExpression> &&having) {
   auto *agg = new SortGroupBy;
   agg->columns_ = std::move(columns);
@@ -711,7 +711,7 @@ common::hash_t SortGroupBy::Hash() const {
 //===--------------------------------------------------------------------===//
 // Aggregate
 //===--------------------------------------------------------------------===//
-Operator Aggregate::make() {
+Operator Aggregate::Make() {
   auto *agg = new Aggregate;
   return Operator(agg);
 }
@@ -730,7 +730,7 @@ common::hash_t Aggregate::Hash() const {
 //===--------------------------------------------------------------------===//
 // Hash
 //===--------------------------------------------------------------------===//
-Operator Distinct::make() {
+Operator Distinct::Make() {
   auto *hash = new Distinct;
   return Operator(hash);
 }

--- a/src/optimizer/physical_operators.cpp
+++ b/src/optimizer/physical_operators.cpp
@@ -754,112 +754,112 @@ void OperatorNode<T>::Accept(OperatorVisitor *v) const {
 
 //===--------------------------------------------------------------------===//
 template <>
-const char *OperatorNode<TableFreeScan>::name_ = "TableFreeScan";
+const char *OperatorNode<TableFreeScan>::name = "TableFreeScan";
 template <>
-const char *OperatorNode<SeqScan>::name_ = "SeqScan";
+const char *OperatorNode<SeqScan>::name = "SeqScan";
 template <>
-const char *OperatorNode<IndexScan>::name_ = "IndexScan";
+const char *OperatorNode<IndexScan>::name = "IndexScan";
 template <>
-const char *OperatorNode<ExternalFileScan>::name_ = "ExternalFileScan";
+const char *OperatorNode<ExternalFileScan>::name = "ExternalFileScan";
 template <>
-const char *OperatorNode<QueryDerivedScan>::name_ = "QueryDerivedScan";
+const char *OperatorNode<QueryDerivedScan>::name = "QueryDerivedScan";
 template <>
-const char *OperatorNode<OrderBy>::name_ = "OrderBy";
+const char *OperatorNode<OrderBy>::name = "OrderBy";
 template <>
-const char *OperatorNode<Limit>::name_ = "Limit";
+const char *OperatorNode<Limit>::name = "Limit";
 template <>
-const char *OperatorNode<InnerNLJoin>::name_ = "InnerNLJoin";
+const char *OperatorNode<InnerNLJoin>::name = "InnerNLJoin";
 template <>
-const char *OperatorNode<LeftNLJoin>::name_ = "LeftNLJoin";
+const char *OperatorNode<LeftNLJoin>::name = "LeftNLJoin";
 template <>
-const char *OperatorNode<RightNLJoin>::name_ = "RightNLJoin";
+const char *OperatorNode<RightNLJoin>::name = "RightNLJoin";
 template <>
-const char *OperatorNode<OuterNLJoin>::name_ = "OuterNLJoin";
+const char *OperatorNode<OuterNLJoin>::name = "OuterNLJoin";
 template <>
-const char *OperatorNode<InnerHashJoin>::name_ = "InnerHashJoin";
+const char *OperatorNode<InnerHashJoin>::name = "InnerHashJoin";
 template <>
-const char *OperatorNode<LeftHashJoin>::name_ = "LeftHashJoin";
+const char *OperatorNode<LeftHashJoin>::name = "LeftHashJoin";
 template <>
-const char *OperatorNode<RightHashJoin>::name_ = "RightHashJoin";
+const char *OperatorNode<RightHashJoin>::name = "RightHashJoin";
 template <>
-const char *OperatorNode<OuterHashJoin>::name_ = "OuterHashJoin";
+const char *OperatorNode<OuterHashJoin>::name = "OuterHashJoin";
 template <>
-const char *OperatorNode<Insert>::name_ = "Insert";
+const char *OperatorNode<Insert>::name = "Insert";
 template <>
-const char *OperatorNode<InsertSelect>::name_ = "InsertSelect";
+const char *OperatorNode<InsertSelect>::name = "InsertSelect";
 template <>
-const char *OperatorNode<Delete>::name_ = "Delete";
+const char *OperatorNode<Delete>::name = "Delete";
 template <>
-const char *OperatorNode<Update>::name_ = "Update";
+const char *OperatorNode<Update>::name = "Update";
 template <>
-const char *OperatorNode<HashGroupBy>::name_ = "HashGroupBy";
+const char *OperatorNode<HashGroupBy>::name = "HashGroupBy";
 template <>
-const char *OperatorNode<SortGroupBy>::name_ = "SortGroupBy";
+const char *OperatorNode<SortGroupBy>::name = "SortGroupBy";
 template <>
-const char *OperatorNode<Distinct>::name_ = "Distinct";
+const char *OperatorNode<Distinct>::name = "Distinct";
 template <>
-const char *OperatorNode<Aggregate>::name_ = "Aggregate";
+const char *OperatorNode<Aggregate>::name = "Aggregate";
 template <>
-const char *OperatorNode<ExportExternalFile>::name_ = "ExportExternalFile";
+const char *OperatorNode<ExportExternalFile>::name = "ExportExternalFile";
 
 //===--------------------------------------------------------------------===//
 template <>
-OpType OperatorNode<TableFreeScan>::type_ = OpType::TABLEFREESCAN;
+OpType OperatorNode<TableFreeScan>::type = OpType::TABLEFREESCAN;
 template <>
-OpType OperatorNode<SeqScan>::type_ = OpType::SEQSCAN;
+OpType OperatorNode<SeqScan>::type = OpType::SEQSCAN;
 template <>
-OpType OperatorNode<IndexScan>::type_ = OpType::INDEXSCAN;
+OpType OperatorNode<IndexScan>::type = OpType::INDEXSCAN;
 template <>
-OpType OperatorNode<ExternalFileScan>::type_ = OpType::EXTERNALFILESCAN;
+OpType OperatorNode<ExternalFileScan>::type = OpType::EXTERNALFILESCAN;
 template <>
-OpType OperatorNode<QueryDerivedScan>::type_ = OpType::QUERYDERIVEDSCAN;
+OpType OperatorNode<QueryDerivedScan>::type = OpType::QUERYDERIVEDSCAN;
 template <>
-OpType OperatorNode<OrderBy>::type_ = OpType::ORDERBY;
+OpType OperatorNode<OrderBy>::type = OpType::ORDERBY;
 template <>
-OpType OperatorNode<Distinct>::type_ = OpType::DISTINCT;
+OpType OperatorNode<Distinct>::type = OpType::DISTINCT;
 template <>
-OpType OperatorNode<Limit>::type_ = OpType::LIMIT;
+OpType OperatorNode<Limit>::type = OpType::LIMIT;
 template <>
-OpType OperatorNode<InnerNLJoin>::type_ = OpType::INNERNLJOIN;
+OpType OperatorNode<InnerNLJoin>::type = OpType::INNERNLJOIN;
 template <>
-OpType OperatorNode<LeftNLJoin>::type_ = OpType::LEFTNLJOIN;
+OpType OperatorNode<LeftNLJoin>::type = OpType::LEFTNLJOIN;
 template <>
-OpType OperatorNode<RightNLJoin>::type_ = OpType::RIGHTNLJOIN;
+OpType OperatorNode<RightNLJoin>::type = OpType::RIGHTNLJOIN;
 template <>
-OpType OperatorNode<OuterNLJoin>::type_ = OpType::OUTERNLJOIN;
+OpType OperatorNode<OuterNLJoin>::type = OpType::OUTERNLJOIN;
 template <>
-OpType OperatorNode<InnerHashJoin>::type_ = OpType::INNERHASHJOIN;
+OpType OperatorNode<InnerHashJoin>::type = OpType::INNERHASHJOIN;
 template <>
-OpType OperatorNode<LeftHashJoin>::type_ = OpType::LEFTHASHJOIN;
+OpType OperatorNode<LeftHashJoin>::type = OpType::LEFTHASHJOIN;
 template <>
-OpType OperatorNode<RightHashJoin>::type_ = OpType::RIGHTHASHJOIN;
+OpType OperatorNode<RightHashJoin>::type = OpType::RIGHTHASHJOIN;
 template <>
-OpType OperatorNode<OuterHashJoin>::type_ = OpType::OUTERHASHJOIN;
+OpType OperatorNode<OuterHashJoin>::type = OpType::OUTERHASHJOIN;
 template <>
-OpType OperatorNode<Insert>::type_ = OpType::INSERT;
+OpType OperatorNode<Insert>::type = OpType::INSERT;
 template <>
-OpType OperatorNode<InsertSelect>::type_ = OpType::INSERTSELECT;
+OpType OperatorNode<InsertSelect>::type = OpType::INSERTSELECT;
 template <>
-OpType OperatorNode<Delete>::type_ = OpType::DELETE;
+OpType OperatorNode<Delete>::type = OpType::DELETE;
 template <>
-OpType OperatorNode<Update>::type_ = OpType::UPDATE;
+OpType OperatorNode<Update>::type = OpType::UPDATE;
 template <>
-OpType OperatorNode<HashGroupBy>::type_ = OpType::HASHGROUPBY;
+OpType OperatorNode<HashGroupBy>::type = OpType::HASHGROUPBY;
 template <>
-OpType OperatorNode<SortGroupBy>::type_ = OpType::SORTGROUPBY;
+OpType OperatorNode<SortGroupBy>::type = OpType::SORTGROUPBY;
 template <>
-OpType OperatorNode<Aggregate>::type_ = OpType::AGGREGATE;
+OpType OperatorNode<Aggregate>::type = OpType::AGGREGATE;
 template <>
-OpType OperatorNode<ExportExternalFile>::type_ = OpType::EXPORTEXTERNALFILE;
+OpType OperatorNode<ExportExternalFile>::type = OpType::EXPORTEXTERNALFILE;
 
 template <typename T>
 bool OperatorNode<T>::IsLogical() const {
-  return type_ < OpType::LOGICALPHYSICALDELIMITER;
+  return type < OpType::LOGICALPHYSICALDELIMITER;
 }
 
 template <typename T>
 bool OperatorNode<T>::IsPhysical() const {
-  return type_ > OpType::LOGICALPHYSICALDELIMITER;
+  return type > OpType::LOGICALPHYSICALDELIMITER;
 }
 
 }  // namespace terrier::optimizer

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1059,10 +1059,10 @@ std::unique_ptr<SQLStatement> PostgresParser::ExplainTransform(ExplainStmt *root
  */
 
 std::unique_ptr<CopyStatement> PostgresParser::CopyTransform(CopyStmt *root) {
-  static constexpr char kDelimiterTok[] = "delimiter";
-  static constexpr char kFormatTok[] = "format";
-  static constexpr char kQuoteTok[] = "quote";
-  static constexpr char kEscapeTok[] = "escape";
+  static constexpr char k_delimiter_tok[] = "delimiter";
+  static constexpr char k_format_tok[] = "format";
+  static constexpr char k_quote_tok[] = "quote";
+  static constexpr char k_escape_tok[] = "escape";
 
   std::unique_ptr<TableRef> table;
   std::unique_ptr<SelectStatement> select_stmt;
@@ -1083,7 +1083,7 @@ std::unique_ptr<CopyStatement> PostgresParser::CopyTransform(CopyStmt *root) {
     for (ListCell *cell = root->options_->head; cell != nullptr; cell = cell->next) {
       auto def_elem = reinterpret_cast<DefElem *>(cell->data.ptr_value);
 
-      if (strncmp(def_elem->defname_, kFormatTok, sizeof(kFormatTok)) == 0) {
+      if (strncmp(def_elem->defname_, k_format_tok, sizeof(k_format_tok)) == 0) {
         auto format_cstr = reinterpret_cast<value *>(def_elem->arg_)->val_.str_;
         // lowercase
         if (strcmp(format_cstr, "csv") == 0) {
@@ -1093,15 +1093,15 @@ std::unique_ptr<CopyStatement> PostgresParser::CopyTransform(CopyStmt *root) {
         }
       }
 
-      if (strncmp(def_elem->defname_, kDelimiterTok, sizeof(kDelimiterTok)) == 0) {
+      if (strncmp(def_elem->defname_, k_delimiter_tok, sizeof(k_delimiter_tok)) == 0) {
         delimiter = *(reinterpret_cast<value *>(def_elem->arg_)->val_.str_);
       }
 
-      if (strncmp(def_elem->defname_, kQuoteTok, sizeof(kQuoteTok)) == 0) {
+      if (strncmp(def_elem->defname_, k_quote_tok, sizeof(k_quote_tok)) == 0) {
         quote = *(reinterpret_cast<value *>(def_elem->arg_)->val_.str_);
       }
 
-      if (strncmp(def_elem->defname_, kEscapeTok, sizeof(kEscapeTok)) == 0) {
+      if (strncmp(def_elem->defname_, k_escape_tok, sizeof(k_escape_tok)) == 0) {
         escape = *(reinterpret_cast<value *>(def_elem->arg_)->val_.str_);
       }
     }

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1059,10 +1059,10 @@ std::unique_ptr<SQLStatement> PostgresParser::ExplainTransform(ExplainStmt *root
  */
 
 std::unique_ptr<CopyStatement> PostgresParser::CopyTransform(CopyStmt *root) {
-  static constexpr char kDelimiterTok[] = "delimiter";
-  static constexpr char kFormatTok[] = "format";
-  static constexpr char kQuoteTok[] = "quote";
-  static constexpr char kEscapeTok[] = "escape";
+  static constexpr char k_delimiter_tok[] = "delimiter";
+  static constexpr char k_format_tok[] = "format";
+  static constexpr char k_quote_tok[] = "quote";
+  static constexpr char k_escape_tok[] = "escape";
 
   std::unique_ptr<TableRef> table;
   std::unique_ptr<SelectStatement> select_stmt;
@@ -1083,7 +1083,7 @@ std::unique_ptr<CopyStatement> PostgresParser::CopyTransform(CopyStmt *root) {
     for (ListCell *cell = root->options->head; cell != nullptr; cell = cell->next) {
       auto def_elem = reinterpret_cast<DefElem *>(cell->data.ptr_value);
 
-      if (strncmp(def_elem->defname, kFormatTok, sizeof(kFormatTok)) == 0) {
+      if (strncmp(def_elem->defname, k_format_tok, sizeof(k_format_tok)) == 0) {
         auto format_cstr = reinterpret_cast<value *>(def_elem->arg)->val.str;
         // lowercase
         if (strcmp(format_cstr, "csv") == 0) {
@@ -1093,15 +1093,15 @@ std::unique_ptr<CopyStatement> PostgresParser::CopyTransform(CopyStmt *root) {
         }
       }
 
-      if (strncmp(def_elem->defname, kDelimiterTok, sizeof(kDelimiterTok)) == 0) {
+      if (strncmp(def_elem->defname, k_delimiter_tok, sizeof(k_delimiter_tok)) == 0) {
         delimiter = *(reinterpret_cast<value *>(def_elem->arg)->val.str);
       }
 
-      if (strncmp(def_elem->defname, kQuoteTok, sizeof(kQuoteTok)) == 0) {
+      if (strncmp(def_elem->defname, k_quote_tok, sizeof(k_quote_tok)) == 0) {
         quote = *(reinterpret_cast<value *>(def_elem->arg)->val.str);
       }
 
-      if (strncmp(def_elem->defname, kEscapeTok, sizeof(kEscapeTok)) == 0) {
+      if (strncmp(def_elem->defname, k_escape_tok, sizeof(k_escape_tok)) == 0) {
         escape = *(reinterpret_cast<value *>(def_elem->arg)->val.str);
       }
     }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -65,7 +65,7 @@ DataTable::SlotIterator &DataTable::SlotIterator::operator++() {
   return *this;
 }
 
-DataTable::SlotIterator DataTable::end() const {
+DataTable::SlotIterator DataTable::end() const {  // NOLINT for STL name compability
   common::SpinLatch::ScopedSpinLatch guard(&blocks_latch_);
   // TODO(Tianyu): Need to look in detail at how this interacts with compaction when that gets in.
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -65,7 +65,7 @@ DataTable::SlotIterator &DataTable::SlotIterator::operator++() {
   return *this;
 }
 
-DataTable::SlotIterator DataTable::end() const {
+DataTable::SlotIterator DataTable::End() const {
   common::SpinLatch::ScopedSpinLatch guard(&blocks_latch_);
   // TODO(Tianyu): Need to look in detail at how this interacts with compaction when that gets in.
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -65,7 +65,7 @@ DataTable::SlotIterator &DataTable::SlotIterator::operator++() {
   return *this;
 }
 
-DataTable::SlotIterator DataTable::End() const {
+DataTable::SlotIterator DataTable::end() const {
   common::SpinLatch::ScopedSpinLatch guard(&blocks_latch_);
   // TODO(Tianyu): Need to look in detail at how this interacts with compaction when that gets in.
 

--- a/src/storage/sql_table.cpp
+++ b/src/storage/sql_table.cpp
@@ -59,8 +59,8 @@ std::vector<col_id_t> SqlTable::ColIdsForOids(const std::vector<catalog::col_oid
 
   // Build the input to the initializer constructor
   for (const catalog::col_oid_t col_oid : col_oids) {
-    TERRIER_ASSERT(table_.column_map.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
-    const col_id_t col_id = table_.column_map.at(col_oid);
+    TERRIER_ASSERT(table_.column_map_.count(col_oid) > 0, "Provided col_oid does not exist in the table.");
+    const col_id_t col_id = table_.column_map_.at(col_oid);
     col_ids.push_back(col_id);
   }
 

--- a/src/storage/write_ahead_log/log_io.cpp
+++ b/src/storage/write_ahead_log/log_io.cpp
@@ -45,13 +45,13 @@ bool BufferedLogReader::Read(void *dest, uint32_t size) {
     return true;
   }
   // Not enough left in the buffer.
-  uint32_t bytes_read_ = 0;
-  while (bytes_read_ < size) {
+  uint32_t bytes_read = 0;
+  while (bytes_read < size) {
     if (!HasMore()) return false;
-    uint32_t read_size = std::min(size - bytes_read_, filled_size_ - read_head_);
+    uint32_t read_size = std::min(size - bytes_read, filled_size_ - read_head_);
     if (read_size == 0) RefillBuffer();  // when all contents in the buffer is fully read
-    ReadFromBuffer(reinterpret_cast<char *>(dest) + bytes_read_, read_size);
-    bytes_read_ += read_size;
+    ReadFromBuffer(reinterpret_cast<char *>(dest) + bytes_read, read_size);
+    bytes_read += read_size;
   }
   return true;
 }

--- a/test/common/hash_util_test.cpp
+++ b/test/common/hash_util_test.cpp
@@ -61,13 +61,13 @@ TEST(HashUtilTests, HashMixedTest) {
   // There is nothing special about this test. It's just a sanity
   // check for me to make sure that things are working correctly in
   // another part of the system.
-  enum class wutang { RZA, GZA, RAEKWON, METHODMAN, GHOSTFACE, ODB, INSPECTAH };
+  enum class Wutang { RZA, GZA, RAEKWON, METHODMAN, GHOSTFACE, ODB, INSPECTAH };
 
-  common::hash_t hash0 = common::HashUtil::Hash(wutang::RAEKWON);
-  common::hash_t hash1 = common::HashUtil::Hash(wutang::RAEKWON);
+  common::hash_t hash0 = common::HashUtil::Hash(Wutang::RAEKWON);
+  common::hash_t hash1 = common::HashUtil::Hash(Wutang::RAEKWON);
   EXPECT_EQ(hash0, hash1);
 
-  wutang val0 = wutang::ODB;
+  Wutang val0 = Wutang::ODB;
   hash0 = common::HashUtil::CombineHashes(hash0, common::HashUtil::Hash(val0));
   hash1 = common::HashUtil::CombineHashes(hash1, common::HashUtil::Hash(val0));
   EXPECT_EQ(hash0, hash1);

--- a/test/common/object_pool_test.cpp
+++ b/test/common/object_pool_test.cpp
@@ -93,7 +93,7 @@ TEST(ObjectPoolTests, ConcurrentCorrectnessTest) {
   const uint64_t reuse_limit = 100;
   common::ObjectPool<ObjectPoolTestType> tested(size_limit, reuse_limit);
   auto workload = [&](uint32_t tid) {
-    std::uniform_int_distribution<uint64_t> size_dist_(1, reuse_limit);
+    std::uniform_int_distribution<uint64_t> size_dist(1, reuse_limit);
 
     // Randomly generate a sequence of use-free
     std::default_random_engine generator;
@@ -116,9 +116,9 @@ TEST(ObjectPoolTests, ConcurrentCorrectnessTest) {
         ptrs.erase(pos);
       }
     };
-    auto set_reuse_limit = [&] { tested.SetReuseLimit(size_dist_(generator)); };
+    auto set_reuse_limit = [size_dist] { tested.SetReuseLimit(size_dist(generator)); };
 
-    auto set_size_limit = [&] { tested.SetSizeLimit(size_dist_(generator)); };
+    auto set_size_limit = [size_dist] { tested.SetSizeLimit(size_dist(generator)); };
 
     RandomTestUtil::InvokeWorkloadWithDistribution({free, allocate, set_reuse_limit, set_size_limit},
                                                    {0.25, 0.25, 0.25, 0.25}, &generator, 1000);

--- a/test/common/object_pool_test.cpp
+++ b/test/common/object_pool_test.cpp
@@ -116,9 +116,9 @@ TEST(ObjectPoolTests, ConcurrentCorrectnessTest) {
         ptrs.erase(pos);
       }
     };
-    auto set_reuse_limit = [size_dist] { tested.SetReuseLimit(size_dist(generator)); };
+    auto set_reuse_limit = [&] { tested.SetReuseLimit(size_dist(generator)); };
 
-    auto set_size_limit = [size_dist] { tested.SetSizeLimit(size_dist(generator)); };
+    auto set_size_limit = [&] { tested.SetSizeLimit(size_dist(generator)); };
 
     RandomTestUtil::InvokeWorkloadWithDistribution({free, allocate, set_reuse_limit, set_size_limit},
                                                    {0.25, 0.25, 0.25, 0.25}, &generator, 1000);

--- a/test/common/performance_counter_test.cpp
+++ b/test/common/performance_counter_test.cpp
@@ -41,10 +41,10 @@ class CacheCounterTestObject {
    * Calls the gtest EXPECT_EQ function for all the relevant variables.
    */
   void Equal() const {
-    EXPECT_EQ(cc->GetNumInsert(), num_insert);
-    EXPECT_EQ(cc->GetNumHit(), num_hit);
-    EXPECT_EQ(cc->GetNumFailure(), num_failure);
-    EXPECT_EQ(cc->GetNumUser(), num_user);
+    EXPECT_EQ(cc_->GetNumInsert(), num_insert_);
+    EXPECT_EQ(cc_->GetNumHit(), num_hit_);
+    EXPECT_EQ(cc_->GetNumFailure(), num_failure_);
+    EXPECT_EQ(cc_->GetNumUser(), num_user_);
   }
 
  public:
@@ -59,11 +59,11 @@ class CacheCounterTestObject {
    * Zeroes the cache counter, automatically checking that all the state remains consistent.
    */
   void Zero() {
-    num_insert.store(0);
-    num_hit.store(0);
-    num_failure.store(0);
-    num_user.store(0);
-    cc->ZeroCounters();
+    num_insert_.store(0);
+    num_hit_.store(0);
+    num_failure_.store(0);
+    num_user_.store(0);
+    cc_->ZeroCounters();
     Equal();
   }
 
@@ -73,67 +73,67 @@ class CacheCounterTestObject {
    * @param num_operations number of operations to run
    */
   void RandomOperation(std::default_random_engine generator, uint32_t num_operations) {
-    uint8_t num = rng(generator);
+    uint8_t num = rng_(generator);
 
     std::vector<std::function<void()>> workloads = {
         [&] {
-          cc->IncrementNumInsert(num);
-          num_insert += num;
+          cc_->IncrementNumInsert(num);
+          num_insert_ += num;
           Equal();
         },
         [&] {
-          cc->IncrementNumHit(num);
-          num_hit += num;
+          cc_->IncrementNumHit(num);
+          num_hit_ += num;
           Equal();
         },
         [&] {
-          cc->IncrementNumFailure(num);
-          num_failure += num;
+          cc_->IncrementNumFailure(num);
+          num_failure_ += num;
           Equal();
         },
         [&] {
-          cc->IncrementNumUser(num);
-          num_user += num;
+          cc_->IncrementNumUser(num);
+          num_user_ += num;
           Equal();
         },
         [&] {
-          cc->DecrementNumInsert(num);
-          num_insert -= num;
+          cc_->DecrementNumInsert(num);
+          num_insert_ -= num;
           Equal();
         },
         [&] {
-          cc->DecrementNumHit(num);
-          num_hit -= num;
+          cc_->DecrementNumHit(num);
+          num_hit_ -= num;
           Equal();
         },
         [&] {
-          cc->DecrementNumFailure(num);
-          num_failure -= num;
+          cc_->DecrementNumFailure(num);
+          num_failure_ -= num;
           Equal();
         },
         [&] {
-          cc->DecrementNumUser(num);
-          num_user -= num;
+          cc_->DecrementNumUser(num);
+          num_user_ -= num;
           Equal();
         },
         [&] {
-          cc->SetNumInsert(num);
-          num_insert = num;
+          cc_->SetNumInsert(num);
+          num_insert_ = num;
           Equal();
         },
         [&] {
-          cc->SetNumHit(num);
-          num_hit = num;
+          cc_->SetNumHit(num);
+          num_hit_ = num;
           Equal();
         },
         [&] {
-          cc->SetNumFailure(num);
-          num_failure = num;
+          cc_->SetNumFailure(num);
+          num_failure_ = num;
           Equal();
         },
         [&] {
-          cc->SetNumUser(num);
-          num_user = num;
+          cc_->SetNumUser(num);
+          num_user_ = num;
           Equal();
         },
     };

--- a/test/common/performance_counter_test.cpp
+++ b/test/common/performance_counter_test.cpp
@@ -30,12 +30,12 @@ DEFINE_PERFORMANCE_CLASS(CacheCounter, CACHE_MEMBERS)
  */
 class CacheCounterTestObject {
  private:
-  std::atomic<uint64_t> num_insert{0};
-  std::atomic<uint32_t> num_hit{0};
-  std::atomic<uint16_t> num_failure{0};
-  std::atomic<uint8_t> num_user{0};
-  CacheCounter *cc;
-  std::uniform_int_distribution<uint8_t> rng;
+  std::atomic<uint64_t> num_insert_{0};
+  std::atomic<uint32_t> num_hit_{0};
+  std::atomic<uint16_t> num_failure_{0};
+  std::atomic<uint8_t> num_user_{0};
+  CacheCounter *cc_;
+  std::uniform_int_distribution<uint8_t> rng_;
 
   /**
    * Calls the gtest EXPECT_EQ function for all the relevant variables.
@@ -53,7 +53,7 @@ class CacheCounterTestObject {
    * It will check that it remains consistent with the CacheCounter;
    * if you modify the CacheCounter, make sure you tell it.
    */
-  explicit CacheCounterTestObject(CacheCounter *cc) : cc(cc), rng(1, 255) {}
+  explicit CacheCounterTestObject(CacheCounter *cc) : cc_(cc), rng_(1, 255) {}
 
   /**
    * Zeroes the cache counter, automatically checking that all the state remains consistent.

--- a/test/common/stat_registry_test.cpp
+++ b/test/common/stat_registry_test.cpp
@@ -161,25 +161,25 @@ TEST(StatRegistryTest, GTEST_DEBUG_ONLY(FreeTest)) {
 // A basic test, registering a DataTable counter
 // NOLINTNEXTLINE
 TEST(StatRegistryTest, GTEST_DEBUG_ONLY(DataTableStatTest)) {
-  terrier::storage::RecordBufferSegmentPool buffer_pool_{100000, 10000};
-  terrier::storage::BlockStore block_store_{1000, 100};
-  terrier::storage::BlockLayout block_layout_({8, 8, 8});
+  terrier::storage::RecordBufferSegmentPool buffer_pool{100000, 10000};
+  terrier::storage::BlockStore block_store{1000, 100};
+  terrier::storage::BlockLayout block_layout({8, 8, 8});
   const std::vector<terrier::storage::col_id_t> col_ids = {terrier::storage::col_id_t{1},
                                                            terrier::storage::col_id_t{2}};
-  terrier::storage::DataTable data_table_(&block_store_, block_layout_, terrier::storage::layout_version_t{0});
+  terrier::storage::DataTable data_table(&block_store, block_layout, terrier::storage::layout_version_t{0});
   terrier::transaction::timestamp_t timestamp(0);
-  auto *txn = new terrier::transaction::TransactionContext(timestamp, timestamp, &buffer_pool_, LOGGING_DISABLED,
+  auto *txn = new terrier::transaction::TransactionContext(timestamp, timestamp, &buffer_pool, LOGGING_DISABLED,
                                                            ACTION_FRAMEWORK_DISABLED);
-  auto init = terrier::storage::ProjectedRowInitializer::Create(block_layout_, col_ids);
-  auto *redo_buffer_ = terrier::common::AllocationUtil::AllocateAligned(init.ProjectedRowSize());
-  auto *redo = init.InitializeRow(redo_buffer_);
+  auto init = terrier::storage::ProjectedRowInitializer::Create(block_layout, col_ids);
+  auto *redo_buffer = terrier::common::AllocationUtil::AllocateAligned(init.ProjectedRowSize());
+  auto *redo = init.InitializeRow(redo_buffer);
 
-  data_table_.Insert(txn, *redo);
+  data_table.Insert(txn, *redo);
 
   // initialize stat registry
   auto test_stat_reg = std::make_shared<terrier::common::StatisticsRegistry>();
-  test_stat_reg->Register({"Storage"}, data_table_.GetDataTableCounter(), &data_table_);
-  delete[] redo_buffer_;
+  test_stat_reg->Register({"Storage"}, data_table.GetDataTableCounter(), &data_table);
+  delete[] redo_buffer;
   delete txn;
 
   test_stat_reg->Shutdown(false);

--- a/test/common/worker_pool_test.cpp
+++ b/test/common/worker_pool_test.cpp
@@ -62,12 +62,12 @@ TEST(WorkerPoolTests, MoreTest) {
   common::TaskQueue tasks;
   common::WorkerPool thread_pool(5, tasks);
   uint32_t iteration = 10;
-  std::default_random_engine generator_;
+  std::default_random_engine generator;
   std::uniform_int_distribution<uint32_t> num_thread{1, MultiThreadTestUtil::HardwareConcurrency()};
   for (uint32_t it = 0; it < iteration; it++) {
     auto workload = [](uint32_t /*unused*/) { std::this_thread::sleep_for(std::chrono::milliseconds(200)); };
 
-    MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_thread(generator_), workload);
+    MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_thread(generator), workload);
   }
   thread_pool.Shutdown();
 }

--- a/test/include/util/catalog_test_util.h
+++ b/test/include/util/catalog_test_util.h
@@ -38,8 +38,8 @@ struct CatalogTestUtil {
 
   // Define contants here for when you need to fake having a catalog in tests. These values may change as the catalog
   // comes in, and tests should be modified accordingly.
-  static constexpr catalog::db_oid_t test_db_oid = catalog::db_oid_t(101);
-  static constexpr catalog::table_oid_t test_table_oid = catalog::table_oid_t(102);
-  static constexpr catalog::namespace_oid_t test_namespace_oid = catalog::namespace_oid_t(103);
+  static constexpr catalog::db_oid_t TEST_DB_OID = catalog::db_oid_t(101);
+  static constexpr catalog::table_oid_t TEST_TABLE_OID = catalog::table_oid_t(102);
+  static constexpr catalog::namespace_oid_t TEST_NAMESPACE_OID = catalog::namespace_oid_t(103);
 };
 }  // namespace terrier

--- a/test/include/util/tpcc/delivery.h
+++ b/test/include/util/tpcc/delivery.h
@@ -74,11 +74,11 @@ class Delivery {
         new_order_pr_initializer_(
             db->new_order_table_->InitializerForProjectedRow({db->new_order_schema_.GetColumn(0).Oid()})),
         no_o_id_key_pr_offset_(
-            static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(no_o_id_key_oid))),
+            static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(no_o_id_key_oid_))),
         no_d_id_key_pr_offset_(
-            static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(no_d_id_key_oid))),
+            static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(no_d_id_key_oid_))),
         no_w_id_key_pr_offset_(
-            static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(no_w_id_key_oid))),
+            static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(no_w_id_key_oid_))),
 
         o_id_key_oid_(db->order_primary_index_schema_.GetColumn(2).Oid()),
         o_d_id_key_oid_(db->order_primary_index_schema_.GetColumn(1).Oid()),
@@ -88,9 +88,11 @@ class Delivery {
             db->order_table_->InitializerForProjectedRow({db->order_schema_.GetColumn(3).Oid()})),
         order_update_pr_initializer_(
             db->order_table_->InitializerForProjectedRow({db->order_schema_.GetColumn(5).Oid()})),
-        o_id_key_pr_offset_(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_id_key_oid))),
-        o_d_id_key_pr_offset_(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_d_id_key_oid))),
-        o_w_id_key_pr_offset_(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_w_id_key_oid))),
+        o_id_key_pr_offset_(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_id_key_oid_))),
+        o_d_id_key_pr_offset_(
+            static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_d_id_key_oid_))),
+        o_w_id_key_pr_offset_(
+            static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_w_id_key_oid_))),
 
         ol_amount_oid_(db->order_line_schema_.GetColumn(8).Oid()),
         ol_delivery_d_oid_(db->order_line_schema_.GetColumn(6).Oid()),
@@ -104,13 +106,13 @@ class Delivery {
         order_line_update_pr_initializer_(
             db->order_line_table_->InitializerForProjectedRow({db->order_line_schema_.GetColumn(6).Oid()})),
         ol_o_id_key_pr_offset_(
-            static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_o_id_key_oid))),
+            static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_o_id_key_oid_))),
         ol_d_id_key_pr_offset_(
-            static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_d_id_key_oid))),
+            static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_d_id_key_oid_))),
         ol_w_id_key_pr_offset_(
-            static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_w_id_key_oid))),
+            static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_w_id_key_oid_))),
         ol_number_key_pr_offset_(
-            static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_number_key_oid))),
+            static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_number_key_oid_))),
 
         c_balance_oid_(db->customer_schema_.GetColumn(16).Oid()),
         c_delivery_cnt_oid_(db->customer_schema_.GetColumn(19).Oid()),
@@ -118,15 +120,17 @@ class Delivery {
         c_d_id_key_oid_(db->customer_primary_index_schema_.GetColumn(1).Oid()),
         c_w_id_key_oid_(db->customer_primary_index_schema_.GetColumn(0).Oid()),
 
-        customer_pr_initializer_(db->customer_table_->InitializerForProjectedRow({c_balance_oid, c_delivery_cnt_oid})),
-        customer_pr_map_(db->customer_table_->ProjectionMapForOids({c_balance_oid, c_delivery_cnt_oid})),
-        c_balance_pr_offset_(static_cast<uint8_t>(customer_pr_map.at(c_balance_oid))),
-        c_delivery_cnt_pr_offset_(static_cast<uint8_t>(customer_pr_map.at(c_delivery_cnt_oid))),
-        c_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_id_key_oid))),
+        customer_pr_initializer_(
+            db->customer_table_->InitializerForProjectedRow({c_balance_oid_, c_delivery_cnt_oid_})),
+        customer_pr_map_(db->customer_table_->ProjectionMapForOids({c_balance_oid_, c_delivery_cnt_oid_})),
+        c_balance_pr_offset_(static_cast<uint8_t>(customer_pr_map_.at(c_balance_oid_))),
+        c_delivery_cnt_pr_offset_(static_cast<uint8_t>(customer_pr_map_.at(c_delivery_cnt_oid_))),
+        c_id_key_pr_offset_(
+            static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_id_key_oid_))),
         c_d_id_key_pr_offset_(
-            static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_d_id_key_oid))),
+            static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_d_id_key_oid_))),
         c_w_id_key_pr_offset_(
-            static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_w_id_key_oid)))
+            static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_w_id_key_oid_)))
 
   {}
 

--- a/test/include/util/tpcc/delivery.h
+++ b/test/include/util/tpcc/delivery.h
@@ -19,113 +19,113 @@ namespace terrier::tpcc {
 class Delivery {
  private:
   // New Order metadata
-  const catalog::indexkeycol_oid_t no_o_id_key_oid;
-  const catalog::indexkeycol_oid_t no_d_id_key_oid;
-  const catalog::indexkeycol_oid_t no_w_id_key_oid;
-  const storage::ProjectedRowInitializer new_order_pr_initializer;
-  const uint8_t no_o_id_key_pr_offset;
-  const uint8_t no_d_id_key_pr_offset;
-  const uint8_t no_w_id_key_pr_offset;
+  const catalog::indexkeycol_oid_t no_o_id_key_oid_;
+  const catalog::indexkeycol_oid_t no_d_id_key_oid_;
+  const catalog::indexkeycol_oid_t no_w_id_key_oid_;
+  const storage::ProjectedRowInitializer new_order_pr_initializer_;
+  const uint8_t no_o_id_key_pr_offset_;
+  const uint8_t no_d_id_key_pr_offset_;
+  const uint8_t no_w_id_key_pr_offset_;
 
   // Order metadata
-  const catalog::indexkeycol_oid_t o_id_key_oid;
-  const catalog::indexkeycol_oid_t o_d_id_key_oid;
-  const catalog::indexkeycol_oid_t o_w_id_key_oid;
-  const storage::ProjectedRowInitializer order_select_pr_initializer;
-  const storage::ProjectedRowInitializer order_update_pr_initializer;
-  const uint8_t o_id_key_pr_offset;
-  const uint8_t o_d_id_key_pr_offset;
-  const uint8_t o_w_id_key_pr_offset;
+  const catalog::indexkeycol_oid_t o_id_key_oid_;
+  const catalog::indexkeycol_oid_t o_d_id_key_oid_;
+  const catalog::indexkeycol_oid_t o_w_id_key_oid_;
+  const storage::ProjectedRowInitializer order_select_pr_initializer_;
+  const storage::ProjectedRowInitializer order_update_pr_initializer_;
+  const uint8_t o_id_key_pr_offset_;
+  const uint8_t o_d_id_key_pr_offset_;
+  const uint8_t o_w_id_key_pr_offset_;
 
   // Order Line metadata
-  const catalog::col_oid_t ol_amount_oid;
-  const catalog::col_oid_t ol_delivery_d_oid;
-  const catalog::indexkeycol_oid_t ol_o_id_key_oid;
-  const catalog::indexkeycol_oid_t ol_d_id_key_oid;
-  const catalog::indexkeycol_oid_t ol_w_id_key_oid;
-  const catalog::indexkeycol_oid_t ol_number_key_oid;
-  const storage::ProjectedRowInitializer order_line_select_pr_initializer;
-  const storage::ProjectedRowInitializer order_line_update_pr_initializer;
-  const uint8_t ol_o_id_key_pr_offset;
-  const uint8_t ol_d_id_key_pr_offset;
-  const uint8_t ol_w_id_key_pr_offset;
-  const uint8_t ol_number_key_pr_offset;
+  const catalog::col_oid_t ol_amount_oid_;
+  const catalog::col_oid_t ol_delivery_d_oid_;
+  const catalog::indexkeycol_oid_t ol_o_id_key_oid_;
+  const catalog::indexkeycol_oid_t ol_d_id_key_oid_;
+  const catalog::indexkeycol_oid_t ol_w_id_key_oid_;
+  const catalog::indexkeycol_oid_t ol_number_key_oid_;
+  const storage::ProjectedRowInitializer order_line_select_pr_initializer_;
+  const storage::ProjectedRowInitializer order_line_update_pr_initializer_;
+  const uint8_t ol_o_id_key_pr_offset_;
+  const uint8_t ol_d_id_key_pr_offset_;
+  const uint8_t ol_w_id_key_pr_offset_;
+  const uint8_t ol_number_key_pr_offset_;
 
   // Customer metadata
-  const catalog::col_oid_t c_balance_oid;
-  const catalog::col_oid_t c_delivery_cnt_oid;
-  const catalog::indexkeycol_oid_t c_id_key_oid;
-  const catalog::indexkeycol_oid_t c_d_id_key_oid;
-  const catalog::indexkeycol_oid_t c_w_id_key_oid;
-  const storage::ProjectedRowInitializer customer_pr_initializer;
-  const storage::ProjectionMap customer_pr_map;
-  const uint8_t c_balance_pr_offset;
-  const uint8_t c_delivery_cnt_pr_offset;
-  const uint8_t c_id_key_pr_offset;
-  const uint8_t c_d_id_key_pr_offset;
-  const uint8_t c_w_id_key_pr_offset;
+  const catalog::col_oid_t c_balance_oid_;
+  const catalog::col_oid_t c_delivery_cnt_oid_;
+  const catalog::indexkeycol_oid_t c_id_key_oid_;
+  const catalog::indexkeycol_oid_t c_d_id_key_oid_;
+  const catalog::indexkeycol_oid_t c_w_id_key_oid_;
+  const storage::ProjectedRowInitializer customer_pr_initializer_;
+  const storage::ProjectionMap customer_pr_map_;
+  const uint8_t c_balance_pr_offset_;
+  const uint8_t c_delivery_cnt_pr_offset_;
+  const uint8_t c_id_key_pr_offset_;
+  const uint8_t c_d_id_key_pr_offset_;
+  const uint8_t c_w_id_key_pr_offset_;
 
  public:
   explicit Delivery(const Database *const db)
-      : no_o_id_key_oid(db->new_order_primary_index_schema_.GetColumn(2).Oid()),
-        no_d_id_key_oid(db->new_order_primary_index_schema_.GetColumn(1).Oid()),
-        no_w_id_key_oid(db->new_order_primary_index_schema_.GetColumn(0).Oid()),
+      : no_o_id_key_oid_(db->new_order_primary_index_schema_.GetColumn(2).Oid()),
+        no_d_id_key_oid_(db->new_order_primary_index_schema_.GetColumn(1).Oid()),
+        no_w_id_key_oid_(db->new_order_primary_index_schema_.GetColumn(0).Oid()),
 
-        new_order_pr_initializer(
+        new_order_pr_initializer_(
             db->new_order_table_->InitializerForProjectedRow({db->new_order_schema_.GetColumn(0).Oid()})),
-        no_o_id_key_pr_offset(
+        no_o_id_key_pr_offset_(
             static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(no_o_id_key_oid))),
-        no_d_id_key_pr_offset(
+        no_d_id_key_pr_offset_(
             static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(no_d_id_key_oid))),
-        no_w_id_key_pr_offset(
+        no_w_id_key_pr_offset_(
             static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(no_w_id_key_oid))),
 
-        o_id_key_oid(db->order_primary_index_schema_.GetColumn(2).Oid()),
-        o_d_id_key_oid(db->order_primary_index_schema_.GetColumn(1).Oid()),
-        o_w_id_key_oid(db->order_primary_index_schema_.GetColumn(0).Oid()),
+        o_id_key_oid_(db->order_primary_index_schema_.GetColumn(2).Oid()),
+        o_d_id_key_oid_(db->order_primary_index_schema_.GetColumn(1).Oid()),
+        o_w_id_key_oid_(db->order_primary_index_schema_.GetColumn(0).Oid()),
 
-        order_select_pr_initializer(
+        order_select_pr_initializer_(
             db->order_table_->InitializerForProjectedRow({db->order_schema_.GetColumn(3).Oid()})),
-        order_update_pr_initializer(
+        order_update_pr_initializer_(
             db->order_table_->InitializerForProjectedRow({db->order_schema_.GetColumn(5).Oid()})),
-        o_id_key_pr_offset(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_id_key_oid))),
-        o_d_id_key_pr_offset(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_d_id_key_oid))),
-        o_w_id_key_pr_offset(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_w_id_key_oid))),
+        o_id_key_pr_offset_(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_id_key_oid))),
+        o_d_id_key_pr_offset_(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_d_id_key_oid))),
+        o_w_id_key_pr_offset_(static_cast<uint8_t>(db->order_primary_index_->GetKeyOidToOffsetMap().at(o_w_id_key_oid))),
 
-        ol_amount_oid(db->order_line_schema_.GetColumn(8).Oid()),
-        ol_delivery_d_oid(db->order_line_schema_.GetColumn(6).Oid()),
-        ol_o_id_key_oid(db->order_line_primary_index_schema_.GetColumn(2).Oid()),
-        ol_d_id_key_oid(db->order_line_primary_index_schema_.GetColumn(1).Oid()),
-        ol_w_id_key_oid(db->order_line_primary_index_schema_.GetColumn(0).Oid()),
-        ol_number_key_oid(db->order_line_primary_index_schema_.GetColumn(3).Oid()),
+        ol_amount_oid_(db->order_line_schema_.GetColumn(8).Oid()),
+        ol_delivery_d_oid_(db->order_line_schema_.GetColumn(6).Oid()),
+        ol_o_id_key_oid_(db->order_line_primary_index_schema_.GetColumn(2).Oid()),
+        ol_d_id_key_oid_(db->order_line_primary_index_schema_.GetColumn(1).Oid()),
+        ol_w_id_key_oid_(db->order_line_primary_index_schema_.GetColumn(0).Oid()),
+        ol_number_key_oid_(db->order_line_primary_index_schema_.GetColumn(3).Oid()),
 
-        order_line_select_pr_initializer(
+        order_line_select_pr_initializer_(
             db->order_line_table_->InitializerForProjectedRow({db->order_line_schema_.GetColumn(8).Oid()})),
-        order_line_update_pr_initializer(
+        order_line_update_pr_initializer_(
             db->order_line_table_->InitializerForProjectedRow({db->order_line_schema_.GetColumn(6).Oid()})),
-        ol_o_id_key_pr_offset(
+        ol_o_id_key_pr_offset_(
             static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_o_id_key_oid))),
-        ol_d_id_key_pr_offset(
+        ol_d_id_key_pr_offset_(
             static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_d_id_key_oid))),
-        ol_w_id_key_pr_offset(
+        ol_w_id_key_pr_offset_(
             static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_w_id_key_oid))),
-        ol_number_key_pr_offset(
+        ol_number_key_pr_offset_(
             static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(ol_number_key_oid))),
 
-        c_balance_oid(db->customer_schema_.GetColumn(16).Oid()),
-        c_delivery_cnt_oid(db->customer_schema_.GetColumn(19).Oid()),
-        c_id_key_oid(db->customer_primary_index_schema_.GetColumn(2).Oid()),
-        c_d_id_key_oid(db->customer_primary_index_schema_.GetColumn(1).Oid()),
-        c_w_id_key_oid(db->customer_primary_index_schema_.GetColumn(0).Oid()),
+        c_balance_oid_(db->customer_schema_.GetColumn(16).Oid()),
+        c_delivery_cnt_oid_(db->customer_schema_.GetColumn(19).Oid()),
+        c_id_key_oid_(db->customer_primary_index_schema_.GetColumn(2).Oid()),
+        c_d_id_key_oid_(db->customer_primary_index_schema_.GetColumn(1).Oid()),
+        c_w_id_key_oid_(db->customer_primary_index_schema_.GetColumn(0).Oid()),
 
-        customer_pr_initializer(db->customer_table_->InitializerForProjectedRow({c_balance_oid, c_delivery_cnt_oid})),
-        customer_pr_map(db->customer_table_->ProjectionMapForOids({c_balance_oid, c_delivery_cnt_oid})),
-        c_balance_pr_offset(static_cast<uint8_t>(customer_pr_map.at(c_balance_oid))),
-        c_delivery_cnt_pr_offset(static_cast<uint8_t>(customer_pr_map.at(c_delivery_cnt_oid))),
-        c_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_id_key_oid))),
-        c_d_id_key_pr_offset(
+        customer_pr_initializer_(db->customer_table_->InitializerForProjectedRow({c_balance_oid, c_delivery_cnt_oid})),
+        customer_pr_map_(db->customer_table_->ProjectionMapForOids({c_balance_oid, c_delivery_cnt_oid})),
+        c_balance_pr_offset_(static_cast<uint8_t>(customer_pr_map.at(c_balance_oid))),
+        c_delivery_cnt_pr_offset_(static_cast<uint8_t>(customer_pr_map.at(c_delivery_cnt_oid))),
+        c_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_id_key_oid))),
+        c_d_id_key_pr_offset_(
             static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_d_id_key_oid))),
-        c_w_id_key_pr_offset(
+        c_w_id_key_pr_offset_(
             static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(c_w_id_key_oid)))
 
   {}

--- a/test/include/util/tpcc/loader.h
+++ b/test/include/util/tpcc/loader.h
@@ -965,8 +965,8 @@ struct Loader {
   }
 
   struct OrderTupleResults {
-    uint64_t o_entry_d;
-    int8_t o_ol_cnt;
+    uint64_t o_entry_d_;
+    int8_t o_ol_cnt_;
   };
 
   template <class Random>

--- a/test/include/util/tpcc/loader.h
+++ b/test/include/util/tpcc/loader.h
@@ -149,7 +149,7 @@ struct Loader {
         const auto item_slot = db->item_table_->Insert(txn, item_redo);
 
         // insert in index
-        const auto *const item_key = BuildItemKey(i_id + 1, worker->item_key_buffer, item_key_pr_initializer,
+        const auto *const item_key = BuildItemKey(i_id + 1, worker->item_key_buffer_, item_key_pr_initializer,
                                                   item_key_pr_map, db->item_primary_index_schema_);
         bool UNUSED_ATTRIBUTE index_insert_result = db->item_primary_index_->InsertUnique(txn, *item_key, item_slot);
         TERRIER_ASSERT(index_insert_result, "Item index insertion failed.");
@@ -167,7 +167,7 @@ struct Loader {
 
       // insert in index
       const auto *const warehouse_key =
-          BuildWarehouseKey(static_cast<int8_t>(w_id + 1), worker->warehouse_key_buffer, warehouse_key_pr_initializer,
+          BuildWarehouseKey(static_cast<int8_t>(w_id + 1), worker->warehouse_key_buffer_, warehouse_key_pr_initializer,
                             warehouse_key_pr_map, db->warehouse_primary_index_schema_);
       bool UNUSED_ATTRIBUTE index_insert_result =
           db->warehouse_primary_index_->InsertUnique(txn, *warehouse_key, warehouse_slot);
@@ -194,7 +194,7 @@ struct Loader {
 
           // insert in index
           const auto *const stock_key =
-              BuildStockKey(s_i_id + 1, static_cast<int8_t>(w_id + 1), worker->stock_key_buffer,
+              BuildStockKey(s_i_id + 1, static_cast<int8_t>(w_id + 1), worker->stock_key_buffer_,
                             stock_key_pr_initializer, stock_key_pr_map, db->stock_primary_index_schema_);
           index_insert_result = db->stock_primary_index_->InsertUnique(txn, *stock_key, stock_slot);
           TERRIER_ASSERT(index_insert_result, "Stock index insertion failed.");
@@ -214,7 +214,7 @@ struct Loader {
 
         // insert in index
         const auto *const district_key =
-            BuildDistrictKey(static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1), worker->district_key_buffer,
+            BuildDistrictKey(static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1), worker->district_key_buffer_,
                              district_key_pr_initializer, district_key_pr_map, db->district_primary_index_schema_);
         index_insert_result = db->district_primary_index_->InsertUnique(txn, *district_key, district_slot);
         TERRIER_ASSERT(index_insert_result, "District index insertion failed.");
@@ -245,7 +245,7 @@ struct Loader {
 
           // insert in index
           const auto *const customer_key = BuildCustomerKey(
-              c_id + 1, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1), worker->customer_key_buffer,
+              c_id + 1, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1), worker->customer_key_buffer_,
               customer_key_pr_initializer, customer_key_pr_map, db->customer_primary_index_schema_);
           index_insert_result = db->customer_primary_index_->InsertUnique(txn, *customer_key, customer_slot);
           TERRIER_ASSERT(index_insert_result, "Customer index insertion failed.");
@@ -259,16 +259,16 @@ struct Loader {
           if (c_last_tuple.Size() <= storage::VarlenEntry::InlineThreshold()) {
             customer_name_key =
                 BuildCustomerNameKey(c_last_tuple, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1),
-                                     worker->customer_name_key_buffer, customer_name_key_pr_initializer,
+                                     worker->customer_name_key_buffer_, customer_name_key_pr_initializer,
                                      customer_name_key_pr_map, db->customer_secondary_index_schema_);
           } else {
-            std::memcpy(worker->customer_name_varlen_buffer, c_last_tuple.Content(), c_last_tuple.Size());
+            std::memcpy(worker->customer_name_varlen_buffer_, c_last_tuple.Content(), c_last_tuple.Size());
             const auto c_last_key =
-                storage::VarlenEntry::Create(worker->customer_name_varlen_buffer, c_last_tuple.Size(), false);
+                storage::VarlenEntry::Create(worker->customer_name_varlen_buffer_, c_last_tuple.Size(), false);
 
             customer_name_key =
                 BuildCustomerNameKey(c_last_key, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1),
-                                     worker->customer_name_key_buffer, customer_name_key_pr_initializer,
+                                     worker->customer_name_key_buffer_, customer_name_key_pr_initializer,
                                      customer_name_key_pr_map, db->customer_secondary_index_schema_);
           }
 
@@ -295,7 +295,7 @@ struct Loader {
 
           // insert in index
           const auto *const order_key = BuildOrderKey(
-              o_id + 1, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1), worker->order_key_buffer,
+              o_id + 1, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1), worker->order_key_buffer_,
               order_key_pr_initializer, order_key_pr_map, db->order_primary_index_schema_);
           index_insert_result = db->order_primary_index_->InsertUnique(txn, *order_key, order_slot);
           TERRIER_ASSERT(index_insert_result, "Order index insertion failed.");
@@ -303,7 +303,7 @@ struct Loader {
           // insert in secondary index
           const auto *const order_secondary_key = BuildOrderSecondaryKey(
               o_id + 1, o_c_ids[c_id], static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1),
-              worker->order_secondary_key_buffer, order_secondary_key_pr_initializer, order_secondary_key_pr_map,
+              worker->order_secondary_key_buffer_, order_secondary_key_pr_initializer, order_secondary_key_pr_map,
               db->order_secondary_index_schema_);
           index_insert_result = db->order_secondary_index_->InsertUnique(txn, *order_secondary_key, order_slot);
           TERRIER_ASSERT(index_insert_result, "Order secondary index insertion failed.");
@@ -311,19 +311,19 @@ struct Loader {
           // For each row in the ORDER table:
           // A number of rows in the ORDER-LINE table equal to O_OL_CNT, generated according to the rules for input
           // data generation of the New-Order transaction (see Clause 2.4.1)
-          for (int8_t ol_number = 0; ol_number < order_results.o_ol_cnt; ol_number++) {
+          for (int8_t ol_number = 0; ol_number < order_results.o_ol_cnt_; ol_number++) {
             // insert in table
             auto *const order_line_redo =
                 txn->StageWrite(db->db_oid_, db->order_line_table_oid_, order_line_tuple_pr_initializer);
             BuildOrderLineTuple(o_id + 1, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1),
-                                static_cast<int8_t>(ol_number + 1), order_results.o_entry_d, order_line_redo->Delta(),
+                                static_cast<int8_t>(ol_number + 1), order_results.o_entry_d_, order_line_redo->Delta(),
                                 order_line_tuple_pr_map, db->order_line_schema_, generator);
             const auto order_line_slot = db->order_line_table_->Insert(txn, order_line_redo);
 
             // insert in index
             const auto *const order_line_key = BuildOrderLineKey(
                 o_id + 1, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1),
-                static_cast<int8_t>(ol_number + 1), worker->order_line_key_buffer, order_line_key_pr_initializer,
+                static_cast<int8_t>(ol_number + 1), worker->order_line_key_buffer_, order_line_key_pr_initializer,
                 order_line_key_pr_map, db->order_line_primary_index_schema_);
             index_insert_result = db->order_line_primary_index_->InsertUnique(txn, *order_line_key, order_line_slot);
             TERRIER_ASSERT(index_insert_result, "Order Line index insertion failed.");
@@ -342,7 +342,7 @@ struct Loader {
 
             // insert in index
             const auto *const new_order_key = BuildNewOrderKey(
-                o_id + 1, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1), worker->new_order_key_buffer,
+                o_id + 1, static_cast<int8_t>(d_id + 1), static_cast<int8_t>(w_id + 1), worker->new_order_key_buffer_,
                 new_order_key_pr_initializer, new_order_key_pr_map, db->new_order_primary_index_schema_);
             index_insert_result = db->new_order_primary_index_->InsertUnique(txn, *new_order_key, new_order_slot);
             TERRIER_ASSERT(index_insert_result, "New Order index insertion failed.");

--- a/test/include/util/tpcc/new_order.h
+++ b/test/include/util/tpcc/new_order.h
@@ -145,24 +145,26 @@ class NewOrder {
         // District metadata
         d_tax_oid_(db->district_schema_.GetColumn(8).Oid()),
         d_next_o_id_oid_(db->district_schema_.GetColumn(10).Oid()),
-        district_select_pr_initializer_(db->district_table_->InitializerForProjectedRow({d_tax_oid, d_next_o_id_oid})),
-        district_select_pr_map_(db->district_table_->ProjectionMapForOids({d_tax_oid, d_next_o_id_oid})),
+        district_select_pr_initializer_(
+            db->district_table_->InitializerForProjectedRow({d_tax_oid_, d_next_o_id_oid_})),
+        district_select_pr_map_(db->district_table_->ProjectionMapForOids({d_tax_oid_, d_next_o_id_oid_})),
         d_id_key_pr_offset_(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
             db->district_primary_index_schema_.GetColumn(1).Oid()))),
         d_w_id_key_pr_offset_(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
             db->district_primary_index_schema_.GetColumn(0).Oid()))),
-        d_tax_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map.at(d_tax_oid))),
-        d_next_o_id_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map.at(d_next_o_id_oid))),
-        district_update_pr_initializer_(db->district_table_->InitializerForProjectedRow({d_next_o_id_oid})),
+        d_tax_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map_.at(d_tax_oid_))),
+        d_next_o_id_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map_.at(d_next_o_id_oid_))),
+        district_update_pr_initializer_(db->district_table_->InitializerForProjectedRow({d_next_o_id_oid_})),
 
         // Customer metadata
         c_discount_oid_(db->customer_schema_.GetColumn(15).Oid()),
         c_last_oid_(db->customer_schema_.GetColumn(5).Oid()),
         c_credit_oid_(db->customer_schema_.GetColumn(13).Oid()),
         customer_select_pr_initializer_(
-            db->customer_table_->InitializerForProjectedRow({c_discount_oid, c_last_oid, c_credit_oid})),
-        customer_select_pr_map_(db->customer_table_->ProjectionMapForOids({c_discount_oid, c_last_oid, c_credit_oid})),
-        c_discount_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_discount_oid))),
+            db->customer_table_->InitializerForProjectedRow({c_discount_oid_, c_last_oid_, c_credit_oid_})),
+        customer_select_pr_map_(
+            db->customer_table_->ProjectionMapForOids({c_discount_oid_, c_last_oid_, c_credit_oid_})),
+        c_discount_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_discount_oid_))),
         c_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(2).Oid()))),
         c_d_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
@@ -176,11 +178,11 @@ class NewOrder {
         new_order_insert_pr_map_(
             db->new_order_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->new_order_schema_))),
         no_o_id_insert_pr_offset_(
-            static_cast<uint8_t>(new_order_insert_pr_map.at(db->new_order_schema_.GetColumn(0).Oid()))),
+            static_cast<uint8_t>(new_order_insert_pr_map_.at(db->new_order_schema_.GetColumn(0).Oid()))),
         no_d_id_insert_pr_offset_(
-            static_cast<uint8_t>(new_order_insert_pr_map.at(db->new_order_schema_.GetColumn(1).Oid()))),
+            static_cast<uint8_t>(new_order_insert_pr_map_.at(db->new_order_schema_.GetColumn(1).Oid()))),
         no_w_id_insert_pr_offset_(
-            static_cast<uint8_t>(new_order_insert_pr_map.at(db->new_order_schema_.GetColumn(2).Oid()))),
+            static_cast<uint8_t>(new_order_insert_pr_map_.at(db->new_order_schema_.GetColumn(2).Oid()))),
         no_o_id_key_pr_offset_(static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(
             db->new_order_primary_index_schema_.GetColumn(2).Oid()))),
         no_d_id_key_pr_offset_(static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(
@@ -192,16 +194,17 @@ class NewOrder {
         order_insert_pr_initializer_(
             db->order_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->order_schema_))),
         order_insert_pr_map_(db->order_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->order_schema_))),
-        o_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(0).Oid()))),
-        o_d_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(1).Oid()))),
-        o_w_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(2).Oid()))),
-        o_c_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(3).Oid()))),
-        o_entry_d_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(4).Oid()))),
+        o_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map_.at(db->order_schema_.GetColumn(0).Oid()))),
+        o_d_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map_.at(db->order_schema_.GetColumn(1).Oid()))),
+        o_w_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map_.at(db->order_schema_.GetColumn(2).Oid()))),
+        o_c_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map_.at(db->order_schema_.GetColumn(3).Oid()))),
+        o_entry_d_insert_pr_offset_(
+            static_cast<uint8_t>(order_insert_pr_map_.at(db->order_schema_.GetColumn(4).Oid()))),
         o_carrier_id_insert_pr_offset_(
-            static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(5).Oid()))),
-        o_ol_cnt_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(6).Oid()))),
+            static_cast<uint8_t>(order_insert_pr_map_.at(db->order_schema_.GetColumn(5).Oid()))),
+        o_ol_cnt_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map_.at(db->order_schema_.GetColumn(6).Oid()))),
         o_all_local_insert_pr_offset_(
-            static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(7).Oid()))),
+            static_cast<uint8_t>(order_insert_pr_map_.at(db->order_schema_.GetColumn(7).Oid()))),
         o_id_key_pr_offset_(static_cast<uint8_t>(
             db->order_primary_index_->GetKeyOidToOffsetMap().at(db->order_primary_index_schema_.GetColumn(2).Oid()))),
         o_d_id_key_pr_offset_(static_cast<uint8_t>(
@@ -221,10 +224,11 @@ class NewOrder {
         i_price_oid_(db->item_schema_.GetColumn(3).Oid()),
         i_name_oid_(db->item_schema_.GetColumn(2).Oid()),
         i_data_oid_(db->item_schema_.GetColumn(4).Oid()),
-        item_select_pr_initializer_(db->item_table_->InitializerForProjectedRow({i_price_oid, i_name_oid, i_data_oid})),
-        item_select_pr_map_(db->item_table_->ProjectionMapForOids({i_price_oid, i_name_oid, i_data_oid})),
-        i_price_select_pr_offset_(static_cast<uint8_t>(item_select_pr_map.at(i_price_oid))),
-        i_data_select_pr_offset_(static_cast<uint8_t>(item_select_pr_map.at(i_data_oid))),
+        item_select_pr_initializer_(
+            db->item_table_->InitializerForProjectedRow({i_price_oid_, i_name_oid_, i_data_oid_})),
+        item_select_pr_map_(db->item_table_->ProjectionMapForOids({i_price_oid_, i_name_oid_, i_data_oid_})),
+        i_price_select_pr_offset_(static_cast<uint8_t>(item_select_pr_map_.at(i_price_oid_))),
+        i_data_select_pr_offset_(static_cast<uint8_t>(item_select_pr_map_.at(i_data_oid_))),
 
         // Stock metadata
         s_quantity_oid_(db->stock_schema_.GetColumn(2).Oid()),
@@ -233,14 +237,14 @@ class NewOrder {
         s_remote_cnt_oid_(db->stock_schema_.GetColumn(15).Oid()),
         s_data_oid_(db->stock_schema_.GetColumn(16).Oid()),
         stock_update_pr_initializer_(db->stock_table_->InitializerForProjectedRow(
-            {s_quantity_oid, s_ytd_oid, s_order_cnt_oid, s_remote_cnt_oid})),
+            {s_quantity_oid_, s_ytd_oid_, s_order_cnt_oid_, s_remote_cnt_oid_})),
         stock_update_pr_map_(
-            db->stock_table_->ProjectionMapForOids({s_quantity_oid, s_ytd_oid, s_order_cnt_oid, s_remote_cnt_oid})),
+            db->stock_table_->ProjectionMapForOids({s_quantity_oid_, s_ytd_oid_, s_order_cnt_oid_, s_remote_cnt_oid_})),
 
-        s_quantity_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map.at(s_quantity_oid))),
-        s_ytd_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map.at(s_ytd_oid))),
-        s_order_cnt_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map.at(s_order_cnt_oid))),
-        s_remote_cnt_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map.at(s_remote_cnt_oid))),
+        s_quantity_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map_.at(s_quantity_oid_))),
+        s_ytd_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map_.at(s_ytd_oid_))),
+        s_order_cnt_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map_.at(s_order_cnt_oid_))),
+        s_remote_cnt_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map_.at(s_remote_cnt_oid_))),
         s_i_id_key_pr_offset_(static_cast<uint8_t>(
             db->stock_primary_index_->GetKeyOidToOffsetMap().at(db->stock_primary_index_schema_.GetColumn(1).Oid()))),
         s_w_id_key_pr_offset_(static_cast<uint8_t>(
@@ -252,25 +256,25 @@ class NewOrder {
         order_line_insert_pr_map_(
             db->order_line_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->order_line_schema_))),
         ol_o_id_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(0).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(0).Oid()))),
         ol_d_id_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(1).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(1).Oid()))),
         ol_w_id_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(2).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(2).Oid()))),
         ol_number_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(3).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(3).Oid()))),
         ol_i_id_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(4).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(4).Oid()))),
         ol_supply_w_id_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(5).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(5).Oid()))),
         ol_delivery_d_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(6).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(6).Oid()))),
         ol_quantity_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(7).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(7).Oid()))),
         ol_amount_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(8).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(8).Oid()))),
         ol_dist_info_insert_pr_offset_(
-            static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(9).Oid()))),
+            static_cast<uint8_t>(order_line_insert_pr_map_.at(db->order_line_schema_.GetColumn(9).Oid()))),
         ol_o_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(2).Oid()))),
         ol_d_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
@@ -280,25 +284,25 @@ class NewOrder {
         ol_number_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(3).Oid()))) {
     // Generate metadata for all 10 districts
-    stock_select_initializers.reserve(10);
+    stock_select_initializers_.reserve(10);
     for (uint8_t d_id = 0; d_id < 10; d_id++) {
       const auto s_dist_xx_oid = db->stock_schema_.GetColumn(3 + d_id).Oid();
-      stock_select_initializers.emplace_back(
-          std::pair((db->stock_table_->InitializerForProjectedRow(
-                        {s_quantity_oid, s_dist_xx_oid, s_ytd_oid, s_order_cnt_oid, s_remote_cnt_oid, s_data_oid})),
-                    db->stock_table_->ProjectionMapForOids(
-                        {s_quantity_oid, s_dist_xx_oid, s_ytd_oid, s_order_cnt_oid, s_remote_cnt_oid, s_data_oid})));
+      stock_select_initializers_.emplace_back(std::pair(
+          (db->stock_table_->InitializerForProjectedRow(
+              {s_quantity_oid_, s_dist_xx_oid, s_ytd_oid_, s_order_cnt_oid_, s_remote_cnt_oid_, s_data_oid_})),
+          db->stock_table_->ProjectionMapForOids(
+              {s_quantity_oid_, s_dist_xx_oid, s_ytd_oid_, s_order_cnt_oid_, s_remote_cnt_oid_, s_data_oid_})));
     }
-    stock_select_pr_offsets.reserve(10);
+    stock_select_pr_offsets_.reserve(10);
     for (uint8_t d_id = 0; d_id < 10; d_id++) {
       const auto s_dist_xx_oid = db->stock_schema_.GetColumn(3 + d_id).Oid();
-      stock_select_pr_offsets.push_back(
-          {static_cast<uint8_t>(stock_select_initializers[d_id].second.at(s_quantity_oid)),
-           static_cast<uint8_t>(stock_select_initializers[d_id].second.at(s_dist_xx_oid)),
-           static_cast<uint8_t>(stock_select_initializers[d_id].second.at(s_ytd_oid)),
-           static_cast<uint8_t>(stock_select_initializers[d_id].second.at(s_order_cnt_oid)),
-           static_cast<uint8_t>(stock_select_initializers[d_id].second.at(s_remote_cnt_oid)),
-           static_cast<uint8_t>(stock_select_initializers[d_id].second.at(s_data_oid))});
+      stock_select_pr_offsets_.push_back(
+          {static_cast<uint8_t>(stock_select_initializers_[d_id].second.at(s_quantity_oid_)),
+           static_cast<uint8_t>(stock_select_initializers_[d_id].second.at(s_dist_xx_oid)),
+           static_cast<uint8_t>(stock_select_initializers_[d_id].second.at(s_ytd_oid_)),
+           static_cast<uint8_t>(stock_select_initializers_[d_id].second.at(s_order_cnt_oid_)),
+           static_cast<uint8_t>(stock_select_initializers_[d_id].second.at(s_remote_cnt_oid_)),
+           static_cast<uint8_t>(stock_select_initializers_[d_id].second.at(s_data_oid_))});
     }
   }
 

--- a/test/include/util/tpcc/new_order.h
+++ b/test/include/util/tpcc/new_order.h
@@ -22,262 +22,262 @@ class NewOrder {
  private:
   // Struct for deferred index inserts after New Order is guaranteed to commit
   struct OrderLineIndexInserts {
-    const int32_t o_id;
-    const int8_t d_id;
-    const int8_t w_id;
-    const int8_t ol_number;
-    storage::TupleSlot slot;
+    const int32_t o_id_;
+    const int8_t d_id_;
+    const int8_t w_id_;
+    const int8_t ol_number_;
+    storage::TupleSlot slot_;
   };
 
   // Warehouse metadata
-  const storage::ProjectedRowInitializer warehouse_select_pr_initializer;
+  const storage::ProjectedRowInitializer warehouse_select_pr_initializer_;
 
   // District metadata
-  const catalog::col_oid_t d_tax_oid;
-  const catalog::col_oid_t d_next_o_id_oid;
-  const storage::ProjectedRowInitializer district_select_pr_initializer;
-  const storage::ProjectionMap district_select_pr_map;
-  const uint8_t d_id_key_pr_offset;
-  const uint8_t d_w_id_key_pr_offset;
-  const uint8_t d_tax_select_pr_offset;
-  const uint8_t d_next_o_id_select_pr_offset;
-  const storage::ProjectedRowInitializer district_update_pr_initializer;
+  const catalog::col_oid_t d_tax_oid_;
+  const catalog::col_oid_t d_next_o_id_oid_;
+  const storage::ProjectedRowInitializer district_select_pr_initializer_;
+  const storage::ProjectionMap district_select_pr_map_;
+  const uint8_t d_id_key_pr_offset_;
+  const uint8_t d_w_id_key_pr_offset_;
+  const uint8_t d_tax_select_pr_offset_;
+  const uint8_t d_next_o_id_select_pr_offset_;
+  const storage::ProjectedRowInitializer district_update_pr_initializer_;
 
   // Customer metadata
-  const catalog::col_oid_t c_discount_oid;
-  const catalog::col_oid_t c_last_oid;
-  const catalog::col_oid_t c_credit_oid;
-  const storage::ProjectedRowInitializer customer_select_pr_initializer;
-  const storage::ProjectionMap customer_select_pr_map;
-  const uint8_t c_discount_select_pr_offset;
-  const uint8_t c_id_key_pr_offset;
-  const uint8_t c_d_id_key_pr_offset;
-  const uint8_t c_w_id_key_pr_offset;
+  const catalog::col_oid_t c_discount_oid_;
+  const catalog::col_oid_t c_last_oid_;
+  const catalog::col_oid_t c_credit_oid_;
+  const storage::ProjectedRowInitializer customer_select_pr_initializer_;
+  const storage::ProjectionMap customer_select_pr_map_;
+  const uint8_t c_discount_select_pr_offset_;
+  const uint8_t c_id_key_pr_offset_;
+  const uint8_t c_d_id_key_pr_offset_;
+  const uint8_t c_w_id_key_pr_offset_;
 
   // New Order metadata
-  const storage::ProjectedRowInitializer new_order_insert_pr_initializer;
-  const storage::ProjectionMap new_order_insert_pr_map;
-  const uint8_t no_o_id_insert_pr_offset;
-  const uint8_t no_d_id_insert_pr_offset;
-  const uint8_t no_w_id_insert_pr_offset;
-  const uint8_t no_o_id_key_pr_offset;
-  const uint8_t no_d_id_key_pr_offset;
-  const uint8_t no_w_id_key_pr_offset;
+  const storage::ProjectedRowInitializer new_order_insert_pr_initializer_;
+  const storage::ProjectionMap new_order_insert_pr_map_;
+  const uint8_t no_o_id_insert_pr_offset_;
+  const uint8_t no_d_id_insert_pr_offset_;
+  const uint8_t no_w_id_insert_pr_offset_;
+  const uint8_t no_o_id_key_pr_offset_;
+  const uint8_t no_d_id_key_pr_offset_;
+  const uint8_t no_w_id_key_pr_offset_;
 
   // Order metadata
-  const storage::ProjectedRowInitializer order_insert_pr_initializer;
-  const storage::ProjectionMap order_insert_pr_map;
-  const uint8_t o_id_insert_pr_offset;
-  const uint8_t o_d_id_insert_pr_offset;
-  const uint8_t o_w_id_insert_pr_offset;
-  const uint8_t o_c_id_insert_pr_offset;
-  const uint8_t o_entry_d_insert_pr_offset;
-  const uint8_t o_carrier_id_insert_pr_offset;
-  const uint8_t o_ol_cnt_insert_pr_offset;
-  const uint8_t o_all_local_insert_pr_offset;
-  const uint8_t o_id_key_pr_offset;
-  const uint8_t o_d_id_key_pr_offset;
-  const uint8_t o_w_id_key_pr_offset;
-  const uint8_t o_id_secondary_key_pr_offset;
-  const uint8_t o_d_id_secondary_key_pr_offset;
-  const uint8_t o_w_id_secondary_key_pr_offset;
-  const uint8_t o_c_id_secondary_key_pr_offset;
+  const storage::ProjectedRowInitializer order_insert_pr_initializer_;
+  const storage::ProjectionMap order_insert_pr_map_;
+  const uint8_t o_id_insert_pr_offset_;
+  const uint8_t o_d_id_insert_pr_offset_;
+  const uint8_t o_w_id_insert_pr_offset_;
+  const uint8_t o_c_id_insert_pr_offset_;
+  const uint8_t o_entry_d_insert_pr_offset_;
+  const uint8_t o_carrier_id_insert_pr_offset_;
+  const uint8_t o_ol_cnt_insert_pr_offset_;
+  const uint8_t o_all_local_insert_pr_offset_;
+  const uint8_t o_id_key_pr_offset_;
+  const uint8_t o_d_id_key_pr_offset_;
+  const uint8_t o_w_id_key_pr_offset_;
+  const uint8_t o_id_secondary_key_pr_offset_;
+  const uint8_t o_d_id_secondary_key_pr_offset_;
+  const uint8_t o_w_id_secondary_key_pr_offset_;
+  const uint8_t o_c_id_secondary_key_pr_offset_;
 
   // Item metadata
-  const catalog::col_oid_t i_price_oid;
-  const catalog::col_oid_t i_name_oid;
-  const catalog::col_oid_t i_data_oid;
-  const storage::ProjectedRowInitializer item_select_pr_initializer;
-  const storage::ProjectionMap item_select_pr_map;
-  const uint8_t i_price_select_pr_offset;
-  const uint8_t i_data_select_pr_offset;
+  const catalog::col_oid_t i_price_oid_;
+  const catalog::col_oid_t i_name_oid_;
+  const catalog::col_oid_t i_data_oid_;
+  const storage::ProjectedRowInitializer item_select_pr_initializer_;
+  const storage::ProjectionMap item_select_pr_map_;
+  const uint8_t i_price_select_pr_offset_;
+  const uint8_t i_data_select_pr_offset_;
 
   // Stock metadata
   struct StockSelectPROffsets {
-    const uint8_t s_quantity_select_pr_offset;
-    const uint8_t s_dist_xx_select_pr_offset;
-    const uint8_t s_ytd_select_pr_offset;
-    const uint8_t s_order_cnt_select_pr_offset;
-    const uint8_t s_remote_cnt_select_pr_offset;
-    const uint8_t s_data_select_pr_offset;
+    const uint8_t s_quantity_select_pr_offset_;
+    const uint8_t s_dist_xx_select_pr_offset_;
+    const uint8_t s_ytd_select_pr_offset_;
+    const uint8_t s_order_cnt_select_pr_offset_;
+    const uint8_t s_remote_cnt_select_pr_offset_;
+    const uint8_t s_data_select_pr_offset_;
   };
-  const catalog::col_oid_t s_quantity_oid;
-  const catalog::col_oid_t s_ytd_oid;
-  const catalog::col_oid_t s_order_cnt_oid;
-  const catalog::col_oid_t s_remote_cnt_oid;
-  const catalog::col_oid_t s_data_oid;
-  const storage::ProjectedRowInitializer stock_update_pr_initializer;
-  const storage::ProjectionMap stock_update_pr_map;
-  const uint8_t s_quantity_update_pr_offset;
-  const uint8_t s_ytd_update_pr_offset;
-  const uint8_t s_order_cnt_update_pr_offset;
-  const uint8_t s_remote_cnt_update_pr_offset;
-  const uint8_t s_i_id_key_pr_offset;
-  const uint8_t s_w_id_key_pr_offset;
-  std::vector<StockSelectPROffsets> stock_select_pr_offsets;
-  std::vector<std::pair<storage::ProjectedRowInitializer, storage::ProjectionMap>> stock_select_initializers;
+  const catalog::col_oid_t s_quantity_oid_;
+  const catalog::col_oid_t s_ytd_oid_;
+  const catalog::col_oid_t s_order_cnt_oid_;
+  const catalog::col_oid_t s_remote_cnt_oid_;
+  const catalog::col_oid_t s_data_oid_;
+  const storage::ProjectedRowInitializer stock_update_pr_initializer_;
+  const storage::ProjectionMap stock_update_pr_map_;
+  const uint8_t s_quantity_update_pr_offset_;
+  const uint8_t s_ytd_update_pr_offset_;
+  const uint8_t s_order_cnt_update_pr_offset_;
+  const uint8_t s_remote_cnt_update_pr_offset_;
+  const uint8_t s_i_id_key_pr_offset_;
+  const uint8_t s_w_id_key_pr_offset_;
+  std::vector<StockSelectPROffsets> stock_select_pr_offsets_;
+  std::vector<std::pair<storage::ProjectedRowInitializer, storage::ProjectionMap>> stock_select_initializers_;
 
   // Order Line metadata
-  const storage::ProjectedRowInitializer order_line_insert_pr_initializer;
-  const storage::ProjectionMap order_line_insert_pr_map;
-  const uint8_t ol_o_id_insert_pr_offset;
-  const uint8_t ol_d_id_insert_pr_offset;
-  const uint8_t ol_w_id_insert_pr_offset;
-  const uint8_t ol_number_insert_pr_offset;
-  const uint8_t ol_i_id_insert_pr_offset;
-  const uint8_t ol_supply_w_id_insert_pr_offset;
-  const uint8_t ol_delivery_d_insert_pr_offset;
-  const uint8_t ol_quantity_insert_pr_offset;
-  const uint8_t ol_amount_insert_pr_offset;
-  const uint8_t ol_dist_info_insert_pr_offset;
-  const uint8_t ol_o_id_key_pr_offset;
-  const uint8_t ol_d_id_key_pr_offset;
-  const uint8_t ol_w_id_key_pr_offset;
-  const uint8_t ol_number_key_pr_offset;
+  const storage::ProjectedRowInitializer order_line_insert_pr_initializer_;
+  const storage::ProjectionMap order_line_insert_pr_map_;
+  const uint8_t ol_o_id_insert_pr_offset_;
+  const uint8_t ol_d_id_insert_pr_offset_;
+  const uint8_t ol_w_id_insert_pr_offset_;
+  const uint8_t ol_number_insert_pr_offset_;
+  const uint8_t ol_i_id_insert_pr_offset_;
+  const uint8_t ol_supply_w_id_insert_pr_offset_;
+  const uint8_t ol_delivery_d_insert_pr_offset_;
+  const uint8_t ol_quantity_insert_pr_offset_;
+  const uint8_t ol_amount_insert_pr_offset_;
+  const uint8_t ol_dist_info_insert_pr_offset_;
+  const uint8_t ol_o_id_key_pr_offset_;
+  const uint8_t ol_d_id_key_pr_offset_;
+  const uint8_t ol_w_id_key_pr_offset_;
+  const uint8_t ol_number_key_pr_offset_;
 
  public:
   explicit NewOrder(const Database *const db)
 
       :  // Warehouse metadata
-        warehouse_select_pr_initializer(
+        warehouse_select_pr_initializer_(
             db->warehouse_table_->InitializerForProjectedRow({db->warehouse_schema_.GetColumn(7).Oid()})),
 
         // District metadata
-        d_tax_oid(db->district_schema_.GetColumn(8).Oid()),
-        d_next_o_id_oid(db->district_schema_.GetColumn(10).Oid()),
-        district_select_pr_initializer(db->district_table_->InitializerForProjectedRow({d_tax_oid, d_next_o_id_oid})),
-        district_select_pr_map(db->district_table_->ProjectionMapForOids({d_tax_oid, d_next_o_id_oid})),
-        d_id_key_pr_offset(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
+        d_tax_oid_(db->district_schema_.GetColumn(8).Oid()),
+        d_next_o_id_oid_(db->district_schema_.GetColumn(10).Oid()),
+        district_select_pr_initializer_(db->district_table_->InitializerForProjectedRow({d_tax_oid, d_next_o_id_oid})),
+        district_select_pr_map_(db->district_table_->ProjectionMapForOids({d_tax_oid, d_next_o_id_oid})),
+        d_id_key_pr_offset_(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
             db->district_primary_index_schema_.GetColumn(1).Oid()))),
-        d_w_id_key_pr_offset(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
+        d_w_id_key_pr_offset_(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
             db->district_primary_index_schema_.GetColumn(0).Oid()))),
-        d_tax_select_pr_offset(static_cast<uint8_t>(district_select_pr_map.at(d_tax_oid))),
-        d_next_o_id_select_pr_offset(static_cast<uint8_t>(district_select_pr_map.at(d_next_o_id_oid))),
-        district_update_pr_initializer(db->district_table_->InitializerForProjectedRow({d_next_o_id_oid})),
+        d_tax_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map.at(d_tax_oid))),
+        d_next_o_id_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map.at(d_next_o_id_oid))),
+        district_update_pr_initializer_(db->district_table_->InitializerForProjectedRow({d_next_o_id_oid})),
 
         // Customer metadata
-        c_discount_oid(db->customer_schema_.GetColumn(15).Oid()),
-        c_last_oid(db->customer_schema_.GetColumn(5).Oid()),
-        c_credit_oid(db->customer_schema_.GetColumn(13).Oid()),
-        customer_select_pr_initializer(
+        c_discount_oid_(db->customer_schema_.GetColumn(15).Oid()),
+        c_last_oid_(db->customer_schema_.GetColumn(5).Oid()),
+        c_credit_oid_(db->customer_schema_.GetColumn(13).Oid()),
+        customer_select_pr_initializer_(
             db->customer_table_->InitializerForProjectedRow({c_discount_oid, c_last_oid, c_credit_oid})),
-        customer_select_pr_map(db->customer_table_->ProjectionMapForOids({c_discount_oid, c_last_oid, c_credit_oid})),
-        c_discount_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_discount_oid))),
-        c_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
+        customer_select_pr_map_(db->customer_table_->ProjectionMapForOids({c_discount_oid, c_last_oid, c_credit_oid})),
+        c_discount_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_discount_oid))),
+        c_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(2).Oid()))),
-        c_d_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
+        c_d_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(1).Oid()))),
-        c_w_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
+        c_w_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(0).Oid()))),
 
         // New Order metadata
-        new_order_insert_pr_initializer(
+        new_order_insert_pr_initializer_(
             db->new_order_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->new_order_schema_))),
-        new_order_insert_pr_map(
+        new_order_insert_pr_map_(
             db->new_order_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->new_order_schema_))),
-        no_o_id_insert_pr_offset(
+        no_o_id_insert_pr_offset_(
             static_cast<uint8_t>(new_order_insert_pr_map.at(db->new_order_schema_.GetColumn(0).Oid()))),
-        no_d_id_insert_pr_offset(
+        no_d_id_insert_pr_offset_(
             static_cast<uint8_t>(new_order_insert_pr_map.at(db->new_order_schema_.GetColumn(1).Oid()))),
-        no_w_id_insert_pr_offset(
+        no_w_id_insert_pr_offset_(
             static_cast<uint8_t>(new_order_insert_pr_map.at(db->new_order_schema_.GetColumn(2).Oid()))),
-        no_o_id_key_pr_offset(static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(
+        no_o_id_key_pr_offset_(static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(
             db->new_order_primary_index_schema_.GetColumn(2).Oid()))),
-        no_d_id_key_pr_offset(static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(
+        no_d_id_key_pr_offset_(static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(
             db->new_order_primary_index_schema_.GetColumn(1).Oid()))),
-        no_w_id_key_pr_offset(static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(
+        no_w_id_key_pr_offset_(static_cast<uint8_t>(db->new_order_primary_index_->GetKeyOidToOffsetMap().at(
             db->new_order_primary_index_schema_.GetColumn(0).Oid()))),
 
         // Order metadata
-        order_insert_pr_initializer(
+        order_insert_pr_initializer_(
             db->order_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->order_schema_))),
-        order_insert_pr_map(db->order_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->order_schema_))),
-        o_id_insert_pr_offset(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(0).Oid()))),
-        o_d_id_insert_pr_offset(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(1).Oid()))),
-        o_w_id_insert_pr_offset(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(2).Oid()))),
-        o_c_id_insert_pr_offset(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(3).Oid()))),
-        o_entry_d_insert_pr_offset(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(4).Oid()))),
-        o_carrier_id_insert_pr_offset(
+        order_insert_pr_map_(db->order_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->order_schema_))),
+        o_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(0).Oid()))),
+        o_d_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(1).Oid()))),
+        o_w_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(2).Oid()))),
+        o_c_id_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(3).Oid()))),
+        o_entry_d_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(4).Oid()))),
+        o_carrier_id_insert_pr_offset_(
             static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(5).Oid()))),
-        o_ol_cnt_insert_pr_offset(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(6).Oid()))),
-        o_all_local_insert_pr_offset(
+        o_ol_cnt_insert_pr_offset_(static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(6).Oid()))),
+        o_all_local_insert_pr_offset_(
             static_cast<uint8_t>(order_insert_pr_map.at(db->order_schema_.GetColumn(7).Oid()))),
-        o_id_key_pr_offset(static_cast<uint8_t>(
+        o_id_key_pr_offset_(static_cast<uint8_t>(
             db->order_primary_index_->GetKeyOidToOffsetMap().at(db->order_primary_index_schema_.GetColumn(2).Oid()))),
-        o_d_id_key_pr_offset(static_cast<uint8_t>(
+        o_d_id_key_pr_offset_(static_cast<uint8_t>(
             db->order_primary_index_->GetKeyOidToOffsetMap().at(db->order_primary_index_schema_.GetColumn(1).Oid()))),
-        o_w_id_key_pr_offset(static_cast<uint8_t>(
+        o_w_id_key_pr_offset_(static_cast<uint8_t>(
             db->order_primary_index_->GetKeyOidToOffsetMap().at(db->order_primary_index_schema_.GetColumn(0).Oid()))),
-        o_id_secondary_key_pr_offset(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
+        o_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
             db->order_secondary_index_schema_.GetColumn(3).Oid()))),
-        o_d_id_secondary_key_pr_offset(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
+        o_d_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
             db->order_secondary_index_schema_.GetColumn(1).Oid()))),
-        o_w_id_secondary_key_pr_offset(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
+        o_w_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
             db->order_secondary_index_schema_.GetColumn(0).Oid()))),
-        o_c_id_secondary_key_pr_offset(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
+        o_c_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
             db->order_secondary_index_schema_.GetColumn(2).Oid()))),
 
         // Item metadata
-        i_price_oid(db->item_schema_.GetColumn(3).Oid()),
-        i_name_oid(db->item_schema_.GetColumn(2).Oid()),
-        i_data_oid(db->item_schema_.GetColumn(4).Oid()),
-        item_select_pr_initializer(db->item_table_->InitializerForProjectedRow({i_price_oid, i_name_oid, i_data_oid})),
-        item_select_pr_map(db->item_table_->ProjectionMapForOids({i_price_oid, i_name_oid, i_data_oid})),
-        i_price_select_pr_offset(static_cast<uint8_t>(item_select_pr_map.at(i_price_oid))),
-        i_data_select_pr_offset(static_cast<uint8_t>(item_select_pr_map.at(i_data_oid))),
+        i_price_oid_(db->item_schema_.GetColumn(3).Oid()),
+        i_name_oid_(db->item_schema_.GetColumn(2).Oid()),
+        i_data_oid_(db->item_schema_.GetColumn(4).Oid()),
+        item_select_pr_initializer_(db->item_table_->InitializerForProjectedRow({i_price_oid, i_name_oid, i_data_oid})),
+        item_select_pr_map_(db->item_table_->ProjectionMapForOids({i_price_oid, i_name_oid, i_data_oid})),
+        i_price_select_pr_offset_(static_cast<uint8_t>(item_select_pr_map.at(i_price_oid))),
+        i_data_select_pr_offset_(static_cast<uint8_t>(item_select_pr_map.at(i_data_oid))),
 
         // Stock metadata
-        s_quantity_oid(db->stock_schema_.GetColumn(2).Oid()),
-        s_ytd_oid(db->stock_schema_.GetColumn(13).Oid()),
-        s_order_cnt_oid(db->stock_schema_.GetColumn(14).Oid()),
-        s_remote_cnt_oid(db->stock_schema_.GetColumn(15).Oid()),
-        s_data_oid(db->stock_schema_.GetColumn(16).Oid()),
-        stock_update_pr_initializer(db->stock_table_->InitializerForProjectedRow(
+        s_quantity_oid_(db->stock_schema_.GetColumn(2).Oid()),
+        s_ytd_oid_(db->stock_schema_.GetColumn(13).Oid()),
+        s_order_cnt_oid_(db->stock_schema_.GetColumn(14).Oid()),
+        s_remote_cnt_oid_(db->stock_schema_.GetColumn(15).Oid()),
+        s_data_oid_(db->stock_schema_.GetColumn(16).Oid()),
+        stock_update_pr_initializer_(db->stock_table_->InitializerForProjectedRow(
             {s_quantity_oid, s_ytd_oid, s_order_cnt_oid, s_remote_cnt_oid})),
-        stock_update_pr_map(
+        stock_update_pr_map_(
             db->stock_table_->ProjectionMapForOids({s_quantity_oid, s_ytd_oid, s_order_cnt_oid, s_remote_cnt_oid})),
 
-        s_quantity_update_pr_offset(static_cast<uint8_t>(stock_update_pr_map.at(s_quantity_oid))),
-        s_ytd_update_pr_offset(static_cast<uint8_t>(stock_update_pr_map.at(s_ytd_oid))),
-        s_order_cnt_update_pr_offset(static_cast<uint8_t>(stock_update_pr_map.at(s_order_cnt_oid))),
-        s_remote_cnt_update_pr_offset(static_cast<uint8_t>(stock_update_pr_map.at(s_remote_cnt_oid))),
-        s_i_id_key_pr_offset(static_cast<uint8_t>(
+        s_quantity_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map.at(s_quantity_oid))),
+        s_ytd_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map.at(s_ytd_oid))),
+        s_order_cnt_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map.at(s_order_cnt_oid))),
+        s_remote_cnt_update_pr_offset_(static_cast<uint8_t>(stock_update_pr_map.at(s_remote_cnt_oid))),
+        s_i_id_key_pr_offset_(static_cast<uint8_t>(
             db->stock_primary_index_->GetKeyOidToOffsetMap().at(db->stock_primary_index_schema_.GetColumn(1).Oid()))),
-        s_w_id_key_pr_offset(static_cast<uint8_t>(
+        s_w_id_key_pr_offset_(static_cast<uint8_t>(
             db->stock_primary_index_->GetKeyOidToOffsetMap().at(db->stock_primary_index_schema_.GetColumn(0).Oid()))),
 
         // Order Line metadata
-        order_line_insert_pr_initializer(
+        order_line_insert_pr_initializer_(
             db->order_line_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->order_line_schema_))),
-        order_line_insert_pr_map(
+        order_line_insert_pr_map_(
             db->order_line_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->order_line_schema_))),
-        ol_o_id_insert_pr_offset(
+        ol_o_id_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(0).Oid()))),
-        ol_d_id_insert_pr_offset(
+        ol_d_id_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(1).Oid()))),
-        ol_w_id_insert_pr_offset(
+        ol_w_id_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(2).Oid()))),
-        ol_number_insert_pr_offset(
+        ol_number_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(3).Oid()))),
-        ol_i_id_insert_pr_offset(
+        ol_i_id_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(4).Oid()))),
-        ol_supply_w_id_insert_pr_offset(
+        ol_supply_w_id_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(5).Oid()))),
-        ol_delivery_d_insert_pr_offset(
+        ol_delivery_d_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(6).Oid()))),
-        ol_quantity_insert_pr_offset(
+        ol_quantity_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(7).Oid()))),
-        ol_amount_insert_pr_offset(
+        ol_amount_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(8).Oid()))),
-        ol_dist_info_insert_pr_offset(
+        ol_dist_info_insert_pr_offset_(
             static_cast<uint8_t>(order_line_insert_pr_map.at(db->order_line_schema_.GetColumn(9).Oid()))),
-        ol_o_id_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_o_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(2).Oid()))),
-        ol_d_id_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_d_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(1).Oid()))),
-        ol_w_id_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_w_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(0).Oid()))),
-        ol_number_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_number_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(3).Oid()))) {
     // Generate metadata for all 10 districts
     stock_select_initializers.reserve(10);

--- a/test/include/util/tpcc/order_status.h
+++ b/test/include/util/tpcc/order_status.h
@@ -86,17 +86,17 @@ class OrderStatus {
         c_middle_oid_(db->customer_schema_.GetColumn(4).Oid()),
         c_last_oid_(db->customer_schema_.GetColumn(5).Oid()),
 
-        c_first_pr_initializer_(db->customer_table_->InitializerForProjectedRow({c_first_oid})),
+        c_first_pr_initializer_(db->customer_table_->InitializerForProjectedRow({c_first_oid_})),
         customer_select_pr_initializer_(db->customer_table_->InitializerForProjectedRow(
-            {c_id_oid, c_balance_oid, c_first_oid, c_middle_oid, c_last_oid})),
+            {c_id_oid_, c_balance_oid_, c_first_oid_, c_middle_oid_, c_last_oid_})),
         customer_select_pr_map_(db->customer_table_->ProjectionMapForOids(
-            {c_id_oid, c_balance_oid, c_first_oid, c_middle_oid, c_last_oid})),
+            {c_id_oid_, c_balance_oid_, c_first_oid_, c_middle_oid_, c_last_oid_})),
 
-        c_id_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_id_oid))),
-        c_balance_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_balance_oid))),
-        c_first_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_first_oid))),
-        c_middle_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_middle_oid))),
-        c_last_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_last_oid))),
+        c_id_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_id_oid_))),
+        c_balance_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_balance_oid_))),
+        c_first_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_first_oid_))),
+        c_middle_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_middle_oid_))),
+        c_last_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_last_oid_))),
         o_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
             db->order_secondary_index_schema_.GetColumn(3).Oid()))),
         o_d_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
@@ -109,9 +109,9 @@ class OrderStatus {
         o_entry_d_oid_(db->order_schema_.GetColumn(4).Oid()),
         o_carrier_id_oid_(db->order_schema_.GetColumn(5).Oid()),
         order_select_pr_initializer_(
-            db->order_table_->InitializerForProjectedRow({o_id_oid, o_entry_d_oid, o_carrier_id_oid})),
-        order_select_pr_map_(db->order_table_->ProjectionMapForOids({o_id_oid, o_entry_d_oid, o_carrier_id_oid})),
-        o_id_select_pr_offset_(static_cast<uint8_t>(order_select_pr_map.at(o_id_oid))),
+            db->order_table_->InitializerForProjectedRow({o_id_oid_, o_entry_d_oid_, o_carrier_id_oid_})),
+        order_select_pr_map_(db->order_table_->ProjectionMapForOids({o_id_oid_, o_entry_d_oid_, o_carrier_id_oid_})),
+        o_id_select_pr_offset_(static_cast<uint8_t>(order_select_pr_map_.at(o_id_oid_))),
         ol_o_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(2).Oid()))),
         ol_d_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
@@ -127,7 +127,7 @@ class OrderStatus {
         ol_amount_oid_(db->order_line_schema_.GetColumn(8).Oid()),
         ol_delivery_d_oid_(db->order_line_schema_.GetColumn(6).Oid()),
         order_line_select_pr_initializer_(db->order_line_table_->InitializerForProjectedRow(
-            {ol_i_id_oid, ol_supply_w_id_oid, ol_quantity_oid, ol_amount_oid, ol_delivery_d_oid}))
+            {ol_i_id_oid_, ol_supply_w_id_oid_, ol_quantity_oid_, ol_amount_oid_, ol_delivery_d_oid_}))
 
   {}
 

--- a/test/include/util/tpcc/order_status.h
+++ b/test/include/util/tpcc/order_status.h
@@ -21,112 +21,112 @@ namespace terrier::tpcc {
 class OrderStatus {
  private:
   // Customer metadata
-  const uint8_t c_id_key_pr_offset;
-  const uint8_t c_d_id_key_pr_offset;
-  const uint8_t c_w_id_key_pr_offset;
-  const uint8_t c_last_name_key_pr_offset;
-  const uint8_t c_d_id_name_key_pr_offset;
-  const uint8_t c_w_id_name_key_pr_offset;
-  const catalog::col_oid_t c_id_oid;
-  const catalog::col_oid_t c_balance_oid;
-  const catalog::col_oid_t c_first_oid;
-  const catalog::col_oid_t c_middle_oid;
-  const catalog::col_oid_t c_last_oid;
-  const storage::ProjectedRowInitializer c_first_pr_initializer;
-  const storage::ProjectedRowInitializer customer_select_pr_initializer;
-  const storage::ProjectionMap customer_select_pr_map;
-  const uint8_t c_id_select_pr_offset;
-  const uint8_t c_balance_select_pr_offset;
-  const uint8_t c_first_select_pr_offset;
-  const uint8_t c_middle_select_pr_offset;
-  const uint8_t c_last_select_pr_offset;
+  const uint8_t c_id_key_pr_offset_;
+  const uint8_t c_d_id_key_pr_offset_;
+  const uint8_t c_w_id_key_pr_offset_;
+  const uint8_t c_last_name_key_pr_offset_;
+  const uint8_t c_d_id_name_key_pr_offset_;
+  const uint8_t c_w_id_name_key_pr_offset_;
+  const catalog::col_oid_t c_id_oid_;
+  const catalog::col_oid_t c_balance_oid_;
+  const catalog::col_oid_t c_first_oid_;
+  const catalog::col_oid_t c_middle_oid_;
+  const catalog::col_oid_t c_last_oid_;
+  const storage::ProjectedRowInitializer c_first_pr_initializer_;
+  const storage::ProjectedRowInitializer customer_select_pr_initializer_;
+  const storage::ProjectionMap customer_select_pr_map_;
+  const uint8_t c_id_select_pr_offset_;
+  const uint8_t c_balance_select_pr_offset_;
+  const uint8_t c_first_select_pr_offset_;
+  const uint8_t c_middle_select_pr_offset_;
+  const uint8_t c_last_select_pr_offset_;
 
   // Order metadata
-  const uint8_t o_id_secondary_key_pr_offset;
-  const uint8_t o_d_id_secondary_key_pr_offset;
-  const uint8_t o_w_id_secondary_key_pr_offset;
-  const uint8_t o_c_id_secondary_key_pr_offset;
-  const catalog::col_oid_t o_id_oid;
-  const catalog::col_oid_t o_entry_d_oid;
-  const catalog::col_oid_t o_carrier_id_oid;
-  const storage::ProjectedRowInitializer order_select_pr_initializer;
-  const storage::ProjectionMap order_select_pr_map;
-  const uint8_t o_id_select_pr_offset;
+  const uint8_t o_id_secondary_key_pr_offset_;
+  const uint8_t o_d_id_secondary_key_pr_offset_;
+  const uint8_t o_w_id_secondary_key_pr_offset_;
+  const uint8_t o_c_id_secondary_key_pr_offset_;
+  const catalog::col_oid_t o_id_oid_;
+  const catalog::col_oid_t o_entry_d_oid_;
+  const catalog::col_oid_t o_carrier_id_oid_;
+  const storage::ProjectedRowInitializer order_select_pr_initializer_;
+  const storage::ProjectionMap order_select_pr_map_;
+  const uint8_t o_id_select_pr_offset_;
 
   // Order Line metadata
-  const uint8_t ol_o_id_key_pr_offset;
-  const uint8_t ol_d_id_key_pr_offset;
-  const uint8_t ol_w_id_key_pr_offset;
-  const uint8_t ol_number_key_pr_offset;
-  const catalog::col_oid_t ol_i_id_oid;
-  const catalog::col_oid_t ol_supply_w_id_oid;
-  const catalog::col_oid_t ol_quantity_oid;
-  const catalog::col_oid_t ol_amount_oid;
-  const catalog::col_oid_t ol_delivery_d_oid;
-  const storage::ProjectedRowInitializer order_line_select_pr_initializer;
+  const uint8_t ol_o_id_key_pr_offset_;
+  const uint8_t ol_d_id_key_pr_offset_;
+  const uint8_t ol_w_id_key_pr_offset_;
+  const uint8_t ol_number_key_pr_offset_;
+  const catalog::col_oid_t ol_i_id_oid_;
+  const catalog::col_oid_t ol_supply_w_id_oid_;
+  const catalog::col_oid_t ol_quantity_oid_;
+  const catalog::col_oid_t ol_amount_oid_;
+  const catalog::col_oid_t ol_delivery_d_oid_;
+  const storage::ProjectedRowInitializer order_line_select_pr_initializer_;
 
  public:
   explicit OrderStatus(const Database *const db)
-      : c_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
+      : c_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(2).Oid()))),
-        c_d_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
+        c_d_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(1).Oid()))),
-        c_w_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
+        c_w_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(0).Oid()))),
-        c_last_name_key_pr_offset(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
+        c_last_name_key_pr_offset_(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
             db->customer_secondary_index_schema_.GetColumn(2).Oid()))),
-        c_d_id_name_key_pr_offset(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
+        c_d_id_name_key_pr_offset_(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
             db->customer_secondary_index_schema_.GetColumn(1).Oid()))),
-        c_w_id_name_key_pr_offset(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
+        c_w_id_name_key_pr_offset_(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
             db->customer_secondary_index_schema_.GetColumn(0).Oid()))),
 
-        c_id_oid(db->customer_schema_.GetColumn(0).Oid()),
-        c_balance_oid(db->customer_schema_.GetColumn(16).Oid()),
-        c_first_oid(db->customer_schema_.GetColumn(3).Oid()),
-        c_middle_oid(db->customer_schema_.GetColumn(4).Oid()),
-        c_last_oid(db->customer_schema_.GetColumn(5).Oid()),
+        c_id_oid_(db->customer_schema_.GetColumn(0).Oid()),
+        c_balance_oid_(db->customer_schema_.GetColumn(16).Oid()),
+        c_first_oid_(db->customer_schema_.GetColumn(3).Oid()),
+        c_middle_oid_(db->customer_schema_.GetColumn(4).Oid()),
+        c_last_oid_(db->customer_schema_.GetColumn(5).Oid()),
 
-        c_first_pr_initializer(db->customer_table_->InitializerForProjectedRow({c_first_oid})),
-        customer_select_pr_initializer(db->customer_table_->InitializerForProjectedRow(
+        c_first_pr_initializer_(db->customer_table_->InitializerForProjectedRow({c_first_oid})),
+        customer_select_pr_initializer_(db->customer_table_->InitializerForProjectedRow(
             {c_id_oid, c_balance_oid, c_first_oid, c_middle_oid, c_last_oid})),
-        customer_select_pr_map(db->customer_table_->ProjectionMapForOids(
+        customer_select_pr_map_(db->customer_table_->ProjectionMapForOids(
             {c_id_oid, c_balance_oid, c_first_oid, c_middle_oid, c_last_oid})),
 
-        c_id_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_id_oid))),
-        c_balance_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_balance_oid))),
-        c_first_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_first_oid))),
-        c_middle_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_middle_oid))),
-        c_last_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_last_oid))),
-        o_id_secondary_key_pr_offset(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
+        c_id_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_id_oid))),
+        c_balance_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_balance_oid))),
+        c_first_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_first_oid))),
+        c_middle_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_middle_oid))),
+        c_last_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_last_oid))),
+        o_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
             db->order_secondary_index_schema_.GetColumn(3).Oid()))),
-        o_d_id_secondary_key_pr_offset(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
+        o_d_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
             db->order_secondary_index_schema_.GetColumn(1).Oid()))),
-        o_w_id_secondary_key_pr_offset(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
+        o_w_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
             db->order_secondary_index_schema_.GetColumn(0).Oid()))),
-        o_c_id_secondary_key_pr_offset(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
+        o_c_id_secondary_key_pr_offset_(static_cast<uint8_t>(db->order_secondary_index_->GetKeyOidToOffsetMap().at(
             db->order_secondary_index_schema_.GetColumn(2).Oid()))),
-        o_id_oid(db->order_schema_.GetColumn(0).Oid()),
-        o_entry_d_oid(db->order_schema_.GetColumn(4).Oid()),
-        o_carrier_id_oid(db->order_schema_.GetColumn(5).Oid()),
-        order_select_pr_initializer(
+        o_id_oid_(db->order_schema_.GetColumn(0).Oid()),
+        o_entry_d_oid_(db->order_schema_.GetColumn(4).Oid()),
+        o_carrier_id_oid_(db->order_schema_.GetColumn(5).Oid()),
+        order_select_pr_initializer_(
             db->order_table_->InitializerForProjectedRow({o_id_oid, o_entry_d_oid, o_carrier_id_oid})),
-        order_select_pr_map(db->order_table_->ProjectionMapForOids({o_id_oid, o_entry_d_oid, o_carrier_id_oid})),
-        o_id_select_pr_offset(static_cast<uint8_t>(order_select_pr_map.at(o_id_oid))),
-        ol_o_id_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        order_select_pr_map_(db->order_table_->ProjectionMapForOids({o_id_oid, o_entry_d_oid, o_carrier_id_oid})),
+        o_id_select_pr_offset_(static_cast<uint8_t>(order_select_pr_map.at(o_id_oid))),
+        ol_o_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(2).Oid()))),
-        ol_d_id_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_d_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(1).Oid()))),
-        ol_w_id_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_w_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(0).Oid()))),
-        ol_number_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_number_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(3).Oid()))),
 
-        ol_i_id_oid(db->order_line_schema_.GetColumn(4).Oid()),
-        ol_supply_w_id_oid(db->order_line_schema_.GetColumn(5).Oid()),
-        ol_quantity_oid(db->order_line_schema_.GetColumn(7).Oid()),
-        ol_amount_oid(db->order_line_schema_.GetColumn(8).Oid()),
-        ol_delivery_d_oid(db->order_line_schema_.GetColumn(6).Oid()),
-        order_line_select_pr_initializer(db->order_line_table_->InitializerForProjectedRow(
+        ol_i_id_oid_(db->order_line_schema_.GetColumn(4).Oid()),
+        ol_supply_w_id_oid_(db->order_line_schema_.GetColumn(5).Oid()),
+        ol_quantity_oid_(db->order_line_schema_.GetColumn(7).Oid()),
+        ol_amount_oid_(db->order_line_schema_.GetColumn(8).Oid()),
+        ol_delivery_d_oid_(db->order_line_schema_.GetColumn(6).Oid()),
+        order_line_select_pr_initializer_(db->order_line_table_->InitializerForProjectedRow(
             {ol_i_id_oid, ol_supply_w_id_oid, ol_quantity_oid, ol_amount_oid, ol_delivery_d_oid}))
 
   {}

--- a/test/include/util/tpcc/payment.h
+++ b/test/include/util/tpcc/payment.h
@@ -23,173 +23,173 @@ namespace terrier::tpcc {
 class Payment {
  private:
   // Warehouse metadata
-  const catalog::col_oid_t w_name_oid;
-  const catalog::col_oid_t w_street_1_oid;
-  const catalog::col_oid_t w_street_2_oid;
-  const catalog::col_oid_t w_city_oid;
-  const catalog::col_oid_t w_state_oid;
-  const catalog::col_oid_t w_zip_oid;
-  const catalog::col_oid_t w_ytd_oid;
-  const storage::ProjectedRowInitializer warehouse_select_pr_initializer;
-  const storage::ProjectionMap warehouse_select_pr_map;
-  const uint8_t w_name_select_pr_offset;
-  const uint8_t w_ytd_select_pr_offset;
-  const storage::ProjectedRowInitializer warehouse_update_pr_initializer;
+  const catalog::col_oid_t w_name_oid_;
+  const catalog::col_oid_t w_street_1_oid_;
+  const catalog::col_oid_t w_street_2_oid_;
+  const catalog::col_oid_t w_city_oid_;
+  const catalog::col_oid_t w_state_oid_;
+  const catalog::col_oid_t w_zip_oid_;
+  const catalog::col_oid_t w_ytd_oid_;
+  const storage::ProjectedRowInitializer warehouse_select_pr_initializer_;
+  const storage::ProjectionMap warehouse_select_pr_map_;
+  const uint8_t w_name_select_pr_offset_;
+  const uint8_t w_ytd_select_pr_offset_;
+  const storage::ProjectedRowInitializer warehouse_update_pr_initializer_;
 
   // District metadata
-  const uint8_t d_id_key_pr_offset;
-  const uint8_t d_w_id_key_pr_offset;
-  const catalog::col_oid_t d_name_oid;
-  const catalog::col_oid_t d_street_1_oid;
-  const catalog::col_oid_t d_street_2_oid;
-  const catalog::col_oid_t d_city_oid;
-  const catalog::col_oid_t d_state_oid;
-  const catalog::col_oid_t d_zip_oid;
-  const catalog::col_oid_t d_ytd_oid;
-  const storage::ProjectedRowInitializer district_select_pr_initializer;
-  const storage::ProjectionMap district_select_pr_map;
-  const uint8_t d_name_select_pr_offset;
-  const uint8_t d_ytd_select_pr_offset;
-  const storage::ProjectedRowInitializer district_update_pr_initializer;
+  const uint8_t d_id_key_pr_offset_;
+  const uint8_t d_w_id_key_pr_offset_;
+  const catalog::col_oid_t d_name_oid_;
+  const catalog::col_oid_t d_street_1_oid_;
+  const catalog::col_oid_t d_street_2_oid_;
+  const catalog::col_oid_t d_city_oid_;
+  const catalog::col_oid_t d_state_oid_;
+  const catalog::col_oid_t d_zip_oid_;
+  const catalog::col_oid_t d_ytd_oid_;
+  const storage::ProjectedRowInitializer district_select_pr_initializer_;
+  const storage::ProjectionMap district_select_pr_map_;
+  const uint8_t d_name_select_pr_offset_;
+  const uint8_t d_ytd_select_pr_offset_;
+  const storage::ProjectedRowInitializer district_update_pr_initializer_;
 
   // Customer metadata
-  const uint8_t c_id_key_pr_offset;
-  const uint8_t c_d_id_key_pr_offset;
-  const uint8_t c_w_id_key_pr_offset;
-  const uint8_t c_last_name_key_pr_offset;
-  const uint8_t c_d_id_name_key_pr_offset;
-  const uint8_t c_w_id_name_key_pr_offset;
-  const storage::ProjectedRowInitializer c_first_pr_initializer;
-  const storage::ProjectedRowInitializer customer_select_pr_initializer;
-  const storage::ProjectionMap customer_select_pr_map;
-  const catalog::col_oid_t c_id_oid;
-  const catalog::col_oid_t c_credit_oid;
-  const catalog::col_oid_t c_balance_oid;
-  const catalog::col_oid_t c_ytd_payment_oid;
-  const catalog::col_oid_t c_payment_cnt_oid;
-  const catalog::col_oid_t c_data_oid;
-  const uint8_t c_id_select_pr_offset;
-  const uint8_t c_credit_select_pr_offset;
-  const uint8_t c_balance_select_pr_offset;
-  const uint8_t c_ytd_payment_select_pr_offset;
-  const uint8_t c_payment_cnt_select_pr_offset;
-  const uint8_t c_data_select_pr_offset;
-  const storage::ProjectedRowInitializer customer_update_pr_initializer;
-  const storage::ProjectionMap customer_update_pr_map;
-  const uint8_t c_balance_update_pr_offset;
-  const uint8_t c_ytd_payment_update_pr_offset;
-  const uint8_t c_payment_cnt_update_pr_offset;
-  const storage::ProjectedRowInitializer c_data_pr_initializer;
+  const uint8_t c_id_key_pr_offset_;
+  const uint8_t c_d_id_key_pr_offset_;
+  const uint8_t c_w_id_key_pr_offset_;
+  const uint8_t c_last_name_key_pr_offset_;
+  const uint8_t c_d_id_name_key_pr_offset_;
+  const uint8_t c_w_id_name_key_pr_offset_;
+  const storage::ProjectedRowInitializer c_first_pr_initializer_;
+  const storage::ProjectedRowInitializer customer_select_pr_initializer_;
+  const storage::ProjectionMap customer_select_pr_map_;
+  const catalog::col_oid_t c_id_oid_;
+  const catalog::col_oid_t c_credit_oid_;
+  const catalog::col_oid_t c_balance_oid_;
+  const catalog::col_oid_t c_ytd_payment_oid_;
+  const catalog::col_oid_t c_payment_cnt_oid_;
+  const catalog::col_oid_t c_data_oid_;
+  const uint8_t c_id_select_pr_offset_;
+  const uint8_t c_credit_select_pr_offset_;
+  const uint8_t c_balance_select_pr_offset_;
+  const uint8_t c_ytd_payment_select_pr_offset_;
+  const uint8_t c_payment_cnt_select_pr_offset_;
+  const uint8_t c_data_select_pr_offset_;
+  const storage::ProjectedRowInitializer customer_update_pr_initializer_;
+  const storage::ProjectionMap customer_update_pr_map_;
+  const uint8_t c_balance_update_pr_offset_;
+  const uint8_t c_ytd_payment_update_pr_offset_;
+  const uint8_t c_payment_cnt_update_pr_offset_;
+  const storage::ProjectedRowInitializer c_data_pr_initializer_;
 
   // History metadata
-  const storage::ProjectedRowInitializer history_insert_pr_initializer;
-  const storage::ProjectionMap history_insert_pr_map;
-  const uint8_t h_c_id_insert_pr_offset;
-  const uint8_t h_c_d_id_insert_pr_offset;
-  const uint8_t h_c_w_id_insert_pr_offset;
-  const uint8_t h_d_id_insert_pr_offset;
-  const uint8_t h_w_id_insert_pr_offset;
-  const uint8_t h_date_insert_pr_offset;
-  const uint8_t h_amount_insert_pr_offset;
-  const uint8_t h_data_insert_pr_offset;
+  const storage::ProjectedRowInitializer history_insert_pr_initializer_;
+  const storage::ProjectionMap history_insert_pr_map_;
+  const uint8_t h_c_id_insert_pr_offset_;
+  const uint8_t h_c_d_id_insert_pr_offset_;
+  const uint8_t h_c_w_id_insert_pr_offset_;
+  const uint8_t h_d_id_insert_pr_offset_;
+  const uint8_t h_w_id_insert_pr_offset_;
+  const uint8_t h_date_insert_pr_offset_;
+  const uint8_t h_amount_insert_pr_offset_;
+  const uint8_t h_data_insert_pr_offset_;
 
  public:
   explicit Payment(const Database *const db)
 
       :  // Warehouse metadata
-        w_name_oid(db->warehouse_schema_.GetColumn(1).Oid()),
-        w_street_1_oid(db->warehouse_schema_.GetColumn(2).Oid()),
-        w_street_2_oid(db->warehouse_schema_.GetColumn(3).Oid()),
-        w_city_oid(db->warehouse_schema_.GetColumn(4).Oid()),
-        w_state_oid(db->warehouse_schema_.GetColumn(5).Oid()),
-        w_zip_oid(db->warehouse_schema_.GetColumn(6).Oid()),
-        w_ytd_oid(db->warehouse_schema_.GetColumn(8).Oid()),
-        warehouse_select_pr_initializer(db->warehouse_table_->InitializerForProjectedRow(
+        w_name_oid_(db->warehouse_schema_.GetColumn(1).Oid()),
+        w_street_1_oid_(db->warehouse_schema_.GetColumn(2).Oid()),
+        w_street_2_oid_(db->warehouse_schema_.GetColumn(3).Oid()),
+        w_city_oid_(db->warehouse_schema_.GetColumn(4).Oid()),
+        w_state_oid_(db->warehouse_schema_.GetColumn(5).Oid()),
+        w_zip_oid_(db->warehouse_schema_.GetColumn(6).Oid()),
+        w_ytd_oid_(db->warehouse_schema_.GetColumn(8).Oid()),
+        warehouse_select_pr_initializer_(db->warehouse_table_->InitializerForProjectedRow(
             {w_name_oid, w_street_1_oid, w_street_2_oid, w_city_oid, w_state_oid, w_zip_oid, w_ytd_oid})),
-        warehouse_select_pr_map(db->warehouse_table_->ProjectionMapForOids(
+        warehouse_select_pr_map_(db->warehouse_table_->ProjectionMapForOids(
             {w_name_oid, w_street_1_oid, w_street_2_oid, w_city_oid, w_state_oid, w_zip_oid, w_ytd_oid})),
-        w_name_select_pr_offset(static_cast<uint8_t>(warehouse_select_pr_map.at(w_name_oid))),
-        w_ytd_select_pr_offset(static_cast<uint8_t>(warehouse_select_pr_map.at(w_ytd_oid))),
-        warehouse_update_pr_initializer(db->warehouse_table_->InitializerForProjectedRow({w_ytd_oid})),
+        w_name_select_pr_offset_(static_cast<uint8_t>(warehouse_select_pr_map.at(w_name_oid))),
+        w_ytd_select_pr_offset_(static_cast<uint8_t>(warehouse_select_pr_map.at(w_ytd_oid))),
+        warehouse_update_pr_initializer_(db->warehouse_table_->InitializerForProjectedRow({w_ytd_oid})),
 
         // District metadata
-        d_id_key_pr_offset(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
+        d_id_key_pr_offset_(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
             db->district_primary_index_schema_.GetColumn(1).Oid()))),
-        d_w_id_key_pr_offset(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
+        d_w_id_key_pr_offset_(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
             db->district_primary_index_schema_.GetColumn(0).Oid()))),
 
-        d_name_oid(db->district_schema_.GetColumn(2).Oid()),
-        d_street_1_oid(db->district_schema_.GetColumn(3).Oid()),
-        d_street_2_oid(db->district_schema_.GetColumn(4).Oid()),
-        d_city_oid(db->district_schema_.GetColumn(5).Oid()),
-        d_state_oid(db->district_schema_.GetColumn(6).Oid()),
-        d_zip_oid(db->district_schema_.GetColumn(7).Oid()),
-        d_ytd_oid(db->district_schema_.GetColumn(9).Oid()),
-        district_select_pr_initializer(db->district_table_->InitializerForProjectedRow(
+        d_name_oid_(db->district_schema_.GetColumn(2).Oid()),
+        d_street_1_oid_(db->district_schema_.GetColumn(3).Oid()),
+        d_street_2_oid_(db->district_schema_.GetColumn(4).Oid()),
+        d_city_oid_(db->district_schema_.GetColumn(5).Oid()),
+        d_state_oid_(db->district_schema_.GetColumn(6).Oid()),
+        d_zip_oid_(db->district_schema_.GetColumn(7).Oid()),
+        d_ytd_oid_(db->district_schema_.GetColumn(9).Oid()),
+        district_select_pr_initializer_(db->district_table_->InitializerForProjectedRow(
             {d_name_oid, d_street_1_oid, d_street_2_oid, d_city_oid, d_state_oid, d_zip_oid, d_ytd_oid})),
-        district_select_pr_map(db->district_table_->ProjectionMapForOids(
+        district_select_pr_map_(db->district_table_->ProjectionMapForOids(
             {d_name_oid, d_street_1_oid, d_street_2_oid, d_city_oid, d_state_oid, d_zip_oid, d_ytd_oid})),
-        d_name_select_pr_offset(static_cast<uint8_t>(district_select_pr_map.at(d_name_oid))),
-        d_ytd_select_pr_offset(static_cast<uint8_t>(district_select_pr_map.at(d_ytd_oid))),
-        district_update_pr_initializer(db->district_table_->InitializerForProjectedRow({d_ytd_oid})),
+        d_name_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map.at(d_name_oid))),
+        d_ytd_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map.at(d_ytd_oid))),
+        district_update_pr_initializer_(db->district_table_->InitializerForProjectedRow({d_ytd_oid})),
 
         // Customer metadata
-        c_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
+        c_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(2).Oid()))),
-        c_d_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
+        c_d_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(1).Oid()))),
-        c_w_id_key_pr_offset(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
+        c_w_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
             db->customer_primary_index_schema_.GetColumn(0).Oid()))),
-        c_last_name_key_pr_offset(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
+        c_last_name_key_pr_offset_(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
             db->customer_secondary_index_schema_.GetColumn(2).Oid()))),
-        c_d_id_name_key_pr_offset(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
+        c_d_id_name_key_pr_offset_(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
             db->customer_secondary_index_schema_.GetColumn(1).Oid()))),
-        c_w_id_name_key_pr_offset(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
+        c_w_id_name_key_pr_offset_(static_cast<uint8_t>(db->customer_secondary_index_->GetKeyOidToOffsetMap().at(
             db->customer_secondary_index_schema_.GetColumn(0).Oid()))),
-        c_first_pr_initializer(
+        c_first_pr_initializer_(
             db->customer_table_->InitializerForProjectedRow({db->customer_schema_.GetColumn(3).Oid()})),
-        customer_select_pr_initializer(
+        customer_select_pr_initializer_(
             db->customer_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->customer_schema_))),
-        customer_select_pr_map(
+        customer_select_pr_map_(
             db->customer_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->customer_schema_))),
 
-        c_id_oid(db->customer_schema_.GetColumn(0).Oid()),
-        c_credit_oid(db->customer_schema_.GetColumn(13).Oid()),
-        c_balance_oid(db->customer_schema_.GetColumn(16).Oid()),
-        c_ytd_payment_oid(db->customer_schema_.GetColumn(17).Oid()),
-        c_payment_cnt_oid(db->customer_schema_.GetColumn(18).Oid()),
-        c_data_oid(db->customer_schema_.GetColumn(20).Oid()),
+        c_id_oid_(db->customer_schema_.GetColumn(0).Oid()),
+        c_credit_oid_(db->customer_schema_.GetColumn(13).Oid()),
+        c_balance_oid_(db->customer_schema_.GetColumn(16).Oid()),
+        c_ytd_payment_oid_(db->customer_schema_.GetColumn(17).Oid()),
+        c_payment_cnt_oid_(db->customer_schema_.GetColumn(18).Oid()),
+        c_data_oid_(db->customer_schema_.GetColumn(20).Oid()),
 
-        c_id_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_id_oid))),
-        c_credit_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_credit_oid))),
-        c_balance_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_balance_oid))),
-        c_ytd_payment_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_ytd_payment_oid))),
-        c_payment_cnt_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_payment_cnt_oid))),
-        c_data_select_pr_offset(static_cast<uint8_t>(customer_select_pr_map.at(c_data_oid))),
-        customer_update_pr_initializer(
+        c_id_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_id_oid))),
+        c_credit_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_credit_oid))),
+        c_balance_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_balance_oid))),
+        c_ytd_payment_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_ytd_payment_oid))),
+        c_payment_cnt_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_payment_cnt_oid))),
+        c_data_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_data_oid))),
+        customer_update_pr_initializer_(
             db->customer_table_->InitializerForProjectedRow({c_balance_oid, c_ytd_payment_oid, c_payment_cnt_oid})),
-        customer_update_pr_map(
+        customer_update_pr_map_(
             db->customer_table_->ProjectionMapForOids({c_balance_oid, c_ytd_payment_oid, c_payment_cnt_oid})),
-        c_balance_update_pr_offset(static_cast<uint8_t>(customer_update_pr_map.at(c_balance_oid))),
-        c_ytd_payment_update_pr_offset(static_cast<uint8_t>(customer_update_pr_map.at(c_ytd_payment_oid))),
-        c_payment_cnt_update_pr_offset(static_cast<uint8_t>(customer_update_pr_map.at(c_payment_cnt_oid))),
-        c_data_pr_initializer(db->customer_table_->InitializerForProjectedRow({c_data_oid})),
+        c_balance_update_pr_offset_(static_cast<uint8_t>(customer_update_pr_map.at(c_balance_oid))),
+        c_ytd_payment_update_pr_offset_(static_cast<uint8_t>(customer_update_pr_map.at(c_ytd_payment_oid))),
+        c_payment_cnt_update_pr_offset_(static_cast<uint8_t>(customer_update_pr_map.at(c_payment_cnt_oid))),
+        c_data_pr_initializer_(db->customer_table_->InitializerForProjectedRow({c_data_oid})),
 
-        history_insert_pr_initializer(
+        history_insert_pr_initializer_(
             db->history_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->history_schema_))),
-        history_insert_pr_map(db->history_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->history_schema_))),
+        history_insert_pr_map_(db->history_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->history_schema_))),
 
-        h_c_id_insert_pr_offset(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(0).Oid()))),
-        h_c_d_id_insert_pr_offset(
+        h_c_id_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(0).Oid()))),
+        h_c_d_id_insert_pr_offset_(
             static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(1).Oid()))),
-        h_c_w_id_insert_pr_offset(
+        h_c_w_id_insert_pr_offset_(
             static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(2).Oid()))),
-        h_d_id_insert_pr_offset(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(3).Oid()))),
-        h_w_id_insert_pr_offset(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(4).Oid()))),
-        h_date_insert_pr_offset(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(5).Oid()))),
-        h_amount_insert_pr_offset(
+        h_d_id_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(3).Oid()))),
+        h_w_id_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(4).Oid()))),
+        h_date_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(5).Oid()))),
+        h_amount_insert_pr_offset_(
             static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(6).Oid()))),
-        h_data_insert_pr_offset(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(7).Oid())))
+        h_data_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(7).Oid())))
 
   {}
 

--- a/test/include/util/tpcc/payment.h
+++ b/test/include/util/tpcc/payment.h
@@ -105,12 +105,12 @@ class Payment {
         w_zip_oid_(db->warehouse_schema_.GetColumn(6).Oid()),
         w_ytd_oid_(db->warehouse_schema_.GetColumn(8).Oid()),
         warehouse_select_pr_initializer_(db->warehouse_table_->InitializerForProjectedRow(
-            {w_name_oid, w_street_1_oid, w_street_2_oid, w_city_oid, w_state_oid, w_zip_oid, w_ytd_oid})),
+            {w_name_oid_, w_street_1_oid_, w_street_2_oid_, w_city_oid_, w_state_oid_, w_zip_oid_, w_ytd_oid_})),
         warehouse_select_pr_map_(db->warehouse_table_->ProjectionMapForOids(
-            {w_name_oid, w_street_1_oid, w_street_2_oid, w_city_oid, w_state_oid, w_zip_oid, w_ytd_oid})),
-        w_name_select_pr_offset_(static_cast<uint8_t>(warehouse_select_pr_map.at(w_name_oid))),
-        w_ytd_select_pr_offset_(static_cast<uint8_t>(warehouse_select_pr_map.at(w_ytd_oid))),
-        warehouse_update_pr_initializer_(db->warehouse_table_->InitializerForProjectedRow({w_ytd_oid})),
+            {w_name_oid_, w_street_1_oid_, w_street_2_oid_, w_city_oid_, w_state_oid_, w_zip_oid_, w_ytd_oid_})),
+        w_name_select_pr_offset_(static_cast<uint8_t>(warehouse_select_pr_map_.at(w_name_oid_))),
+        w_ytd_select_pr_offset_(static_cast<uint8_t>(warehouse_select_pr_map_.at(w_ytd_oid_))),
+        warehouse_update_pr_initializer_(db->warehouse_table_->InitializerForProjectedRow({w_ytd_oid_})),
 
         // District metadata
         d_id_key_pr_offset_(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
@@ -126,12 +126,12 @@ class Payment {
         d_zip_oid_(db->district_schema_.GetColumn(7).Oid()),
         d_ytd_oid_(db->district_schema_.GetColumn(9).Oid()),
         district_select_pr_initializer_(db->district_table_->InitializerForProjectedRow(
-            {d_name_oid, d_street_1_oid, d_street_2_oid, d_city_oid, d_state_oid, d_zip_oid, d_ytd_oid})),
+            {d_name_oid_, d_street_1_oid_, d_street_2_oid_, d_city_oid_, d_state_oid_, d_zip_oid_, d_ytd_oid_})),
         district_select_pr_map_(db->district_table_->ProjectionMapForOids(
-            {d_name_oid, d_street_1_oid, d_street_2_oid, d_city_oid, d_state_oid, d_zip_oid, d_ytd_oid})),
-        d_name_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map.at(d_name_oid))),
-        d_ytd_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map.at(d_ytd_oid))),
-        district_update_pr_initializer_(db->district_table_->InitializerForProjectedRow({d_ytd_oid})),
+            {d_name_oid_, d_street_1_oid_, d_street_2_oid_, d_city_oid_, d_state_oid_, d_zip_oid_, d_ytd_oid_})),
+        d_name_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map_.at(d_name_oid_))),
+        d_ytd_select_pr_offset_(static_cast<uint8_t>(district_select_pr_map_.at(d_ytd_oid_))),
+        district_update_pr_initializer_(db->district_table_->InitializerForProjectedRow({d_ytd_oid_})),
 
         // Customer metadata
         c_id_key_pr_offset_(static_cast<uint8_t>(db->customer_primary_index_->GetKeyOidToOffsetMap().at(
@@ -160,36 +160,42 @@ class Payment {
         c_payment_cnt_oid_(db->customer_schema_.GetColumn(18).Oid()),
         c_data_oid_(db->customer_schema_.GetColumn(20).Oid()),
 
-        c_id_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_id_oid))),
-        c_credit_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_credit_oid))),
-        c_balance_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_balance_oid))),
-        c_ytd_payment_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_ytd_payment_oid))),
-        c_payment_cnt_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_payment_cnt_oid))),
-        c_data_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map.at(c_data_oid))),
+        c_id_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_id_oid_))),
+        c_credit_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_credit_oid_))),
+        c_balance_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_balance_oid_))),
+        c_ytd_payment_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_ytd_payment_oid_))),
+        c_payment_cnt_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_payment_cnt_oid_))),
+        c_data_select_pr_offset_(static_cast<uint8_t>(customer_select_pr_map_.at(c_data_oid_))),
         customer_update_pr_initializer_(
-            db->customer_table_->InitializerForProjectedRow({c_balance_oid, c_ytd_payment_oid, c_payment_cnt_oid})),
+            db->customer_table_->InitializerForProjectedRow({c_balance_oid_, c_ytd_payment_oid_, c_payment_cnt_oid_})),
         customer_update_pr_map_(
-            db->customer_table_->ProjectionMapForOids({c_balance_oid, c_ytd_payment_oid, c_payment_cnt_oid})),
-        c_balance_update_pr_offset_(static_cast<uint8_t>(customer_update_pr_map.at(c_balance_oid))),
-        c_ytd_payment_update_pr_offset_(static_cast<uint8_t>(customer_update_pr_map.at(c_ytd_payment_oid))),
-        c_payment_cnt_update_pr_offset_(static_cast<uint8_t>(customer_update_pr_map.at(c_payment_cnt_oid))),
-        c_data_pr_initializer_(db->customer_table_->InitializerForProjectedRow({c_data_oid})),
+            db->customer_table_->ProjectionMapForOids({c_balance_oid_, c_ytd_payment_oid_, c_payment_cnt_oid_})),
+        c_balance_update_pr_offset_(static_cast<uint8_t>(customer_update_pr_map_.at(c_balance_oid_))),
+        c_ytd_payment_update_pr_offset_(static_cast<uint8_t>(customer_update_pr_map_.at(c_ytd_payment_oid_))),
+        c_payment_cnt_update_pr_offset_(static_cast<uint8_t>(customer_update_pr_map_.at(c_payment_cnt_oid_))),
+        c_data_pr_initializer_(db->customer_table_->InitializerForProjectedRow({c_data_oid_})),
 
         history_insert_pr_initializer_(
             db->history_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->history_schema_))),
-        history_insert_pr_map_(db->history_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->history_schema_))),
+        history_insert_pr_map_(
+            db->history_table_->ProjectionMapForOids(Util::AllColOidsForSchema(db->history_schema_))),
 
-        h_c_id_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(0).Oid()))),
+        h_c_id_insert_pr_offset_(
+            static_cast<uint8_t>(history_insert_pr_map_.at(db->history_schema_.GetColumn(0).Oid()))),
         h_c_d_id_insert_pr_offset_(
-            static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(1).Oid()))),
+            static_cast<uint8_t>(history_insert_pr_map_.at(db->history_schema_.GetColumn(1).Oid()))),
         h_c_w_id_insert_pr_offset_(
-            static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(2).Oid()))),
-        h_d_id_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(3).Oid()))),
-        h_w_id_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(4).Oid()))),
-        h_date_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(5).Oid()))),
+            static_cast<uint8_t>(history_insert_pr_map_.at(db->history_schema_.GetColumn(2).Oid()))),
+        h_d_id_insert_pr_offset_(
+            static_cast<uint8_t>(history_insert_pr_map_.at(db->history_schema_.GetColumn(3).Oid()))),
+        h_w_id_insert_pr_offset_(
+            static_cast<uint8_t>(history_insert_pr_map_.at(db->history_schema_.GetColumn(4).Oid()))),
+        h_date_insert_pr_offset_(
+            static_cast<uint8_t>(history_insert_pr_map_.at(db->history_schema_.GetColumn(5).Oid()))),
         h_amount_insert_pr_offset_(
-            static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(6).Oid()))),
-        h_data_insert_pr_offset_(static_cast<uint8_t>(history_insert_pr_map.at(db->history_schema_.GetColumn(7).Oid())))
+            static_cast<uint8_t>(history_insert_pr_map_.at(db->history_schema_.GetColumn(6).Oid()))),
+        h_data_insert_pr_offset_(
+            static_cast<uint8_t>(history_insert_pr_map_.at(db->history_schema_.GetColumn(7).Oid())))
 
   {}
 

--- a/test/include/util/tpcc/schemas.h
+++ b/test/include/util/tpcc/schemas.h
@@ -27,7 +27,7 @@ class Schemas {
    */
   static catalog::Schema BuildWarehouseTableSchema(uint32_t *const oid_counter) {
     std::vector<catalog::Schema::Column> warehouse_columns;
-    warehouse_columns.reserve(num_warehouse_table_cols_);
+    warehouse_columns.reserve(NUM_WAREHOUSE_TABLE_COLS);
 
     // 2*W unique IDs
     warehouse_columns.emplace_back(
@@ -75,7 +75,7 @@ class Schemas {
         parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::DECIMAL)));
     warehouse_columns.back().SetOid(static_cast<catalog::col_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(warehouse_columns.size() == num_warehouse_table_cols_,
+    TERRIER_ASSERT(warehouse_columns.size() == NUM_WAREHOUSE_TABLE_COLS,
                    "Wrong number of columns for Warehouse table schema.");
 
     return catalog::Schema(warehouse_columns);
@@ -89,7 +89,7 @@ class Schemas {
   static catalog::IndexSchema BuildWarehousePrimaryIndexSchema(const catalog::Schema &schema,
                                                                uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> warehouse_key_schema;
-    warehouse_key_schema.reserve(num_warehouse_primary_index_cols_);
+    warehouse_key_schema.reserve(NUM_WAREHOUSE_PRIMARY_INDEX_COLS);
 
     // Primary Key: W_ID
     warehouse_key_schema.emplace_back(
@@ -98,7 +98,7 @@ class Schemas {
                                       schema.GetColumn(0).Oid()));
     warehouse_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(warehouse_key_schema.size() == num_warehouse_primary_index_cols_,
+    TERRIER_ASSERT(warehouse_key_schema.size() == NUM_WAREHOUSE_PRIMARY_INDEX_COLS,
                    "Wrong number of columns for Warehouse primary index schema.");
 
     return catalog::IndexSchema(warehouse_key_schema, true, true, false, true);
@@ -110,7 +110,7 @@ class Schemas {
    */
   static catalog::Schema BuildDistrictTableSchema(uint32_t *const oid_counter) {
     std::vector<catalog::Schema::Column> district_columns;
-    district_columns.reserve(num_district_table_cols_);
+    district_columns.reserve(NUM_DISTRICT_TABLE_COLS);
 
     // 20 unique IDs
     district_columns.emplace_back(
@@ -168,7 +168,7 @@ class Schemas {
         parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::INTEGER)));
     district_columns.back().SetOid(static_cast<catalog::col_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(district_columns.size() == num_district_table_cols_,
+    TERRIER_ASSERT(district_columns.size() == NUM_DISTRICT_TABLE_COLS,
                    "Wrong number of columns for District table schema.");
 
     return catalog::Schema(district_columns);
@@ -182,7 +182,7 @@ class Schemas {
   static catalog::IndexSchema BuildDistrictPrimaryIndexSchema(const catalog::Schema &schema,
                                                               uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> district_key_schema;
-    district_key_schema.reserve(num_district_primary_index_cols_);
+    district_key_schema.reserve(NUM_DISTRICT_PRIMARY_INDEX_COLS);
 
     // Primary Key: (D_W_ID, D_ID)
     district_key_schema.emplace_back("", schema.GetColumn(1).Type(), schema.GetColumn(1).Nullable(),
@@ -194,7 +194,7 @@ class Schemas {
                                                                    catalog::table_oid_t(0), schema.GetColumn(0).Oid()));
     district_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(district_key_schema.size() == num_district_primary_index_cols_,
+    TERRIER_ASSERT(district_key_schema.size() == NUM_DISTRICT_PRIMARY_INDEX_COLS,
                    "Wrong number of columns for District primary index schema.");
 
     return catalog::IndexSchema(district_key_schema, true, true, false, true);
@@ -206,7 +206,7 @@ class Schemas {
    */
   static catalog::Schema BuildCustomerTableSchema(uint32_t *const oid_counter) {
     std::vector<catalog::Schema::Column> customer_columns;
-    customer_columns.reserve(num_customer_table_cols_);
+    customer_columns.reserve(NUM_CUSTOMER_TABLE_COLS);
 
     // 96,000 unique IDs
     customer_columns.emplace_back(
@@ -314,7 +314,7 @@ class Schemas {
         parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::VARCHAR)));
     customer_columns.back().SetOid(static_cast<catalog::col_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(customer_columns.size() == num_customer_table_cols_,
+    TERRIER_ASSERT(customer_columns.size() == NUM_CUSTOMER_TABLE_COLS,
                    "Wrong number of columns for Customer table schema.");
 
     return catalog::Schema(customer_columns);
@@ -328,7 +328,7 @@ class Schemas {
   static catalog::IndexSchema BuildCustomerPrimaryIndexSchema(const catalog::Schema &schema,
                                                               uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> customer_key_schema;
-    customer_key_schema.reserve(num_customer_primary_index_cols_);
+    customer_key_schema.reserve(NUM_CUSTOMER_PRIMARY_INDEX_COLS);
 
     // Primary Key: (C_W_ID, C_D_ID, C_ID)
     customer_key_schema.emplace_back("", schema.GetColumn(2).Type(), schema.GetColumn(2).Nullable(),
@@ -344,7 +344,7 @@ class Schemas {
                                                                    catalog::table_oid_t(0), schema.GetColumn(0).Oid()));
     customer_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(customer_key_schema.size() == num_customer_primary_index_cols_,
+    TERRIER_ASSERT(customer_key_schema.size() == NUM_CUSTOMER_PRIMARY_INDEX_COLS,
                    "Wrong number of columns for Customer primary index schema.");
 
     return catalog::IndexSchema(customer_key_schema, true, true, false, true);
@@ -358,7 +358,7 @@ class Schemas {
   static catalog::IndexSchema BuildCustomerSecondaryIndexSchema(const catalog::Schema &schema,
                                                                 uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> customer_secondary_key_schema;
-    customer_secondary_key_schema.reserve(num_customer_secondary_index_cols_);
+    customer_secondary_key_schema.reserve(NUM_CUSTOMER_SECONDARY_INDEX_COLS);
 
     // C_W_ID, C_D_ID, C_LAST for Order Status and Payment transactions
     customer_secondary_key_schema.emplace_back(
@@ -377,7 +377,7 @@ class Schemas {
                                       schema.GetColumn(5).Oid()));
     customer_secondary_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(customer_secondary_key_schema.size() == num_customer_secondary_index_cols_,
+    TERRIER_ASSERT(customer_secondary_key_schema.size() == NUM_CUSTOMER_SECONDARY_INDEX_COLS,
                    "Wrong number of columns for Customer secondary index schema.");
 
     return catalog::IndexSchema(customer_secondary_key_schema, false, false, false, true);
@@ -389,7 +389,7 @@ class Schemas {
    */
   static catalog::Schema BuildHistoryTableSchema(uint32_t *const oid_counter) {
     std::vector<catalog::Schema::Column> history_columns;
-    history_columns.reserve(num_history_table_cols_);
+    history_columns.reserve(NUM_HISTORY_TABLE_COLS);
 
     // 96,000 unique IDs
     history_columns.emplace_back(
@@ -432,7 +432,7 @@ class Schemas {
         parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::VARCHAR)));
     history_columns.back().SetOid(static_cast<catalog::col_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(history_columns.size() == num_history_table_cols_,
+    TERRIER_ASSERT(history_columns.size() == NUM_HISTORY_TABLE_COLS,
                    "Wrong number of columns for History table schema.");
 
     return catalog::Schema(history_columns);
@@ -444,7 +444,7 @@ class Schemas {
    */
   static catalog::Schema BuildNewOrderTableSchema(uint32_t *const oid_counter) {
     std::vector<catalog::Schema::Column> new_order_columns;
-    new_order_columns.reserve(num_new_order_table_cols_);
+    new_order_columns.reserve(NUM_NEW_ORDER_TABLE_COLS);
 
     // 10,000,000 unique IDs
     new_order_columns.emplace_back(
@@ -462,7 +462,7 @@ class Schemas {
         parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::TINYINT)));
     new_order_columns.back().SetOid(static_cast<catalog::col_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(new_order_columns.size() == num_new_order_table_cols_,
+    TERRIER_ASSERT(new_order_columns.size() == NUM_NEW_ORDER_TABLE_COLS,
                    "Wrong number of columns for New Order table schema.");
 
     return catalog::Schema(new_order_columns);
@@ -476,7 +476,7 @@ class Schemas {
   static catalog::IndexSchema BuildNewOrderPrimaryIndexSchema(const catalog::Schema &schema,
                                                               uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> new_order_key_schema;
-    new_order_key_schema.reserve(num_new_order_primary_index_cols_);
+    new_order_key_schema.reserve(NUM_NEW_ORDER_PRIMARY_INDEX_COLS);
 
     // Primary Key: (NO_W_ID, NO_D_ID, NO_O_ID)
     new_order_key_schema.emplace_back(
@@ -495,7 +495,7 @@ class Schemas {
                                       schema.GetColumn(0).Oid()));
     new_order_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(new_order_key_schema.size() == num_new_order_primary_index_cols_,
+    TERRIER_ASSERT(new_order_key_schema.size() == NUM_NEW_ORDER_PRIMARY_INDEX_COLS,
                    "Wrong number of columns for New Order primary index schema.");
 
     return catalog::IndexSchema(new_order_key_schema, true, true, false, true);
@@ -507,7 +507,7 @@ class Schemas {
    */
   static catalog::Schema BuildOrderTableSchema(uint32_t *const oid_counter) {
     std::vector<catalog::Schema::Column> order_columns;
-    order_columns.reserve(num_order_table_cols_);
+    order_columns.reserve(NUM_ORDER_TABLE_COLS);
 
     // 10,000,000 unique IDs
     order_columns.emplace_back(
@@ -550,7 +550,7 @@ class Schemas {
         parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::TINYINT)));
     order_columns.back().SetOid(static_cast<catalog::col_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(order_columns.size() == num_order_table_cols_, "Wrong number of columns for Order table schema.");
+    TERRIER_ASSERT(order_columns.size() == NUM_ORDER_TABLE_COLS, "Wrong number of columns for Order table schema.");
 
     return catalog::Schema(order_columns);
   }
@@ -562,7 +562,7 @@ class Schemas {
    */
   static catalog::IndexSchema BuildOrderPrimaryIndexSchema(const catalog::Schema &schema, uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> order_key_schema;
-    order_key_schema.reserve(num_order_primary_index_cols_);
+    order_key_schema.reserve(NUM_ORDER_PRIMARY_INDEX_COLS);
 
     // Primary Key: (O_W_ID, O_D_ID, O_ID)
     order_key_schema.emplace_back("", schema.GetColumn(2).Type(), schema.GetColumn(2).Nullable(),
@@ -578,7 +578,7 @@ class Schemas {
                                                                 schema.GetColumn(0).Oid()));
     order_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(order_key_schema.size() == num_order_primary_index_cols_,
+    TERRIER_ASSERT(order_key_schema.size() == NUM_ORDER_PRIMARY_INDEX_COLS,
                    "Wrong number of columns for Order primary index schema.");
 
     return catalog::IndexSchema(order_key_schema, true, true, false, true);
@@ -592,7 +592,7 @@ class Schemas {
   static catalog::IndexSchema BuildOrderSecondaryIndexSchema(const catalog::Schema &schema,
                                                              uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> order_secondary_key_schema;
-    order_secondary_key_schema.reserve(num_order_secondary_index_cols_);
+    order_secondary_key_schema.reserve(NUM_ORDER_SECONDARY_INDEX_COLS);
 
     // O_W_ID, O_D_ID, O_C_ID, O_ID for Order Status transaction
     order_secondary_key_schema.emplace_back(
@@ -616,7 +616,7 @@ class Schemas {
                                       schema.GetColumn(0).Oid()));
     order_secondary_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(order_secondary_key_schema.size() == num_order_secondary_index_cols_,
+    TERRIER_ASSERT(order_secondary_key_schema.size() == NUM_ORDER_SECONDARY_INDEX_COLS,
                    "Wrong number of columns for Order secondary index schema.");
 
     return catalog::IndexSchema(order_secondary_key_schema, true, false, false, true);
@@ -628,7 +628,7 @@ class Schemas {
    */
   static catalog::Schema BuildOrderLineTableSchema(uint32_t *const oid_counter) {
     std::vector<catalog::Schema::Column> order_line_columns;
-    order_line_columns.reserve(num_order_line_table_cols_);
+    order_line_columns.reserve(NUM_ORDER_LINE_TABLE_COLS);
 
     // 10,000,000 unique IDs
     order_line_columns.emplace_back(
@@ -681,7 +681,7 @@ class Schemas {
         parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::VARCHAR)));
     order_line_columns.back().SetOid(static_cast<catalog::col_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(order_line_columns.size() == num_order_line_table_cols_,
+    TERRIER_ASSERT(order_line_columns.size() == NUM_ORDER_LINE_TABLE_COLS,
                    "Wrong number of columns for Order Line table schema.");
 
     return catalog::Schema(order_line_columns);
@@ -695,7 +695,7 @@ class Schemas {
   static catalog::IndexSchema BuildOrderLinePrimaryIndexSchema(const catalog::Schema &schema,
                                                                uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> order_line_key_schema;
-    order_line_key_schema.reserve(num_order_line_primary_index_cols_);
+    order_line_key_schema.reserve(NUM_ORDER_LINE_PRIMARY_INDEX_COLS);
 
     // Primary Key: (OL_W_ID, OL_D_ID, OL_O_ID, OL_NUMBER)
     order_line_key_schema.emplace_back(
@@ -719,7 +719,7 @@ class Schemas {
                                       schema.GetColumn(3).Oid()));
     order_line_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(order_line_key_schema.size() == num_order_line_primary_index_cols_,
+    TERRIER_ASSERT(order_line_key_schema.size() == NUM_ORDER_LINE_PRIMARY_INDEX_COLS,
                    "Wrong number of columns for Order Line key schema.");
 
     return catalog::IndexSchema(order_line_key_schema, true, true, false, true);
@@ -731,7 +731,7 @@ class Schemas {
    */
   static catalog::Schema BuildItemTableSchema(uint32_t *const oid_counter) {
     std::vector<catalog::Schema::Column> item_columns;
-    item_columns.reserve(num_item_table_cols_);
+    item_columns.reserve(NUM_ITEM_TABLE_COLS);
 
     // 200,000 unique IDs
     item_columns.emplace_back(
@@ -759,7 +759,7 @@ class Schemas {
         parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::VARCHAR)));
     item_columns.back().SetOid(static_cast<catalog::col_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(item_columns.size() == num_item_table_cols_, "Wrong number of columns for Item table schema.");
+    TERRIER_ASSERT(item_columns.size() == NUM_ITEM_TABLE_COLS, "Wrong number of columns for Item table schema.");
 
     return catalog::Schema(item_columns);
   }
@@ -771,7 +771,7 @@ class Schemas {
    */
   static catalog::IndexSchema BuildItemPrimaryIndexSchema(const catalog::Schema &schema, uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> item_key_schema;
-    item_key_schema.reserve(num_item_primary_index_cols_);
+    item_key_schema.reserve(NUM_ITEM_PRIMARY_INDEX_COLS);
 
     // Primary Key: I_ID
     item_key_schema.emplace_back("", schema.GetColumn(0).Type(), schema.GetColumn(0).Nullable(),
@@ -779,7 +779,7 @@ class Schemas {
                                                                schema.GetColumn(0).Oid()));
     item_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(item_key_schema.size() == num_item_primary_index_cols_,
+    TERRIER_ASSERT(item_key_schema.size() == NUM_ITEM_PRIMARY_INDEX_COLS,
                    "Wrong number of columns for Item primary index schema.");
 
     return catalog::IndexSchema(item_key_schema, true, true, false, true);
@@ -791,7 +791,7 @@ class Schemas {
    */
   static catalog::Schema BuildStockTableSchema(uint32_t *const oid_counter) {
     std::vector<catalog::Schema::Column> stock_columns;
-    stock_columns.reserve(num_stock_table_cols_);
+    stock_columns.reserve(NUM_STOCK_TABLE_COLS);
 
     // 200,000 unique IDs
     stock_columns.emplace_back(
@@ -879,7 +879,7 @@ class Schemas {
         parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::VARCHAR)));
     stock_columns.back().SetOid(static_cast<catalog::col_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(stock_columns.size() == num_stock_table_cols_, "Wrong number of columns for Stock table schema.");
+    TERRIER_ASSERT(stock_columns.size() == NUM_STOCK_TABLE_COLS, "Wrong number of columns for Stock table schema.");
 
     return catalog::Schema(stock_columns);
   }
@@ -891,7 +891,7 @@ class Schemas {
    */
   static catalog::IndexSchema BuildStockPrimaryIndexSchema(const catalog::Schema &schema, uint32_t *const oid_counter) {
     std::vector<catalog::IndexSchema::Column> stock_key_schema;
-    stock_key_schema.reserve(num_stock_primary_index_cols_);
+    stock_key_schema.reserve(NUM_STOCK_PRIMARY_INDEX_COLS);
 
     // Primary Key: (S_W_ID, S_I_ID)
     stock_key_schema.emplace_back("", schema.GetColumn(1).Type(), schema.GetColumn(1).Nullable(),
@@ -903,7 +903,7 @@ class Schemas {
                                                                 schema.GetColumn(0).Oid()));
     stock_key_schema.back().SetOid(static_cast<catalog::indexkeycol_oid_t>(++(*oid_counter)));
 
-    TERRIER_ASSERT(stock_key_schema.size() == num_stock_primary_index_cols_,
+    TERRIER_ASSERT(stock_key_schema.size() == NUM_STOCK_PRIMARY_INDEX_COLS,
                    "Wrong number of columns for Stock primary index schema.");
 
     return catalog::IndexSchema(stock_key_schema, true, true, false, true);
@@ -911,26 +911,26 @@ class Schemas {
 
  private:
   // The values below are just to sanity check the schema functions
-  static constexpr uint8_t num_warehouse_table_cols_ = 9;
-  static constexpr uint8_t num_district_table_cols_ = 11;
-  static constexpr uint8_t num_customer_table_cols_ = 21;
-  static constexpr uint8_t num_history_table_cols_ = 8;
-  static constexpr uint8_t num_new_order_table_cols_ = 3;
-  static constexpr uint8_t num_order_table_cols_ = 8;
-  static constexpr uint8_t num_order_line_table_cols_ = 10;
-  static constexpr uint8_t num_item_table_cols_ = 5;
-  static constexpr uint8_t num_stock_table_cols_ = 17;
+  static constexpr uint8_t NUM_WAREHOUSE_TABLE_COLS = 9;
+  static constexpr uint8_t NUM_DISTRICT_TABLE_COLS = 11;
+  static constexpr uint8_t NUM_CUSTOMER_TABLE_COLS = 21;
+  static constexpr uint8_t NUM_HISTORY_TABLE_COLS = 8;
+  static constexpr uint8_t NUM_NEW_ORDER_TABLE_COLS = 3;
+  static constexpr uint8_t NUM_ORDER_TABLE_COLS = 8;
+  static constexpr uint8_t NUM_ORDER_LINE_TABLE_COLS = 10;
+  static constexpr uint8_t NUM_ITEM_TABLE_COLS = 5;
+  static constexpr uint8_t NUM_STOCK_TABLE_COLS = 17;
 
-  static constexpr uint8_t num_warehouse_primary_index_cols_ = 1;
-  static constexpr uint8_t num_district_primary_index_cols_ = 2;
-  static constexpr uint8_t num_customer_primary_index_cols_ = 3;
-  static constexpr uint8_t num_customer_secondary_index_cols_ = 3;
-  static constexpr uint8_t num_new_order_primary_index_cols_ = 3;
-  static constexpr uint8_t num_order_primary_index_cols_ = 3;
-  static constexpr uint8_t num_order_secondary_index_cols_ = 4;
-  static constexpr uint8_t num_order_line_primary_index_cols_ = 4;
-  static constexpr uint8_t num_item_primary_index_cols_ = 1;
-  static constexpr uint8_t num_stock_primary_index_cols_ = 2;
+  static constexpr uint8_t NUM_WAREHOUSE_PRIMARY_INDEX_COLS = 1;
+  static constexpr uint8_t NUM_DISTRICT_PRIMARY_INDEX_COLS = 2;
+  static constexpr uint8_t NUM_CUSTOMER_PRIMARY_INDEX_COLS = 3;
+  static constexpr uint8_t NUM_CUSTOMER_SECONDARY_INDEX_COLS = 3;
+  static constexpr uint8_t NUM_NEW_ORDER_PRIMARY_INDEX_COLS = 3;
+  static constexpr uint8_t NUM_ORDER_PRIMARY_INDEX_COLS = 3;
+  static constexpr uint8_t NUM_ORDER_SECONDARY_INDEX_COLS = 4;
+  static constexpr uint8_t NUM_ORDER_LINE_PRIMARY_INDEX_COLS = 4;
+  static constexpr uint8_t NUM_ITEM_PRIMARY_INDEX_COLS = 1;
+  static constexpr uint8_t NUM_STOCK_PRIMARY_INDEX_COLS = 2;
 };
 
 }  // namespace terrier::tpcc

--- a/test/include/util/tpcc/stock_level.h
+++ b/test/include/util/tpcc/stock_level.h
@@ -20,45 +20,45 @@ namespace terrier::tpcc {
 class StockLevel {
  private:
   // District metadata
-  const storage::ProjectedRowInitializer district_select_pr_initializer;
-  const uint8_t d_id_key_pr_offset;
-  const uint8_t d_w_id_key_pr_offset;
+  const storage::ProjectedRowInitializer district_select_pr_initializer_;
+  const uint8_t d_id_key_pr_offset_;
+  const uint8_t d_w_id_key_pr_offset_;
 
   // Order Line metadata
-  const storage::ProjectedRowInitializer order_line_select_pr_initializer;
-  const uint8_t ol_o_id_key_pr_offset;
-  const uint8_t ol_d_id_key_pr_offset;
-  const uint8_t ol_w_id_key_pr_offset;
-  const uint8_t ol_number_key_pr_offset;
+  const storage::ProjectedRowInitializer order_line_select_pr_initializer_;
+  const uint8_t ol_o_id_key_pr_offset_;
+  const uint8_t ol_d_id_key_pr_offset_;
+  const uint8_t ol_w_id_key_pr_offset_;
+  const uint8_t ol_number_key_pr_offset_;
 
   // Stock metadata
-  const storage::ProjectedRowInitializer stock_select_pr_initializer;
-  const uint8_t s_w_id_key_pr_offset;
-  const uint8_t s_i_id_key_pr_offset;
+  const storage::ProjectedRowInitializer stock_select_pr_initializer_;
+  const uint8_t s_w_id_key_pr_offset_;
+  const uint8_t s_i_id_key_pr_offset_;
 
  public:
   explicit StockLevel(const Database *const db)
-      : district_select_pr_initializer(
+      : district_select_pr_initializer_(
             db->district_table_->InitializerForProjectedRow({db->district_schema_.GetColumn(10).Oid()})),
-        d_id_key_pr_offset(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
+        d_id_key_pr_offset_(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
             db->district_primary_index_schema_.GetColumn(1).Oid()))),
-        d_w_id_key_pr_offset(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
+        d_w_id_key_pr_offset_(static_cast<uint8_t>(db->district_primary_index_->GetKeyOidToOffsetMap().at(
             db->district_primary_index_schema_.GetColumn(0).Oid()))),
-        order_line_select_pr_initializer(
+        order_line_select_pr_initializer_(
             db->order_line_table_->InitializerForProjectedRow({db->order_line_schema_.GetColumn(4).Oid()})),
-        ol_o_id_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_o_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(2).Oid()))),
-        ol_d_id_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_d_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(1).Oid()))),
-        ol_w_id_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_w_id_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(0).Oid()))),
-        ol_number_key_pr_offset(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
+        ol_number_key_pr_offset_(static_cast<uint8_t>(db->order_line_primary_index_->GetKeyOidToOffsetMap().at(
             db->order_line_primary_index_schema_.GetColumn(3).Oid()))),
-        stock_select_pr_initializer(
+        stock_select_pr_initializer_(
             db->stock_table_->InitializerForProjectedRow({db->stock_schema_.GetColumn(2).Oid()})),
-        s_w_id_key_pr_offset(static_cast<uint8_t>(
+        s_w_id_key_pr_offset_(static_cast<uint8_t>(
             db->stock_primary_index_->GetKeyOidToOffsetMap().at(db->stock_primary_index_schema_.GetColumn(0).Oid()))),
-        s_i_id_key_pr_offset(static_cast<uint8_t>(
+        s_i_id_key_pr_offset_(static_cast<uint8_t>(
             db->stock_primary_index_->GetKeyOidToOffsetMap().at(db->stock_primary_index_schema_.GetColumn(1).Oid()))) {}
 
   bool Execute(transaction::TransactionManager *txn_manager, Database *db, Worker *worker,

--- a/test/include/util/tpcc/tpcc_defs.h
+++ b/test/include/util/tpcc/tpcc_defs.h
@@ -10,32 +10,32 @@ enum class TransactionType : uint8_t { NewOrder, Payment, OrderStatus, Delivery,
  * Contains the input arguments for all transaction types, but only args for the matching type are populated.
  */
 struct TransactionArgs {
-  TransactionType type;
+  TransactionType type_;
 
   struct NewOrderItem {
-    int32_t ol_i_id;
-    int8_t ol_supply_w_id;
-    int8_t ol_quantity;
-    bool remote;
+    int32_t ol_i_id_;
+    int8_t ol_supply_w_id_;
+    int8_t ol_quantity_;
+    bool remote_;
   };
 
-  int8_t w_id;                      // NewOrder, Payment, Order Status, Delivery, StockLevel
-  int8_t d_id;                      // NewOrder, Payment, Order Status, StockLevel
-  int32_t c_id;                     // NewOrder, Payment, Order Status
-  int8_t ol_cnt;                    // NewOrder
-  uint8_t rbk;                      // NewOrder
-  std::vector<NewOrderItem> items;  // NewOrder
-  uint64_t o_entry_d;               // NewOrder
-  bool o_all_local;                 // NewOrder
-  int8_t c_d_id;                    // Payment
-  int8_t c_w_id;                    // Payment
-  bool remote;                      // Payment
-  bool use_c_last;                  // Payment, Order Status
-  storage::VarlenEntry c_last;      // Payment, Order Status
-  double h_amount;                  // Payment
-  uint64_t h_date;                  // Payment
-  int8_t o_carrier_id;              // Delivery
-  uint64_t ol_delivery_d;           // Delivery
-  int8_t s_quantity_threshold;      // StockLevel
+  int8_t w_id_;                      // NewOrder, Payment, Order Status, Delivery, StockLevel
+  int8_t d_id_;                      // NewOrder, Payment, Order Status, StockLevel
+  int32_t c_id_;                     // NewOrder, Payment, Order Status
+  int8_t ol_cnt_;                    // NewOrder
+  uint8_t rbk_;                      // NewOrder
+  std::vector<NewOrderItem> items_;  // NewOrder
+  uint64_t o_entry_d_;               // NewOrder
+  bool o_all_local_;                 // NewOrder
+  int8_t c_d_id_;                    // Payment
+  int8_t c_w_id_;                    // Payment
+  bool remote_;                      // Payment
+  bool use_c_last_;                  // Payment, Order Status
+  storage::VarlenEntry c_last_;      // Payment, Order Status
+  double h_amount_;                  // Payment
+  uint64_t h_date_;                  // Payment
+  int8_t o_carrier_id_;              // Delivery
+  uint64_t ol_delivery_d_;           // Delivery
+  int8_t s_quantity_threshold_;      // StockLevel
 };
 }  // namespace terrier::tpcc

--- a/test/include/util/tpcc/util.h
+++ b/test/include/util/tpcc/util.h
@@ -77,24 +77,24 @@ struct Util {
                        || (A == 8191 && x == 1 && y == 100000),  // OL_I_ID
                    "Invalid inputs to NURand().");
 
-    static const auto C_c_last = RandomWithin<uint32_t>(0, 255, 0, generator);
-    static const auto C_c_id = RandomWithin<uint32_t>(0, 1023, 0, generator);
-    static const auto C_ol_i_id = RandomWithin<uint32_t>(0, 8191, 0, generator);
+    static const auto c_c_last = RandomWithin<uint32_t>(0, 255, 0, generator);
+    static const auto c_c_id = RandomWithin<uint32_t>(0, 1023, 0, generator);
+    static const auto c_ol_i_id = RandomWithin<uint32_t>(0, 8191, 0, generator);
 
-    uint32_t C;
+    uint32_t c;
 
     if (A == 255) {
-      C = C_c_last;
+      c = c_c_last;
     } else if (A == 1023) {
-      C = C_c_id;
+      c = c_c_id;
     } else {
-      C = C_ol_i_id;
+      c = c_ol_i_id;
     }
 
-    const auto rand0A = RandomWithin<uint32_t>(0, A, 0, generator);
+    const auto rand0_a = RandomWithin<uint32_t>(0, A, 0, generator);
     const auto randxy = RandomWithin<uint32_t>(x, y, 0, generator);
 
-    return (((rand0A | randxy) + C) % (y - x + 1)) + x;
+    return (((rand0_a | randxy) + c) % (y - x + 1)) + x;
   }
 
   // 4.3.2.2

--- a/test/include/util/tpcc/worker.h
+++ b/test/include/util/tpcc/worker.h
@@ -61,27 +61,27 @@ struct Worker {
             db->order_line_primary_index_->GetProjectedRowInitializer().ProjectedRowSize())) {}
 
   ~Worker() {
-    delete[] item_tuple_buffer;
-    delete[] warehouse_tuple_buffer;
-    delete[] stock_tuple_buffer;
-    delete[] district_tuple_buffer;
-    delete[] customer_tuple_buffer;
-    delete[] history_tuple_buffer;
-    delete[] order_tuple_buffer;
-    delete[] new_order_tuple_buffer;
-    delete[] order_line_tuple_buffer;
+    delete[] item_tuple_buffer_;
+    delete[] warehouse_tuple_buffer_;
+    delete[] stock_tuple_buffer_;
+    delete[] district_tuple_buffer_;
+    delete[] customer_tuple_buffer_;
+    delete[] history_tuple_buffer_;
+    delete[] order_tuple_buffer_;
+    delete[] new_order_tuple_buffer_;
+    delete[] order_line_tuple_buffer_;
 
-    delete[] item_key_buffer;
-    delete[] warehouse_key_buffer;
-    delete[] stock_key_buffer;
-    delete[] district_key_buffer;
-    delete[] customer_key_buffer;
-    delete[] customer_name_key_buffer;
-    delete[] customer_name_varlen_buffer;
-    delete[] order_key_buffer;
-    delete[] order_secondary_key_buffer;
-    delete[] new_order_key_buffer;
-    delete[] order_line_key_buffer;
+    delete[] item_key_buffer_;
+    delete[] warehouse_key_buffer_;
+    delete[] stock_key_buffer_;
+    delete[] district_key_buffer_;
+    delete[] customer_key_buffer_;
+    delete[] customer_name_key_buffer_;
+    delete[] customer_name_varlen_buffer_;
+    delete[] order_key_buffer_;
+    delete[] order_secondary_key_buffer_;
+    delete[] new_order_key_buffer_;
+    delete[] order_line_key_buffer_;
   }
 
   byte *const item_tuple_buffer_;

--- a/test/include/util/tpcc/worker.h
+++ b/test/include/util/tpcc/worker.h
@@ -11,53 +11,53 @@ namespace terrier::tpcc {
  */
 struct Worker {
   explicit Worker(tpcc::Database *const db)
-      : item_tuple_buffer(common::AllocationUtil::AllocateAligned(
+      : item_tuple_buffer_(common::AllocationUtil::AllocateAligned(
             db->item_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->item_schema_))
                 .ProjectedRowSize())),
-        warehouse_tuple_buffer(common::AllocationUtil::AllocateAligned(
+        warehouse_tuple_buffer_(common::AllocationUtil::AllocateAligned(
             db->warehouse_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->warehouse_schema_))
                 .ProjectedRowSize())),
-        stock_tuple_buffer(common::AllocationUtil::AllocateAligned(
+        stock_tuple_buffer_(common::AllocationUtil::AllocateAligned(
             db->stock_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->stock_schema_))
                 .ProjectedRowSize())),
-        district_tuple_buffer(common::AllocationUtil::AllocateAligned(
+        district_tuple_buffer_(common::AllocationUtil::AllocateAligned(
             db->district_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->district_schema_))
                 .ProjectedRowSize())),
-        customer_tuple_buffer(common::AllocationUtil::AllocateAligned(
+        customer_tuple_buffer_(common::AllocationUtil::AllocateAligned(
             db->customer_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->customer_schema_))
                 .ProjectedRowSize())),
-        history_tuple_buffer(common::AllocationUtil::AllocateAligned(
+        history_tuple_buffer_(common::AllocationUtil::AllocateAligned(
             db->history_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->history_schema_))
                 .ProjectedRowSize())),
-        order_tuple_buffer(common::AllocationUtil::AllocateAligned(
+        order_tuple_buffer_(common::AllocationUtil::AllocateAligned(
             db->order_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->order_schema_))
                 .ProjectedRowSize())),
-        new_order_tuple_buffer(common::AllocationUtil::AllocateAligned(
+        new_order_tuple_buffer_(common::AllocationUtil::AllocateAligned(
             db->new_order_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->new_order_schema_))
                 .ProjectedRowSize())),
-        order_line_tuple_buffer(common::AllocationUtil::AllocateAligned(
+        order_line_tuple_buffer_(common::AllocationUtil::AllocateAligned(
             db->order_line_table_->InitializerForProjectedRow(Util::AllColOidsForSchema(db->order_line_schema_))
                 .ProjectedRowSize())),
-        item_key_buffer(common::AllocationUtil::AllocateAligned(
+        item_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->item_primary_index_->GetProjectedRowInitializer().ProjectedRowSize())),
-        warehouse_key_buffer(common::AllocationUtil::AllocateAligned(
+        warehouse_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->warehouse_primary_index_->GetProjectedRowInitializer().ProjectedRowSize())),
-        stock_key_buffer(common::AllocationUtil::AllocateAligned(
+        stock_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->stock_primary_index_->GetProjectedRowInitializer().ProjectedRowSize())),
-        district_key_buffer(common::AllocationUtil::AllocateAligned(
+        district_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->district_primary_index_->GetProjectedRowInitializer().ProjectedRowSize())),
-        customer_key_buffer(common::AllocationUtil::AllocateAligned(
+        customer_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->customer_primary_index_->GetProjectedRowInitializer().ProjectedRowSize())),
-        customer_name_key_buffer(common::AllocationUtil::AllocateAligned(
+        customer_name_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->customer_secondary_index_->GetProjectedRowInitializer().ProjectedRowSize())),
-        customer_name_varlen_buffer(common::AllocationUtil::AllocateAligned(16)),
-        order_key_buffer(common::AllocationUtil::AllocateAligned(
+        customer_name_varlen_buffer_(common::AllocationUtil::AllocateAligned(16)),
+        order_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->order_primary_index_->GetProjectedRowInitializer().ProjectedRowSize())),
-        order_secondary_key_buffer(common::AllocationUtil::AllocateAligned(
+        order_secondary_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->order_secondary_index_->GetProjectedRowInitializer().ProjectedRowSize())),
-        new_order_key_buffer(common::AllocationUtil::AllocateAligned(
+        new_order_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->new_order_primary_index_->GetProjectedRowInitializer().ProjectedRowSize())),
-        order_line_key_buffer(common::AllocationUtil::AllocateAligned(
+        order_line_key_buffer_(common::AllocationUtil::AllocateAligned(
             db->order_line_primary_index_->GetProjectedRowInitializer().ProjectedRowSize())) {}
 
   ~Worker() {
@@ -84,26 +84,26 @@ struct Worker {
     delete[] order_line_key_buffer;
   }
 
-  byte *const item_tuple_buffer;
-  byte *const warehouse_tuple_buffer;
-  byte *const stock_tuple_buffer;
-  byte *const district_tuple_buffer;
-  byte *const customer_tuple_buffer;
-  byte *const history_tuple_buffer;
-  byte *const order_tuple_buffer;
-  byte *const new_order_tuple_buffer;
-  byte *const order_line_tuple_buffer;
+  byte *const item_tuple_buffer_;
+  byte *const warehouse_tuple_buffer_;
+  byte *const stock_tuple_buffer_;
+  byte *const district_tuple_buffer_;
+  byte *const customer_tuple_buffer_;
+  byte *const history_tuple_buffer_;
+  byte *const order_tuple_buffer_;
+  byte *const new_order_tuple_buffer_;
+  byte *const order_line_tuple_buffer_;
 
-  byte *const item_key_buffer;
-  byte *const warehouse_key_buffer;
-  byte *const stock_key_buffer;
-  byte *const district_key_buffer;
-  byte *const customer_key_buffer;
-  byte *const customer_name_key_buffer;
-  byte *const customer_name_varlen_buffer;
-  byte *const order_key_buffer;
-  byte *const order_secondary_key_buffer;
-  byte *const new_order_key_buffer;
-  byte *const order_line_key_buffer;
+  byte *const item_key_buffer_;
+  byte *const warehouse_key_buffer_;
+  byte *const stock_key_buffer_;
+  byte *const district_key_buffer_;
+  byte *const customer_key_buffer_;
+  byte *const customer_name_key_buffer_;
+  byte *const customer_name_varlen_buffer_;
+  byte *const order_key_buffer_;
+  byte *const order_secondary_key_buffer_;
+  byte *const new_order_key_buffer_;
+  byte *const order_line_key_buffer_;
 };
 }  // namespace terrier::tpcc

--- a/test/include/util/tpcc/workload.h
+++ b/test/include/util/tpcc/workload.h
@@ -14,10 +14,10 @@ namespace terrier::tpcc {
 // Txn distribution. New Order is not provided because it's the implicit difference of the txns below from 100. Default
 // values come from TPC-C spec.
 struct TransactionWeights {
-  uint32_t w_payment = 43;
-  uint32_t w_delivery = 4;
-  uint32_t w_order_status = 4;
-  uint32_t w_stock_level = 4;
+  uint32_t w_payment_ = 43;
+  uint32_t w_delivery_ = 4;
+  uint32_t w_order_status_ = 4;
+  uint32_t w_stock_level_ = 4;
 };
 
 /*
@@ -106,8 +106,8 @@ class Deck {
 
  private:
   std::default_random_engine generator_;
-  std::vector<tpcc::TransactionType> cards;
-  uint32_t card_idx = 0;
+  std::vector<tpcc::TransactionType> cards_;
+  uint32_t card_idx_ = 0;
 };
 
 // 2.4.1

--- a/test/include/util/tpcc/workload.h
+++ b/test/include/util/tpcc/workload.h
@@ -21,7 +21,7 @@ struct TransactionWeights {
 };
 
 /*
- * An infinite deck of randomly shuffled TPCC cards.
+ * An infinite deck of randomly shuffled TPCC cards_.
  */
 class Deck {
  public:
@@ -29,13 +29,13 @@ class Deck {
    * Default deck suggested by section 5.2.4.2 of the specification.
    */
   Deck() {
-    cards.reserve(23);
-    for (uint32_t i = 0; i < 10; i++) cards.emplace_back(tpcc::TransactionType::NewOrder);
-    for (uint32_t i = 0; i < 10; i++) cards.emplace_back(tpcc::TransactionType::Payment);
-    cards.emplace_back(tpcc::TransactionType::OrderStatus);
-    cards.emplace_back(tpcc::TransactionType::Delivery);
-    cards.emplace_back(tpcc::TransactionType::StockLevel);
-    std::shuffle(cards.begin(), cards.end(), generator_);
+    cards_.reserve(23);
+    for (uint32_t i = 0; i < 10; i++) cards_.emplace_back(tpcc::TransactionType::NewOrder);
+    for (uint32_t i = 0; i < 10; i++) cards_.emplace_back(tpcc::TransactionType::Payment);
+    cards_.emplace_back(tpcc::TransactionType::OrderStatus);
+    cards_.emplace_back(tpcc::TransactionType::Delivery);
+    cards_.emplace_back(tpcc::TransactionType::StockLevel);
+    std::shuffle(cards_.begin(), cards_.end(), generator_);
   }
 
   /*
@@ -47,59 +47,62 @@ class Deck {
    * calls for deck sizes to be multiples of 23, an exact lower bound cannot always be achieved.
    */
   explicit Deck(const TransactionWeights &txn_weights) {
-    TERRIER_ASSERT(txn_weights.w_payment >= 43, "At least 43% payment.");
-    TERRIER_ASSERT(txn_weights.w_order_status >= 4, "At least 4% order status.");
-    TERRIER_ASSERT(txn_weights.w_delivery >= 4, "At least 4% delivery.");
-    TERRIER_ASSERT(txn_weights.w_payment >= 4, "At least 4% stock level.");
+    TERRIER_ASSERT(txn_weights.w_payment_ >= 43, "At least 43% payment.");
+    TERRIER_ASSERT(txn_weights.w_order_status_ >= 4, "At least 4% order status.");
+    TERRIER_ASSERT(txn_weights.w_delivery_ >= 4, "At least 4% delivery.");
+    TERRIER_ASSERT(txn_weights.w_payment_ >= 4, "At least 4% stock level.");
     TERRIER_ASSERT(
-        txn_weights.w_payment + txn_weights.w_order_status + txn_weights.w_delivery + txn_weights.w_stock_level <= 100,
+        txn_weights.w_payment_ + txn_weights.w_order_status_ + txn_weights.w_delivery_ + txn_weights.w_stock_level_ <=
+            100,
         "Weights cannot be more than 100.");
 
-    auto min_payment = static_cast<uint32_t>(std::ceil(static_cast<double>(txn_weights.w_payment) / 100.0 * 23));
+    auto min_payment = static_cast<uint32_t>(std::ceil(static_cast<double>(txn_weights.w_payment_) / 100.0 * 23));
     auto min_order_status =
-        static_cast<uint32_t>(std::ceil(static_cast<double>(txn_weights.w_order_status) / 100.0 * 23));
-    auto min_delivery = static_cast<uint32_t>(std::ceil(static_cast<double>(txn_weights.w_delivery) / 100.0 * 23));
+        static_cast<uint32_t>(std::ceil(static_cast<double>(txn_weights.w_order_status_) / 100.0 * 23));
+    auto min_delivery = static_cast<uint32_t>(std::ceil(static_cast<double>(txn_weights.w_delivery_) / 100.0 * 23));
     auto min_stock_level =
-        static_cast<uint32_t>(std::ceil(static_cast<double>(txn_weights.w_stock_level) / 100.0 * 23));
+        static_cast<uint32_t>(std::ceil(static_cast<double>(txn_weights.w_stock_level_) / 100.0 * 23));
 
     uint32_t min_num_cards = min_payment + min_order_status + min_delivery + min_stock_level;
     TERRIER_ASSERT(min_num_cards <= 23, "Can't have more than 23 cards!");
     auto min_new_order = 23 - min_num_cards;
 
-    cards.reserve(23);
-    for (uint32_t i = 0; i < min_new_order; i++) cards.emplace_back(tpcc::TransactionType::NewOrder);
-    for (uint32_t i = 0; i < min_payment; i++) cards.emplace_back(tpcc::TransactionType::Payment);
-    for (uint32_t i = 0; i < min_order_status; i++) cards.emplace_back(tpcc::TransactionType::OrderStatus);
-    for (uint32_t i = 0; i < min_delivery; i++) cards.emplace_back(tpcc::TransactionType::Delivery);
-    for (uint32_t i = 0; i < min_stock_level; i++) cards.emplace_back(tpcc::TransactionType::StockLevel);
+    cards_.reserve(23);
+    for (uint32_t i = 0; i < min_new_order; i++) cards_.emplace_back(tpcc::TransactionType::NewOrder);
+    for (uint32_t i = 0; i < min_payment; i++) cards_.emplace_back(tpcc::TransactionType::Payment);
+    for (uint32_t i = 0; i < min_order_status; i++) cards_.emplace_back(tpcc::TransactionType::OrderStatus);
+    for (uint32_t i = 0; i < min_delivery; i++) cards_.emplace_back(tpcc::TransactionType::Delivery);
+    for (uint32_t i = 0; i < min_stock_level; i++) cards_.emplace_back(tpcc::TransactionType::StockLevel);
 
     auto UNUSED_ATTRIBUTE c_new_order = std::count_if(
-        cards.begin(), cards.end(), [](tpcc::TransactionType txn) { return txn == tpcc::TransactionType::NewOrder; });
+        cards_.begin(), cards_.end(), [](tpcc::TransactionType txn) { return txn == tpcc::TransactionType::NewOrder; });
     auto UNUSED_ATTRIBUTE c_payment = std::count_if(
-        cards.begin(), cards.end(), [](tpcc::TransactionType txn) { return txn == tpcc::TransactionType::Payment; });
-    auto UNUSED_ATTRIBUTE c_order_status = std::count_if(cards.begin(), cards.end(), [](tpcc::TransactionType txn) {
+        cards_.begin(), cards_.end(), [](tpcc::TransactionType txn) { return txn == tpcc::TransactionType::Payment; });
+    auto UNUSED_ATTRIBUTE c_order_status = std::count_if(cards_.begin(), cards_.end(), [](tpcc::TransactionType txn) {
       return txn == tpcc::TransactionType::OrderStatus;
     });
     auto UNUSED_ATTRIBUTE c_delivery = std::count_if(
-        cards.begin(), cards.end(), [](tpcc::TransactionType txn) { return txn == tpcc::TransactionType::Delivery; });
-    auto UNUSED_ATTRIBUTE c_stock_level = std::count_if(
-        cards.begin(), cards.end(), [](tpcc::TransactionType txn) { return txn == tpcc::TransactionType::StockLevel; });
-    TERRIER_ASSERT(static_cast<double>(c_payment) / 23.0 * 100 >= txn_weights.w_payment, "Payment weight unsatisfied.");
-    TERRIER_ASSERT(static_cast<double>(c_order_status) / 23.0 * 100 >= txn_weights.w_order_status,
+        cards_.begin(), cards_.end(), [](tpcc::TransactionType txn) { return txn == tpcc::TransactionType::Delivery; });
+    auto UNUSED_ATTRIBUTE c_stock_level = std::count_if(cards_.begin(), cards_.end(), [](tpcc::TransactionType txn) {
+      return txn == tpcc::TransactionType::StockLevel;
+    });
+    TERRIER_ASSERT(static_cast<double>(c_payment) / 23.0 * 100 >= txn_weights.w_payment_,
+                   "Payment weight unsatisfied.");
+    TERRIER_ASSERT(static_cast<double>(c_order_status) / 23.0 * 100 >= txn_weights.w_order_status_,
                    "Order status weight unsatisfied.");
-    TERRIER_ASSERT(static_cast<double>(c_delivery) / 23.0 * 100 >= txn_weights.w_delivery,
+    TERRIER_ASSERT(static_cast<double>(c_delivery) / 23.0 * 100 >= txn_weights.w_delivery_,
                    "Delivery weight unsatisfied.");
-    TERRIER_ASSERT(static_cast<double>(c_stock_level) / 23.0 * 100 >= txn_weights.w_stock_level,
+    TERRIER_ASSERT(static_cast<double>(c_stock_level) / 23.0 * 100 >= txn_weights.w_stock_level_,
                    "Stock level weight unsatisfied.");
 
-    std::shuffle(cards.begin(), cards.end(), generator_);
+    std::shuffle(cards_.begin(), cards_.end(), generator_);
   }
 
   tpcc::TransactionType NextCard() {
-    auto next_txn = cards[card_idx++];
-    if (card_idx == cards.size()) {
-      std::shuffle(cards.begin(), cards.end(), generator_);
-      card_idx = 0;
+    auto next_txn = cards_[card_idx_++];
+    if (card_idx_ == cards_.size()) {
+      std::shuffle(cards_.begin(), cards_.end(), generator_);
+      card_idx_ = 0;
     }
     return next_txn;
   }
@@ -115,18 +118,18 @@ template <class Random>
 TransactionArgs BuildNewOrderArgs(Random *const generator, const int8_t w_id, const int8_t num_warehouses) {
   TERRIER_ASSERT(w_id >= 1 && w_id <= num_warehouses, "Invalid w_id.");
   TransactionArgs args;
-  args.type = TransactionType::NewOrder;
-  args.w_id = w_id;
-  args.d_id = Util::RandomWithin<int8_t>(1, 10, 0, generator);
-  args.c_id = Util::NURand(1023, 1, 3000, generator);
-  args.ol_cnt = Util::RandomWithin<int8_t>(5, 15, 0, generator);
-  args.rbk = Util::RandomWithin<uint8_t>(1, 100, 0, generator);
-  args.o_all_local = true;
+  args.type_ = TransactionType::NewOrder;
+  args.w_id_ = w_id;
+  args.d_id_ = Util::RandomWithin<int8_t>(1, 10, 0, generator);
+  args.c_id_ = Util::NURand(1023, 1, 3000, generator);
+  args.ol_cnt_ = Util::RandomWithin<int8_t>(5, 15, 0, generator);
+  args.rbk_ = Util::RandomWithin<uint8_t>(1, 100, 0, generator);
+  args.o_all_local_ = true;
 
-  args.items.reserve(args.ol_cnt);
+  args.items_.reserve(args.ol_cnt_);
 
-  for (int32_t i = 0; i < args.ol_cnt; i++) {
-    int32_t ol_i_id = (i == args.ol_cnt - 1 && args.rbk == 1) ? 8491138 : Util::NURand(8191, 1, 100000, generator);
+  for (int32_t i = 0; i < args.ol_cnt_; i++) {
+    int32_t ol_i_id = (i == args.ol_cnt_ - 1 && args.rbk_ == 1) ? 8491138 : Util::NURand(8191, 1, 100000, generator);
     int8_t ol_supply_w_id;
     bool remote;
     if (num_warehouses == 1 || Util::RandomWithin<uint8_t>(1, 100, 0, generator) > 1) {
@@ -139,12 +142,12 @@ TransactionArgs BuildNewOrderArgs(Random *const generator, const int8_t w_id, co
       } while (remote_w_id == w_id);
       ol_supply_w_id = remote_w_id;
       remote = true;
-      args.o_all_local = false;
+      args.o_all_local_ = false;
     }
     int8_t ol_quantity = Util::RandomWithin<uint8_t>(1, 10, 0, generator);
-    args.items.push_back({ol_i_id, ol_supply_w_id, ol_quantity, remote});
+    args.items_.push_back({ol_i_id, ol_supply_w_id, ol_quantity, remote});
   }
-  args.o_entry_d = Util::Timestamp();
+  args.o_entry_d_ = Util::Timestamp();
   return args;
 }
 
@@ -153,31 +156,31 @@ template <class Random>
 TransactionArgs BuildPaymentArgs(Random *const generator, const int8_t w_id, const int8_t num_warehouses) {
   TERRIER_ASSERT(w_id >= 1 && w_id <= num_warehouses, "Invalid w_id.");
   TransactionArgs args;
-  args.type = TransactionType::Payment;
-  args.w_id = w_id;
-  args.d_id = Util::RandomWithin<int8_t>(1, 10, 0, generator);
+  args.type_ = TransactionType::Payment;
+  args.w_id_ = w_id;
+  args.d_id_ = Util::RandomWithin<int8_t>(1, 10, 0, generator);
   if (Util::RandomWithin<int8_t>(1, 100, 0, generator) <= 85) {
-    args.c_d_id = args.d_id;
-    args.c_w_id = args.w_id;
-    args.remote = false;
+    args.c_d_id_ = args.d_id_;
+    args.c_w_id_ = args.w_id_;
+    args.remote_ = false;
   } else {
-    args.c_d_id = Util::RandomWithin<int8_t>(1, 10, 0, generator);
+    args.c_d_id_ = Util::RandomWithin<int8_t>(1, 10, 0, generator);
     int8_t remote_w_id;
     do {
       remote_w_id = Util::RandomWithin<int8_t>(1, num_warehouses, 0, generator);
     } while (num_warehouses > 1 && remote_w_id == w_id);
-    args.c_w_id = remote_w_id;
-    args.remote = true;
+    args.c_w_id_ = remote_w_id;
+    args.remote_ = true;
   }
   if (Util::RandomWithin<int8_t>(1, 100, 0, generator) <= 60) {
-    args.c_last = Util::LastNameVarlenEntry(static_cast<uint16_t>(Util::NURand(255, 0, 999, generator)));
-    args.use_c_last = true;
+    args.c_last_ = Util::LastNameVarlenEntry(static_cast<uint16_t>(Util::NURand(255, 0, 999, generator)));
+    args.use_c_last_ = true;
   } else {
-    args.c_id = Util::NURand(1023, 1, 3000, generator);
-    args.use_c_last = false;
+    args.c_id_ = Util::NURand(1023, 1, 3000, generator);
+    args.use_c_last_ = false;
   }
-  args.h_amount = Util::RandomWithin<double>(100, 500000, 2, generator);
-  args.h_date = Util::Timestamp();
+  args.h_amount_ = Util::RandomWithin<double>(100, 500000, 2, generator);
+  args.h_date_ = Util::Timestamp();
   return args;
 }
 
@@ -186,15 +189,15 @@ template <class Random>
 TransactionArgs BuildOrderStatusArgs(Random *const generator, const int8_t w_id, const int8_t num_warehouses) {
   TERRIER_ASSERT(w_id >= 1 && w_id <= num_warehouses, "Invalid w_id.");
   TransactionArgs args;
-  args.type = TransactionType::OrderStatus;
-  args.w_id = w_id;
-  args.d_id = Util::RandomWithin<int8_t>(1, 10, 0, generator);
+  args.type_ = TransactionType::OrderStatus;
+  args.w_id_ = w_id;
+  args.d_id_ = Util::RandomWithin<int8_t>(1, 10, 0, generator);
   if (Util::RandomWithin<int8_t>(1, 100, 0, generator) <= 60) {
-    args.c_last = Util::LastNameVarlenEntry(static_cast<uint16_t>(Util::NURand(255, 0, 999, generator)));
-    args.use_c_last = true;
+    args.c_last_ = Util::LastNameVarlenEntry(static_cast<uint16_t>(Util::NURand(255, 0, 999, generator)));
+    args.use_c_last_ = true;
   } else {
-    args.c_id = Util::NURand(1023, 1, 3000, generator);
-    args.use_c_last = false;
+    args.c_id_ = Util::NURand(1023, 1, 3000, generator);
+    args.use_c_last_ = false;
   }
   return args;
 }
@@ -204,10 +207,10 @@ template <class Random>
 TransactionArgs BuildDeliveryArgs(Random *const generator, const int8_t w_id, const int8_t num_warehouses) {
   TERRIER_ASSERT(w_id >= 1 && w_id <= num_warehouses, "Invalid w_id.");
   TransactionArgs args;
-  args.type = TransactionType::Delivery;
-  args.w_id = w_id;
-  args.o_carrier_id = Util::RandomWithin<int8_t>(1, 10, 0, generator);
-  args.ol_delivery_d = Util::Timestamp();
+  args.type_ = TransactionType::Delivery;
+  args.w_id_ = w_id;
+  args.o_carrier_id_ = Util::RandomWithin<int8_t>(1, 10, 0, generator);
+  args.ol_delivery_d_ = Util::Timestamp();
   return args;
 }
 
@@ -216,10 +219,10 @@ template <class Random>
 TransactionArgs BuildStockLevelArgs(Random *const generator, const int8_t w_id, const int8_t num_warehouses) {
   TERRIER_ASSERT(w_id >= 1 && w_id <= num_warehouses, "Invalid w_id.");
   TransactionArgs args;
-  args.type = TransactionType::StockLevel;
-  args.w_id = w_id;
-  args.d_id = Util::RandomWithin<int8_t>(1, 10, 0, generator);  // specification doesn't specify computing this
-  args.s_quantity_threshold = Util::RandomWithin<int8_t>(10, 20, 0, generator);
+  args.type_ = TransactionType::StockLevel;
+  args.w_id_ = w_id;
+  args.d_id_ = Util::RandomWithin<int8_t>(1, 10, 0, generator);  // specification doesn't specify computing this
+  args.s_quantity_threshold_ = Util::RandomWithin<int8_t>(10, 20, 0, generator);
   return args;
 }
 

--- a/test/integration/tpcc_test.cpp
+++ b/test/integration/tpcc_test.cpp
@@ -47,7 +47,7 @@ class TPCCTests : public TerrierTest {
   const int8_t num_threads_ = 4;  // defines the number of terminals (workers running txns) and warehouses for the
   // benchmark. Sometimes called scale factor
   const uint32_t num_precomputed_txns_per_worker_ = 10000;  // Number of txns to run per terminal (worker thread)
-  TransactionWeights txn_weights_;                           // default txn_weights. See definition for values
+  TransactionWeights txn_weights_;                          // default txn_weights. See definition for values
 
   common::WorkerPool thread_pool_{static_cast<uint32_t>(num_threads_), {}};
   common::DedicatedThreadRegistry *thread_registry_ = nullptr;
@@ -79,7 +79,7 @@ TEST_F(TPCCTests, WithoutLogging) {
 
   // Precompute all of the input arguments for every txn to be run. We want to avoid the overhead at benchmark time
   const auto precomputed_args =
-      PrecomputeArgs(&generator_, txn_weights, num_threads_, num_precomputed_txns_per_worker_);
+      PrecomputeArgs(&generator_, txn_weights_, num_threads_, num_precomputed_txns_per_worker_);
 
   // build the TPCC database
   auto *const tpcc_db = tpcc_builder.Build();
@@ -133,7 +133,7 @@ TEST_F(TPCCTests, WithLogging) {
 
   // Precompute all of the input arguments for every txn to be run. We want to avoid the overhead at benchmark time
   const auto precomputed_args =
-      PrecomputeArgs(&generator_, txn_weights, num_threads_, num_precomputed_txns_per_worker_);
+      PrecomputeArgs(&generator_, txn_weights_, num_threads_, num_precomputed_txns_per_worker_);
 
   // build the TPCC database
   auto *const tpcc_db = tpcc_builder.Build();

--- a/test/integration/tpcc_test.cpp
+++ b/test/integration/tpcc_test.cpp
@@ -47,7 +47,7 @@ class TPCCTests : public TerrierTest {
   const int8_t num_threads_ = 4;  // defines the number of terminals (workers running txns) and warehouses for the
   // benchmark. Sometimes called scale factor
   const uint32_t num_precomputed_txns_per_worker_ = 10000;  // Number of txns to run per terminal (worker thread)
-  TransactionWeights txn_weights;                           // default txn_weights. See definition for values
+  TransactionWeights txn_weights_;                           // default txn_weights. See definition for values
 
   common::WorkerPool thread_pool_{static_cast<uint32_t>(num_threads_), {}};
   common::DedicatedThreadRegistry *thread_registry_ = nullptr;

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -52,7 +52,7 @@ class NetworkTests : public TerrierTest {
       handle_factory_ = std::make_unique<ConnectionHandleFactory>(common::ManagedPointer(&tcop_));
       server_ = std::make_unique<TerrierServer>(
           common::ManagedPointer<ProtocolInterpreter::Provider>(&protocol_provider_),
-          common::ManagedPointer(handle_factory_.get()), common::ManagedPointer(&thread_registry));
+          common::ManagedPointer(handle_factory_.get()), common::ManagedPointer(&thread_registry_));
       server_->SetPort(port_);
       server_->RunServer();
     } catch (NetworkProcessException &exception) {

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -35,7 +35,7 @@ class NetworkTests : public TerrierTest {
  protected:
   std::unique_ptr<TerrierServer> server_;
   std::unique_ptr<ConnectionHandleFactory> handle_factory_;
-  common::DedicatedThreadRegistry thread_registry;
+  common::DedicatedThreadRegistry thread_registry_;
   uint16_t port_ = common::Settings::SERVER_PORT;
   trafficcop::TrafficCop tcop_;
   FakeCommandFactory fake_command_factory_;
@@ -118,17 +118,17 @@ class NetworkTests : public TerrierTest {
 // NOLINTNEXTLINE
 TEST_F(NetworkTests, SimpleQueryTest) {
   try {
-    pqxx::connection C(
+    pqxx::connection c(
         fmt::format("host=127.0.0.1 port={0} user=postgres sslmode=disable application_name=psql", port_));
 
-    pqxx::work txn1(C);
+    pqxx::work txn1(c);
     txn1.exec("INSERT INTO employee VALUES (1, 'Han LI');");
     txn1.exec("INSERT INTO employee VALUES (2, 'Shaokun ZOU');");
     txn1.exec("INSERT INTO employee VALUES (3, 'Yilei CHU');");
 
-    pqxx::result R = txn1.exec("SELECT name FROM employee where id=1;");
+    pqxx::result r = txn1.exec("SELECT name FROM employee where id=1;");
     txn1.commit();
-    EXPECT_EQ(R.size(), 0);
+    EXPECT_EQ(r.size(), 0);
   } catch (const std::exception &e) {
     TEST_LOG_ERROR("[SimpleQueryTest] Exception occurred: {0}", e.what());
     EXPECT_TRUE(false);
@@ -169,9 +169,9 @@ TEST_F(NetworkTests, BadQueryTest) {
 // NOLINTNEXTLINE
 TEST_F(NetworkTests, NoSSLTest) {
   try {
-    pqxx::connection C(fmt::format("host=127.0.0.1 port={0} user=postgres application_name=psql", port_));
+    pqxx::connection c(fmt::format("host=127.0.0.1 port={0} user=postgres application_name=psql", port_));
 
-    pqxx::work txn1(C);
+    pqxx::work txn1(c);
     txn1.exec("INSERT INTO employee VALUES (1, 'Han LI');");
     txn1.exec("INSERT INTO employee VALUES (2, 'Shaokun ZOU');");
     txn1.exec("INSERT INTO employee VALUES (3, 'Yilei CHU');");
@@ -194,13 +194,13 @@ TEST_F(NetworkTests, PgNetworkCommandsTest) {
 // NOLINTNEXTLINE
 TEST_F(NetworkTests, LargePacketsTest) {
   try {
-    pqxx::connection C(
+    pqxx::connection c(
         fmt::format("host=127.0.0.1 port={0} user=postgres sslmode=disable application_name=psql", port_));
 
-    pqxx::work txn1(C);
-    std::string longQueryPacketString(255555, 'a');
-    longQueryPacketString[longQueryPacketString.size() - 1] = '\0';
-    txn1.exec(longQueryPacketString);
+    pqxx::work txn1(c);
+    std::string long_query_packet_string(255555, 'a');
+    long_query_packet_string[long_query_packet_string.size() - 1] = '\0';
+    txn1.exec(long_query_packet_string);
     txn1.commit();
   } catch (const std::exception &e) {
     TEST_LOG_ERROR("[LargePacketstest] Exception occurred: {0}", e.what());

--- a/test/optimizer/logical_operator_test.cpp
+++ b/test/optimizer/logical_operator_test.cpp
@@ -31,7 +31,7 @@ TEST(OperatorTests, LogicalInsertTest) {
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values))};
 
   // Check that all of our GET methods work as expected
-  Operator op1 = LogicalInsert::make(
+  Operator op1 = LogicalInsert::Make(
       database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
       std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(values));
   EXPECT_EQ(op1.GetType(), OpType::LOGICALINSERT);
@@ -44,7 +44,7 @@ TEST(OperatorTests, LogicalInsertTest) {
 
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
-  Operator op2 = LogicalInsert::make(
+  Operator op2 = LogicalInsert::Make(
       database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
       std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(values));
   EXPECT_TRUE(op1 == op2);
@@ -55,7 +55,7 @@ TEST(OperatorTests, LogicalInsertTest) {
   std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> other_values = {
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values)),
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values))};
-  Operator op3 = LogicalInsert::make(
+  Operator op3 = LogicalInsert::Make(
       database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
       std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(other_values));
   EXPECT_FALSE(op1 == op3);
@@ -71,7 +71,7 @@ TEST(OperatorTests, LogicalInsertTest) {
       new parser::ConstantValueExpression(type::TransientValueFactory::GetTinyInt(3))};
   std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> bad_values = {
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(bad_raw_values, std::end(bad_raw_values))};
-  EXPECT_DEATH(LogicalInsert::make(
+  EXPECT_DEATH(LogicalInsert::Make(
                    database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
                    std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(bad_values)),
                "Mismatched");
@@ -88,7 +88,7 @@ TEST(OperatorTests, LogicalInsertSelectTest) {
   catalog::table_oid_t table_oid(789);
 
   // Check that all of our GET methods work as expected
-  Operator op1 = LogicalInsertSelect::make(database_oid, namespace_oid, table_oid);
+  Operator op1 = LogicalInsertSelect::Make(database_oid, namespace_oid, table_oid);
   EXPECT_EQ(op1.GetType(), OpType::LOGICALINSERTSELECT);
   EXPECT_EQ(op1.As<LogicalInsertSelect>()->GetDatabaseOid(), database_oid);
   EXPECT_EQ(op1.As<LogicalInsertSelect>()->GetNamespaceOid(), namespace_oid);
@@ -96,14 +96,14 @@ TEST(OperatorTests, LogicalInsertSelectTest) {
 
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
-  Operator op2 = LogicalInsertSelect::make(database_oid, namespace_oid, table_oid);
+  Operator op2 = LogicalInsertSelect::Make(database_oid, namespace_oid, table_oid);
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // Lastly, make a different object and make sure that it is not equal
   // and that it's hash is not the same!
   catalog::db_oid_t other_database_oid(999);
-  Operator op3 = LogicalInsertSelect::make(other_database_oid, namespace_oid, table_oid);
+  Operator op3 = LogicalInsertSelect::Make(other_database_oid, namespace_oid, table_oid);
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 }
@@ -113,10 +113,10 @@ TEST(OperatorTests, LogicalDistinctTest) {
   // DISTINCT operator does not have any data members.
   // So we just need to make sure that all instantiations
   // of the object are equivalent.
-  Operator op1 = LogicalDistinct::make();
+  Operator op1 = LogicalDistinct::Make();
   EXPECT_EQ(op1.GetType(), OpType::LOGICALDISTINCT);
 
-  Operator op2 = LogicalDistinct::make();
+  Operator op2 = LogicalDistinct::Make();
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 }
@@ -130,7 +130,7 @@ TEST(OperatorTests, LogicalLimitTest) {
   planner::OrderByOrderingType sort_dir = planner::OrderByOrderingType::ASC;
 
   // Check that all of our GET methods work as expected
-  Operator op1 = LogicalLimit::make(offset, limit, {sort_expr}, {sort_dir});
+  Operator op1 = LogicalLimit::Make(offset, limit, {sort_expr}, {sort_dir});
   EXPECT_EQ(op1.GetType(), OpType::LOGICALLIMIT);
   EXPECT_EQ(op1.As<LogicalLimit>()->GetOffset(), offset);
   EXPECT_EQ(op1.As<LogicalLimit>()->GetLimit(), limit);
@@ -141,14 +141,14 @@ TEST(OperatorTests, LogicalLimitTest) {
 
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
-  Operator op2 = LogicalLimit::make(offset, limit, {sort_expr}, {sort_dir});
+  Operator op2 = LogicalLimit::Make(offset, limit, {sort_expr}, {sort_dir});
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // Lastly, make a different object and make sure that it is not equal
   // and that it's hash is not the same!
   size_t other_offset = 1111;
-  Operator op3 = LogicalLimit::make(other_offset, limit, {sort_expr}, {sort_dir});
+  Operator op3 = LogicalLimit::Make(other_offset, limit, {sort_expr}, {sort_dir});
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 
@@ -162,7 +162,7 @@ TEST(OperatorTests, LogicalDeleteTest) {
   catalog::table_oid_t table_oid(789);
 
   // Check that all of our GET methods work as expected
-  Operator op1 = LogicalDelete::make(database_oid, namespace_oid, table_oid);
+  Operator op1 = LogicalDelete::Make(database_oid, namespace_oid, table_oid);
   EXPECT_EQ(op1.GetType(), OpType::LOGICALDELETE);
   EXPECT_EQ(op1.As<LogicalDelete>()->GetDatabaseOid(), database_oid);
   EXPECT_EQ(op1.As<LogicalDelete>()->GetNamespaceOid(), namespace_oid);
@@ -170,14 +170,14 @@ TEST(OperatorTests, LogicalDeleteTest) {
 
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
-  Operator op2 = LogicalDelete::make(database_oid, namespace_oid, table_oid);
+  Operator op2 = LogicalDelete::Make(database_oid, namespace_oid, table_oid);
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // Lastly, make a different object and make sure that it is not equal
   // and that it's hash is not the same!
   catalog::db_oid_t other_database_oid(999);
-  Operator op3 = LogicalDelete::make(other_database_oid, namespace_oid, table_oid);
+  Operator op3 = LogicalDelete::Make(other_database_oid, namespace_oid, table_oid);
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 }
@@ -193,7 +193,7 @@ TEST(OperatorTests, LogicalUpdateTest) {
   catalog::table_oid_t table_oid(789);
 
   // Check that all of our GET methods work as expected
-  Operator op1 = LogicalUpdate::make(database_oid, namespace_oid, table_oid, {update_clause});
+  Operator op1 = LogicalUpdate::Make(database_oid, namespace_oid, table_oid, {update_clause});
   EXPECT_EQ(op1.GetType(), OpType::LOGICALUPDATE);
   EXPECT_EQ(op1.As<LogicalUpdate>()->GetDatabaseOid(), database_oid);
   EXPECT_EQ(op1.As<LogicalUpdate>()->GetNamespaceOid(), namespace_oid);
@@ -203,13 +203,13 @@ TEST(OperatorTests, LogicalUpdateTest) {
 
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
-  Operator op2 = LogicalUpdate::make(database_oid, namespace_oid, table_oid, {update_clause});
+  Operator op2 = LogicalUpdate::Make(database_oid, namespace_oid, table_oid, {update_clause});
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // Lastly, make a different object and make sure that it is not equal
   // and that it's hash is not the same!
-  Operator op3 = LogicalUpdate::make(database_oid, namespace_oid, table_oid, {});
+  Operator op3 = LogicalUpdate::Make(database_oid, namespace_oid, table_oid, {});
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 
@@ -226,7 +226,7 @@ TEST(OperatorTests, LogicalExportExternalFileTest) {
 
   // Check that all of our GET methods work as expected
   Operator op1 =
-      LogicalExportExternalFile::make(parser::ExternalFileFormat::BINARY, file_name, delimiter, quote, escape);
+      LogicalExportExternalFile::Make(parser::ExternalFileFormat::BINARY, file_name, delimiter, quote, escape);
   EXPECT_EQ(op1.GetType(), OpType::LOGICALEXPORTEXTERNALFILE);
   EXPECT_EQ(op1.As<LogicalExportExternalFile>()->GetFormat(), parser::ExternalFileFormat::BINARY);
   EXPECT_EQ(op1.As<LogicalExportExternalFile>()->GetFilename(), file_name);
@@ -239,13 +239,13 @@ TEST(OperatorTests, LogicalExportExternalFileTest) {
   std::string file_name_copy = file_name;  // NOLINT
   Operator op2 =
 
-      LogicalExportExternalFile::make(parser::ExternalFileFormat::BINARY, file_name_copy, delimiter, quote, escape);
+      LogicalExportExternalFile::Make(parser::ExternalFileFormat::BINARY, file_name_copy, delimiter, quote, escape);
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // Lastly, make a different object and make sure that it is not equal
   // and that it's hash is not the same!
-  Operator op3 = LogicalExportExternalFile::make(parser::ExternalFileFormat::CSV, file_name, delimiter, quote, escape);
+  Operator op3 = LogicalExportExternalFile::Make(parser::ExternalFileFormat::CSV, file_name, delimiter, quote, escape);
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 }
@@ -269,27 +269,27 @@ TEST(OperatorTests, LogicalGetTest) {
   auto annotated_expr_2 = AnnotatedExpression(x_2, std::unordered_set<std::string>());
   auto annotated_expr_3 = AnnotatedExpression(x_3, std::unordered_set<std::string>());
 
-  Operator logical_get_01 = LogicalGet::make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator logical_get_01 = LogicalGet::Make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                              std::vector<AnnotatedExpression>(), "table", false);
-  Operator logical_get_02 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::table_oid_t(3),
+  Operator logical_get_02 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::table_oid_t(3),
                                              std::vector<AnnotatedExpression>(), "table", false);
-  Operator logical_get_03 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+  Operator logical_get_03 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
                                              std::vector<AnnotatedExpression>(), "table", false);
-  Operator logical_get_04 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator logical_get_04 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                              std::vector<AnnotatedExpression>(), "tableTable", false);
-  Operator logical_get_05 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator logical_get_05 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                              std::vector<AnnotatedExpression>(), "table", true);
-  Operator logical_get_1 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator logical_get_1 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                             std::vector<AnnotatedExpression>(), "table", false);
-  Operator logical_get_2 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator logical_get_2 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                             std::vector<AnnotatedExpression>(), "table", false);
-  Operator logical_get_3 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator logical_get_3 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                             std::vector<AnnotatedExpression>{annotated_expr_0}, "table", false);
-  Operator logical_get_4 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator logical_get_4 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                             std::vector<AnnotatedExpression>{annotated_expr_1}, "table", false);
-  Operator logical_get_5 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator logical_get_5 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                             std::vector<AnnotatedExpression>{annotated_expr_2}, "table", false);
-  Operator logical_get_6 = LogicalGet::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator logical_get_6 = LogicalGet::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                             std::vector<AnnotatedExpression>{annotated_expr_3}, "table", false);
 
   EXPECT_EQ(logical_get_1.GetType(), OpType::LOGICALGET);
@@ -333,19 +333,19 @@ TEST(OperatorTests, LogicalExternalFileGetTest) {
   // LogicalExternalFileGet
   //===--------------------------------------------------------------------===//
   Operator logical_ext_file_get_1 =
-      LogicalExternalFileGet::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
+      LogicalExternalFileGet::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
   Operator logical_ext_file_get_2 =
-      LogicalExternalFileGet::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
+      LogicalExternalFileGet::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
   Operator logical_ext_file_get_3 =
-      LogicalExternalFileGet::make(parser::ExternalFileFormat::CSV, "file2.txt", ',', '"', '\\');
+      LogicalExternalFileGet::Make(parser::ExternalFileFormat::CSV, "file2.txt", ',', '"', '\\');
   Operator logical_ext_file_get_4 =
-      LogicalExternalFileGet::make(parser::ExternalFileFormat::BINARY, "file.txt", ',', '"', '\\');
+      LogicalExternalFileGet::Make(parser::ExternalFileFormat::BINARY, "file.txt", ',', '"', '\\');
   Operator logical_ext_file_get_5 =
-      LogicalExternalFileGet::make(parser::ExternalFileFormat::CSV, "file.txt", ' ', '"', '\\');
+      LogicalExternalFileGet::Make(parser::ExternalFileFormat::CSV, "file.txt", ' ', '"', '\\');
   Operator logical_ext_file_get_6 =
-      LogicalExternalFileGet::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '\'', '\\');
+      LogicalExternalFileGet::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '\'', '\\');
   Operator logical_ext_file_get_7 =
-      LogicalExternalFileGet::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '&');
+      LogicalExternalFileGet::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '&');
 
   EXPECT_EQ(logical_ext_file_get_1.GetType(), OpType::LOGICALEXTERNALFILEGET);
   EXPECT_EQ(logical_ext_file_get_1.GetName(), "LogicalExternalFileGet");
@@ -395,13 +395,13 @@ TEST(OperatorTests, LogicalQueryDerivedGetTest) {
   alias_to_expr_map_5["constant expr"] = expr1;
   alias_to_expr_map_5["constant expr2"] = expr2;
 
-  Operator logical_query_derived_get_1 = LogicalQueryDerivedGet::make("alias", std::move(alias_to_expr_map_1));
-  Operator logical_query_derived_get_2 = LogicalQueryDerivedGet::make("alias", std::move(alias_to_expr_map_2));
-  Operator logical_query_derived_get_3 = LogicalQueryDerivedGet::make(
+  Operator logical_query_derived_get_1 = LogicalQueryDerivedGet::Make("alias", std::move(alias_to_expr_map_1));
+  Operator logical_query_derived_get_2 = LogicalQueryDerivedGet::Make("alias", std::move(alias_to_expr_map_2));
+  Operator logical_query_derived_get_3 = LogicalQueryDerivedGet::Make(
       "alias", std::unordered_map<std::string, common::ManagedPointer<parser::AbstractExpression>>());
-  Operator logical_query_derived_get_4 = LogicalQueryDerivedGet::make("alias", std::move(alias_to_expr_map_3));
-  Operator logical_query_derived_get_5 = LogicalQueryDerivedGet::make("alias", std::move(alias_to_expr_map_4));
-  Operator logical_query_derived_get_6 = LogicalQueryDerivedGet::make("alias", std::move(alias_to_expr_map_5));
+  Operator logical_query_derived_get_4 = LogicalQueryDerivedGet::Make("alias", std::move(alias_to_expr_map_3));
+  Operator logical_query_derived_get_5 = LogicalQueryDerivedGet::Make("alias", std::move(alias_to_expr_map_4));
+  Operator logical_query_derived_get_6 = LogicalQueryDerivedGet::Make("alias", std::move(alias_to_expr_map_5));
 
   EXPECT_EQ(logical_query_derived_get_1.GetType(), OpType::LOGICALQUERYDERIVEDGET);
   EXPECT_EQ(logical_query_derived_get_1.GetName(), "LogicalQueryDerivedGet");
@@ -441,12 +441,12 @@ TEST(OperatorTests, LogicalFilterTest) {
   auto annotated_expr_2 = AnnotatedExpression(x_2, std::unordered_set<std::string>());
   auto annotated_expr_3 = AnnotatedExpression(x_3, std::unordered_set<std::string>());
 
-  Operator logical_filter_1 = LogicalFilter::make(std::vector<AnnotatedExpression>());
-  Operator logical_filter_2 = LogicalFilter::make(std::vector<AnnotatedExpression>());
-  Operator logical_filter_3 = LogicalFilter::make(std::vector<AnnotatedExpression>{annotated_expr_0});
-  Operator logical_filter_4 = LogicalFilter::make(std::vector<AnnotatedExpression>{annotated_expr_1});
-  Operator logical_filter_5 = LogicalFilter::make(std::vector<AnnotatedExpression>{annotated_expr_2});
-  Operator logical_filter_6 = LogicalFilter::make(std::vector<AnnotatedExpression>{annotated_expr_3});
+  Operator logical_filter_1 = LogicalFilter::Make(std::vector<AnnotatedExpression>());
+  Operator logical_filter_2 = LogicalFilter::Make(std::vector<AnnotatedExpression>());
+  Operator logical_filter_3 = LogicalFilter::Make(std::vector<AnnotatedExpression>{annotated_expr_0});
+  Operator logical_filter_4 = LogicalFilter::Make(std::vector<AnnotatedExpression>{annotated_expr_1});
+  Operator logical_filter_5 = LogicalFilter::Make(std::vector<AnnotatedExpression>{annotated_expr_2});
+  Operator logical_filter_6 = LogicalFilter::Make(std::vector<AnnotatedExpression>{annotated_expr_3});
 
   EXPECT_EQ(logical_filter_1.GetType(), OpType::LOGICALFILTER);
   EXPECT_EQ(logical_filter_3.GetType(), OpType::LOGICALFILTER);
@@ -482,11 +482,11 @@ TEST(OperatorTests, LogicalProjectionTest) {
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
   Operator logical_projection_1 =
-      LogicalProjection::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1});
+      LogicalProjection::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1});
   Operator logical_projection_2 =
-      LogicalProjection::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_2});
+      LogicalProjection::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_2});
   Operator logical_projection_3 =
-      LogicalProjection::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_3});
+      LogicalProjection::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_3});
 
   EXPECT_EQ(logical_projection_1.GetType(), OpType::LOGICALPROJECTION);
   EXPECT_EQ(logical_projection_3.GetType(), OpType::LOGICALPROJECTION);
@@ -524,13 +524,13 @@ TEST(OperatorTests, LogicalDependentJoinTest) {
   auto annotated_expr_2 = AnnotatedExpression(x_2, std::unordered_set<std::string>());
   auto annotated_expr_3 = AnnotatedExpression(x_3, std::unordered_set<std::string>());
 
-  Operator logical_dep_join_0 = LogicalDependentJoin::make();
-  Operator logical_dep_join_1 = LogicalDependentJoin::make(std::vector<AnnotatedExpression>());
-  Operator logical_dep_join_2 = LogicalDependentJoin::make(std::vector<AnnotatedExpression>());
-  Operator logical_dep_join_3 = LogicalDependentJoin::make(std::vector<AnnotatedExpression>{annotated_expr_0});
-  Operator logical_dep_join_4 = LogicalDependentJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1});
-  Operator logical_dep_join_5 = LogicalDependentJoin::make(std::vector<AnnotatedExpression>{annotated_expr_2});
-  Operator logical_dep_join_6 = LogicalDependentJoin::make(std::vector<AnnotatedExpression>{annotated_expr_3});
+  Operator logical_dep_join_0 = LogicalDependentJoin::Make();
+  Operator logical_dep_join_1 = LogicalDependentJoin::Make(std::vector<AnnotatedExpression>());
+  Operator logical_dep_join_2 = LogicalDependentJoin::Make(std::vector<AnnotatedExpression>());
+  Operator logical_dep_join_3 = LogicalDependentJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_0});
+  Operator logical_dep_join_4 = LogicalDependentJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1});
+  Operator logical_dep_join_5 = LogicalDependentJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_2});
+  Operator logical_dep_join_6 = LogicalDependentJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_3});
 
   EXPECT_EQ(logical_dep_join_1.GetType(), OpType::LOGICALDEPENDENTJOIN);
   EXPECT_EQ(logical_dep_join_3.GetType(), OpType::LOGICALDEPENDENTJOIN);
@@ -575,13 +575,13 @@ TEST(OperatorTests, LogicalMarkJoinTest) {
   auto annotated_expr_2 = AnnotatedExpression(x_2, std::unordered_set<std::string>());
   auto annotated_expr_3 = AnnotatedExpression(x_3, std::unordered_set<std::string>());
 
-  Operator logical_mark_join_0 = LogicalMarkJoin::make();
-  Operator logical_mark_join_1 = LogicalMarkJoin::make(std::vector<AnnotatedExpression>());
-  Operator logical_mark_join_2 = LogicalMarkJoin::make(std::vector<AnnotatedExpression>());
-  Operator logical_mark_join_3 = LogicalMarkJoin::make(std::vector<AnnotatedExpression>{annotated_expr_0});
-  Operator logical_mark_join_4 = LogicalMarkJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1});
-  Operator logical_mark_join_5 = LogicalMarkJoin::make(std::vector<AnnotatedExpression>{annotated_expr_2});
-  Operator logical_mark_join_6 = LogicalMarkJoin::make(std::vector<AnnotatedExpression>{annotated_expr_3});
+  Operator logical_mark_join_0 = LogicalMarkJoin::Make();
+  Operator logical_mark_join_1 = LogicalMarkJoin::Make(std::vector<AnnotatedExpression>());
+  Operator logical_mark_join_2 = LogicalMarkJoin::Make(std::vector<AnnotatedExpression>());
+  Operator logical_mark_join_3 = LogicalMarkJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_0});
+  Operator logical_mark_join_4 = LogicalMarkJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1});
+  Operator logical_mark_join_5 = LogicalMarkJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_2});
+  Operator logical_mark_join_6 = LogicalMarkJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_3});
 
   EXPECT_EQ(logical_mark_join_1.GetType(), OpType::LOGICALMARKJOIN);
   EXPECT_EQ(logical_mark_join_3.GetType(), OpType::LOGICALMARKJOIN);
@@ -626,13 +626,13 @@ TEST(OperatorTests, LogicalSingleJoinTest) {
   auto annotated_expr_2 = AnnotatedExpression(x_2, std::unordered_set<std::string>());
   auto annotated_expr_3 = AnnotatedExpression(x_3, std::unordered_set<std::string>());
 
-  Operator logical_single_join_0 = LogicalSingleJoin::make();
-  Operator logical_single_join_1 = LogicalSingleJoin::make(std::vector<AnnotatedExpression>());
-  Operator logical_single_join_2 = LogicalSingleJoin::make(std::vector<AnnotatedExpression>());
-  Operator logical_single_join_3 = LogicalSingleJoin::make(std::vector<AnnotatedExpression>{annotated_expr_0});
-  Operator logical_single_join_4 = LogicalSingleJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1});
-  Operator logical_single_join_5 = LogicalSingleJoin::make(std::vector<AnnotatedExpression>{annotated_expr_2});
-  Operator logical_single_join_6 = LogicalSingleJoin::make(std::vector<AnnotatedExpression>{annotated_expr_3});
+  Operator logical_single_join_0 = LogicalSingleJoin::Make();
+  Operator logical_single_join_1 = LogicalSingleJoin::Make(std::vector<AnnotatedExpression>());
+  Operator logical_single_join_2 = LogicalSingleJoin::Make(std::vector<AnnotatedExpression>());
+  Operator logical_single_join_3 = LogicalSingleJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_0});
+  Operator logical_single_join_4 = LogicalSingleJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1});
+  Operator logical_single_join_5 = LogicalSingleJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_2});
+  Operator logical_single_join_6 = LogicalSingleJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_3});
 
   EXPECT_EQ(logical_single_join_1.GetType(), OpType::LOGICALSINGLEJOIN);
   EXPECT_EQ(logical_single_join_3.GetType(), OpType::LOGICALSINGLEJOIN);
@@ -677,13 +677,13 @@ TEST(OperatorTests, LogicalInnerJoinTest) {
   auto annotated_expr_2 = AnnotatedExpression(x_2, std::unordered_set<std::string>());
   auto annotated_expr_3 = AnnotatedExpression(x_3, std::unordered_set<std::string>());
 
-  Operator logical_inner_join_0 = LogicalInnerJoin::make();
-  Operator logical_inner_join_1 = LogicalInnerJoin::make(std::vector<AnnotatedExpression>());
-  Operator logical_inner_join_2 = LogicalInnerJoin::make(std::vector<AnnotatedExpression>());
-  Operator logical_inner_join_3 = LogicalInnerJoin::make(std::vector<AnnotatedExpression>{annotated_expr_0});
-  Operator logical_inner_join_4 = LogicalInnerJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1});
-  Operator logical_inner_join_5 = LogicalInnerJoin::make(std::vector<AnnotatedExpression>{annotated_expr_2});
-  Operator logical_inner_join_6 = LogicalInnerJoin::make(std::vector<AnnotatedExpression>{annotated_expr_3});
+  Operator logical_inner_join_0 = LogicalInnerJoin::Make();
+  Operator logical_inner_join_1 = LogicalInnerJoin::Make(std::vector<AnnotatedExpression>());
+  Operator logical_inner_join_2 = LogicalInnerJoin::Make(std::vector<AnnotatedExpression>());
+  Operator logical_inner_join_3 = LogicalInnerJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_0});
+  Operator logical_inner_join_4 = LogicalInnerJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1});
+  Operator logical_inner_join_5 = LogicalInnerJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_2});
+  Operator logical_inner_join_6 = LogicalInnerJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_3});
 
   EXPECT_EQ(logical_inner_join_1.GetType(), OpType::LOGICALINNERJOIN);
   EXPECT_EQ(logical_inner_join_3.GetType(), OpType::LOGICALINNERJOIN);
@@ -722,9 +722,9 @@ TEST(OperatorTests, LogicalLeftJoinTest) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator logical_left_join_1 = LogicalLeftJoin::make(x_1);
-  Operator logical_left_join_2 = LogicalLeftJoin::make(x_2);
-  Operator logical_left_join_3 = LogicalLeftJoin::make(x_3);
+  Operator logical_left_join_1 = LogicalLeftJoin::Make(x_1);
+  Operator logical_left_join_2 = LogicalLeftJoin::Make(x_2);
+  Operator logical_left_join_3 = LogicalLeftJoin::Make(x_3);
 
   EXPECT_EQ(logical_left_join_1.GetType(), OpType::LOGICALLEFTJOIN);
   EXPECT_EQ(logical_left_join_3.GetType(), OpType::LOGICALLEFTJOIN);
@@ -755,9 +755,9 @@ TEST(OperatorTests, LogicalRightJoinTest) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator logical_right_join_1 = LogicalRightJoin::make(x_1);
-  Operator logical_right_join_2 = LogicalRightJoin::make(x_2);
-  Operator logical_right_join_3 = LogicalRightJoin::make(x_3);
+  Operator logical_right_join_1 = LogicalRightJoin::Make(x_1);
+  Operator logical_right_join_2 = LogicalRightJoin::Make(x_2);
+  Operator logical_right_join_3 = LogicalRightJoin::Make(x_3);
 
   EXPECT_EQ(logical_right_join_1.GetType(), OpType::LOGICALRIGHTJOIN);
   EXPECT_EQ(logical_right_join_3.GetType(), OpType::LOGICALRIGHTJOIN);
@@ -788,9 +788,9 @@ TEST(OperatorTests, LogicalOuterJoinTest) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator logical_outer_join_1 = LogicalOuterJoin::make(x_1);
-  Operator logical_outer_join_2 = LogicalOuterJoin::make(x_2);
-  Operator logical_outer_join_3 = LogicalOuterJoin::make(x_3);
+  Operator logical_outer_join_1 = LogicalOuterJoin::Make(x_1);
+  Operator logical_outer_join_2 = LogicalOuterJoin::Make(x_2);
+  Operator logical_outer_join_3 = LogicalOuterJoin::Make(x_3);
 
   EXPECT_EQ(logical_outer_join_1.GetType(), OpType::LOGICALOUTERJOIN);
   EXPECT_EQ(logical_outer_join_3.GetType(), OpType::LOGICALOUTERJOIN);
@@ -821,9 +821,9 @@ TEST(OperatorTests, LogicalSemiJoinTest) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator logical_semi_join_1 = LogicalSemiJoin::make(x_1);
-  Operator logical_semi_join_2 = LogicalSemiJoin::make(x_2);
-  Operator logical_semi_join_3 = LogicalSemiJoin::make(x_3);
+  Operator logical_semi_join_1 = LogicalSemiJoin::Make(x_1);
+  Operator logical_semi_join_2 = LogicalSemiJoin::Make(x_2);
+  Operator logical_semi_join_3 = LogicalSemiJoin::Make(x_3);
 
   EXPECT_EQ(logical_semi_join_1.GetType(), OpType::LOGICALSEMIJOIN);
   EXPECT_EQ(logical_semi_join_3.GetType(), OpType::LOGICALSEMIJOIN);
@@ -877,18 +877,18 @@ TEST(OperatorTests, LogicalAggregateAndGroupByTest) {
   auto annotated_expr_4 = AnnotatedExpression(x_8, std::unordered_set<std::string>());
 
   Operator logical_group_1_0 =
-      LogicalAggregateAndGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
+      LogicalAggregateAndGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
                                        std::vector<AnnotatedExpression>{annotated_expr_0});
   Operator logical_group_1_1 =
-      LogicalAggregateAndGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
+      LogicalAggregateAndGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
                                        std::vector<AnnotatedExpression>{annotated_expr_1});
   Operator logical_group_2_2 =
-      LogicalAggregateAndGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_2},
+      LogicalAggregateAndGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_2},
                                        std::vector<AnnotatedExpression>{annotated_expr_2});
   Operator logical_group_3 =
-      LogicalAggregateAndGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_3});
+      LogicalAggregateAndGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_3});
   Operator logical_group_7_4 =
-      LogicalAggregateAndGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_7},
+      LogicalAggregateAndGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_7},
                                        std::vector<AnnotatedExpression>{annotated_expr_4});
 
   EXPECT_EQ(logical_group_1_1.GetType(), OpType::LOGICALAGGREGATEANDGROUPBY);

--- a/test/optimizer/operator_expression_test.cpp
+++ b/test/optimizer/operator_expression_test.cpp
@@ -11,22 +11,22 @@ namespace terrier::optimizer {
 
 // NOLINTNEXTLINE
 TEST(OperatorExpressionTests, BasicOperatorExpressionTest) {
-  auto ope1 = new OperatorExpression(TableFreeScan::make(), std::vector<OperatorExpression *>());
-  auto ope2 = new OperatorExpression(LogicalDistinct::make(), std::vector<OperatorExpression *>());
-  auto ope3 = new OperatorExpression(TableFreeScan::make(), std::vector<OperatorExpression *>());
+  auto ope1 = new OperatorExpression(TableFreeScan::Make(), std::vector<OperatorExpression *>());
+  auto ope2 = new OperatorExpression(LogicalDistinct::Make(), std::vector<OperatorExpression *>());
+  auto ope3 = new OperatorExpression(TableFreeScan::Make(), std::vector<OperatorExpression *>());
 
-  auto ope4 = new OperatorExpression(LogicalDistinct::make(), std::vector<OperatorExpression *>{ope1, ope2});
+  auto ope4 = new OperatorExpression(LogicalDistinct::Make(), std::vector<OperatorExpression *>{ope1, ope2});
   Operator logical_ext_file_get_1 =
-      LogicalExternalFileGet::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
+      LogicalExternalFileGet::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
   Operator logical_ext_file_get_2 =
-      LogicalExternalFileGet::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
+      LogicalExternalFileGet::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
   auto ope5 = new OperatorExpression(std::move(logical_ext_file_get_1), std::vector<OperatorExpression *>{ope3});
-  auto ope6 = new OperatorExpression(LogicalDistinct::make(), std::vector<OperatorExpression *>());
+  auto ope6 = new OperatorExpression(LogicalDistinct::Make(), std::vector<OperatorExpression *>());
 
-  auto ope7 = new OperatorExpression(TableFreeScan::make(), std::vector<OperatorExpression *>{ope4, ope5, ope6});
+  auto ope7 = new OperatorExpression(TableFreeScan::Make(), std::vector<OperatorExpression *>{ope4, ope5, ope6});
 
-  EXPECT_TRUE(TableFreeScan::make() == ope7->GetOp());
-  EXPECT_TRUE(LogicalDistinct::make() == ope6->GetOp());
+  EXPECT_TRUE(TableFreeScan::Make() == ope7->GetOp());
+  EXPECT_TRUE(LogicalDistinct::Make() == ope6->GetOp());
   EXPECT_TRUE(logical_ext_file_get_2 == ope5->GetOp());
   EXPECT_EQ(ope1->GetChildren(), std::vector<OperatorExpression *>());
   EXPECT_EQ(ope4->GetChildren(), (std::vector<OperatorExpression *>{ope1, ope2}));

--- a/test/optimizer/physical_operator_test.cpp
+++ b/test/optimizer/physical_operator_test.cpp
@@ -26,10 +26,10 @@ TEST(OperatorTests, TableFreeScanTest) {
   // TableFreeScan operator does not have any data members.
   // So we just need to make sure that all instantiations
   // of the object are equivalent.
-  Operator op1 = TableFreeScan::make();
+  Operator op1 = TableFreeScan::Make();
   EXPECT_EQ(op1.GetType(), OpType::TABLEFREESCAN);
 
-  Operator op2 = TableFreeScan::make();
+  Operator op2 = TableFreeScan::Make();
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 }
@@ -53,27 +53,27 @@ TEST(OperatorTests, SeqScanTest) {
   auto annotated_expr_2 = AnnotatedExpression(x_2, std::unordered_set<std::string>());
   auto annotated_expr_3 = AnnotatedExpression(x_3, std::unordered_set<std::string>());
 
-  Operator seq_scan_01 = SeqScan::make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator seq_scan_01 = SeqScan::Make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                        std::vector<AnnotatedExpression>(), "table", false);
-  Operator seq_scan_02 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::table_oid_t(3),
+  Operator seq_scan_02 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::table_oid_t(3),
                                        std::vector<AnnotatedExpression>(), "table", false);
-  Operator seq_scan_03 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+  Operator seq_scan_03 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
                                        std::vector<AnnotatedExpression>(), "table", false);
-  Operator seq_scan_04 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator seq_scan_04 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                        std::vector<AnnotatedExpression>(), "tableTable", false);
-  Operator seq_scan_05 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator seq_scan_05 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                        std::vector<AnnotatedExpression>(), "table", true);
-  Operator seq_scan_1 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator seq_scan_1 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                       std::vector<AnnotatedExpression>(), "table", false);
-  Operator seq_scan_2 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator seq_scan_2 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                       std::vector<AnnotatedExpression>(), "table", false);
-  Operator seq_scan_3 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator seq_scan_3 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                       std::vector<AnnotatedExpression>{annotated_expr_0}, "table", false);
-  Operator seq_scan_4 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator seq_scan_4 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                       std::vector<AnnotatedExpression>{annotated_expr_1}, "table", false);
-  Operator seq_scan_5 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator seq_scan_5 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                       std::vector<AnnotatedExpression>{annotated_expr_2}, "table", false);
-  Operator seq_scan_6 = SeqScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
+  Operator seq_scan_6 = SeqScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(3),
                                       std::vector<AnnotatedExpression>{annotated_expr_3}, "table", false);
 
   EXPECT_EQ(seq_scan_1.GetType(), OpType::SEQSCAN);
@@ -133,39 +133,39 @@ TEST(OperatorTests, IndexScanTest) {
 
   // different from index_scan_1 in dbOID
   Operator index_scan_01 =
-      IndexScan::make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+      IndexScan::Make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                       std::vector<AnnotatedExpression>(), "table", false, std::vector<catalog::col_oid_t>(),
                       std::vector<parser::ExpressionType>(), std::vector<type::TransientValue>());
   // different from index_scan_1 in namespace OID
   Operator index_scan_02 =
-      IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::index_oid_t(3),
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::index_oid_t(3),
                       std::vector<AnnotatedExpression>(), "table", false, std::vector<catalog::col_oid_t>(),
                       std::vector<parser::ExpressionType>(), std::vector<type::TransientValue>());
   // different from index_scan_1 in index OID
   Operator index_scan_03 =
-      IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(4),
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(4),
                       std::vector<AnnotatedExpression>(), "table", false, std::vector<catalog::col_oid_t>(),
                       std::vector<parser::ExpressionType>(), std::vector<type::TransientValue>());
   // different from index_scan_1 in table alias
   Operator index_scan_04 =
-      IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                       std::vector<AnnotatedExpression>(), "tableTable", false, std::vector<catalog::col_oid_t>(),
                       std::vector<parser::ExpressionType>(), std::vector<type::TransientValue>());
   // different from index_scan_1 in 'is for update'
   Operator index_scan_05 =
-      IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                       std::vector<AnnotatedExpression>(), "table", true, std::vector<catalog::col_oid_t>(),
                       std::vector<parser::ExpressionType>(), std::vector<type::TransientValue>());
   // different from index_scan_1 in key column list
   std::vector<catalog::col_oid_t> key_column1 = {catalog::col_oid_t(1), catalog::col_oid_t(2)};
   std::vector<catalog::col_oid_t> key_column2 = {catalog::col_oid_t(1), catalog::col_oid_t(2)};
-  Operator index_scan_06 = IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+  Operator index_scan_06 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                                            std::vector<AnnotatedExpression>(), "table", false, std::move(key_column1),
                                            std::vector<parser::ExpressionType>(), std::vector<type::TransientValue>());
   // different from index_scan_1 in expr type list
   std::vector<parser::ExpressionType> expr_type1 = {parser::ExpressionType::COMPARE_IN};
   std::vector<parser::ExpressionType> expr_type2 = {parser::ExpressionType::COMPARE_IN};
-  Operator index_scan_07 = IndexScan::make(
+  Operator index_scan_07 = IndexScan::Make(
       catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3), std::vector<AnnotatedExpression>(),
       "table", false, std::vector<catalog::col_oid_t>(), std::move(expr_type1), std::vector<type::TransientValue>());
   // different from index_scan_1 in value list
@@ -173,32 +173,32 @@ TEST(OperatorTests, IndexScanTest) {
   std::vector<type::TransientValue> value2;
   value1.push_back(type::TransientValueFactory::GetInteger(1));
   value2.push_back(type::TransientValueFactory::GetInteger(1));
-  Operator index_scan_08 = IndexScan::make(
+  Operator index_scan_08 = IndexScan::Make(
       catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3), std::vector<AnnotatedExpression>(),
       "table", false, std::vector<catalog::col_oid_t>(), std::vector<parser::ExpressionType>(), std::move(value1));
 
   Operator index_scan_1 =
-      IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                       std::vector<AnnotatedExpression>(), "table", false, std::vector<catalog::col_oid_t>(),
                       std::vector<parser::ExpressionType>(), std::vector<type::TransientValue>());
   Operator index_scan_2 =
-      IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                       std::vector<AnnotatedExpression>(), "table", false, std::vector<catalog::col_oid_t>(),
                       std::vector<parser::ExpressionType>(), std::vector<type::TransientValue>());
   // different from index_scan_1 in predicates
-  Operator index_scan_3 = IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+  Operator index_scan_3 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                                           std::vector<AnnotatedExpression>{annotated_expr_0}, "table", false,
                                           std::vector<catalog::col_oid_t>(), std::vector<parser::ExpressionType>(),
                                           std::vector<type::TransientValue>());
-  Operator index_scan_4 = IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+  Operator index_scan_4 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                                           std::vector<AnnotatedExpression>{annotated_expr_1}, "table", false,
                                           std::vector<catalog::col_oid_t>(), std::vector<parser::ExpressionType>(),
                                           std::vector<type::TransientValue>());
-  Operator index_scan_5 = IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+  Operator index_scan_5 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                                           std::vector<AnnotatedExpression>{annotated_expr_2}, "table", false,
                                           std::vector<catalog::col_oid_t>(), std::vector<parser::ExpressionType>(),
                                           std::vector<type::TransientValue>());
-  Operator index_scan_6 = IndexScan::make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
+  Operator index_scan_6 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
                                           std::vector<AnnotatedExpression>{annotated_expr_3}, "table", false,
                                           std::vector<catalog::col_oid_t>(), std::vector<parser::ExpressionType>(),
                                           std::vector<type::TransientValue>());
@@ -252,13 +252,13 @@ TEST(OperatorTests, ExternalFileScanTest) {
   //===--------------------------------------------------------------------===//
   // ExternalFileScan
   //===--------------------------------------------------------------------===//
-  Operator ext_file_scan_1 = ExternalFileScan::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
-  Operator ext_file_scan_2 = ExternalFileScan::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
-  Operator ext_file_scan_3 = ExternalFileScan::make(parser::ExternalFileFormat::CSV, "file2.txt", ',', '"', '\\');
-  Operator ext_file_scan_4 = ExternalFileScan::make(parser::ExternalFileFormat::BINARY, "file.txt", ',', '"', '\\');
-  Operator ext_file_scan_5 = ExternalFileScan::make(parser::ExternalFileFormat::CSV, "file.txt", ' ', '"', '\\');
-  Operator ext_file_scan_6 = ExternalFileScan::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '\'', '\\');
-  Operator ext_file_scan_7 = ExternalFileScan::make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '&');
+  Operator ext_file_scan_1 = ExternalFileScan::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
+  Operator ext_file_scan_2 = ExternalFileScan::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '\\');
+  Operator ext_file_scan_3 = ExternalFileScan::Make(parser::ExternalFileFormat::CSV, "file2.txt", ',', '"', '\\');
+  Operator ext_file_scan_4 = ExternalFileScan::Make(parser::ExternalFileFormat::BINARY, "file.txt", ',', '"', '\\');
+  Operator ext_file_scan_5 = ExternalFileScan::Make(parser::ExternalFileFormat::CSV, "file.txt", ' ', '"', '\\');
+  Operator ext_file_scan_6 = ExternalFileScan::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '\'', '\\');
+  Operator ext_file_scan_7 = ExternalFileScan::Make(parser::ExternalFileFormat::CSV, "file.txt", ',', '"', '&');
 
   EXPECT_EQ(ext_file_scan_1.GetType(), OpType::EXTERNALFILESCAN);
   EXPECT_EQ(ext_file_scan_1.GetName(), "ExternalFileScan");
@@ -308,13 +308,13 @@ TEST(OperatorTests, QueryDerivedScanTest) {
   alias_to_expr_map_5["constant expr"] = expr1;
   alias_to_expr_map_5["constant expr2"] = expr2;
 
-  Operator query_derived_scan_1 = QueryDerivedScan::make("alias", std::move(alias_to_expr_map_1));
-  Operator query_derived_scan_2 = QueryDerivedScan::make("alias", std::move(alias_to_expr_map_2));
-  Operator query_derived_scan_3 = QueryDerivedScan::make(
+  Operator query_derived_scan_1 = QueryDerivedScan::Make("alias", std::move(alias_to_expr_map_1));
+  Operator query_derived_scan_2 = QueryDerivedScan::Make("alias", std::move(alias_to_expr_map_2));
+  Operator query_derived_scan_3 = QueryDerivedScan::Make(
       "alias", std::unordered_map<std::string, common::ManagedPointer<parser::AbstractExpression>>());
-  Operator query_derived_scan_4 = QueryDerivedScan::make("alias", std::move(alias_to_expr_map_3));
-  Operator query_derived_scan_5 = QueryDerivedScan::make("alias", std::move(alias_to_expr_map_4));
-  Operator query_derived_scan_6 = QueryDerivedScan::make("alias", std::move(alias_to_expr_map_5));
+  Operator query_derived_scan_4 = QueryDerivedScan::Make("alias", std::move(alias_to_expr_map_3));
+  Operator query_derived_scan_5 = QueryDerivedScan::Make("alias", std::move(alias_to_expr_map_4));
+  Operator query_derived_scan_6 = QueryDerivedScan::Make("alias", std::move(alias_to_expr_map_5));
 
   EXPECT_EQ(query_derived_scan_1.GetType(), OpType::QUERYDERIVEDSCAN);
   EXPECT_EQ(query_derived_scan_1.GetName(), "QueryDerivedScan");
@@ -340,10 +340,10 @@ TEST(OperatorTests, OrderByTest) {
   // OrderBy operator does not have any data members.
   // So we just need to make sure that all instantiations
   // of the object are equivalent.
-  Operator op1 = OrderBy::make();
+  Operator op1 = OrderBy::Make();
   EXPECT_EQ(op1.GetType(), OpType::ORDERBY);
 
-  Operator op2 = OrderBy::make();
+  Operator op2 = OrderBy::Make();
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 }
@@ -360,7 +360,7 @@ TEST(OperatorTests, LimitTest) {
   planner::OrderByOrderingType sort_dir = planner::OrderByOrderingType::ASC;
 
   // Check that all of our GET methods work as expected
-  Operator op1 = Limit::make(offset, limit, {sort_expr}, {sort_dir});
+  Operator op1 = Limit::Make(offset, limit, {sort_expr}, {sort_dir});
   EXPECT_EQ(op1.GetType(), OpType::LIMIT);
   EXPECT_EQ(op1.As<Limit>()->GetOffset(), offset);
   EXPECT_EQ(op1.As<Limit>()->GetLimit(), limit);
@@ -371,14 +371,14 @@ TEST(OperatorTests, LimitTest) {
 
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
-  Operator op2 = Limit::make(offset, limit, {sort_expr}, {sort_dir});
+  Operator op2 = Limit::Make(offset, limit, {sort_expr}, {sort_dir});
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // Lastly, make a different object and make sure that it is not equal
   // and that it's hash is not the same!
   size_t other_offset = 1111;
-  Operator op3 = Limit::make(other_offset, limit, {sort_expr}, {sort_dir});
+  Operator op3 = Limit::Make(other_offset, limit, {sort_expr}, {sort_dir});
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 
@@ -404,15 +404,15 @@ TEST(OperatorTests, InnerNLJoinTest) {
   auto annotated_expr_2 = AnnotatedExpression(x_2, std::unordered_set<std::string>());
   auto annotated_expr_3 = AnnotatedExpression(x_3, std::unordered_set<std::string>());
 
-  Operator inner_nl_join_1 = InnerNLJoin::make(std::vector<AnnotatedExpression>(), {x_1}, {x_1});
-  Operator inner_nl_join_2 = InnerNLJoin::make(std::vector<AnnotatedExpression>(), {x_1}, {x_1});
-  Operator inner_nl_join_3 = InnerNLJoin::make(std::vector<AnnotatedExpression>{annotated_expr_0}, {x_1}, {x_1});
-  Operator inner_nl_join_4 = InnerNLJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_1});
-  Operator inner_nl_join_5 = InnerNLJoin::make(std::vector<AnnotatedExpression>{annotated_expr_2}, {x_2}, {x_1});
-  Operator inner_nl_join_6 = InnerNLJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_2});
-  Operator inner_nl_join_7 = InnerNLJoin::make(std::vector<AnnotatedExpression>{annotated_expr_3}, {x_1}, {x_1});
-  Operator inner_nl_join_8 = InnerNLJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_3}, {x_1});
-  Operator inner_nl_join_9 = InnerNLJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_3});
+  Operator inner_nl_join_1 = InnerNLJoin::Make(std::vector<AnnotatedExpression>(), {x_1}, {x_1});
+  Operator inner_nl_join_2 = InnerNLJoin::Make(std::vector<AnnotatedExpression>(), {x_1}, {x_1});
+  Operator inner_nl_join_3 = InnerNLJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_0}, {x_1}, {x_1});
+  Operator inner_nl_join_4 = InnerNLJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_1});
+  Operator inner_nl_join_5 = InnerNLJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_2}, {x_2}, {x_1});
+  Operator inner_nl_join_6 = InnerNLJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_2});
+  Operator inner_nl_join_7 = InnerNLJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_3}, {x_1}, {x_1});
+  Operator inner_nl_join_8 = InnerNLJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_3}, {x_1});
+  Operator inner_nl_join_9 = InnerNLJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_3});
 
   EXPECT_EQ(inner_nl_join_1.GetType(), OpType::INNERNLJOIN);
   EXPECT_EQ(inner_nl_join_3.GetType(), OpType::INNERNLJOIN);
@@ -459,9 +459,9 @@ TEST(OperatorTests, LeftNLJoinTest) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator left_nl_join_1 = LeftNLJoin::make(x_1);
-  Operator left_nl_join_2 = LeftNLJoin::make(x_2);
-  Operator left_nl_join_3 = LeftNLJoin::make(x_3);
+  Operator left_nl_join_1 = LeftNLJoin::Make(x_1);
+  Operator left_nl_join_2 = LeftNLJoin::Make(x_2);
+  Operator left_nl_join_3 = LeftNLJoin::Make(x_3);
 
   EXPECT_EQ(left_nl_join_1.GetType(), OpType::LEFTNLJOIN);
   EXPECT_EQ(left_nl_join_3.GetType(), OpType::LEFTNLJOIN);
@@ -492,9 +492,9 @@ TEST(OperatorTests, RightNLJoinTest) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator right_nl_join_1 = RightNLJoin::make(x_1);
-  Operator right_nl_join_2 = RightNLJoin::make(x_2);
-  Operator right_nl_join_3 = RightNLJoin::make(x_3);
+  Operator right_nl_join_1 = RightNLJoin::Make(x_1);
+  Operator right_nl_join_2 = RightNLJoin::Make(x_2);
+  Operator right_nl_join_3 = RightNLJoin::Make(x_3);
 
   EXPECT_EQ(right_nl_join_1.GetType(), OpType::RIGHTNLJOIN);
   EXPECT_EQ(right_nl_join_3.GetType(), OpType::RIGHTNLJOIN);
@@ -525,9 +525,9 @@ TEST(OperatorTests, OuterNLJoin) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator outer_nl_join_1 = OuterNLJoin::make(x_1);
-  Operator outer_nl_join_2 = OuterNLJoin::make(x_2);
-  Operator outer_nl_join_3 = OuterNLJoin::make(x_3);
+  Operator outer_nl_join_1 = OuterNLJoin::Make(x_1);
+  Operator outer_nl_join_2 = OuterNLJoin::Make(x_2);
+  Operator outer_nl_join_3 = OuterNLJoin::Make(x_3);
 
   EXPECT_EQ(outer_nl_join_1.GetType(), OpType::OUTERNLJOIN);
   EXPECT_EQ(outer_nl_join_3.GetType(), OpType::OUTERNLJOIN);
@@ -564,15 +564,15 @@ TEST(OperatorTests, InnerHashJoinTest) {
   auto annotated_expr_2 = AnnotatedExpression(x_2, std::unordered_set<std::string>());
   auto annotated_expr_3 = AnnotatedExpression(x_3, std::unordered_set<std::string>());
 
-  Operator inner_hash_join_1 = InnerHashJoin::make(std::vector<AnnotatedExpression>(), {x_1}, {x_1});
-  Operator inner_hash_join_2 = InnerHashJoin::make(std::vector<AnnotatedExpression>(), {x_1}, {x_1});
-  Operator inner_hash_join_3 = InnerHashJoin::make(std::vector<AnnotatedExpression>{annotated_expr_0}, {x_1}, {x_1});
-  Operator inner_hash_join_4 = InnerHashJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_1});
-  Operator inner_hash_join_5 = InnerHashJoin::make(std::vector<AnnotatedExpression>{annotated_expr_2}, {x_2}, {x_1});
-  Operator inner_hash_join_6 = InnerHashJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_2});
-  Operator inner_hash_join_7 = InnerHashJoin::make(std::vector<AnnotatedExpression>{annotated_expr_3}, {x_1}, {x_1});
-  Operator inner_hash_join_8 = InnerHashJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_3}, {x_1});
-  Operator inner_hash_join_9 = InnerHashJoin::make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_3});
+  Operator inner_hash_join_1 = InnerHashJoin::Make(std::vector<AnnotatedExpression>(), {x_1}, {x_1});
+  Operator inner_hash_join_2 = InnerHashJoin::Make(std::vector<AnnotatedExpression>(), {x_1}, {x_1});
+  Operator inner_hash_join_3 = InnerHashJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_0}, {x_1}, {x_1});
+  Operator inner_hash_join_4 = InnerHashJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_1});
+  Operator inner_hash_join_5 = InnerHashJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_2}, {x_2}, {x_1});
+  Operator inner_hash_join_6 = InnerHashJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_2});
+  Operator inner_hash_join_7 = InnerHashJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_3}, {x_1}, {x_1});
+  Operator inner_hash_join_8 = InnerHashJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_3}, {x_1});
+  Operator inner_hash_join_9 = InnerHashJoin::Make(std::vector<AnnotatedExpression>{annotated_expr_1}, {x_1}, {x_3});
 
   EXPECT_EQ(inner_hash_join_1.GetType(), OpType::INNERHASHJOIN);
   EXPECT_EQ(inner_hash_join_3.GetType(), OpType::INNERHASHJOIN);
@@ -621,9 +621,9 @@ TEST(OperatorTests, LeftHashJoinTest) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator left_hash_join_1 = LeftHashJoin::make(x_1);
-  Operator left_hash_join_2 = LeftHashJoin::make(x_2);
-  Operator left_hash_join_3 = LeftHashJoin::make(x_3);
+  Operator left_hash_join_1 = LeftHashJoin::Make(x_1);
+  Operator left_hash_join_2 = LeftHashJoin::Make(x_2);
+  Operator left_hash_join_3 = LeftHashJoin::Make(x_3);
 
   EXPECT_EQ(left_hash_join_1.GetType(), OpType::LEFTHASHJOIN);
   EXPECT_EQ(left_hash_join_3.GetType(), OpType::LEFTHASHJOIN);
@@ -654,9 +654,9 @@ TEST(OperatorTests, RightHashJoinTest) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator right_hash_join_1 = RightHashJoin::make(x_1);
-  Operator right_hash_join_2 = RightHashJoin::make(x_2);
-  Operator right_hash_join_3 = RightHashJoin::make(x_3);
+  Operator right_hash_join_1 = RightHashJoin::Make(x_1);
+  Operator right_hash_join_2 = RightHashJoin::Make(x_2);
+  Operator right_hash_join_3 = RightHashJoin::Make(x_3);
 
   EXPECT_EQ(right_hash_join_1.GetType(), OpType::RIGHTHASHJOIN);
   EXPECT_EQ(right_hash_join_3.GetType(), OpType::RIGHTHASHJOIN);
@@ -687,9 +687,9 @@ TEST(OperatorTests, OuterHashJoinTest) {
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
   auto x_3 = common::ManagedPointer<parser::AbstractExpression>(expr_b_3);
 
-  Operator outer_hash_join_1 = OuterHashJoin::make(x_1);
-  Operator outer_hash_join_2 = OuterHashJoin::make(x_2);
-  Operator outer_hash_join_3 = OuterHashJoin::make(x_3);
+  Operator outer_hash_join_1 = OuterHashJoin::Make(x_1);
+  Operator outer_hash_join_2 = OuterHashJoin::Make(x_2);
+  Operator outer_hash_join_3 = OuterHashJoin::Make(x_3);
 
   EXPECT_EQ(outer_hash_join_1.GetType(), OpType::OUTERHASHJOIN);
   EXPECT_EQ(outer_hash_join_3.GetType(), OpType::OUTERHASHJOIN);
@@ -724,7 +724,7 @@ TEST(OperatorTests, InsertTest) {
 
   // Check that all of our GET methods work as expected
   Operator op1 =
-      Insert::make(database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
+      Insert::Make(database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
                    std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(values));
   EXPECT_EQ(op1.GetType(), OpType::INSERT);
   EXPECT_EQ(op1.As<Insert>()->GetDatabaseOid(), database_oid);
@@ -736,7 +736,7 @@ TEST(OperatorTests, InsertTest) {
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
   Operator op2 =
-      Insert::make(database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
+      Insert::Make(database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
                    std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(values));
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
@@ -747,7 +747,7 @@ TEST(OperatorTests, InsertTest) {
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values)),
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values))};
   Operator op3 =
-      Insert::make(database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
+      Insert::Make(database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
                    std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(other_values));
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
@@ -763,7 +763,7 @@ TEST(OperatorTests, InsertTest) {
   std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> bad_values = {
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(bad_raw_values, std::end(bad_raw_values))};
   EXPECT_DEATH(
-      Insert::make(database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
+      Insert::Make(database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),
                    std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(bad_values)),
       "Mismatched");
   for (auto entry : bad_raw_values) delete entry;
@@ -782,7 +782,7 @@ TEST(OperatorTests, InsertSelectTest) {
   catalog::table_oid_t table_oid(789);
 
   // Check that all of our GET methods work as expected
-  Operator op1 = InsertSelect::make(database_oid, namespace_oid, table_oid);
+  Operator op1 = InsertSelect::Make(database_oid, namespace_oid, table_oid);
   EXPECT_EQ(op1.GetType(), OpType::INSERTSELECT);
   EXPECT_EQ(op1.As<InsertSelect>()->GetDatabaseOid(), database_oid);
   EXPECT_EQ(op1.As<InsertSelect>()->GetNamespaceOid(), namespace_oid);
@@ -790,14 +790,14 @@ TEST(OperatorTests, InsertSelectTest) {
 
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
-  Operator op2 = InsertSelect::make(database_oid, namespace_oid, table_oid);
+  Operator op2 = InsertSelect::Make(database_oid, namespace_oid, table_oid);
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // Lastly, make a different object and make sure that it is not equal
   // and that it's hash is not the same!
   catalog::db_oid_t other_database_oid(999);
-  Operator op3 = InsertSelect::make(other_database_oid, namespace_oid, table_oid);
+  Operator op3 = InsertSelect::Make(other_database_oid, namespace_oid, table_oid);
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 }
@@ -820,7 +820,7 @@ TEST(OperatorTests, DeleteTest) {
   catalog::table_oid_t table_oid(789);
 
   // Check that all of our GET methods work as expected
-  Operator op1 = Delete::make(database_oid, namespace_oid, table_oid, x_1);
+  Operator op1 = Delete::Make(database_oid, namespace_oid, table_oid, x_1);
   EXPECT_EQ(op1.GetType(), OpType::DELETE);
   EXPECT_EQ(op1.As<Delete>()->GetDatabaseOid(), database_oid);
   EXPECT_EQ(op1.As<Delete>()->GetNamespaceOid(), namespace_oid);
@@ -829,20 +829,20 @@ TEST(OperatorTests, DeleteTest) {
 
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
-  Operator op2 = Delete::make(database_oid, namespace_oid, table_oid, x_2);
+  Operator op2 = Delete::Make(database_oid, namespace_oid, table_oid, x_2);
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // make a different object and make sure that it is not equal
   // and that it's hash is not the same!
   catalog::db_oid_t other_database_oid(999);
-  Operator op3 = Delete::make(other_database_oid, namespace_oid, table_oid, x_1);
+  Operator op3 = Delete::Make(other_database_oid, namespace_oid, table_oid, x_1);
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 
   // Lastly, make another different object and make sure that it is not equal
   // and that it's hash is not the same!
-  Operator op4 = Delete::make(database_oid, namespace_oid, table_oid, x_3);
+  Operator op4 = Delete::Make(database_oid, namespace_oid, table_oid, x_3);
   EXPECT_FALSE(op1 == op4);
   EXPECT_NE(op1.Hash(), op4.Hash());
 
@@ -862,7 +862,7 @@ TEST(OperatorTests, ExportExternalFileTest) {
   char escape = 'Z';
 
   // Check that all of our GET methods work as expected
-  Operator op1 = ExportExternalFile::make(parser::ExternalFileFormat::BINARY, file_name, delimiter, quote, escape);
+  Operator op1 = ExportExternalFile::Make(parser::ExternalFileFormat::BINARY, file_name, delimiter, quote, escape);
   EXPECT_EQ(op1.GetType(), OpType::EXPORTEXTERNALFILE);
   EXPECT_EQ(op1.As<ExportExternalFile>()->GetFilename(), file_name);
   EXPECT_EQ(op1.As<ExportExternalFile>()->GetFormat(), parser::ExternalFileFormat::BINARY);
@@ -873,13 +873,13 @@ TEST(OperatorTests, ExportExternalFileTest) {
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
   std::string file_name_copy = file_name;  // NOLINT
-  Operator op2 = ExportExternalFile::make(parser::ExternalFileFormat::BINARY, file_name_copy, delimiter, quote, escape);
+  Operator op2 = ExportExternalFile::Make(parser::ExternalFileFormat::BINARY, file_name_copy, delimiter, quote, escape);
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // Lastly, make a different object and make sure that it is not equal
   // and that it's hash is not the same!
-  Operator op3 = ExportExternalFile::make(parser::ExternalFileFormat::CSV, file_name, delimiter, quote, escape);
+  Operator op3 = ExportExternalFile::Make(parser::ExternalFileFormat::CSV, file_name, delimiter, quote, escape);
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 }
@@ -898,7 +898,7 @@ TEST(OperatorTests, UpdateTest) {
   catalog::table_oid_t table_oid(789);
 
   // Check that all of our GET methods work as expected
-  Operator op1 = Update::make(database_oid, namespace_oid, table_oid, {update_clause});
+  Operator op1 = Update::Make(database_oid, namespace_oid, table_oid, {update_clause});
   EXPECT_EQ(op1.GetType(), OpType::UPDATE);
   EXPECT_EQ(op1.As<Update>()->GetDatabaseOid(), database_oid);
   EXPECT_EQ(op1.As<Update>()->GetNamespaceOid(), namespace_oid);
@@ -908,13 +908,13 @@ TEST(OperatorTests, UpdateTest) {
 
   // Check that if we make a new object with the same values, then it will
   // be equal to our first object and have the same hash
-  Operator op2 = Update::make(database_oid, namespace_oid, table_oid, {update_clause});
+  Operator op2 = Update::Make(database_oid, namespace_oid, table_oid, {update_clause});
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 
   // Lastly, make a different object and make sure that it is not equal
   // and that it's hash is not the same!
-  Operator op3 = Update::make(database_oid, namespace_oid, table_oid, {});
+  Operator op3 = Update::Make(database_oid, namespace_oid, table_oid, {});
   EXPECT_FALSE(op1 == op3);
   EXPECT_NE(op1.Hash(), op3.Hash());
 
@@ -957,17 +957,17 @@ TEST(OperatorTests, HashGroupByTest) {
   auto annotated_expr_3 = AnnotatedExpression(x_6, std::unordered_set<std::string>());
   auto annotated_expr_4 = AnnotatedExpression(x_8, std::unordered_set<std::string>());
 
-  Operator group_by_1_0 = HashGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
+  Operator group_by_1_0 = HashGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
                                             std::vector<AnnotatedExpression>{annotated_expr_0});
-  Operator group_by_1_1 = HashGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
+  Operator group_by_1_1 = HashGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
                                             std::vector<AnnotatedExpression>{annotated_expr_1});
-  Operator group_by_2_2 = HashGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_2},
+  Operator group_by_2_2 = HashGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_2},
                                             std::vector<AnnotatedExpression>{annotated_expr_2});
-  Operator group_by_3 = HashGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_3},
+  Operator group_by_3 = HashGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_3},
                                           std::vector<AnnotatedExpression>());
-  Operator group_by_7_4 = HashGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_7},
+  Operator group_by_7_4 = HashGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_7},
                                             std::vector<AnnotatedExpression>{annotated_expr_4});
-  Operator group_by_4 = HashGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>(),
+  Operator group_by_4 = HashGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>(),
                                           std::vector<AnnotatedExpression>{annotated_expr_1});
 
   EXPECT_EQ(group_by_1_1.GetType(), OpType::HASHGROUPBY);
@@ -1036,17 +1036,17 @@ TEST(OperatorTests, SortGroupByTest) {
   auto annotated_expr_3 = AnnotatedExpression(x_6, std::unordered_set<std::string>());
   auto annotated_expr_4 = AnnotatedExpression(x_8, std::unordered_set<std::string>());
 
-  Operator group_by_1_0 = SortGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
+  Operator group_by_1_0 = SortGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
                                             std::vector<AnnotatedExpression>{annotated_expr_0});
-  Operator group_by_1_1 = SortGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
+  Operator group_by_1_1 = SortGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_1},
                                             std::vector<AnnotatedExpression>{annotated_expr_1});
-  Operator group_by_2_2 = SortGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_2},
+  Operator group_by_2_2 = SortGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_2},
                                             std::vector<AnnotatedExpression>{annotated_expr_2});
-  Operator group_by_3 = SortGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_3},
+  Operator group_by_3 = SortGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_3},
                                           std::vector<AnnotatedExpression>());
-  Operator group_by_7_4 = SortGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_7},
+  Operator group_by_7_4 = SortGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>{x_7},
                                             std::vector<AnnotatedExpression>{annotated_expr_4});
-  Operator group_by_4 = SortGroupBy::make(std::vector<common::ManagedPointer<parser::AbstractExpression>>(),
+  Operator group_by_4 = SortGroupBy::Make(std::vector<common::ManagedPointer<parser::AbstractExpression>>(),
                                           std::vector<AnnotatedExpression>{annotated_expr_1});
 
   EXPECT_EQ(group_by_1_1.GetType(), OpType::SORTGROUPBY);
@@ -1088,10 +1088,10 @@ TEST(OperatorTests, AggregateTest) {
   // Aggregate operator does not have any data members.
   // So we just need to make sure that all instantiations
   // of the object are equivalent.
-  Operator op1 = Aggregate::make();
+  Operator op1 = Aggregate::Make();
   EXPECT_EQ(op1.GetType(), OpType::AGGREGATE);
 
-  Operator op2 = Aggregate::make();
+  Operator op2 = Aggregate::Make();
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 }
@@ -1104,10 +1104,10 @@ TEST(OperatorTests, DistinctTest) {
   // Distinct operator does not have any data members.
   // So we just need to make sure that all instantiations
   // of the object are equivalent.
-  Operator op1 = Distinct::make();
+  Operator op1 = Distinct::Make();
   EXPECT_EQ(op1.GetType(), OpType::DISTINCT);
 
-  Operator op2 = Distinct::make();
+  Operator op2 = Distinct::Make();
   EXPECT_TRUE(op1 == op2);
   EXPECT_EQ(op1.Hash(), op2.Hash());
 }

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -53,7 +53,7 @@ TEST_F(ParserTestBase, AnalyzeTest) {
    * ANALYZE table_name (column_name, ...) : (segfaults)
    */
 
-  auto stmts = pgparser.BuildParseTree("ANALYZE table_name;");
+  auto stmts = pgparser_.BuildParseTree("ANALYZE table_name;");
   auto analyze_stmt = reinterpret_cast<AnalyzeStatement *>(stmts[0].get());
   EXPECT_EQ(analyze_stmt->GetType(), StatementType::ANALYZE);
   EXPECT_EQ(analyze_stmt->GetAnalyzeTable()->GetTableName(), "table_name");
@@ -61,7 +61,7 @@ TEST_F(ParserTestBase, AnalyzeTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, CastTest) {
-  auto stmts = pgparser.BuildParseTree("SELECT CAST('100' AS INTEGER);");
+  auto stmts = pgparser_.BuildParseTree("SELECT CAST('100' AS INTEGER);");
   auto cast_stmt = reinterpret_cast<SelectStatement *>(stmts[0].get());
   EXPECT_EQ(cast_stmt->GetType(), StatementType::SELECT);
   EXPECT_EQ(cast_stmt->GetSelectColumns().at(0)->GetExpressionType(), ExpressionType::OPERATOR_CAST);
@@ -70,7 +70,7 @@ TEST_F(ParserTestBase, CastTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, CopyTest) {
-  auto stmts = pgparser.BuildParseTree("COPY foo FROM STDIN WITH BINARY;");
+  auto stmts = pgparser_.BuildParseTree("COPY foo FROM STDIN WITH BINARY;");
   auto copy_stmt = reinterpret_cast<CopyStatement *>(stmts[0].get());
   EXPECT_EQ(copy_stmt->GetType(), StatementType::COPY);
   EXPECT_EQ(copy_stmt->GetExternalFileFormat(), ExternalFileFormat::BINARY);
@@ -87,7 +87,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
       " RETURNS DOUBLE AS $$ "
       " BEGIN RETURN i + 1; END; $$ "
       "LANGUAGE plpgsql;";
-  auto stmts = pgparser.BuildParseTree(query);
+  auto stmts = pgparser_.BuildParseTree(query);
   auto stmt = reinterpret_cast<CreateFunctionStatement *>(stmts[0].get());
   auto func_params = stmt->GetFuncParameters();
   EXPECT_EQ(stmt->GetFuncName(), "increment");
@@ -102,7 +102,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
       " RETURNS DOUBLE AS $$ "
       " BEGIN RETURN i + j; END; $$ "
       "LANGUAGE plpgsql;";
-  stmts = pgparser.BuildParseTree(query);
+  stmts = pgparser_.BuildParseTree(query);
   stmt = reinterpret_cast<CreateFunctionStatement *>(stmts[0].get());
   func_params = stmt->GetFuncParameters();
   EXPECT_EQ(stmt->GetFuncName(), "increment1");
@@ -119,7 +119,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
       " RETURNS INT AS $$ "
       "BEGIN RETURN i + 1; END; $$ "
       "LANGUAGE plpgsql;";
-  stmts = pgparser.BuildParseTree(query);
+  stmts = pgparser_.BuildParseTree(query);
   stmt = reinterpret_cast<CreateFunctionStatement *>(stmts[0].get());
   func_params = stmt->GetFuncParameters();
   EXPECT_EQ(stmt->GetFuncName(), "increment2");
@@ -136,7 +136,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
       " RETURNS VARCHAR AS $$ "
       "BEGIN RETURN 'foo'; END; $$ "
       "LANGUAGE plpgsql;";
-  stmts = pgparser.BuildParseTree(query);
+  stmts = pgparser_.BuildParseTree(query);
   stmt = reinterpret_cast<CreateFunctionStatement *>(stmts[0].get());
   func_params = stmt->GetFuncParameters();
   EXPECT_EQ(stmt->GetFuncName(), "return_varchar");
@@ -151,7 +151,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
       " RETURNS TEXT AS $$ "
       "BEGIN RETURN 'foo'; END; $$ "
       "LANGUAGE plpgsql;";
-  stmts = pgparser.BuildParseTree(query);
+  stmts = pgparser_.BuildParseTree(query);
   stmt = reinterpret_cast<CreateFunctionStatement *>(stmts[0].get());
   func_params = stmt->GetFuncParameters();
   EXPECT_EQ(stmt->GetFuncName(), "return_text");
@@ -166,7 +166,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
       " RETURNS BOOL AS $$ "
       "BEGIN RETURN false; END; $$ "
       "LANGUAGE plpgsql;";
-  stmts = pgparser.BuildParseTree(query);
+  stmts = pgparser_.BuildParseTree(query);
   stmt = reinterpret_cast<CreateFunctionStatement *>(stmts[0].get());
   func_params = stmt->GetFuncParameters();
   EXPECT_EQ(stmt->GetFuncName(), "return_bool");
@@ -178,7 +178,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, CreateIndexTest) {
   std::string query = "CREATE INDEX IDX_ORDER ON oorder ((O_W_ID - 2), (O + W + O));";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
 
   EXPECT_EQ(create_stmt->GetCreateType(), CreateStatement::kIndex);
@@ -224,15 +224,15 @@ TEST_F(ParserTestBase, CreateTableTest) {
       "PRIMARY KEY (id),"
       "FOREIGN KEY (c_id) REFERENCES country (cid));";
 
-  auto stmts = pgparser.BuildParseTree(query);
+  auto stmts = pgparser_.BuildParseTree(query);
 
   query = "CREATE TABLE Foo (id BAZ, PRIMARY KEY (id));";
-  EXPECT_THROW(pgparser.BuildParseTree(query), ParserException);
+  EXPECT_THROW(pgparser_.BuildParseTree(query), ParserException);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, CreateViewTest) {
-  auto stmts = pgparser.BuildParseTree("CREATE VIEW foo AS SELECT * FROM bar WHERE baz = 1;");
+  auto stmts = pgparser_.BuildParseTree("CREATE VIEW foo AS SELECT * FROM bar WHERE baz = 1;");
   auto create_stmt = reinterpret_cast<CreateStatement *>(stmts[0].get());
 
   EXPECT_EQ(create_stmt->GetViewName(), "foo");
@@ -255,7 +255,7 @@ TEST_F(ParserTestBase, CreateViewTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, DropDBTest) {
-  auto stmts = pgparser.BuildParseTree("DROP DATABASE test_db;");
+  auto stmts = pgparser_.BuildParseTree("DROP DATABASE test_db;");
   EXPECT_EQ(stmts.size(), 1);
 
   auto drop_stmt = reinterpret_cast<DropStatement *>(stmts[0].get());
@@ -265,7 +265,7 @@ TEST_F(ParserTestBase, DropDBTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, DropIndexTest) {
-  auto stmts = pgparser.BuildParseTree("DROP INDEX foo;");
+  auto stmts = pgparser_.BuildParseTree("DROP INDEX foo;");
   EXPECT_EQ(stmts.size(), 1);
 
   auto drop_stmt = reinterpret_cast<DropStatement *>(stmts[0].get());
@@ -275,7 +275,7 @@ TEST_F(ParserTestBase, DropIndexTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, DropSchemaTest) {
-  auto stmts = pgparser.BuildParseTree("DROP SCHEMA IF EXISTS foo CASCADE;");
+  auto stmts = pgparser_.BuildParseTree("DROP SCHEMA IF EXISTS foo CASCADE;");
   EXPECT_EQ(stmts.size(), 1);
 
   auto drop_stmt = reinterpret_cast<DropStatement *>(stmts[0].get());
@@ -287,7 +287,7 @@ TEST_F(ParserTestBase, DropSchemaTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, DropTableTest) {
-  auto stmts = pgparser.BuildParseTree("DROP TABLE test_db;");
+  auto stmts = pgparser_.BuildParseTree("DROP TABLE test_db;");
   EXPECT_EQ(stmts.size(), 1);
 
   auto drop_stmt = reinterpret_cast<DropStatement *>(stmts[0].get());
@@ -297,36 +297,36 @@ TEST_F(ParserTestBase, DropTableTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, ExecuteTest) {
-  auto stmts = pgparser.BuildParseTree("EXECUTE prepared_statement_name;");
+  auto stmts = pgparser_.BuildParseTree("EXECUTE prepared_statement_name;");
   EXPECT_EQ(stmts[0]->GetType(), StatementType::EXECUTE);
 
-  stmts = pgparser.BuildParseTree("EXECUTE prepared_statement_name(1, 2.0)");
+  stmts = pgparser_.BuildParseTree("EXECUTE prepared_statement_name(1, 2.0)");
   EXPECT_EQ(stmts[0]->GetType(), StatementType::EXECUTE);
 
-  stmts = pgparser.BuildParseTree("EXECUTE prepared_statement_name(1, 'arg_2', 3.0)");
+  stmts = pgparser_.BuildParseTree("EXECUTE prepared_statement_name(1, 'arg_2', 3.0)");
   EXPECT_EQ(stmts[0]->GetType(), StatementType::EXECUTE);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, ExplainTest) {
-  auto stmts = pgparser.BuildParseTree("EXPLAIN SELECT * FROM foo;");
+  auto stmts = pgparser_.BuildParseTree("EXPLAIN SELECT * FROM foo;");
   EXPECT_EQ(stmts[0]->GetType(), StatementType::EXPLAIN);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, GarbageTest) {
-  EXPECT_THROW(pgparser.BuildParseTree("blarglesnarf"), ParserException);
-  EXPECT_THROW(pgparser.BuildParseTree("SELECT;"), ParserException);
+  EXPECT_THROW(pgparser_.BuildParseTree("blarglesnarf"), ParserException);
+  EXPECT_THROW(pgparser_.BuildParseTree("SELECT;"), ParserException);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, InsertTest) {
-  auto stmts = pgparser.BuildParseTree("INSERT INTO foo VALUES (1, 2, 3), (4, 5, 6);");
+  auto stmts = pgparser_.BuildParseTree("INSERT INTO foo VALUES (1, 2, 3), (4, 5, 6);");
   auto insert_stmt = reinterpret_cast<InsertStatement *>(stmts.at(0).get());
   EXPECT_EQ(insert_stmt->GetInsertionTable()->GetTableName(), "foo");
   EXPECT_EQ(insert_stmt->GetInsertColumns()->size(), 0);
 
-  stmts = pgparser.BuildParseTree("INSERT INTO foo (id,bar,entry) VALUES (DEFAULT, 2, 3);");
+  stmts = pgparser_.BuildParseTree("INSERT INTO foo (id,bar,entry) VALUES (DEFAULT, 2, 3);");
   insert_stmt = reinterpret_cast<InsertStatement *>(stmts.at(0).get());
   EXPECT_EQ(insert_stmt->GetInsertionTable()->GetTableName(), "foo");
   EXPECT_EQ(insert_stmt->GetInsertColumns()->size(), 3);
@@ -335,7 +335,7 @@ TEST_F(ParserTestBase, InsertTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, PrepareTest) {
-  auto stmts = pgparser.BuildParseTree("PREPARE insert_plan AS INSERT INTO table_name VALUES($1);");
+  auto stmts = pgparser_.BuildParseTree("PREPARE insert_plan AS INSERT INTO table_name VALUES($1);");
 
   EXPECT_EQ(stmts.size(), 1);
   EXPECT_EQ(stmts[0]->GetType(), StatementType::PREPARE);
@@ -346,7 +346,7 @@ TEST_F(ParserTestBase, PrepareTest) {
   // - check table name == table_name
   // - check value_idx == 0
 
-  stmts = pgparser.BuildParseTree("PREPARE insert_plan (INT) AS INSERT INTO table_name VALUES($1);");
+  stmts = pgparser_.BuildParseTree("PREPARE insert_plan (INT) AS INSERT INTO table_name VALUES($1);");
 
   EXPECT_EQ(stmts.size(), 1);
   EXPECT_EQ(stmts[0]->GetType(), StatementType::PREPARE);
@@ -358,7 +358,7 @@ TEST_F(ParserTestBase, PrepareTest) {
   // - check value_idx == 0
   // - can we check the type?
 
-  stmts = pgparser.BuildParseTree("PREPARE select_stmt_plan (INT) AS SELECT column_name FROM table_name WHERE id=$1;");
+  stmts = pgparser_.BuildParseTree("PREPARE select_stmt_plan (INT) AS SELECT column_name FROM table_name WHERE id=$1;");
   EXPECT_EQ(stmts.size(), 1);
   EXPECT_EQ(stmts[0]->GetType(), StatementType::PREPARE);
   stmt = std::move(stmts[0]);
@@ -372,7 +372,7 @@ TEST_F(ParserTestBase, PrepareTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, SelectTest) {
-  auto stmts = pgparser.BuildParseTree("SELECT * FROM foo;");
+  auto stmts = pgparser_.BuildParseTree("SELECT * FROM foo;");
 
   EXPECT_EQ(stmts.size(), 1);
   EXPECT_EQ(stmts[0]->GetType(), StatementType::SELECT);
@@ -383,7 +383,7 @@ TEST_F(ParserTestBase, SelectTest) {
   // CheckTable(select_stmt->from_->table_info_, std::string("foo"));
   EXPECT_EQ(select_stmt->GetSelectColumns()[0]->GetExpressionType(), ExpressionType::STAR);
 
-  stmts = pgparser.BuildParseTree("SELECT id FROM foo LIMIT 1 OFFSET 1;");
+  stmts = pgparser_.BuildParseTree("SELECT id FROM foo LIMIT 1 OFFSET 1;");
   EXPECT_EQ(stmts[0]->GetType(), StatementType::SELECT);
   select_stmt = reinterpret_cast<SelectStatement *>(stmts[0].get());
   EXPECT_EQ(select_stmt->GetSelectLimit()->GetLimit(), 1);
@@ -392,28 +392,28 @@ TEST_F(ParserTestBase, SelectTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, SelectUnionTest) {
-  auto stmts = pgparser.BuildParseTree("SELECT * FROM foo UNION SELECT * FROM bar;");
+  auto stmts = pgparser_.BuildParseTree("SELECT * FROM foo UNION SELECT * FROM bar;");
   EXPECT_EQ(stmts.size(), 1);
   EXPECT_EQ(stmts[0]->GetType(), StatementType::SELECT);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, SetTest) {
-  auto stmts = pgparser.BuildParseTree("SET var_name TO 1;");
+  auto stmts = pgparser_.BuildParseTree("SET var_name TO 1;");
   EXPECT_EQ(stmts.size(), 1);
   EXPECT_EQ(stmts[0]->GetType(), StatementType::VARIABLE_SET);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, SubqueryTest) {
-  auto stmts = pgparser.BuildParseTree("SELECT * FROM foo WHERE id IN (SELECT id FROM foo WHERE x > 400)");
+  auto stmts = pgparser_.BuildParseTree("SELECT * FROM foo WHERE id IN (SELECT id FROM foo WHERE x > 400)");
   EXPECT_EQ(stmts.size(), 1);
   EXPECT_EQ(stmts[0]->GetType(), StatementType::SELECT);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, TruncateTest) {
-  auto stmts = pgparser.BuildParseTree("TRUNCATE TABLE test_db;");
+  auto stmts = pgparser_.BuildParseTree("TRUNCATE TABLE test_db;");
   EXPECT_EQ(stmts.size(), 1);
   EXPECT_EQ(stmts[0]->GetType(), StatementType::DELETE);
 
@@ -424,7 +424,7 @@ TEST_F(ParserTestBase, TruncateTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, UpdateTest) {
-  auto stmts = pgparser.BuildParseTree("UPDATE students SET grade = 1.0;");
+  auto stmts = pgparser_.BuildParseTree("UPDATE students SET grade = 1.0;");
 
   EXPECT_EQ(stmts.size(), 1);
   EXPECT_EQ(stmts[0]->GetType(), StatementType::UPDATE);
@@ -434,14 +434,14 @@ TEST_F(ParserTestBase, UpdateTest) {
   // check expression here
   EXPECT_EQ(update_stmt->GetUpdateCondition(), nullptr);
 
-  for (auto clause : update_stmt->GetUpdateClauses()) delete clause->GetUpdateValue().get();  // NOLINT
+  for (auto clause : update_stmt->GetUpdateClauses()) delete clause->GetUpdateValue().Get();  // NOLINT
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OperatorTest) {
   {
     std::string query = "SELECT 10+10 AS Addition;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectColumns().at(0).get();
@@ -450,7 +450,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 15-721 AS Subtraction;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectColumns().at(0).get();
@@ -459,7 +459,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 5*7 AS Multiplication;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectColumns().at(0).get();
@@ -468,7 +468,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 1/2 AS Division;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectColumns().at(0).get();
@@ -477,7 +477,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 15||213 AS Concatenation;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectColumns().at(0).get();
@@ -486,7 +486,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 4%2 AS Mod;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectColumns().at(0).get();
@@ -495,7 +495,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT CAST('100' AS INTEGER) AS Casting;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectColumns().at(0).get();
@@ -505,7 +505,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE NOT id = 1;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition().get();
@@ -514,7 +514,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE id IS NULL;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition().get();
@@ -525,7 +525,7 @@ TEST_F(ParserTestBase, OperatorTest) {
   {
     // Coverage for NullNodeTransform
     std::string query = "SELECT * FROM foo WHERE 0 IS NULL;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition();
@@ -534,14 +534,14 @@ TEST_F(ParserTestBase, OperatorTest) {
     EXPECT_EQ(expr->GetChild(0)->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
 
     query = "SELECT * FROM foo WHERE 0*1 IS NULL;";
-    stmt_list = pgparser.BuildParseTree(query);
+    stmt_list = pgparser_.BuildParseTree(query);
     select_stmt = reinterpret_cast<SelectStatement *>((stmt_list.at(0).get()));
     expr = select_stmt->GetSelectCondition();
     EXPECT_EQ(expr->GetExpressionType(), ExpressionType::OPERATOR_IS_NULL);
     EXPECT_EQ(expr->GetReturnValueType(), type::TypeId::BOOLEAN);
 
     query = "SELECT * FROM foo WHERE ? IS NULL;";
-    stmt_list = pgparser.BuildParseTree(query);
+    stmt_list = pgparser_.BuildParseTree(query);
     select_stmt = reinterpret_cast<SelectStatement *>((stmt_list.at(0).get()));
     expr = select_stmt->GetSelectCondition();
     EXPECT_EQ(expr->GetExpressionType(), ExpressionType::OPERATOR_IS_NULL);
@@ -551,7 +551,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE EXISTS (SELECT * from bar);";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition().get();
@@ -564,7 +564,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 TEST_F(ParserTestBase, CompareTest) {
   {
     std::string query = "SELECT * FROM foo WHERE id < 10;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition().get();
@@ -574,7 +574,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE id <= 10;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition().get();
@@ -584,7 +584,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE id >= 10;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition().get();
@@ -594,7 +594,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE str ~~ '%test%';";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition().get();
@@ -604,7 +604,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE str !~~ '%test%';";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition().get();
@@ -614,7 +614,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE str IS DISTINCT FROM 'test';";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
     auto expr = select_stmt->GetSelectCondition().get();
@@ -633,7 +633,7 @@ TEST_F(ParserTestBase, CompareTest) {
 TEST_F(ParserTestBase, OldBasicTest) {
   std::string query = "SELECT * FROM foo;";
 
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   EXPECT_EQ(1, stmt_list.size());
   EXPECT_EQ(StatementType::SELECT, stmt_list[0]->GetType());
 
@@ -649,7 +649,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT COUNT(*) FROM foo;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     EXPECT_EQ(1, stmt_list.size());
     EXPECT_EQ(StatementType::SELECT, stmt_list[0]->GetType());
 
@@ -660,7 +660,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT COUNT(DISTINCT id) FROM foo;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
 
     EXPECT_EQ(1, stmt_list.size());
     EXPECT_EQ(StatementType::SELECT, stmt_list[0]->GetType());
@@ -677,7 +677,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT MAX(*) FROM foo;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     EXPECT_EQ(1, stmt_list.size());
     EXPECT_EQ(StatementType::SELECT, stmt_list[0]->GetType());
 
@@ -688,7 +688,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT MIN(*) FROM foo;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     EXPECT_EQ(1, stmt_list.size());
     EXPECT_EQ(StatementType::SELECT, stmt_list[0]->GetType());
 
@@ -699,7 +699,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT AVG(*) FROM foo;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     EXPECT_EQ(1, stmt_list.size());
     EXPECT_EQ(StatementType::SELECT, stmt_list[0]->GetType());
 
@@ -713,7 +713,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 TEST_F(ParserTestBase, OldGroupByTest) {
   // Select with group by clause
   std::string query = "SELECT * FROM foo GROUP BY id, name HAVING id > 10;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
 
   auto statement = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
   auto columns = statement->GetSelectGroupBy()->GetColumns();
@@ -739,7 +739,7 @@ TEST_F(ParserTestBase, OldGroupByTest) {
 TEST_F(ParserTestBase, OldOrderByTest) {
   {
     std::string query = "SELECT * FROM foo ORDER BY id;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
@@ -757,7 +757,7 @@ TEST_F(ParserTestBase, OldOrderByTest) {
 
   {
     std::string query = "SELECT * FROM foo ORDER BY id ASC;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
@@ -774,7 +774,7 @@ TEST_F(ParserTestBase, OldOrderByTest) {
 
   {
     std::string query = "SELECT * FROM foo ORDER BY id DESC;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
@@ -791,7 +791,7 @@ TEST_F(ParserTestBase, OldOrderByTest) {
 
   {
     std::string query = "SELECT * FROM foo ORDER BY id, name;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
@@ -812,7 +812,7 @@ TEST_F(ParserTestBase, OldOrderByTest) {
 
   {
     std::string query = "SELECT * FROM foo ORDER BY id, name DESC;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto &sql_stmt = stmt_list[0];
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = reinterpret_cast<SelectStatement *>(sql_stmt.get());
@@ -837,7 +837,7 @@ TEST_F(ParserTestBase, OldConstTest) {
   // Select constants
   std::string query = "SELECT 'str', 1, 3.14 FROM foo;";
 
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto statement = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
   auto select_columns = statement->GetSelectColumns();
   EXPECT_EQ(3, select_columns.size());
@@ -860,7 +860,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo JOIN bar ON foo.id=bar.id JOIN baz ON foo.id2=baz.id2;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto select_stmt = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
     auto join_table = select_stmt->GetSelectTable().get();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -890,7 +890,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo INNER JOIN bar ON foo.id=bar.id AND foo.val > bar.val;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto select_stmt = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
     auto join_table = select_stmt->GetSelectTable().get();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -899,7 +899,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo LEFT JOIN bar ON foo.id=bar.id AND foo.val > bar.val;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto select_stmt = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
     auto join_table = select_stmt->GetSelectTable().get();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -908,7 +908,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo RIGHT JOIN bar ON foo.id=bar.id AND foo.val > bar.val;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto select_stmt = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
     auto join_table = select_stmt->GetSelectTable().get();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -917,7 +917,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo FULL OUTER JOIN bar ON foo.id=bar.id AND foo.val > bar.val;";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto select_stmt = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
     auto join_table = select_stmt->GetSelectTable().get();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -927,7 +927,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
   {
     // test case from SQLite
     query = "SELECT * FROM tab0 AS cor0 CROSS JOIN tab0 AS cor1 WHERE NULL IS NOT NULL;";
-    EXPECT_THROW(pgparser.BuildParseTree(query), ParserException);
+    EXPECT_THROW(pgparser_.BuildParseTree(query), ParserException);
   }
 }
 
@@ -935,7 +935,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 TEST_F(ParserTestBase, OldNestedQueryTest) {
   // Select with nested query
   std::string query = "SELECT * FROM (SELECT * FROM foo) as t;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
 
   EXPECT_EQ(1, stmt_list.size());
   auto statement = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
@@ -950,7 +950,7 @@ TEST_F(ParserTestBase, OldNestedQueryTest) {
 TEST_F(ParserTestBase, OldMultiTableTest) {
   // Select from multiple tables
   std::string query = "SELECT foo.name as name_new FROM (SELECT * FROM bar) as b, foo, bar WHERE foo.id = b.id;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   EXPECT_EQ(1, stmt_list.size());
   auto statement = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
 
@@ -990,7 +990,7 @@ TEST_F(ParserTestBase, OldColumnUpdateTest) {
   queries.emplace_back("UPDATE CUSTOMER SET C_BALANCE = C_BALANCE, C_DELIVERY_CNT = C_DELIVERY_CNT WHERE C_W_ID = 2");
 
   for (const auto &query : queries) {
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
 
     EXPECT_EQ(stmt_list.size(), 1);
     auto &sql_stmt = stmt_list[0];
@@ -1007,12 +1007,12 @@ TEST_F(ParserTestBase, OldColumnUpdateTest) {
     EXPECT_EQ(updates.size(), 2);
     EXPECT_EQ(updates[0]->GetColumnName(), "c_balance");
     EXPECT_EQ(updates[0]->GetUpdateValue()->GetExpressionType(), ExpressionType::COLUMN_VALUE);
-    auto column_value_0 = reinterpret_cast<ColumnValueExpression *>(updates[0]->GetUpdateValue().get());
+    auto column_value_0 = reinterpret_cast<ColumnValueExpression *>(updates[0]->GetUpdateValue().Get());
     EXPECT_EQ(column_value_0->GetColumnName(), "c_balance");
 
     EXPECT_EQ(updates[1]->GetColumnName(), "c_delivery_cnt");
     EXPECT_EQ(updates[1]->GetUpdateValue()->GetExpressionType(), ExpressionType::COLUMN_VALUE);
-    auto column_value_1 = reinterpret_cast<ColumnValueExpression *>(updates[1]->GetUpdateValue().get());
+    auto column_value_1 = reinterpret_cast<ColumnValueExpression *>(updates[1]->GetUpdateValue().Get());
     EXPECT_EQ(column_value_1->GetColumnName(), "c_delivery_cnt");
 
     EXPECT_NE(where_clause, nullptr);
@@ -1028,28 +1028,28 @@ TEST_F(ParserTestBase, OldColumnUpdateTest) {
     EXPECT_EQ(right_const->GetValue().Type(), type::TypeId::INTEGER);
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(right_const->GetValue()), 2);
 
-    for (auto clause : update_stmt->GetUpdateClauses()) delete clause->GetUpdateValue().get();  // NOLINT
+    for (auto clause : update_stmt->GetUpdateClauses()) delete clause->GetUpdateValue().Get();  // NOLINT
   }
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldExpressionUpdateTest) {
   std::string query = "UPDATE STOCK SET S_QUANTITY = 48.0 , S_YTD = S_YTD + 1 WHERE S_I_ID = 68999 AND S_W_ID = 4";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto update_stmt = reinterpret_cast<UpdateStatement *>(stmt_list[0].get());
   EXPECT_EQ(update_stmt->GetUpdateTable()->GetTableName(), "stock");
 
   // Test First Set Condition
   auto upd0 = update_stmt->GetUpdateClauses().at(0);
   EXPECT_EQ(upd0->GetColumnName(), "s_quantity");
-  auto constant = reinterpret_cast<ConstantValueExpression *>(upd0->GetUpdateValue().get());
+  auto constant = reinterpret_cast<ConstantValueExpression *>(upd0->GetUpdateValue().Get());
   EXPECT_EQ(constant->GetValue().Type(), type::TypeId::DECIMAL);
   ASSERT_DOUBLE_EQ(type::TransientValuePeeker::PeekDecimal(constant->GetValue()), 48.0);
 
   // Test Second Set Condition
   auto upd1 = update_stmt->GetUpdateClauses().at(1);
   EXPECT_EQ(upd1->GetColumnName(), "s_ytd");
-  auto op_expr = reinterpret_cast<OperatorExpression *>(upd1->GetUpdateValue().get());
+  auto op_expr = reinterpret_cast<OperatorExpression *>(upd1->GetUpdateValue().Get());
   EXPECT_EQ(op_expr->GetExpressionType(), ExpressionType::OPERATOR_PLUS);
   auto child1 = reinterpret_cast<ColumnValueExpression *>(op_expr->GetChild(0).get());
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
@@ -1077,7 +1077,7 @@ TEST_F(ParserTestBase, OldExpressionUpdateTest) {
   EXPECT_EQ(constant->GetValue().Type(), type::TypeId::INTEGER);
   EXPECT_EQ(type::TransientValuePeeker::PeekInteger(constant->GetValue()), 4);
 
-  for (auto clause : update_stmt->GetUpdateClauses()) delete clause->GetUpdateValue().get();  // NOLINT
+  for (auto clause : update_stmt->GetUpdateClauses()) delete clause->GetUpdateValue().Get();  // NOLINT
 }
 
 // NOLINTNEXTLINE
@@ -1086,7 +1086,7 @@ TEST_F(ParserTestBase, OldStringUpdateTest) {
   std::string query =
       "UPDATE ORDER_LINE SET OL_DELIVERY_D = '2016-11-15 15:07:37' WHERE OL_O_ID = 2101 AND OL_D_ID = 2";
 
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto &sql_stmt = stmt_list[0];
 
   // Check root type
@@ -1134,20 +1134,20 @@ TEST_F(ParserTestBase, OldStringUpdateTest) {
   EXPECT_EQ(update_clause->GetColumnName(), "ol_delivery_d");
   auto value = update_clause->GetUpdateValue();
   EXPECT_EQ(value->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
-  auto value_expr = reinterpret_cast<ConstantValueExpression *>(value.get());
+  auto value_expr = reinterpret_cast<ConstantValueExpression *>(value.Get());
   type::TransientValue tmp_value = value_expr->GetValue();
   auto string_view = type::TransientValuePeeker::PeekVarChar(tmp_value);
   EXPECT_EQ("2016-11-15 15:07:37", string_view);
   EXPECT_EQ(type::TypeId::VARCHAR, value_expr->GetReturnValueType());
 
-  for (auto clause : update->GetUpdateClauses()) delete clause->GetUpdateValue().get();  // NOLINT
+  for (auto clause : update->GetUpdateClauses()) delete clause->GetUpdateValue().Get();  // NOLINT
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldDeleteTest) {
   // Simple delete
   std::string query = "DELETE FROM foo;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
 
   EXPECT_EQ(stmt_list.size(), 1);
   EXPECT_EQ(stmt_list[0]->GetType(), StatementType::DELETE);
@@ -1160,7 +1160,7 @@ TEST_F(ParserTestBase, OldDeleteTest) {
 TEST_F(ParserTestBase, OldDeleteTestWithPredicate) {
   // Delete with a predicate
   std::string query = "DELETE FROM foo WHERE id=3;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
 
   EXPECT_EQ(stmt_list.size(), 1);
   EXPECT_EQ(stmt_list[0]->GetType(), StatementType::DELETE);
@@ -1173,7 +1173,7 @@ TEST_F(ParserTestBase, OldDeleteTestWithPredicate) {
 TEST_F(ParserTestBase, OldInsertTest) {
   // Insert multiple tuples into the table
   std::string query = "INSERT INTO foo VALUES (NULL, 2, 3), (4, 5, 6);";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
 
   EXPECT_EQ(1, stmt_list.size());
   EXPECT_TRUE(stmt_list[0]->GetType() == StatementType::INSERT);
@@ -1203,7 +1203,7 @@ TEST_F(ParserTestBase, OldCreateTest) {
       "PRIMARY KEY (id),"
       "FOREIGN KEY (c_id) REFERENCES country (cid));";
 
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
 
   // Check column definition
@@ -1235,22 +1235,22 @@ TEST_F(ParserTestBase, OldCreateTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldTransactionTest) {
   std::string query = "BEGIN TRANSACTION;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto transac_stmt = reinterpret_cast<TransactionStatement *>(stmt_list[0].get());
   EXPECT_EQ(transac_stmt->GetTransactionType(), TransactionStatement::kBegin);
 
   query = "BEGIN;";
-  stmt_list = pgparser.BuildParseTree(query);
+  stmt_list = pgparser_.BuildParseTree(query);
   transac_stmt = reinterpret_cast<TransactionStatement *>(stmt_list[0].get());
   EXPECT_EQ(transac_stmt->GetTransactionType(), TransactionStatement::kBegin);
 
   query = "COMMIT TRANSACTION;";
-  stmt_list = pgparser.BuildParseTree(query);
+  stmt_list = pgparser_.BuildParseTree(query);
   transac_stmt = reinterpret_cast<TransactionStatement *>(stmt_list[0].get());
   EXPECT_EQ(transac_stmt->GetTransactionType(), TransactionStatement::kCommit);
 
   query = "ROLLBACK;";
-  stmt_list = pgparser.BuildParseTree(query);
+  stmt_list = pgparser_.BuildParseTree(query);
   transac_stmt = reinterpret_cast<TransactionStatement *>(stmt_list[0].get());
   EXPECT_EQ(transac_stmt->GetTransactionType(), TransactionStatement::kRollback);
 }
@@ -1258,7 +1258,7 @@ TEST_F(ParserTestBase, OldTransactionTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCreateIndexTest) {
   std::string query = "CREATE UNIQUE INDEX IDX_ORDER ON oorder (O_W_ID, O_D_ID);";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
 
   // Check attributes
@@ -1270,7 +1270,7 @@ TEST_F(ParserTestBase, OldCreateIndexTest) {
   EXPECT_EQ(create_stmt->GetIndexAttributes()[1].GetName(), "o_d_id");
 
   query = "CREATE INDEX ii ON t USING SKIPLIST (col);";
-  stmt_list = pgparser.BuildParseTree(query);
+  stmt_list = pgparser_.BuildParseTree(query);
   create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
 
   // Check attributes
@@ -1280,7 +1280,7 @@ TEST_F(ParserTestBase, OldCreateIndexTest) {
   EXPECT_EQ(create_stmt->GetTableName(), "t");
 
   query = "CREATE INDEX ii ON t (col);";
-  stmt_list = pgparser.BuildParseTree(query);
+  stmt_list = pgparser_.BuildParseTree(query);
   create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
 
   // Check attributes
@@ -1290,14 +1290,14 @@ TEST_F(ParserTestBase, OldCreateIndexTest) {
   EXPECT_EQ(create_stmt->GetTableName(), "t");
 
   query = "CREATE INDEX ii ON t USING GIN (col);";
-  EXPECT_THROW(pgparser.BuildParseTree(query), NotImplementedException);
+  EXPECT_THROW(pgparser_.BuildParseTree(query), NotImplementedException);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldInsertIntoSelectTest) {
   // insert into a table with select sub-query
   std::string query = "INSERT INTO foo select * from bar where id = 5;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
 
   EXPECT_EQ(stmt_list.size(), 1);
   EXPECT_TRUE(stmt_list[0]->GetType() == StatementType::INSERT);
@@ -1311,7 +1311,7 @@ TEST_F(ParserTestBase, OldInsertIntoSelectTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCreateDbTest) {
   std::string query = "CREATE DATABASE tt";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
 
   auto create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
   EXPECT_EQ(create_stmt->GetCreateType(), CreateStatement::CreateType::kDatabase);
@@ -1321,13 +1321,13 @@ TEST_F(ParserTestBase, OldCreateDbTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCreateSchemaTest) {
   std::string query = "CREATE SCHEMA tt";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
   EXPECT_EQ("tt", create_stmt->GetSchemaName());
 
   // Test default schema name
   query = "CREATE SCHEMA AUTHORIZATION joe";
-  stmt_list = pgparser.BuildParseTree(query);
+  stmt_list = pgparser_.BuildParseTree(query);
   create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
   EXPECT_EQ("joe", create_stmt->GetSchemaName());
 }
@@ -1335,7 +1335,7 @@ TEST_F(ParserTestBase, OldCreateSchemaTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCreateViewTest) {
   std::string query = "CREATE VIEW comedies AS SELECT * FROM films WHERE kind = 'Comedy';";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
 
   // Check attributes
@@ -1362,7 +1362,7 @@ TEST_F(ParserTestBase, OldCreateViewTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldDistinctFromTest) {
   std::string query = "SELECT id, value FROM foo WHERE id IS DISTINCT FROM value;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto statement = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
   auto where_expr = statement->GetSelectCondition();
   EXPECT_EQ(ExpressionType::COMPARE_IS_DISTINCT_FROM, where_expr->GetExpressionType());
@@ -1386,7 +1386,7 @@ TEST_F(ParserTestBase, OldConstraintTest) {
       "DEFAULT"
       ");";
 
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
 
   // Check column definition
@@ -1486,7 +1486,7 @@ TEST_F(ParserTestBase, OldDataTypeTest) {
       "b varchar(1024),"
       "c varbinary(32)"
       ");";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto create_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
 
   EXPECT_EQ(create_stmt->GetColumns().size(), 3);
@@ -1519,7 +1519,7 @@ TEST_F(ParserTestBase, OldCreateTriggerTest) {
       "FOR EACH ROW "
       "WHEN (OLD.balance <> NEW.balance) "
       "EXECUTE PROCEDURE check_account_update(update_date);";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
 
   EXPECT_EQ(stmt_list[0]->GetType(), StatementType::CREATE);
   auto create_trigger_stmt = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
@@ -1569,7 +1569,7 @@ TEST_F(ParserTestBase, OldCreateTriggerTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldDropTriggerTest) {
   std::string query = "DROP TRIGGER if_dist_exists ON terrier.films;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   EXPECT_EQ(stmt_list[0]->GetType(), StatementType::DROP);
   auto drop_trigger_stmt = reinterpret_cast<DropStatement *>(stmt_list[0].get());
 
@@ -1581,7 +1581,7 @@ TEST_F(ParserTestBase, OldDropTriggerTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldFuncCallTest) {
   std::string query = "SELECT add(1,a), chr(99) FROM TEST WHERE FUN(b) > 2";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto select_stmt = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
 
   // Check ADD(1,a)
@@ -1627,7 +1627,7 @@ TEST_F(ParserTestBase, OldFuncCallTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldUDFFuncCallTest) {
   std::string query = "SELECT increment(1,b) FROM TEST;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto select_stmt = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
 
   auto fun_expr = reinterpret_cast<FunctionExpression *>(select_stmt->GetSelectColumns()[0].get());
@@ -1648,14 +1648,14 @@ TEST_F(ParserTestBase, OldUDFFuncCallTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCaseTest) {
   std::string query = "SELECT id, case when id=100 then 1 else 0 end from tbl;";
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = pgparser_.BuildParseTree(query);
   auto select_stmt = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
   auto select_args = select_stmt->GetSelectColumns();
   EXPECT_EQ(select_args.at(0)->GetExpressionType(), ExpressionType::COLUMN_VALUE);
   EXPECT_EQ(select_args.at(1)->GetExpressionType(), ExpressionType::OPERATOR_CASE_EXPR);
 
   query = "SELECT id, case id when 100 then 1 when 200 then 2 end from tbl;";
-  stmt_list = pgparser.BuildParseTree(query);
+  stmt_list = pgparser_.BuildParseTree(query);
   select_stmt = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
   select_args = select_stmt->GetSelectColumns();
   EXPECT_EQ(select_args.at(0)->GetExpressionType(), ExpressionType::COLUMN_VALUE);
@@ -1669,7 +1669,7 @@ TEST_F(ParserTestBase, OldDateTypeTest) {
 
   {
     query = "INSERT INTO test_table VALUES (1, 2, '2017-01-01'::DATE);";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto statement = reinterpret_cast<InsertStatement *>(stmt_list[0].get());
     auto values = *(statement->GetValues());
     auto cast_expr = reinterpret_cast<TypeCastExpression *>(values[0][2].get());
@@ -1683,7 +1683,7 @@ TEST_F(ParserTestBase, OldDateTypeTest) {
 
   {
     query = "CREATE TABLE students (name TEXT, graduation DATE)";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto statement = reinterpret_cast<CreateStatement *>(stmt_list[0].get());
     auto values = statement->GetColumns();
     auto date_column = values[1];
@@ -1707,7 +1707,7 @@ TEST_F(ParserTestBase, OldTypeCastTest) {
     std::string query = queries[i];
     type::TypeId correct_type = types[i];
 
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto statement = reinterpret_cast<InsertStatement *>(stmt_list[0].get());
     auto values = *(statement->GetValues());
     auto cast_expr = reinterpret_cast<ConstantValueExpression *>(values[0][2].get());
@@ -1720,7 +1720,7 @@ TEST_F(ParserTestBase, OldTypeCastInExpressionTest) {
   std::string query;
   {
     query = "SELECT * FROM a WHERE d <= date '2018-04-04';";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto statement = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
     auto where_expr = statement->GetSelectCondition();
     auto cast_expr = reinterpret_cast<TypeCastExpression *>(where_expr->GetChild(1).get());
@@ -1734,7 +1734,7 @@ TEST_F(ParserTestBase, OldTypeCastInExpressionTest) {
 
   {
     query = "SELECT '12345'::INTEGER - 12";
-    auto stmt_list = pgparser.BuildParseTree(query);
+    auto stmt_list = pgparser_.BuildParseTree(query);
     auto statement = reinterpret_cast<SelectStatement *>(stmt_list[0].get());
     auto column = statement->GetSelectColumns()[0];
     EXPECT_EQ(ExpressionType::OPERATOR_MINUS, column->GetExpressionType());

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -27,8 +27,8 @@ class ParserTestBase : public TerrierTest {
    * Initialization
    */
   void SetUp() override {
-    init_main_logger();
-    init_parser_logger();
+    InitMainLogger();
+    InitParserLogger();
     parser_logger->set_level(spdlog::level::debug);
     spdlog::flush_every(std::chrono::seconds(1));
   }
@@ -39,7 +39,7 @@ class ParserTestBase : public TerrierTest {
     EXPECT_EQ(table_info->GetTableName(), table_name);
   }
 
-  PostgresParser pgparser;
+  PostgresParser pgparser_;
 };
 
 // NOLINTNEXTLINE

--- a/test/settings/settings_test.cpp
+++ b/test/settings/settings_test.cpp
@@ -143,19 +143,19 @@ TEST_F(SettingsTests, ParamCallbackTest) {
   // Check that if we set a parameter with a callback that the change gets propagated to the object
 
   auto buffer_pool_size = static_cast<int64_t>(settings_manager_->GetInt(Param::record_buffer_segment_size));
-  EXPECT_EQ(buffer_pool_size, defaultBufferPoolSize);
+  EXPECT_EQ(buffer_pool_size, default_buffer_pool_size_);
 
   buffer_pool_size = buffer_segment_pool_->GetSizeLimit();
-  EXPECT_EQ(buffer_pool_size, defaultBufferPoolSize);
+  EXPECT_EQ(buffer_pool_size, default_buffer_pool_size_);
 
   const common::action_id_t action_id(1);
   setter_callback_fn setter_callback = SettingsTests::EmptySetterCallback;
   std::shared_ptr<common::ActionContext> action_context = std::make_shared<common::ActionContext>(action_id);
 
   // Setting new value should invoke callback.
-  const int64_t new_buffer_pool_size = defaultBufferPoolSize + 1;
-  settings_manager_->SetInt(Param::record_buffer_segment_size, static_cast<int32_t>(new_buffer_pool_size), action_context,
-                            setter_callback);
+  const int64_t new_buffer_pool_size = default_buffer_pool_size_ + 1;
+  settings_manager_->SetInt(Param::record_buffer_segment_size, static_cast<int32_t>(new_buffer_pool_size),
+                            action_context, setter_callback);
   buffer_pool_size = static_cast<int64_t>(settings_manager_->GetInt(Param::record_buffer_segment_size));
   EXPECT_EQ(buffer_pool_size, new_buffer_pool_size);
 

--- a/test/settings/settings_test.cpp
+++ b/test/settings/settings_test.cpp
@@ -24,7 +24,7 @@ class SettingsTests : public TerrierTest {
   transaction::TransactionManager *txn_manager_;
   storage::RecordBufferSegmentPool *buffer_segment_pool_;
 
-  const uint64_t defaultBufferPoolSize = 100000;
+  const uint64_t default_buffer_pool_size_ = 100000;
 
   void SetUp() override {
     std::unordered_map<Param, ParamInfo> param_map;
@@ -142,25 +142,25 @@ TEST_F(SettingsTests, SetterCallbackTest) {
 TEST_F(SettingsTests, ParamCallbackTest) {
   // Check that if we set a parameter with a callback that the change gets propagated to the object
 
-  auto bufferPoolSize = static_cast<int64_t>(settings_manager_->GetInt(Param::record_buffer_segment_size));
-  EXPECT_EQ(bufferPoolSize, defaultBufferPoolSize);
+  auto buffer_pool_size = static_cast<int64_t>(settings_manager_->GetInt(Param::record_buffer_segment_size));
+  EXPECT_EQ(buffer_pool_size, defaultBufferPoolSize);
 
-  bufferPoolSize = buffer_segment_pool_->GetSizeLimit();
-  EXPECT_EQ(bufferPoolSize, defaultBufferPoolSize);
+  buffer_pool_size = buffer_segment_pool_->GetSizeLimit();
+  EXPECT_EQ(buffer_pool_size, defaultBufferPoolSize);
 
   const common::action_id_t action_id(1);
   setter_callback_fn setter_callback = SettingsTests::EmptySetterCallback;
   std::shared_ptr<common::ActionContext> action_context = std::make_shared<common::ActionContext>(action_id);
 
   // Setting new value should invoke callback.
-  const int64_t newBufferPoolSize = defaultBufferPoolSize + 1;
-  settings_manager_->SetInt(Param::record_buffer_segment_size, static_cast<int32_t>(newBufferPoolSize), action_context,
+  const int64_t new_buffer_pool_size = defaultBufferPoolSize + 1;
+  settings_manager_->SetInt(Param::record_buffer_segment_size, static_cast<int32_t>(new_buffer_pool_size), action_context,
                             setter_callback);
-  bufferPoolSize = static_cast<int64_t>(settings_manager_->GetInt(Param::record_buffer_segment_size));
-  EXPECT_EQ(bufferPoolSize, newBufferPoolSize);
+  buffer_pool_size = static_cast<int64_t>(settings_manager_->GetInt(Param::record_buffer_segment_size));
+  EXPECT_EQ(buffer_pool_size, new_buffer_pool_size);
 
-  bufferPoolSize = buffer_segment_pool_->GetSizeLimit();
-  EXPECT_EQ(bufferPoolSize, newBufferPoolSize);
+  buffer_pool_size = buffer_segment_pool_->GetSizeLimit();
+  EXPECT_EQ(buffer_pool_size, new_buffer_pool_size);
 }
 
 // NOLINTNEXTLINE
@@ -205,9 +205,9 @@ TEST_F(SettingsTests, ConcurrentModifyTest) {
     thread.join();
   }
 
-  auto bufferPoolSizeParam = static_cast<uint64_t>(settings_manager_->GetInt(Param::record_buffer_segment_size));
-  uint64_t bufferPoolSize = buffer_segment_pool_->GetSizeLimit();
-  EXPECT_EQ(bufferPoolSizeParam, bufferPoolSize);
+  auto buffer_pool_size_param = static_cast<uint64_t>(settings_manager_->GetInt(Param::record_buffer_segment_size));
+  uint64_t buffer_pool_size = buffer_segment_pool_->GetSizeLimit();
+  EXPECT_EQ(buffer_pool_size_param, buffer_pool_size);
 }
 
 }  // namespace terrier::settings

--- a/test/storage/bwtree_index_test.cpp
+++ b/test/storage/bwtree_index_test.cpp
@@ -115,7 +115,7 @@ class BwTreeIndexTests : public TerrierTest {
  */
 // NOLINTNEXTLINE
 TEST_F(BwTreeIndexTests, UniqueInsert) {
-  const uint32_t num_inserts_ = 100000;  // number of tuples/primary keys for each worker to attempt to insert
+  const uint32_t num_inserts = 100000;  // number of tuples/primary keys for each worker to attempt to insert
   auto workload = [&](uint32_t worker_id) {
     //    auto *const insert_buffer =
     //        common::AllocationUtil::AllocateAligned(unique_index_->GetProjectedRowInitializer().ProjectedRowSize());
@@ -127,10 +127,10 @@ TEST_F(BwTreeIndexTests, UniqueInsert) {
     // some threads count up, others count down. This is to mix whether threads abort for write-write conflict or
     // previously committed versions
     if (worker_id % 2 == 0) {
-      for (uint32_t i = 0; i < num_inserts_; i++) {
+      for (uint32_t i = 0; i < num_inserts; i++) {
         auto *const insert_txn = txn_manager_.BeginTransaction();
         auto *const insert_redo =
-            insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+            insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
         const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -144,10 +144,10 @@ TEST_F(BwTreeIndexTests, UniqueInsert) {
       }
 
     } else {
-      for (uint32_t i = num_inserts_ - 1; i < num_inserts_; i--) {
+      for (uint32_t i = num_inserts - 1; i < num_inserts; i--) {
         auto *const insert_txn = txn_manager_.BeginTransaction();
         auto *const insert_redo =
-            insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+            insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
         const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -179,9 +179,9 @@ TEST_F(BwTreeIndexTests, UniqueInsert) {
 
   // scan[0,num_inserts_) should hit num_inserts_ keys (no duplicates)
   *reinterpret_cast<int32_t *>(low_key_pr->AccessForceNotNull(0)) = 0;
-  *reinterpret_cast<int32_t *>(high_key_pr->AccessForceNotNull(0)) = num_inserts_ - 1;
+  *reinterpret_cast<int32_t *>(high_key_pr->AccessForceNotNull(0)) = num_inserts - 1;
   unique_index_->ScanAscending(*scan_txn, *low_key_pr, *high_key_pr, &results);
-  EXPECT_EQ(results.size(), num_inserts_);
+  EXPECT_EQ(results.size(), num_inserts);
 
   txn_manager_.Commit(scan_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 }
@@ -193,7 +193,7 @@ TEST_F(BwTreeIndexTests, UniqueInsert) {
  */
 // NOLINTNEXTLINE
 TEST_F(BwTreeIndexTests, DefaultInsert) {
-  const uint32_t num_inserts_ = 100000;  // number of tuples/primary keys for each worker to attempt to insert
+  const uint32_t num_inserts = 100000;  // number of tuples/primary keys for each worker to attempt to insert
   auto workload = [&](uint32_t worker_id) {
     auto *const key_buffer =
         common::AllocationUtil::AllocateAligned(default_index_->GetProjectedRowInitializer().ProjectedRowSize());
@@ -201,10 +201,10 @@ TEST_F(BwTreeIndexTests, DefaultInsert) {
 
     // some threads count up, others count down. Threads shouldn't abort each other
     if (worker_id % 2 == 0) {
-      for (uint32_t i = 0; i < num_inserts_; i++) {
+      for (uint32_t i = 0; i < num_inserts; i++) {
         auto *const insert_txn = txn_manager_.BeginTransaction();
         auto *const insert_redo =
-            insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+            insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
         const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -214,10 +214,10 @@ TEST_F(BwTreeIndexTests, DefaultInsert) {
         txn_manager_.Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
       }
     } else {
-      for (uint32_t i = num_inserts_ - 1; i < num_inserts_; i--) {
+      for (uint32_t i = num_inserts - 1; i < num_inserts; i--) {
         auto *const insert_txn = txn_manager_.BeginTransaction();
         auto *const insert_redo =
-            insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+            insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
         const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -247,9 +247,9 @@ TEST_F(BwTreeIndexTests, DefaultInsert) {
 
   // scan[0,num_inserts_) should hit num_inserts_ * num_threads_ keys
   *reinterpret_cast<int32_t *>(low_key_pr->AccessForceNotNull(0)) = 0;
-  *reinterpret_cast<int32_t *>(high_key_pr->AccessForceNotNull(0)) = num_inserts_ - 1;
+  *reinterpret_cast<int32_t *>(high_key_pr->AccessForceNotNull(0)) = num_inserts - 1;
   default_index_->ScanAscending(*scan_txn, *low_key_pr, *high_key_pr, &results);
-  EXPECT_EQ(results.size(), num_inserts_ * num_threads_);
+  EXPECT_EQ(results.size(), num_inserts * num_threads_);
 
   txn_manager_.Commit(scan_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 }
@@ -265,7 +265,7 @@ TEST_F(BwTreeIndexTests, ScanAscending) {
   auto *const insert_txn = txn_manager_.BeginTransaction();
   for (int32_t i = 0; i <= 20; i += 2) {
     auto *const insert_redo =
-        insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+        insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
     const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -339,7 +339,7 @@ TEST_F(BwTreeIndexTests, ScanDescending) {
   auto *const insert_txn = txn_manager_.BeginTransaction();
   for (int32_t i = 0; i <= 20; i += 2) {
     auto *const insert_redo =
-        insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+        insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
     const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -412,7 +412,7 @@ TEST_F(BwTreeIndexTests, ScanLimitAscending) {
   auto *const insert_txn = txn_manager_.BeginTransaction();
   for (int32_t i = 0; i <= 20; i += 2) {
     auto *const insert_redo =
-        insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+        insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
     const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -481,7 +481,7 @@ TEST_F(BwTreeIndexTests, ScanLimitDescending) {
   auto *const insert_txn = txn_manager_.BeginTransaction();
   for (int32_t i = 0; i <= 20; i += 2) {
     auto *const insert_redo =
-        insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+        insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
     const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -546,7 +546,7 @@ TEST_F(BwTreeIndexTests, UniqueKey1) {
 
   // txn 0 inserts into table
   auto *insert_redo =
-      txn0->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
@@ -575,7 +575,7 @@ TEST_F(BwTreeIndexTests, UniqueKey1) {
   results.clear();
 
   // txn 1 inserts into table
-  insert_redo = txn1->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+  insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
@@ -607,7 +607,7 @@ TEST_F(BwTreeIndexTests, UniqueKey2) {
 
   // txn 0 inserts into table
   auto *insert_redo =
-      txn0->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
@@ -633,7 +633,7 @@ TEST_F(BwTreeIndexTests, UniqueKey2) {
   auto *txn1 = txn_manager_.BeginTransaction();
 
   // txn 1 inserts into table
-  insert_redo = txn1->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+  insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
@@ -663,7 +663,7 @@ TEST_F(BwTreeIndexTests, UniqueKey3) {
 
   // txn 0 inserts into table
   auto *insert_redo =
-      txn0->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
@@ -685,7 +685,7 @@ TEST_F(BwTreeIndexTests, UniqueKey3) {
   results.clear();
 
   // txn 0 inserts into table
-  insert_redo = txn0->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+  insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto new_tuple_slot = sql_table_->Insert(txn0, insert_redo);
@@ -714,7 +714,7 @@ TEST_F(BwTreeIndexTests, UniqueKey4) {
 
   // txn 0 inserts into table
   auto *insert_redo =
-      txn0->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
@@ -736,7 +736,7 @@ TEST_F(BwTreeIndexTests, UniqueKey4) {
   results.clear();
 
   // txn 0 deletes from table
-  txn0->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_slot);
+  txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_slot);
   EXPECT_TRUE(sql_table_->Delete(txn0, tuple_slot));
 
   // txn 0 deletes from index
@@ -747,7 +747,7 @@ TEST_F(BwTreeIndexTests, UniqueKey4) {
   auto *txn1 = txn_manager_.BeginTransaction();
 
   // txn 1 inserts into table
-  insert_redo = txn1->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+  insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
@@ -796,7 +796,7 @@ TEST_F(BwTreeIndexTests, CommitInsert1) {
 
   // txn 0 inserts into table
   auto *insert_redo =
-      txn0->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
@@ -870,7 +870,7 @@ TEST_F(BwTreeIndexTests, CommitInsert2) {
 
   // txn 1 inserts into table
   auto *insert_redo =
-      txn1->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(txn1, insert_redo);
@@ -941,7 +941,7 @@ TEST_F(BwTreeIndexTests, AbortInsert1) {
 
   // txn 0 inserts into table
   auto *insert_redo =
-      txn0->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
@@ -1014,7 +1014,7 @@ TEST_F(BwTreeIndexTests, AbortInsert2) {
 
   // txn 1 inserts into table
   auto *insert_redo =
-      txn1->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(txn1, insert_redo);
@@ -1084,7 +1084,7 @@ TEST_F(BwTreeIndexTests, CommitUpdate1) {
 
   // insert_txn inserts into table
   auto *insert_redo =
-      insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -1110,11 +1110,11 @@ TEST_F(BwTreeIndexTests, CommitUpdate1) {
   results.clear();
 
   // txn 0 updates in the table, which is really a delete and insert since it's an indexed attribute
-  txn0->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, results[0]);
+  txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
   default_index_->Delete(txn0, *insert_key, results[0]);
 
-  insert_redo = txn0->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+  insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
   const auto new_tuple_slot = sql_table_->Insert(txn0, insert_redo);
@@ -1211,7 +1211,7 @@ TEST_F(BwTreeIndexTests, CommitUpdate2) {
 
   // insert_txn inserts into table
   auto *insert_redo =
-      insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -1237,11 +1237,11 @@ TEST_F(BwTreeIndexTests, CommitUpdate2) {
   EXPECT_EQ(tuple_slot, results[0]);
 
   // txn 1 updates in the table, which is really a delete and insert since it's an indexed attribute
-  txn1->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, results[0]);
+  txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
   default_index_->Delete(txn1, *insert_key, results[0]);
 
-  insert_redo = txn1->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+  insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
   const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
@@ -1338,7 +1338,7 @@ TEST_F(BwTreeIndexTests, AbortUpdate1) {
 
   // insert_txn inserts into table
   auto *insert_redo =
-      insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -1364,11 +1364,11 @@ TEST_F(BwTreeIndexTests, AbortUpdate1) {
   results.clear();
 
   // txn 0 updates in the table, which is really a delete and insert since it's an indexed attribute
-  txn0->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, results[0]);
+  txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
   default_index_->Delete(txn0, *insert_key, results[0]);
 
-  insert_redo = txn0->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+  insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
   const auto new_tuple_slot = sql_table_->Insert(txn0, insert_redo);
@@ -1465,7 +1465,7 @@ TEST_F(BwTreeIndexTests, AbortUpdate2) {
 
   // insert_txn inserts into table
   auto *insert_redo =
-      insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -1491,11 +1491,11 @@ TEST_F(BwTreeIndexTests, AbortUpdate2) {
   EXPECT_EQ(tuple_slot, results[0]);
 
   // txn 1 updates in the table, which is really a delete and insert since it's an indexed attribute
-  txn1->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, results[0]);
+  txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
   default_index_->Delete(txn1, *insert_key, results[0]);
 
-  insert_redo = txn1->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+  insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
   const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
@@ -1592,7 +1592,7 @@ TEST_F(BwTreeIndexTests, CommitDelete1) {
 
   // insert_txn inserts into table
   auto *insert_redo =
-      insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -1618,7 +1618,7 @@ TEST_F(BwTreeIndexTests, CommitDelete1) {
   results.clear();
 
   // txn 0 deletes in the table and index
-  txn0->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, results[0]);
+  txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
   default_index_->Delete(txn0, *insert_key, results[0]);
 
@@ -1684,7 +1684,7 @@ TEST_F(BwTreeIndexTests, CommitDelete2) {
 
   // insert_txn inserts into table
   auto *insert_redo =
-      insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -1710,7 +1710,7 @@ TEST_F(BwTreeIndexTests, CommitDelete2) {
   EXPECT_EQ(tuple_slot, results[0]);
 
   // txn 1 deletes in the table and index
-  txn1->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, results[0]);
+  txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
   default_index_->Delete(txn1, *insert_key, results[0]);
 
@@ -1776,7 +1776,7 @@ TEST_F(BwTreeIndexTests, AbortDelete1) {
 
   // insert_txn inserts into table
   auto *insert_redo =
-      insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -1802,7 +1802,7 @@ TEST_F(BwTreeIndexTests, AbortDelete1) {
   results.clear();
 
   // txn 0 deletes in the table and index
-  txn0->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, results[0]);
+  txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
   default_index_->Delete(txn0, *insert_key, results[0]);
 
@@ -1869,7 +1869,7 @@ TEST_F(BwTreeIndexTests, AbortDelete2) {
 
   // insert_txn inserts into table
   auto *insert_redo =
-      insert_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer_);
+      insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
   const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
@@ -1895,7 +1895,7 @@ TEST_F(BwTreeIndexTests, AbortDelete2) {
   EXPECT_EQ(tuple_slot, results[0]);
 
   // txn 1 deletes in the table and index
-  txn1->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, results[0]);
+  txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
   default_index_->Delete(txn1, *insert_key, results[0]);
 

--- a/test/storage/bwtree_key_test.cpp
+++ b/test/storage/bwtree_key_test.cpp
@@ -228,7 +228,7 @@ class BwTreeKeyTests : public TerrierTest {
 
     // dummy tuple to insert for each key. We just need the visible TupleSlot
     auto *const insert_redo =
-        txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer);
+        txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
 
@@ -254,7 +254,7 @@ class BwTreeKeyTests : public TerrierTest {
     EXPECT_EQ(results.size(), 1);
     EXPECT_EQ(results[0], tuple_slot);
 
-    txn->StageDelete(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_slot);
+    txn->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_slot);
     sql_table.Delete(txn, tuple_slot);
     index->Delete(txn, *key, tuple_slot);
 
@@ -386,11 +386,11 @@ class BwTreeKeyTests : public TerrierTest {
 template <uint8_t KeySize>
 bool CompactIntsFromProjectedRowEq(const IndexMetadata &metadata, const storage::ProjectedRow &pr_A,
                                    const storage::ProjectedRow &pr_B) {
-  auto key_A = CompactIntsKey<KeySize>();
-  auto key_B = CompactIntsKey<KeySize>();
-  key_A.SetFromProjectedRow(pr_A, metadata);
-  key_B.SetFromProjectedRow(pr_B, metadata);
-  return std::equal_to<CompactIntsKey<KeySize>>()(key_A, key_B);
+  auto key_a = CompactIntsKey<KeySize>();
+  auto key_b = CompactIntsKey<KeySize>();
+  key_a.SetFromProjectedRow(pr_A, metadata);
+  key_b.SetFromProjectedRow(pr_B, metadata);
+  return std::equal_to<CompactIntsKey<KeySize>>()(key_a, key_b);
 }
 
 /**
@@ -399,11 +399,11 @@ bool CompactIntsFromProjectedRowEq(const IndexMetadata &metadata, const storage:
 template <uint8_t KeySize>
 bool CompactIntsFromProjectedRowCmp(const IndexMetadata &metadata, const storage::ProjectedRow &pr_A,
                                     const storage::ProjectedRow &pr_B) {
-  auto key_A = CompactIntsKey<KeySize>();
-  auto key_B = CompactIntsKey<KeySize>();
-  key_A.SetFromProjectedRow(pr_A, metadata);
-  key_B.SetFromProjectedRow(pr_B, metadata);
-  return std::less<CompactIntsKey<KeySize>>()(key_A, key_B);
+  auto key_a = CompactIntsKey<KeySize>();
+  auto key_b = CompactIntsKey<KeySize>();
+  key_a.SetFromProjectedRow(pr_A, metadata);
+  key_b.SetFromProjectedRow(pr_B, metadata);
+  return std::less<CompactIntsKey<KeySize>>()(key_a, key_b);
 }
 
 // Test that we generate the right metadata for CompactIntsKey compatible schemas
@@ -730,33 +730,33 @@ TEST_F(BwTreeKeyTests, RandomCompactIntsKeyTest) {
     TERRIER_ASSERT(1 <= key_type && key_type <= 4, "CompactIntsKey only has 4 possible KeySizes.");
 
     // create our projected row buffers
-    auto *pr_buffer_A = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
-    auto *pr_buffer_B = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
-    auto *pr_A = initializer.InitializeRow(pr_buffer_A);
-    auto *pr_B = initializer.InitializeRow(pr_buffer_B);
+    auto *pr_buffer_a = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+    auto *pr_buffer_b = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
+    auto *pr_a = initializer.InitializeRow(pr_buffer_a);
+    auto *pr_b = initializer.InitializeRow(pr_buffer_b);
     //
     for (uint8_t j = 0; j < 10; j++) {
       // fill our buffers with random data
-      const auto data_A = FillProjectedRowWithRandomCompactInts(metadata, pr_A, &generator_);
-      const auto data_B = FillProjectedRowWithRandomCompactInts(metadata, pr_B, &generator_);
+      const auto data_a = FillProjectedRowWithRandomCompactInts(metadata, pr_a, &generator_);
+      const auto data_b = FillProjectedRowWithRandomCompactInts(metadata, pr_b, &generator_);
 
       // perform the relevant checks
       switch (key_type) {
         case 1:
-          EXPECT_EQ(CompactIntsFromProjectedRowEq<1>(metadata, *pr_A, *pr_B), data_A == data_B);
-          EXPECT_EQ(CompactIntsFromProjectedRowCmp<1>(metadata, *pr_A, *pr_B), data_A < data_B);
+          EXPECT_EQ(CompactIntsFromProjectedRowEq<1>(metadata, *pr_a, *pr_b), data_a == data_b);
+          EXPECT_EQ(CompactIntsFromProjectedRowCmp<1>(metadata, *pr_a, *pr_b), data_a < data_b);
           break;
         case 2:
-          EXPECT_EQ(CompactIntsFromProjectedRowEq<2>(metadata, *pr_A, *pr_B), data_A == data_B);
-          EXPECT_EQ(CompactIntsFromProjectedRowCmp<2>(metadata, *pr_A, *pr_B), data_A < data_B);
+          EXPECT_EQ(CompactIntsFromProjectedRowEq<2>(metadata, *pr_a, *pr_b), data_a == data_b);
+          EXPECT_EQ(CompactIntsFromProjectedRowCmp<2>(metadata, *pr_a, *pr_b), data_a < data_b);
           break;
         case 3:
-          EXPECT_EQ(CompactIntsFromProjectedRowEq<3>(metadata, *pr_A, *pr_B), data_A == data_B);
-          EXPECT_EQ(CompactIntsFromProjectedRowCmp<3>(metadata, *pr_A, *pr_B), data_A < data_B);
+          EXPECT_EQ(CompactIntsFromProjectedRowEq<3>(metadata, *pr_a, *pr_b), data_a == data_b);
+          EXPECT_EQ(CompactIntsFromProjectedRowCmp<3>(metadata, *pr_a, *pr_b), data_a < data_b);
           break;
         case 4:
-          EXPECT_EQ(CompactIntsFromProjectedRowEq<4>(metadata, *pr_A, *pr_B), data_A == data_B);
-          EXPECT_EQ(CompactIntsFromProjectedRowCmp<4>(metadata, *pr_A, *pr_B), data_A < data_B);
+          EXPECT_EQ(CompactIntsFromProjectedRowEq<4>(metadata, *pr_a, *pr_b), data_a == data_b);
+          EXPECT_EQ(CompactIntsFromProjectedRowCmp<4>(metadata, *pr_a, *pr_b), data_a < data_b);
           break;
         default:
           throw std::runtime_error("Invalid compact ints key type.");
@@ -765,55 +765,55 @@ TEST_F(BwTreeKeyTests, RandomCompactIntsKeyTest) {
 
     for (uint8_t j = 0; j < 10; j++) {
       // fill buffer pr_A with random data data_A
-      const auto data_A = FillProjectedRow(metadata, pr_A, &generator_);
+      const auto data_a = FillProjectedRow(metadata, pr_a, &generator_);
       float probabilities[] = {0.0, 0.5, 1.0};
 
       for (float prob : probabilities) {
         // have B copy A
-        std::memcpy(pr_B, pr_A, initializer.ProjectedRowSize());
-        auto *data_B = new byte[key_size];
-        std::memcpy(data_B, data_A, key_size);
+        std::memcpy(pr_b, pr_a, initializer.ProjectedRowSize());
+        auto *data_b = new byte[key_size];
+        std::memcpy(data_b, data_a, key_size);
 
         // modify a column of B with some probability, this also updates the reference data_B
-        bool modified = ModifyRandomColumn(metadata, pr_B, data_B, prob, &generator_);
+        bool modified = ModifyRandomColumn(metadata, pr_b, data_b, prob, &generator_);
 
         // perform the relevant checks
         switch (key_type) {
           case 1:
-            EXPECT_EQ(CompactIntsFromProjectedRowEq<1>(metadata, *pr_A, *pr_B),
-                      std::memcmp(data_A, data_B, key_size) == 0 && !modified);
-            EXPECT_EQ(CompactIntsFromProjectedRowCmp<1>(metadata, *pr_A, *pr_B),
-                      std::memcmp(data_A, data_B, key_size) < 0);
+            EXPECT_EQ(CompactIntsFromProjectedRowEq<1>(metadata, *pr_a, *pr_b),
+                      std::memcmp(data_a, data_b, key_size) == 0 && !modified);
+            EXPECT_EQ(CompactIntsFromProjectedRowCmp<1>(metadata, *pr_a, *pr_b),
+                      std::memcmp(data_a, data_b, key_size) < 0);
             break;
           case 2:
-            EXPECT_EQ(CompactIntsFromProjectedRowEq<2>(metadata, *pr_A, *pr_B),
-                      std::memcmp(data_A, data_B, key_size) == 0 && !modified);
-            EXPECT_EQ(CompactIntsFromProjectedRowCmp<2>(metadata, *pr_A, *pr_B),
-                      std::memcmp(data_A, data_B, key_size) < 0);
+            EXPECT_EQ(CompactIntsFromProjectedRowEq<2>(metadata, *pr_a, *pr_b),
+                      std::memcmp(data_a, data_b, key_size) == 0 && !modified);
+            EXPECT_EQ(CompactIntsFromProjectedRowCmp<2>(metadata, *pr_a, *pr_b),
+                      std::memcmp(data_a, data_b, key_size) < 0);
             break;
           case 3:
-            EXPECT_EQ(CompactIntsFromProjectedRowEq<3>(metadata, *pr_A, *pr_B),
-                      std::memcmp(data_A, data_B, key_size) == 0 && !modified);
-            EXPECT_EQ(CompactIntsFromProjectedRowCmp<3>(metadata, *pr_A, *pr_B),
-                      std::memcmp(data_A, data_B, key_size) < 0);
+            EXPECT_EQ(CompactIntsFromProjectedRowEq<3>(metadata, *pr_a, *pr_b),
+                      std::memcmp(data_a, data_b, key_size) == 0 && !modified);
+            EXPECT_EQ(CompactIntsFromProjectedRowCmp<3>(metadata, *pr_a, *pr_b),
+                      std::memcmp(data_a, data_b, key_size) < 0);
             break;
           case 4:
-            EXPECT_EQ(CompactIntsFromProjectedRowEq<4>(metadata, *pr_A, *pr_B),
-                      std::memcmp(data_A, data_B, key_size) == 0 && !modified);
-            EXPECT_EQ(CompactIntsFromProjectedRowCmp<4>(metadata, *pr_A, *pr_B),
-                      std::memcmp(data_A, data_B, key_size) < 0);
+            EXPECT_EQ(CompactIntsFromProjectedRowEq<4>(metadata, *pr_a, *pr_b),
+                      std::memcmp(data_a, data_b, key_size) == 0 && !modified);
+            EXPECT_EQ(CompactIntsFromProjectedRowCmp<4>(metadata, *pr_a, *pr_b),
+                      std::memcmp(data_a, data_b, key_size) < 0);
             break;
           default:
             throw std::runtime_error("Invalid compact ints key type.");
         }
-        delete[] data_B;
+        delete[] data_b;
       }
 
-      delete[] data_A;
+      delete[] data_a;
     }
 
-    delete[] pr_buffer_A;
-    delete[] pr_buffer_B;
+    delete[] pr_buffer_a;
+    delete[] pr_buffer_b;
   }
 }
 

--- a/test/storage/bwtree_test.cpp
+++ b/test/storage/bwtree_test.cpp
@@ -335,7 +335,7 @@ TEST_F(BwTreeTests, Interleaved) {
    *
    * |---- thread 0 ----|---- thread 1----|----thread 2----| .... |---- thread n----|
    */
-  auto InsertTest1 = [&](uint32_t id) {
+  auto insert_test1 = [&](uint32_t id) {
     const uint32_t gcid = id + 1;
     tree->AssignGCID(gcid);
     for (uint32_t i = id * basic_test_key_num; i < static_cast<uint32_t>(id + 1) * basic_test_key_num; i++) {
@@ -350,7 +350,7 @@ TEST_F(BwTreeTests, Interleaved) {
   /*
    * DeleteTest1() - Same pattern as InsertTest1()
    */
-  auto DeleteTest1 = [&](uint32_t id) {
+  auto delete_test1 = [&](uint32_t id) {
     const uint32_t gcid = id + 1;
     tree->AssignGCID(gcid);
     for (uint32_t i = id * basic_test_key_num; i < static_cast<uint32_t>(id + 1) * basic_test_key_num; i++) {
@@ -370,7 +370,7 @@ TEST_F(BwTreeTests, Interleaved) {
    * This test is supposed to be slower since the contention is very high
    * between different threads
    */
-  auto InsertTest2 = [&](uint32_t id) {
+  auto insert_test2 = [&](uint32_t id) {
     const uint32_t gcid = id + 1;
     tree->AssignGCID(gcid);
     for (uint32_t i = 0; i < basic_test_key_num; i++) {
@@ -387,7 +387,7 @@ TEST_F(BwTreeTests, Interleaved) {
   /*
    * DeleteTest2() - The same pattern as InsertTest2()
    */
-  auto DeleteTest2 = [&](uint32_t id) {
+  auto delete_test2 = [&](uint32_t id) {
     const uint32_t gcid = id + 1;
     tree->AssignGCID(gcid);
     for (uint32_t i = 0; i < basic_test_key_num; i++) {
@@ -406,7 +406,7 @@ TEST_F(BwTreeTests, Interleaved) {
    *
    * This function verifies on key_num * thread_num key space
    */
-  auto DeleteGetValueTest = [&]() {
+  auto delete_get_value_test = [&]() {
     for (uint32_t i = 0; i < basic_test_key_num * num_threads_; i++) {
       auto value_set = tree->GetValue(i);
 
@@ -417,7 +417,7 @@ TEST_F(BwTreeTests, Interleaved) {
   /*
    * InsertGetValueTest() - Verifies all values have been inserted
    */
-  auto InsertGetValueTest = [&]() {
+  auto insert_get_value_test = [&]() {
     for (uint32_t i = 0; i < basic_test_key_num * num_threads_; i++) {
       auto value_set = tree->GetValue(i);
 
@@ -426,52 +426,52 @@ TEST_F(BwTreeTests, Interleaved) {
   };
 
   tree->UpdateThreadLocal(num_threads_ + 1);
-  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, InsertTest2);
+  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, insert_test2);
   tree->UpdateThreadLocal(1);
 
-  InsertGetValueTest();
+  insert_get_value_test();
 
   tree->UpdateThreadLocal(num_threads_ + 1);
-  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, DeleteTest1);
+  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, delete_test1);
   tree->UpdateThreadLocal(1);
 
-  DeleteGetValueTest();
+  delete_get_value_test();
 
   tree->UpdateThreadLocal(num_threads_ + 1);
-  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, InsertTest1);
+  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, insert_test1);
   tree->UpdateThreadLocal(1);
 
-  InsertGetValueTest();
+  insert_get_value_test();
 
   tree->UpdateThreadLocal(num_threads_ + 1);
-  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, DeleteTest2);
+  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, delete_test2);
   tree->UpdateThreadLocal(1);
 
-  DeleteGetValueTest();
+  delete_get_value_test();
 
   tree->UpdateThreadLocal(num_threads_ + 1);
-  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, InsertTest1);
+  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, insert_test1);
   tree->UpdateThreadLocal(1);
 
-  InsertGetValueTest();
+  insert_get_value_test();
 
   tree->UpdateThreadLocal(num_threads_ + 1);
-  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, DeleteTest1);
+  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, delete_test1);
   tree->UpdateThreadLocal(1);
 
-  DeleteGetValueTest();
+  delete_get_value_test();
 
   tree->UpdateThreadLocal(num_threads_ + 1);
-  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, InsertTest2);
+  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, insert_test2);
   tree->UpdateThreadLocal(1);
 
-  InsertGetValueTest();
+  insert_get_value_test();
 
   tree->UpdateThreadLocal(num_threads_ + 1);
-  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, DeleteTest2);
+  MultiThreadTestUtil::RunThreadsUntilFinish(&thread_pool, num_threads_, delete_test2);
   tree->UpdateThreadLocal(1);
 
-  DeleteGetValueTest();
+  delete_get_value_test();
 
   delete tree;
 }

--- a/test/storage/log_test.cpp
+++ b/test/storage/log_test.cpp
@@ -310,7 +310,7 @@ TEST_F(WriteAheadLoggingTests, AbortRecordTest) {
   // Initialize first transaction, this txn will write a single tuple
   auto *first_txn = txn_manager->BeginTransaction();
   auto *insert_redo =
-      first_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer);
+      first_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 1;
   auto first_tuple_slot = sql_table.Insert(first_txn, insert_redo);
@@ -321,7 +321,7 @@ TEST_F(WriteAheadLoggingTests, AbortRecordTest) {
   int32_t insert_value = 2;
   while (!GetRedoBuffer(second_txn).HasFlushed()) {
     insert_redo =
-        second_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer);
+        second_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer);
     insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = insert_value++;
     sql_table.Insert(second_txn, insert_redo);
@@ -332,7 +332,7 @@ TEST_F(WriteAheadLoggingTests, AbortRecordTest) {
   // Now the second txn will try to update the tuple the first txn wrote, and thus will abort. We expect this txn to
   // write an abort record
   auto update_redo =
-      second_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer);
+      second_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer);
   auto update_tuple = update_redo->Delta();
   *reinterpret_cast<int32_t *>(update_tuple->AccessForceNotNull(0)) = 0;
   update_redo->SetTupleSlot(first_tuple_slot);
@@ -388,7 +388,7 @@ TEST_F(WriteAheadLoggingTests, NoAbortRecordTest) {
   auto *txn_manager = injector.create<transaction::TransactionManager *>();
   auto *first_txn = txn_manager->BeginTransaction();
   auto *insert_redo =
-      first_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer);
+      first_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 1;
   auto first_tuple_slot = sql_table.Insert(first_txn, insert_redo);
@@ -398,7 +398,7 @@ TEST_F(WriteAheadLoggingTests, NoAbortRecordTest) {
   // expect this txn to not write an abort record
   auto second_txn = txn_manager->BeginTransaction();
   auto update_redo =
-      second_txn->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, tuple_initializer);
+      second_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer);
   auto update_tuple = update_redo->Delta();
   *reinterpret_cast<int32_t *>(update_tuple->AccessForceNotNull(0)) = 0;
   update_redo->SetTupleSlot(first_tuple_slot);

--- a/test/storage/log_test.cpp
+++ b/test/storage/log_test.cpp
@@ -350,7 +350,7 @@ TEST_F(WriteAheadLoggingTests, AbortRecordTest) {
   bool found_abort_record = false;
   storage::BufferedLogReader in(LOG_FILE_NAME);
   while (in.HasMore()) {
-    storage::LogRecord *log_record = ReadNextRecord(&in, sql_table.table_.layout);
+    storage::LogRecord *log_record = ReadNextRecord(&in, sql_table.table_.layout_);
     if (log_record->RecordType() == LogRecordType::ABORT) {
       found_abort_record = true;
       auto *abort_record = log_record->GetUnderlyingRecordBodyAs<storage::AbortRecord>();
@@ -417,7 +417,7 @@ TEST_F(WriteAheadLoggingTests, NoAbortRecordTest) {
   bool found_abort_record = false;
   storage::BufferedLogReader in(LOG_FILE_NAME);
   while (in.HasMore()) {
-    storage::LogRecord *log_record = ReadNextRecord(&in, sql_table.table_.layout);
+    storage::LogRecord *log_record = ReadNextRecord(&in, sql_table.table_.layout_);
     if (log_record->RecordType() == LogRecordType::ABORT) {
       found_abort_record = true;
     }

--- a/test/traffic_cop/traffic_cop_test.cpp
+++ b/test/traffic_cop/traffic_cop_test.cpp
@@ -42,7 +42,7 @@ class TrafficCopTests : public TerrierTest {
       server_ = std::make_unique<network::TerrierServer>(
           common::ManagedPointer<network::ProtocolInterpreter::Provider>(&interpreter_provider_),
           common::ManagedPointer(handle_factory_.get()),
-          common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry));
+          common::ManagedPointer<common::DedicatedThreadRegistry>(&thread_registry_));
       server_->SetPort(port_);
       server_->RunServer();
     } catch (NetworkProcessException &exception) {

--- a/test/traffic_cop/traffic_cop_test.cpp
+++ b/test/traffic_cop/traffic_cop_test.cpp
@@ -28,7 +28,7 @@ class TrafficCopTests : public TerrierTest {
   network::PostgresCommandFactory command_factory_;
   network::PostgresProtocolInterpreter::Provider interpreter_provider_{common::ManagedPointer(&command_factory_)};
   std::unique_ptr<network::ConnectionHandleFactory> handle_factory_;
-  common::DedicatedThreadRegistry thread_registry;
+  common::DedicatedThreadRegistry thread_registry_;
 
   void SetUp() override {
     TerrierTest::SetUp();
@@ -59,7 +59,7 @@ class TrafficCopTests : public TerrierTest {
   }
 
   // The port used to connect a Postgres backend. Useful for debugging.
-  const int POSTGRES_PORT = 5432;
+  const int postgres_port_ = 5432;
 
   /**
    * Read packet from the server (without parsing) until receiving ReadyForQuery or the connection is closed.
@@ -146,8 +146,8 @@ TEST_F(TrafficCopTests, RoundTripTest) {
     txn1.exec("CREATE TABLE TableA (id INT PRIMARY KEY, data TEXT);");
     txn1.exec("INSERT INTO TableA VALUES (1, 'abc');");
 
-    pqxx::result R = txn1.exec("SELECT * FROM TableA");
-    for (const pqxx::row &row : R) {
+    pqxx::result r = txn1.exec("SELECT * FROM TableA");
+    for (const pqxx::row &row : r) {
       std::string row_str;
       for (const pqxx::field &col : row) {
         row_str += col.c_str();
@@ -157,7 +157,7 @@ TEST_F(TrafficCopTests, RoundTripTest) {
     }
     txn1.commit();
 
-    EXPECT_EQ(R.size(), 1);
+    EXPECT_EQ(r.size(), 1);
   } catch (const std::exception &e) {
     TEST_LOG_ERROR("Exception occurred: {0}", e.what());
     EXPECT_TRUE(false);

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -75,7 +75,7 @@ class MVCCDataTableTestObject {
   const double null_bias_ = 0;
   std::vector<byte *> loose_pointers_;
   std::vector<transaction::TransactionContext *> loose_txns_;
-  storage::ProjectedRowInitializer redo_initializer =
+  storage::ProjectedRowInitializer redo_initializer_ =
       storage::ProjectedRowInitializer::Create(layout_, StorageTestUtil::ProjectionListAllColumns(layout_));
   byte *select_buffer_ = common::AllocationUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
   bool select_result_;

--- a/test/transaction/mvcc_test.cpp
+++ b/test/transaction/mvcc_test.cpp
@@ -30,9 +30,9 @@ class MVCCDataTableTestObject {
 
   template <class Random>
   storage::ProjectedRow *GenerateRandomTuple(Random *generator) {
-    auto *buffer = common::AllocationUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
+    auto *buffer = common::AllocationUtil::AllocateAligned(redo_initializer_.ProjectedRowSize());
     loose_pointers_.push_back(buffer);
-    storage::ProjectedRow *redo = redo_initializer.InitializeRow(buffer);
+    storage::ProjectedRow *redo = redo_initializer_.InitializeRow(buffer);
     StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
     return redo;
   }
@@ -51,10 +51,10 @@ class MVCCDataTableTestObject {
 
   storage::ProjectedRow *GenerateVersionFromUpdate(const storage::ProjectedRow &delta,
                                                    const storage::ProjectedRow &previous) {
-    auto *buffer = common::AllocationUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
+    auto *buffer = common::AllocationUtil::AllocateAligned(redo_initializer_.ProjectedRowSize());
     loose_pointers_.push_back(buffer);
     // Copy previous version
-    std::memcpy(buffer, &previous, redo_initializer.ProjectedRowSize());
+    std::memcpy(buffer, &previous, redo_initializer_.ProjectedRowSize());
     auto *version = reinterpret_cast<storage::ProjectedRow *>(buffer);
     std::unordered_map<uint16_t, uint16_t> col_to_projection_list_index;
     storage::StorageUtil::ApplyDelta(layout_, delta, version);
@@ -63,7 +63,7 @@ class MVCCDataTableTestObject {
 
   storage::ProjectedRow *SelectIntoBuffer(transaction::TransactionContext *const txn, const storage::TupleSlot slot) {
     // generate a redo ProjectedRow for Select
-    storage::ProjectedRow *select_row = redo_initializer.InitializeRow(select_buffer_);
+    storage::ProjectedRow *select_row = redo_initializer_.InitializeRow(select_buffer_);
     select_result_ = table_.Select(txn, slot, select_row);
     return select_row;
   }
@@ -77,7 +77,7 @@ class MVCCDataTableTestObject {
   std::vector<transaction::TransactionContext *> loose_txns_;
   storage::ProjectedRowInitializer redo_initializer_ =
       storage::ProjectedRowInitializer::Create(layout_, StorageTestUtil::ProjectionListAllColumns(layout_));
-  byte *select_buffer_ = common::AllocationUtil::AllocateAligned(redo_initializer.ProjectedRowSize());
+  byte *select_buffer_ = common::AllocationUtil::AllocateAligned(redo_initializer_.ProjectedRowSize());
   bool select_result_;
 };
 

--- a/test/util/tpcc/new_order.cpp
+++ b/test/util/tpcc/new_order.cpp
@@ -7,7 +7,7 @@ namespace terrier::tpcc {
 // 2.4.2
 bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Database *const db, Worker *const worker,
                        const TransactionArgs &args) const {
-  TERRIER_ASSERT(args.type == TransactionType::NewOrder, "Wrong transaction type.");
+  TERRIER_ASSERT(args.type_ == TransactionType::NewOrder, "Wrong transaction type.");
 
   double UNUSED_ATTRIBUTE total_amount = 0;
 
@@ -15,16 +15,16 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
 
   // Look up W_ID in index
   const auto warehouse_key_pr_initializer = db->warehouse_primary_index_->GetProjectedRowInitializer();
-  auto *const warehouse_key = warehouse_key_pr_initializer.InitializeRow(worker->warehouse_key_buffer);
+  auto *const warehouse_key = warehouse_key_pr_initializer.InitializeRow(worker->warehouse_key_buffer_);
 
-  *reinterpret_cast<int8_t *>(warehouse_key->AccessForceNotNull(0)) = args.w_id;
+  *reinterpret_cast<int8_t *>(warehouse_key->AccessForceNotNull(0)) = args.w_id_;
 
   std::vector<storage::TupleSlot> index_scan_results;
   db->warehouse_primary_index_->ScanKey(*txn, *warehouse_key, &index_scan_results);
   TERRIER_ASSERT(index_scan_results.size() == 1, "Warehouse index lookup failed.");
 
   // Select W_TAX in table
-  auto *const warehouse_select_tuple = warehouse_select_pr_initializer.InitializeRow(worker->warehouse_tuple_buffer);
+  auto *const warehouse_select_tuple = warehouse_select_pr_initializer_.InitializeRow(worker->warehouse_tuple_buffer_);
   bool UNUSED_ATTRIBUTE select_result =
       db->warehouse_table_->Select(txn, index_scan_results[0], warehouse_select_tuple);
   TERRIER_ASSERT(select_result, "Warehouse table doesn't change. All lookups should succeed.");
@@ -33,29 +33,29 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
 
   // Look up D_ID, W_ID in index
   const auto district_key_pr_initializer = db->district_primary_index_->GetProjectedRowInitializer();
-  auto *const district_key = district_key_pr_initializer.InitializeRow(worker->district_key_buffer);
+  auto *const district_key = district_key_pr_initializer.InitializeRow(worker->district_key_buffer_);
 
-  *reinterpret_cast<int8_t *>(district_key->AccessForceNotNull(d_id_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(district_key->AccessForceNotNull(d_w_id_key_pr_offset)) = args.w_id;
+  *reinterpret_cast<int8_t *>(district_key->AccessForceNotNull(d_id_key_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(district_key->AccessForceNotNull(d_w_id_key_pr_offset_)) = args.w_id_;
 
   index_scan_results.clear();
   db->district_primary_index_->ScanKey(*txn, *district_key, &index_scan_results);
   TERRIER_ASSERT(index_scan_results.size() == 1, "District index lookup failed.");
 
   // Select D_TAX, D_NEXT_O_ID in table
-  auto *const district_select_tuple = district_select_pr_initializer.InitializeRow(worker->district_tuple_buffer);
+  auto *const district_select_tuple = district_select_pr_initializer_.InitializeRow(worker->district_tuple_buffer_);
   select_result = db->district_table_->Select(txn, index_scan_results[0], district_select_tuple);
   TERRIER_ASSERT(select_result, "District table doesn't change. All lookups should succeed.");
 
-  const auto d_tax = *reinterpret_cast<double *>(district_select_tuple->AccessWithNullCheck(d_tax_select_pr_offset));
+  const auto d_tax = *reinterpret_cast<double *>(district_select_tuple->AccessWithNullCheck(d_tax_select_pr_offset_));
   const auto d_next_o_id =
-      *reinterpret_cast<int32_t *>(district_select_tuple->AccessWithNullCheck(d_next_o_id_select_pr_offset));
+      *reinterpret_cast<int32_t *>(district_select_tuple->AccessWithNullCheck(d_next_o_id_select_pr_offset_));
   TERRIER_ASSERT(d_tax >= 0 && d_tax <= 0.2, "Invalid d_tax read from the District table.");
   TERRIER_ASSERT(d_next_o_id >= 3001, "Invalid d_next_o_id read from the District table.");
 
   // Increment D_NEXT_O_ID in table
   auto *const district_update_redo =
-      txn->StageWrite(db->db_oid_, db->district_table_oid_, district_update_pr_initializer);
+      txn->StageWrite(db->db_oid_, db->district_table_oid_, district_update_pr_initializer_);
   *reinterpret_cast<int32_t *>(district_update_redo->Delta()->AccessForceNotNull(0)) = d_next_o_id + 1;
   district_update_redo->SetTupleSlot(index_scan_results[0]);
   bool UNUSED_ATTRIBUTE result = db->district_table_->Update(txn, district_update_redo);
@@ -63,70 +63,70 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
 
   // Look up C_ID, D_ID, W_ID in index
   const auto customer_key_pr_initializer = db->customer_primary_index_->GetProjectedRowInitializer();
-  auto *const customer_key = customer_key_pr_initializer.InitializeRow(worker->customer_key_buffer);
+  auto *const customer_key = customer_key_pr_initializer.InitializeRow(worker->customer_key_buffer_);
 
-  *reinterpret_cast<int32_t *>(customer_key->AccessForceNotNull(c_id_key_pr_offset)) = args.c_id;
-  *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_d_id_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_w_id_key_pr_offset)) = args.w_id;
+  *reinterpret_cast<int32_t *>(customer_key->AccessForceNotNull(c_id_key_pr_offset_)) = args.c_id_;
+  *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_d_id_key_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_w_id_key_pr_offset_)) = args.w_id_;
 
   index_scan_results.clear();
   db->customer_primary_index_->ScanKey(*txn, *customer_key, &index_scan_results);
   TERRIER_ASSERT(index_scan_results.size() == 1, "Customer index lookup failed.");
 
   // Select C_DISCOUNT, C_LAST, and C_CREDIT in table
-  auto *const customer_select_tuple = customer_select_pr_initializer.InitializeRow(worker->customer_tuple_buffer);
+  auto *const customer_select_tuple = customer_select_pr_initializer_.InitializeRow(worker->customer_tuple_buffer_);
   select_result = db->customer_table_->Select(txn, index_scan_results[0], customer_select_tuple);
   TERRIER_ASSERT(select_result, "Customer table doesn't change. All lookups should succeed.");
   const auto c_discount =
-      *reinterpret_cast<double *>(customer_select_tuple->AccessWithNullCheck(c_discount_select_pr_offset));
+      *reinterpret_cast<double *>(customer_select_tuple->AccessWithNullCheck(c_discount_select_pr_offset_));
   TERRIER_ASSERT(c_discount >= 0 && c_discount <= 0.5, "Invalid c_discount read from the Customer table.");
 
   // Insert new row in New Order
   auto *const new_order_insert_redo =
-      txn->StageWrite(db->db_oid_, db->new_order_table_oid_, new_order_insert_pr_initializer);
+      txn->StageWrite(db->db_oid_, db->new_order_table_oid_, new_order_insert_pr_initializer_);
   auto *const new_order_insert_tuple = new_order_insert_redo->Delta();
 
-  *reinterpret_cast<int32_t *>(new_order_insert_tuple->AccessForceNotNull(no_o_id_insert_pr_offset)) = d_next_o_id;
-  *reinterpret_cast<int8_t *>(new_order_insert_tuple->AccessForceNotNull(no_d_id_insert_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(new_order_insert_tuple->AccessForceNotNull(no_w_id_insert_pr_offset)) = args.w_id;
+  *reinterpret_cast<int32_t *>(new_order_insert_tuple->AccessForceNotNull(no_o_id_insert_pr_offset_)) = d_next_o_id;
+  *reinterpret_cast<int8_t *>(new_order_insert_tuple->AccessForceNotNull(no_d_id_insert_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(new_order_insert_tuple->AccessForceNotNull(no_w_id_insert_pr_offset_)) = args.w_id_;
 
   const auto new_order_slot = db->new_order_table_->Insert(txn, new_order_insert_redo);
 
   // insert in New Order index
   const auto new_order_key_pr_initializer = db->new_order_primary_index_->GetProjectedRowInitializer();
-  auto *const new_order_key = new_order_key_pr_initializer.InitializeRow(worker->new_order_key_buffer);
+  auto *const new_order_key = new_order_key_pr_initializer.InitializeRow(worker->new_order_key_buffer_);
 
-  *reinterpret_cast<int32_t *>(new_order_key->AccessForceNotNull(no_o_id_key_pr_offset)) = d_next_o_id;
-  *reinterpret_cast<int8_t *>(new_order_key->AccessForceNotNull(no_d_id_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(new_order_key->AccessForceNotNull(no_w_id_key_pr_offset)) = args.w_id;
+  *reinterpret_cast<int32_t *>(new_order_key->AccessForceNotNull(no_o_id_key_pr_offset_)) = d_next_o_id;
+  *reinterpret_cast<int8_t *>(new_order_key->AccessForceNotNull(no_d_id_key_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(new_order_key->AccessForceNotNull(no_w_id_key_pr_offset_)) = args.w_id_;
 
   bool UNUSED_ATTRIBUTE index_insert_result =
       db->new_order_primary_index_->InsertUnique(txn, *new_order_key, new_order_slot);
   TERRIER_ASSERT(index_insert_result, "New Order index insertion failed.");
 
   // Insert new row in Order
-  auto *const order_insert_redo = txn->StageWrite(db->db_oid_, db->order_table_oid_, order_insert_pr_initializer);
+  auto *const order_insert_redo = txn->StageWrite(db->db_oid_, db->order_table_oid_, order_insert_pr_initializer_);
   auto *const order_insert_tuple = order_insert_redo->Delta();
 
-  *reinterpret_cast<int32_t *>(order_insert_tuple->AccessForceNotNull(o_id_insert_pr_offset)) = d_next_o_id;
-  *reinterpret_cast<int8_t *>(order_insert_tuple->AccessForceNotNull(o_d_id_insert_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(order_insert_tuple->AccessForceNotNull(o_w_id_insert_pr_offset)) = args.w_id;
-  *reinterpret_cast<int32_t *>(order_insert_tuple->AccessForceNotNull(o_c_id_insert_pr_offset)) = args.c_id;
-  *reinterpret_cast<uint64_t *>(order_insert_tuple->AccessForceNotNull(o_entry_d_insert_pr_offset)) = args.o_entry_d;
-  order_insert_tuple->SetNull(o_carrier_id_insert_pr_offset);
-  *reinterpret_cast<int8_t *>(order_insert_tuple->AccessForceNotNull(o_ol_cnt_insert_pr_offset)) = args.ol_cnt;
-  *reinterpret_cast<int8_t *>(order_insert_tuple->AccessForceNotNull(o_all_local_insert_pr_offset)) =
-      static_cast<int8_t>(args.o_all_local);
+  *reinterpret_cast<int32_t *>(order_insert_tuple->AccessForceNotNull(o_id_insert_pr_offset_)) = d_next_o_id;
+  *reinterpret_cast<int8_t *>(order_insert_tuple->AccessForceNotNull(o_d_id_insert_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(order_insert_tuple->AccessForceNotNull(o_w_id_insert_pr_offset_)) = args.w_id_;
+  *reinterpret_cast<int32_t *>(order_insert_tuple->AccessForceNotNull(o_c_id_insert_pr_offset_)) = args.c_id_;
+  *reinterpret_cast<uint64_t *>(order_insert_tuple->AccessForceNotNull(o_entry_d_insert_pr_offset_)) = args.o_entry_d_;
+  order_insert_tuple->SetNull(o_carrier_id_insert_pr_offset_);
+  *reinterpret_cast<int8_t *>(order_insert_tuple->AccessForceNotNull(o_ol_cnt_insert_pr_offset_)) = args.ol_cnt_;
+  *reinterpret_cast<int8_t *>(order_insert_tuple->AccessForceNotNull(o_all_local_insert_pr_offset_)) =
+      static_cast<int8_t>(args.o_all_local_);
 
   const auto order_slot = db->order_table_->Insert(txn, order_insert_redo);
 
   // insert in Order index
   const auto order_key_pr_initializer = db->order_primary_index_->GetProjectedRowInitializer();
-  auto *const order_key = order_key_pr_initializer.InitializeRow(worker->order_key_buffer);
+  auto *const order_key = order_key_pr_initializer.InitializeRow(worker->order_key_buffer_);
 
-  *reinterpret_cast<int32_t *>(order_key->AccessForceNotNull(o_id_key_pr_offset)) = d_next_o_id;
-  *reinterpret_cast<int8_t *>(order_key->AccessForceNotNull(o_d_id_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(order_key->AccessForceNotNull(o_w_id_key_pr_offset)) = args.w_id;
+  *reinterpret_cast<int32_t *>(order_key->AccessForceNotNull(o_id_key_pr_offset_)) = d_next_o_id;
+  *reinterpret_cast<int8_t *>(order_key->AccessForceNotNull(o_d_id_key_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(order_key->AccessForceNotNull(o_w_id_key_pr_offset_)) = args.w_id_;
 
   index_insert_result = db->order_primary_index_->InsertUnique(txn, *order_key, order_slot);
   TERRIER_ASSERT(index_insert_result, "Order index insertion failed.");
@@ -134,28 +134,28 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
   // insert in Order secondary index
   const auto order_secondary_key_pr_initializer = db->order_secondary_index_->GetProjectedRowInitializer();
   auto *const order_secondary_key =
-      order_secondary_key_pr_initializer.InitializeRow(worker->order_secondary_key_buffer);
+      order_secondary_key_pr_initializer.InitializeRow(worker->order_secondary_key_buffer_);
 
-  *reinterpret_cast<int32_t *>(order_secondary_key->AccessForceNotNull(o_id_secondary_key_pr_offset)) = d_next_o_id;
-  *reinterpret_cast<int8_t *>(order_secondary_key->AccessForceNotNull(o_d_id_secondary_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(order_secondary_key->AccessForceNotNull(o_w_id_secondary_key_pr_offset)) = args.w_id;
-  *reinterpret_cast<int32_t *>(order_secondary_key->AccessForceNotNull(o_c_id_secondary_key_pr_offset)) = args.c_id;
+  *reinterpret_cast<int32_t *>(order_secondary_key->AccessForceNotNull(o_id_secondary_key_pr_offset_)) = d_next_o_id;
+  *reinterpret_cast<int8_t *>(order_secondary_key->AccessForceNotNull(o_d_id_secondary_key_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(order_secondary_key->AccessForceNotNull(o_w_id_secondary_key_pr_offset_)) = args.w_id_;
+  *reinterpret_cast<int32_t *>(order_secondary_key->AccessForceNotNull(o_c_id_secondary_key_pr_offset_)) = args.c_id_;
 
   index_insert_result = db->order_secondary_index_->InsertUnique(txn, *order_secondary_key, order_slot);
   TERRIER_ASSERT(index_insert_result, "Order secondary index insertion failed.");
 
   // for each item in order
   int8_t ol_number = 1;
-  for (const auto &item : args.items) {
+  for (const auto &item : args.items_) {
     // Look up I_ID in index
     const auto item_key_pr_initializer = db->item_primary_index_->GetProjectedRowInitializer();
-    auto *const item_key = item_key_pr_initializer.InitializeRow(worker->item_key_buffer);
-    *reinterpret_cast<int32_t *>(item_key->AccessForceNotNull(0)) = item.ol_i_id;
+    auto *const item_key = item_key_pr_initializer.InitializeRow(worker->item_key_buffer_);
+    *reinterpret_cast<int32_t *>(item_key->AccessForceNotNull(0)) = item.ol_i_id_;
     index_scan_results.clear();
     db->item_primary_index_->ScanKey(*txn, *item_key, &index_scan_results);
 
     if (index_scan_results.empty()) {
-      TERRIER_ASSERT(item.ol_i_id == 8491138, "It's the unused value.");
+      TERRIER_ASSERT(item.ol_i_id_ == 8491138, "It's the unused value.");
       txn_manager->Abort(txn);
       return false;
     }
@@ -163,20 +163,20 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
     TERRIER_ASSERT(index_scan_results.size() == 1, "Item index lookup failed.");
 
     // Select I_PRICE, I_NAME, and I_DATE in table
-    auto *const item_select_tuple = item_select_pr_initializer.InitializeRow(worker->item_tuple_buffer);
+    auto *const item_select_tuple = item_select_pr_initializer_.InitializeRow(worker->item_tuple_buffer_);
     select_result = db->item_table_->Select(txn, index_scan_results[0], item_select_tuple);
     TERRIER_ASSERT(select_result, "Item table doesn't change. All lookups should succeed.");
-    const auto i_price = *reinterpret_cast<double *>(item_select_tuple->AccessWithNullCheck(i_price_select_pr_offset));
+    const auto i_price = *reinterpret_cast<double *>(item_select_tuple->AccessWithNullCheck(i_price_select_pr_offset_));
     const auto i_data =
-        *reinterpret_cast<storage::VarlenEntry *>(item_select_tuple->AccessWithNullCheck(i_data_select_pr_offset));
+        *reinterpret_cast<storage::VarlenEntry *>(item_select_tuple->AccessWithNullCheck(i_data_select_pr_offset_));
     TERRIER_ASSERT(i_price >= 1.0 && i_price <= 100.0, "Invalid i_price read from the Item table.");
 
     // Look up S_I_ID, S_W_ID in index
     const auto stock_key_pr_initializer = db->stock_primary_index_->GetProjectedRowInitializer();
-    auto *const stock_key = stock_key_pr_initializer.InitializeRow(worker->stock_key_buffer);
+    auto *const stock_key = stock_key_pr_initializer.InitializeRow(worker->stock_key_buffer_);
 
-    *reinterpret_cast<int32_t *>(stock_key->AccessForceNotNull(s_i_id_key_pr_offset)) = item.ol_i_id;
-    *reinterpret_cast<int8_t *>(stock_key->AccessForceNotNull(s_w_id_key_pr_offset)) = item.ol_supply_w_id;
+    *reinterpret_cast<int32_t *>(stock_key->AccessForceNotNull(s_i_id_key_pr_offset_)) = item.ol_i_id_;
+    *reinterpret_cast<int8_t *>(stock_key->AccessForceNotNull(s_w_id_key_pr_offset_)) = item.ol_supply_w_id_;
 
     index_scan_results.clear();
     db->stock_primary_index_->ScanKey(*txn, *stock_key, &index_scan_results);
@@ -184,35 +184,35 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
 
     // Select S_QUANTITY, S_DIST_xx (xx = args.d_id), S_YTD, S_ORDER_CNT, S_REMOTE_CNT, S_DATA in table
     auto *const stock_select_tuple =
-        stock_select_initializers[args.d_id - 1].first.InitializeRow(worker->stock_tuple_buffer);
+        stock_select_initializers_[args.d_id_ - 1].first.InitializeRow(worker->stock_tuple_buffer_);
     select_result = db->stock_table_->Select(txn, index_scan_results[0], stock_select_tuple);
     TERRIER_ASSERT(select_result, "Stock table doesn't change (no new entries). All lookups should succeed.");
     const auto s_quantity = *reinterpret_cast<int16_t *>(
-        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets[args.d_id - 1].s_quantity_select_pr_offset));
+        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets_[args.d_id_ - 1].s_quantity_select_pr_offset_));
     const auto s_dist_xx = *reinterpret_cast<storage::VarlenEntry *>(
-        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets[args.d_id - 1].s_dist_xx_select_pr_offset));
+        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets_[args.d_id_ - 1].s_dist_xx_select_pr_offset_));
     const auto s_ytd = *reinterpret_cast<int32_t *>(
-        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets[args.d_id - 1].s_ytd_select_pr_offset));
-    const auto s_order_cnt = *reinterpret_cast<int16_t *>(
-        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets[args.d_id - 1].s_order_cnt_select_pr_offset));
-    const auto s_remote_cnt = *reinterpret_cast<int16_t *>(
-        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets[args.d_id - 1].s_remote_cnt_select_pr_offset));
+        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets_[args.d_id_ - 1].s_ytd_select_pr_offset_));
+    const auto s_order_cnt = *reinterpret_cast<int16_t *>(stock_select_tuple->AccessWithNullCheck(
+        stock_select_pr_offsets_[args.d_id_ - 1].s_order_cnt_select_pr_offset_));
+    const auto s_remote_cnt = *reinterpret_cast<int16_t *>(stock_select_tuple->AccessWithNullCheck(
+        stock_select_pr_offsets_[args.d_id_ - 1].s_remote_cnt_select_pr_offset_));
     const auto s_data = *reinterpret_cast<storage::VarlenEntry *>(
-        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets[args.d_id - 1].s_data_select_pr_offset));
+        stock_select_tuple->AccessWithNullCheck(stock_select_pr_offsets_[args.d_id_ - 1].s_data_select_pr_offset_));
 
     // Update S_QUANTITY, S_YTD, S_ORDER_CNT, S_REMOTE_CNT
-    auto *const stock_update_redo = txn->StageWrite(db->db_oid_, db->stock_table_oid_, stock_update_pr_initializer);
+    auto *const stock_update_redo = txn->StageWrite(db->db_oid_, db->stock_table_oid_, stock_update_pr_initializer_);
     auto *const stock_update_tuple = stock_update_redo->Delta();
 
-    *reinterpret_cast<int16_t *>(stock_update_tuple->AccessForceNotNull(s_quantity_update_pr_offset)) =
-        static_cast<int16_t>((s_quantity >= item.ol_quantity + 10) ? s_quantity - item.ol_quantity
-                                                                   : s_quantity - item.ol_quantity + 91);
-    *reinterpret_cast<int32_t *>(stock_update_tuple->AccessForceNotNull(s_ytd_update_pr_offset)) =
-        s_ytd + item.ol_quantity;
-    *reinterpret_cast<int16_t *>(stock_update_tuple->AccessForceNotNull(s_order_cnt_update_pr_offset)) =
+    *reinterpret_cast<int16_t *>(stock_update_tuple->AccessForceNotNull(s_quantity_update_pr_offset_)) =
+        static_cast<int16_t>((s_quantity >= item.ol_quantity_ + 10) ? s_quantity - item.ol_quantity_
+                                                                    : s_quantity - item.ol_quantity_ + 91);
+    *reinterpret_cast<int32_t *>(stock_update_tuple->AccessForceNotNull(s_ytd_update_pr_offset_)) =
+        s_ytd + item.ol_quantity_;
+    *reinterpret_cast<int16_t *>(stock_update_tuple->AccessForceNotNull(s_order_cnt_update_pr_offset_)) =
         static_cast<int16_t>(s_order_cnt + 1);
-    *reinterpret_cast<int16_t *>(stock_update_tuple->AccessForceNotNull(s_remote_cnt_update_pr_offset)) =
-        static_cast<int16_t>(item.remote ? s_remote_cnt + 1 : s_remote_cnt);
+    *reinterpret_cast<int16_t *>(stock_update_tuple->AccessForceNotNull(s_remote_cnt_update_pr_offset_)) =
+        static_cast<int16_t>(item.remote_ ? s_remote_cnt + 1 : s_remote_cnt);
     stock_update_redo->SetTupleSlot(index_scan_results[0]);
     result = db->stock_table_->Update(txn, stock_update_redo);
     if (!result) {
@@ -221,7 +221,7 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
       return false;
     }
 
-    const double ol_amount = item.ol_quantity * i_price;
+    const double ol_amount = item.ol_quantity_ * i_price;
 
     const auto i_data_str = i_data.StringView();
     const auto s_data_str = s_data.StringView();
@@ -233,44 +233,45 @@ bool NewOrder::Execute(transaction::TransactionManager *const txn_manager, Datab
 
     // Insert new row in Order Line
     auto *const order_line_insert_redo =
-        txn->StageWrite(db->db_oid_, db->order_line_table_oid_, order_line_insert_pr_initializer);
+        txn->StageWrite(db->db_oid_, db->order_line_table_oid_, order_line_insert_pr_initializer_);
     auto *const order_line_insert_tuple = order_line_insert_redo->Delta();
 
-    *reinterpret_cast<int32_t *>(order_line_insert_tuple->AccessForceNotNull(ol_o_id_insert_pr_offset)) = d_next_o_id;
-    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_d_id_insert_pr_offset)) = args.d_id;
-    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_w_id_insert_pr_offset)) = args.w_id;
-    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_number_insert_pr_offset)) = ol_number;
-    *reinterpret_cast<int32_t *>(order_line_insert_tuple->AccessForceNotNull(ol_i_id_insert_pr_offset)) = item.ol_i_id;
-    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_supply_w_id_insert_pr_offset)) =
-        item.ol_supply_w_id;
-    order_line_insert_tuple->SetNull(ol_delivery_d_insert_pr_offset);
-    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_quantity_insert_pr_offset)) =
-        item.ol_quantity;
-    *reinterpret_cast<double *>(order_line_insert_tuple->AccessForceNotNull(ol_amount_insert_pr_offset)) =
-        item.ol_quantity * i_price;
+    *reinterpret_cast<int32_t *>(order_line_insert_tuple->AccessForceNotNull(ol_o_id_insert_pr_offset_)) = d_next_o_id;
+    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_d_id_insert_pr_offset_)) = args.d_id_;
+    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_w_id_insert_pr_offset_)) = args.w_id_;
+    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_number_insert_pr_offset_)) = ol_number;
+    *reinterpret_cast<int32_t *>(order_line_insert_tuple->AccessForceNotNull(ol_i_id_insert_pr_offset_)) =
+        item.ol_i_id_;
+    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_supply_w_id_insert_pr_offset_)) =
+        item.ol_supply_w_id_;
+    order_line_insert_tuple->SetNull(ol_delivery_d_insert_pr_offset_);
+    *reinterpret_cast<int8_t *>(order_line_insert_tuple->AccessForceNotNull(ol_quantity_insert_pr_offset_)) =
+        item.ol_quantity_;
+    *reinterpret_cast<double *>(order_line_insert_tuple->AccessForceNotNull(ol_amount_insert_pr_offset_)) =
+        item.ol_quantity_ * i_price;
 
     if (s_dist_xx.Size() <= storage::VarlenEntry::InlineThreshold()) {
       *reinterpret_cast<storage::VarlenEntry *>(
-          order_line_insert_tuple->AccessForceNotNull(ol_dist_info_insert_pr_offset)) = s_dist_xx;
+          order_line_insert_tuple->AccessForceNotNull(ol_dist_info_insert_pr_offset_)) = s_dist_xx;
 
     } else {
       auto *const varlen = common::AllocationUtil::AllocateAligned(s_dist_xx.Size());
       std::memcpy(varlen, s_dist_xx.Content(), s_dist_xx.Size());
       const auto varlen_entry = storage::VarlenEntry::Create(varlen, s_dist_xx.Size(), true);
       *reinterpret_cast<storage::VarlenEntry *>(
-          order_line_insert_tuple->AccessForceNotNull(ol_dist_info_insert_pr_offset)) = varlen_entry;
+          order_line_insert_tuple->AccessForceNotNull(ol_dist_info_insert_pr_offset_)) = varlen_entry;
     }
 
     const auto order_line_slot = db->order_line_table_->Insert(txn, order_line_insert_redo);
 
     // insert in Order Line index
     const auto order_line_key_pr_initializer = db->order_line_primary_index_->GetProjectedRowInitializer();
-    auto *const order_line_key = order_line_key_pr_initializer.InitializeRow(worker->order_line_key_buffer);
+    auto *const order_line_key = order_line_key_pr_initializer.InitializeRow(worker->order_line_key_buffer_);
 
-    *reinterpret_cast<int8_t *>(order_line_key->AccessForceNotNull(ol_w_id_key_pr_offset)) = args.w_id;
-    *reinterpret_cast<int8_t *>(order_line_key->AccessForceNotNull(ol_d_id_key_pr_offset)) = args.d_id;
-    *reinterpret_cast<int32_t *>(order_line_key->AccessForceNotNull(ol_o_id_key_pr_offset)) = d_next_o_id;
-    *reinterpret_cast<int8_t *>(order_line_key->AccessForceNotNull(ol_number_key_pr_offset)) = ol_number;
+    *reinterpret_cast<int8_t *>(order_line_key->AccessForceNotNull(ol_w_id_key_pr_offset_)) = args.w_id_;
+    *reinterpret_cast<int8_t *>(order_line_key->AccessForceNotNull(ol_d_id_key_pr_offset_)) = args.d_id_;
+    *reinterpret_cast<int32_t *>(order_line_key->AccessForceNotNull(ol_o_id_key_pr_offset_)) = d_next_o_id;
+    *reinterpret_cast<int8_t *>(order_line_key->AccessForceNotNull(ol_number_key_pr_offset_)) = ol_number;
 
     index_insert_result = db->order_line_primary_index_->InsertUnique(txn, *order_line_key, order_line_slot);
     TERRIER_ASSERT(index_insert_result, "Order Line index insertion failed.");

--- a/test/util/tpcc/order_status.cpp
+++ b/test/util/tpcc/order_status.cpp
@@ -8,20 +8,20 @@ namespace terrier::tpcc {
 // 2.6.2
 bool OrderStatus::Execute(transaction::TransactionManager *const txn_manager, Database *const db, Worker *const worker,
                           const TransactionArgs &args) const {
-  TERRIER_ASSERT(args.type == TransactionType::OrderStatus, "Wrong transaction type.");
+  TERRIER_ASSERT(args.type_ == TransactionType::OrderStatus, "Wrong transaction type.");
 
   auto *const txn = txn_manager->BeginTransaction();
 
   storage::TupleSlot customer_slot;
   std::vector<storage::TupleSlot> index_scan_results;
-  if (!args.use_c_last) {
+  if (!args.use_c_last_) {
     // Look up C_ID, D_ID, W_ID in index
     const auto customer_key_pr_initializer = db->customer_primary_index_->GetProjectedRowInitializer();
-    auto *const customer_key = customer_key_pr_initializer.InitializeRow(worker->customer_key_buffer);
+    auto *const customer_key = customer_key_pr_initializer.InitializeRow(worker->customer_key_buffer_);
 
-    *reinterpret_cast<int32_t *>(customer_key->AccessForceNotNull(c_id_key_pr_offset)) = args.c_id;
-    *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_d_id_key_pr_offset)) = args.d_id;
-    *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_w_id_key_pr_offset)) = args.w_id;
+    *reinterpret_cast<int32_t *>(customer_key->AccessForceNotNull(c_id_key_pr_offset_)) = args.c_id_;
+    *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_d_id_key_pr_offset_)) = args.d_id_;
+    *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_w_id_key_pr_offset_)) = args.w_id_;
 
     index_scan_results.clear();
     db->customer_primary_index_->ScanKey(*txn, *customer_key, &index_scan_results);
@@ -30,12 +30,12 @@ bool OrderStatus::Execute(transaction::TransactionManager *const txn_manager, Da
   } else {
     // Look up C_LAST, D_ID, W_ID in index
     const auto customer_name_key_pr_initializer = db->customer_secondary_index_->GetProjectedRowInitializer();
-    auto *const customer_name_key = customer_name_key_pr_initializer.InitializeRow(worker->customer_name_key_buffer);
+    auto *const customer_name_key = customer_name_key_pr_initializer.InitializeRow(worker->customer_name_key_buffer_);
 
-    *reinterpret_cast<storage::VarlenEntry *>(customer_name_key->AccessForceNotNull(c_last_name_key_pr_offset)) =
-        args.c_last;
-    *reinterpret_cast<int8_t *>(customer_name_key->AccessForceNotNull(c_d_id_name_key_pr_offset)) = args.d_id;
-    *reinterpret_cast<int8_t *>(customer_name_key->AccessForceNotNull(c_w_id_name_key_pr_offset)) = args.w_id;
+    *reinterpret_cast<storage::VarlenEntry *>(customer_name_key->AccessForceNotNull(c_last_name_key_pr_offset_)) =
+        args.c_last_;
+    *reinterpret_cast<int8_t *>(customer_name_key->AccessForceNotNull(c_d_id_name_key_pr_offset_)) = args.d_id_;
+    *reinterpret_cast<int8_t *>(customer_name_key->AccessForceNotNull(c_w_id_name_key_pr_offset_)) = args.w_id_;
 
     index_scan_results.clear();
     db->customer_secondary_index_->ScanKey(*txn, *customer_name_key, &index_scan_results);
@@ -44,7 +44,7 @@ bool OrderStatus::Execute(transaction::TransactionManager *const txn_manager, Da
     if (index_scan_results.size() > 1) {
       std::map<std::string, storage::TupleSlot> sorted_index_scan_results;
       for (const auto &tuple_slot : index_scan_results) {
-        auto *const c_first_select_tuple = c_first_pr_initializer.InitializeRow(worker->customer_tuple_buffer);
+        auto *const c_first_select_tuple = c_first_pr_initializer_.InitializeRow(worker->customer_tuple_buffer_);
         bool UNUSED_ATTRIBUTE select_result = db->customer_table_->Select(txn, tuple_slot, c_first_select_tuple);
         TERRIER_ASSERT(select_result, "Customer table doesn't change (no new entries). All lookups should succeed.");
         const auto c_first = *reinterpret_cast<storage::VarlenEntry *>(c_first_select_tuple->AccessWithNullCheck(0));
@@ -61,32 +61,36 @@ bool OrderStatus::Execute(transaction::TransactionManager *const txn_manager, Da
   }
 
   // Select customer in table
-  auto *const customer_select_tuple = customer_select_pr_initializer.InitializeRow(worker->customer_tuple_buffer);
+  auto *const customer_select_tuple = customer_select_pr_initializer_.InitializeRow(worker->customer_tuple_buffer_);
   bool UNUSED_ATTRIBUTE select_result = db->customer_table_->Select(txn, customer_slot, customer_select_tuple);
   TERRIER_ASSERT(select_result, "Customer table doesn't change (no new entries). All lookups should succeed.");
 
   const auto *const c_id_ptr =
-      reinterpret_cast<int32_t *>(customer_select_tuple->AccessWithNullCheck(c_id_select_pr_offset));
+      reinterpret_cast<int32_t *>(customer_select_tuple->AccessWithNullCheck(c_id_select_pr_offset_));
   TERRIER_ASSERT(c_id_ptr != nullptr, "This is a non-NULLable field.");
-  const auto UNUSED_ATTRIBUTE c_id = !args.use_c_last ? args.c_id : *c_id_ptr;
+  const auto UNUSED_ATTRIBUTE c_id = !args.use_c_last_ ? args.c_id_ : *c_id_ptr;
   TERRIER_ASSERT(c_id >= 1 && c_id <= 3000, "Invalid c_id read from the Customer table.");
 
   // look up in secondary Order index
   const auto order_secondary_key_pr_initializer = db->order_secondary_index_->GetProjectedRowInitializer();
   auto *const order_secondary_low_key =
-      order_secondary_key_pr_initializer.InitializeRow(worker->order_secondary_key_buffer);
+      order_secondary_key_pr_initializer.InitializeRow(worker->order_secondary_key_buffer_);
   auto *const order_secondary_high_key =
-      order_secondary_key_pr_initializer.InitializeRow(worker->order_tuple_buffer);  // it's large enough
+      order_secondary_key_pr_initializer.InitializeRow(worker->order_tuple_buffer_);  // it's large enough
 
-  *reinterpret_cast<int32_t *>(order_secondary_low_key->AccessForceNotNull(o_id_secondary_key_pr_offset)) = 1;
-  *reinterpret_cast<int8_t *>(order_secondary_low_key->AccessForceNotNull(o_d_id_secondary_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(order_secondary_low_key->AccessForceNotNull(o_w_id_secondary_key_pr_offset)) = args.w_id;
-  *reinterpret_cast<int32_t *>(order_secondary_low_key->AccessForceNotNull(o_c_id_secondary_key_pr_offset)) = c_id;
+  *reinterpret_cast<int32_t *>(order_secondary_low_key->AccessForceNotNull(o_id_secondary_key_pr_offset_)) = 1;
+  *reinterpret_cast<int8_t *>(order_secondary_low_key->AccessForceNotNull(o_d_id_secondary_key_pr_offset_)) =
+      args.d_id_;
+  *reinterpret_cast<int8_t *>(order_secondary_low_key->AccessForceNotNull(o_w_id_secondary_key_pr_offset_)) =
+      args.w_id_;
+  *reinterpret_cast<int32_t *>(order_secondary_low_key->AccessForceNotNull(o_c_id_secondary_key_pr_offset_)) = c_id;
 
-  *reinterpret_cast<int32_t *>(order_secondary_high_key->AccessForceNotNull(o_id_secondary_key_pr_offset)) = 10000000;
-  *reinterpret_cast<int8_t *>(order_secondary_high_key->AccessForceNotNull(o_d_id_secondary_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(order_secondary_high_key->AccessForceNotNull(o_w_id_secondary_key_pr_offset)) = args.w_id;
-  *reinterpret_cast<int32_t *>(order_secondary_high_key->AccessForceNotNull(o_c_id_secondary_key_pr_offset)) = c_id;
+  *reinterpret_cast<int32_t *>(order_secondary_high_key->AccessForceNotNull(o_id_secondary_key_pr_offset_)) = 10000000;
+  *reinterpret_cast<int8_t *>(order_secondary_high_key->AccessForceNotNull(o_d_id_secondary_key_pr_offset_)) =
+      args.d_id_;
+  *reinterpret_cast<int8_t *>(order_secondary_high_key->AccessForceNotNull(o_w_id_secondary_key_pr_offset_)) =
+      args.w_id_;
+  *reinterpret_cast<int32_t *>(order_secondary_high_key->AccessForceNotNull(o_c_id_secondary_key_pr_offset_)) = c_id;
 
   index_scan_results.clear();
   db->order_secondary_index_->ScanLimitDescending(*txn, *order_secondary_low_key, *order_secondary_high_key,
@@ -95,28 +99,28 @@ bool OrderStatus::Execute(transaction::TransactionManager *const txn_manager, Da
                  "Order index lookup failed. There should always be at least one order for each customer.");
 
   // Select O_ID, O_ENTRY_D, O_CARRIER_ID from table for largest key (back of vector)
-  auto *const order_select_tuple = order_select_pr_initializer.InitializeRow(worker->order_tuple_buffer);
+  auto *const order_select_tuple = order_select_pr_initializer_.InitializeRow(worker->order_tuple_buffer_);
   select_result = db->order_table_->Select(txn, index_scan_results[0], order_select_tuple);
   TERRIER_ASSERT(select_result,
                  "Order select failed. This assertion assumes 1:1 mapping between warehouse and workers.");
 
-  const auto o_id = *reinterpret_cast<int32_t *>(order_select_tuple->AccessWithNullCheck(o_id_select_pr_offset));
+  const auto o_id = *reinterpret_cast<int32_t *>(order_select_tuple->AccessWithNullCheck(o_id_select_pr_offset_));
 
   // look up in Order Line index
   const auto order_line_key_pr_initializer = db->order_line_primary_index_->GetProjectedRowInitializer();
-  auto *const order_line_low_key = order_line_key_pr_initializer.InitializeRow(worker->order_line_key_buffer);
+  auto *const order_line_low_key = order_line_key_pr_initializer.InitializeRow(worker->order_line_key_buffer_);
   auto *const order_line_high_key =
-      order_line_key_pr_initializer.InitializeRow(worker->order_line_tuple_buffer);  // it's large enough
+      order_line_key_pr_initializer.InitializeRow(worker->order_line_tuple_buffer_);  // it's large enough
 
-  *reinterpret_cast<int8_t *>(order_line_low_key->AccessForceNotNull(ol_number_key_pr_offset)) = 1;
-  *reinterpret_cast<int8_t *>(order_line_low_key->AccessForceNotNull(ol_d_id_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(order_line_low_key->AccessForceNotNull(ol_w_id_key_pr_offset)) = args.w_id;
-  *reinterpret_cast<int32_t *>(order_line_low_key->AccessForceNotNull(ol_o_id_key_pr_offset)) = o_id;
+  *reinterpret_cast<int8_t *>(order_line_low_key->AccessForceNotNull(ol_number_key_pr_offset_)) = 1;
+  *reinterpret_cast<int8_t *>(order_line_low_key->AccessForceNotNull(ol_d_id_key_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(order_line_low_key->AccessForceNotNull(ol_w_id_key_pr_offset_)) = args.w_id_;
+  *reinterpret_cast<int32_t *>(order_line_low_key->AccessForceNotNull(ol_o_id_key_pr_offset_)) = o_id;
 
-  *reinterpret_cast<int8_t *>(order_line_high_key->AccessForceNotNull(ol_number_key_pr_offset)) = 15;
-  *reinterpret_cast<int8_t *>(order_line_high_key->AccessForceNotNull(ol_d_id_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(order_line_high_key->AccessForceNotNull(ol_w_id_key_pr_offset)) = args.w_id;
-  *reinterpret_cast<int32_t *>(order_line_high_key->AccessForceNotNull(ol_o_id_key_pr_offset)) = o_id;
+  *reinterpret_cast<int8_t *>(order_line_high_key->AccessForceNotNull(ol_number_key_pr_offset_)) = 15;
+  *reinterpret_cast<int8_t *>(order_line_high_key->AccessForceNotNull(ol_d_id_key_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(order_line_high_key->AccessForceNotNull(ol_w_id_key_pr_offset_)) = args.w_id_;
+  *reinterpret_cast<int32_t *>(order_line_high_key->AccessForceNotNull(ol_o_id_key_pr_offset_)) = o_id;
 
   index_scan_results.clear();
   db->order_line_primary_index_->ScanAscending(*txn, *order_line_low_key, *order_line_high_key, &index_scan_results);
@@ -125,7 +129,8 @@ bool OrderStatus::Execute(transaction::TransactionManager *const txn_manager, Da
                  "There should be at least 1 Order Line item, but no more than 15.");
 
   // Select OL_I_ID, OL_SUPPLY_W_ID, OL_QUANTITY, OL_AMOUNT, OL_DELIVERY_D for every result of the index scan
-  auto *const order_line_select_tuple = order_line_select_pr_initializer.InitializeRow(worker->order_line_tuple_buffer);
+  auto *const order_line_select_tuple =
+      order_line_select_pr_initializer_.InitializeRow(worker->order_line_tuple_buffer_);
   for (const auto &tuple_slot : index_scan_results) {
     select_result = db->order_line_table_->Select(txn, tuple_slot, order_line_select_tuple);
     TERRIER_ASSERT(select_result,

--- a/test/util/tpcc/payment.cpp
+++ b/test/util/tpcc/payment.cpp
@@ -9,75 +9,75 @@ namespace terrier::tpcc {
 // 2.5.2
 bool Payment::Execute(transaction::TransactionManager *const txn_manager, Database *const db, Worker *const worker,
                       const TransactionArgs &args) const {
-  TERRIER_ASSERT(args.type == TransactionType::Payment, "Wrong transaction type.");
+  TERRIER_ASSERT(args.type_ == TransactionType::Payment, "Wrong transaction type.");
 
   auto *const txn = txn_manager->BeginTransaction();
 
   // Look up W_ID in index
   const auto warehouse_key_pr_initializer = db->warehouse_primary_index_->GetProjectedRowInitializer();
-  auto *const warehouse_key = warehouse_key_pr_initializer.InitializeRow(worker->warehouse_key_buffer);
+  auto *const warehouse_key = warehouse_key_pr_initializer.InitializeRow(worker->warehouse_key_buffer_);
 
-  *reinterpret_cast<int8_t *>(warehouse_key->AccessForceNotNull(0)) = args.w_id;
+  *reinterpret_cast<int8_t *>(warehouse_key->AccessForceNotNull(0)) = args.w_id_;
 
   std::vector<storage::TupleSlot> index_scan_results;
   db->warehouse_primary_index_->ScanKey(*txn, *warehouse_key, &index_scan_results);
   TERRIER_ASSERT(index_scan_results.size() == 1, "Warehouse index lookup failed.");
 
   // Select W_NAME, W_STREET_1, W_STREET_2, W_CITY, W_STATE, W_ZIP, W_YTD in table
-  auto *const warehouse_select_tuple = warehouse_select_pr_initializer.InitializeRow(worker->warehouse_tuple_buffer);
+  auto *const warehouse_select_tuple = warehouse_select_pr_initializer_.InitializeRow(worker->warehouse_tuple_buffer_);
   bool UNUSED_ATTRIBUTE select_result =
       db->warehouse_table_->Select(txn, index_scan_results[0], warehouse_select_tuple);
   TERRIER_ASSERT(select_result, "Warehouse table doesn't change. All lookups should succeed.");
   const auto w_name =
-      *reinterpret_cast<storage::VarlenEntry *>(warehouse_select_tuple->AccessWithNullCheck(w_name_select_pr_offset));
-  const auto w_ytd = *reinterpret_cast<double *>(warehouse_select_tuple->AccessWithNullCheck(w_ytd_select_pr_offset));
+      *reinterpret_cast<storage::VarlenEntry *>(warehouse_select_tuple->AccessWithNullCheck(w_name_select_pr_offset_));
+  const auto w_ytd = *reinterpret_cast<double *>(warehouse_select_tuple->AccessWithNullCheck(w_ytd_select_pr_offset_));
   TERRIER_ASSERT(w_ytd >= 300000.0, "Invalid w_ytd read from the Warehouse table.");
 
   // Increase W_YTD by H_AMOUNT in table
   auto *const warehouse_update_redo =
-      txn->StageWrite(db->db_oid_, db->warehouse_table_oid_, warehouse_update_pr_initializer);
-  *reinterpret_cast<double *>(warehouse_update_redo->Delta()->AccessForceNotNull(0)) = w_ytd + args.h_amount;
+      txn->StageWrite(db->db_oid_, db->warehouse_table_oid_, warehouse_update_pr_initializer_);
+  *reinterpret_cast<double *>(warehouse_update_redo->Delta()->AccessForceNotNull(0)) = w_ytd + args.h_amount_;
   warehouse_update_redo->SetTupleSlot(index_scan_results[0]);
   bool UNUSED_ATTRIBUTE result = db->warehouse_table_->Update(txn, warehouse_update_redo);
   TERRIER_ASSERT(result, "Warehouse update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
 
   // Look up D_ID, W_ID in index
   const auto district_key_pr_initializer = db->district_primary_index_->GetProjectedRowInitializer();
-  auto *const district_key = district_key_pr_initializer.InitializeRow(worker->district_key_buffer);
+  auto *const district_key = district_key_pr_initializer.InitializeRow(worker->district_key_buffer_);
 
-  *reinterpret_cast<int8_t *>(district_key->AccessForceNotNull(d_id_key_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(district_key->AccessForceNotNull(d_w_id_key_pr_offset)) = args.w_id;
+  *reinterpret_cast<int8_t *>(district_key->AccessForceNotNull(d_id_key_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(district_key->AccessForceNotNull(d_w_id_key_pr_offset_)) = args.w_id_;
 
   index_scan_results.clear();
   db->district_primary_index_->ScanKey(*txn, *district_key, &index_scan_results);
   TERRIER_ASSERT(index_scan_results.size() == 1, "District index lookup failed.");
 
   // Select D_NAME, D_STREET_1, D_STREET_2, D_CITY, D_STATE, D_ZIP, D_YTD in table
-  auto *const district_select_tuple = district_select_pr_initializer.InitializeRow(worker->district_tuple_buffer);
+  auto *const district_select_tuple = district_select_pr_initializer_.InitializeRow(worker->district_tuple_buffer_);
   select_result = db->district_table_->Select(txn, index_scan_results[0], district_select_tuple);
   TERRIER_ASSERT(select_result, "District table doesn't change. All lookups should succeed.");
   const auto d_name =
-      *reinterpret_cast<storage::VarlenEntry *>(district_select_tuple->AccessWithNullCheck(d_name_select_pr_offset));
-  const auto d_ytd = *reinterpret_cast<double *>(district_select_tuple->AccessWithNullCheck(d_ytd_select_pr_offset));
+      *reinterpret_cast<storage::VarlenEntry *>(district_select_tuple->AccessWithNullCheck(d_name_select_pr_offset_));
+  const auto d_ytd = *reinterpret_cast<double *>(district_select_tuple->AccessWithNullCheck(d_ytd_select_pr_offset_));
   TERRIER_ASSERT(d_ytd >= 30000.0, "Invalid d_ytd read from the District table.");
 
   // Increase D_YTD by H_AMOUNT in table
   auto *const district_update_redo =
-      txn->StageWrite(db->db_oid_, db->district_table_oid_, district_update_pr_initializer);
-  *reinterpret_cast<double *>(district_update_redo->Delta()->AccessForceNotNull(0)) = d_ytd + args.h_amount;
+      txn->StageWrite(db->db_oid_, db->district_table_oid_, district_update_pr_initializer_);
+  *reinterpret_cast<double *>(district_update_redo->Delta()->AccessForceNotNull(0)) = d_ytd + args.h_amount_;
   district_update_redo->SetTupleSlot(index_scan_results[0]);
   result = db->district_table_->Update(txn, district_update_redo);
   TERRIER_ASSERT(result, "District update failed. This assertion assumes 1:1 mapping between warehouse and workers.");
 
   storage::TupleSlot customer_slot;
-  if (!args.use_c_last) {
+  if (!args.use_c_last_) {
     // Look up C_ID, D_ID, W_ID in index
     const auto customer_key_pr_initializer = db->customer_primary_index_->GetProjectedRowInitializer();
-    auto *const customer_key = customer_key_pr_initializer.InitializeRow(worker->customer_key_buffer);
+    auto *const customer_key = customer_key_pr_initializer.InitializeRow(worker->customer_key_buffer_);
 
-    *reinterpret_cast<int32_t *>(customer_key->AccessForceNotNull(c_id_key_pr_offset)) = args.c_id;
-    *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_d_id_key_pr_offset)) = args.d_id;
-    *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_w_id_key_pr_offset)) = args.w_id;
+    *reinterpret_cast<int32_t *>(customer_key->AccessForceNotNull(c_id_key_pr_offset_)) = args.c_id_;
+    *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_d_id_key_pr_offset_)) = args.d_id_;
+    *reinterpret_cast<int8_t *>(customer_key->AccessForceNotNull(c_w_id_key_pr_offset_)) = args.w_id_;
 
     index_scan_results.clear();
     db->customer_primary_index_->ScanKey(*txn, *customer_key, &index_scan_results);
@@ -86,12 +86,12 @@ bool Payment::Execute(transaction::TransactionManager *const txn_manager, Databa
   } else {
     // Look up C_LAST, D_ID, W_ID in index
     const auto customer_name_key_pr_initializer = db->customer_secondary_index_->GetProjectedRowInitializer();
-    auto *const customer_name_key = customer_name_key_pr_initializer.InitializeRow(worker->customer_name_key_buffer);
+    auto *const customer_name_key = customer_name_key_pr_initializer.InitializeRow(worker->customer_name_key_buffer_);
 
-    *reinterpret_cast<storage::VarlenEntry *>(customer_name_key->AccessForceNotNull(c_last_name_key_pr_offset)) =
-        args.c_last;
-    *reinterpret_cast<int8_t *>(customer_name_key->AccessForceNotNull(c_d_id_name_key_pr_offset)) = args.d_id;
-    *reinterpret_cast<int8_t *>(customer_name_key->AccessForceNotNull(c_w_id_name_key_pr_offset)) = args.w_id;
+    *reinterpret_cast<storage::VarlenEntry *>(customer_name_key->AccessForceNotNull(c_last_name_key_pr_offset_)) =
+        args.c_last_;
+    *reinterpret_cast<int8_t *>(customer_name_key->AccessForceNotNull(c_d_id_name_key_pr_offset_)) = args.d_id_;
+    *reinterpret_cast<int8_t *>(customer_name_key->AccessForceNotNull(c_w_id_name_key_pr_offset_)) = args.w_id_;
 
     index_scan_results.clear();
     db->customer_secondary_index_->ScanKey(*txn, *customer_name_key, &index_scan_results);
@@ -100,7 +100,7 @@ bool Payment::Execute(transaction::TransactionManager *const txn_manager, Databa
     if (index_scan_results.size() > 1) {
       std::map<std::string, storage::TupleSlot> sorted_index_scan_results;
       for (const auto &tuple_slot : index_scan_results) {
-        auto *const c_first_select_tuple = c_first_pr_initializer.InitializeRow(worker->customer_tuple_buffer);
+        auto *const c_first_select_tuple = c_first_pr_initializer_.InitializeRow(worker->customer_tuple_buffer_);
         select_result = db->customer_table_->Select(txn, tuple_slot, c_first_select_tuple);
         TERRIER_ASSERT(select_result, "Customer table doesn't change (no new entries). All lookups should succeed.");
         const auto c_first = *reinterpret_cast<storage::VarlenEntry *>(c_first_select_tuple->AccessWithNullCheck(0));
@@ -117,36 +117,36 @@ bool Payment::Execute(transaction::TransactionManager *const txn_manager, Databa
   }
 
   // Select customer in table
-  auto *const customer_select_tuple = customer_select_pr_initializer.InitializeRow(worker->customer_tuple_buffer);
+  auto *const customer_select_tuple = customer_select_pr_initializer_.InitializeRow(worker->customer_tuple_buffer_);
   select_result = db->customer_table_->Select(txn, customer_slot, customer_select_tuple);
   TERRIER_ASSERT(select_result, "Customer table doesn't change (no new entries). All lookups should succeed.");
 
   const auto *const c_id_ptr =
-      reinterpret_cast<int32_t *>(customer_select_tuple->AccessWithNullCheck(c_id_select_pr_offset));
+      reinterpret_cast<int32_t *>(customer_select_tuple->AccessWithNullCheck(c_id_select_pr_offset_));
   TERRIER_ASSERT(c_id_ptr != nullptr, "This is a non-NULLable field.");
-  const auto UNUSED_ATTRIBUTE c_id = !args.use_c_last ? args.c_id : *c_id_ptr;
+  const auto UNUSED_ATTRIBUTE c_id = !args.use_c_last_ ? args.c_id_ : *c_id_ptr;
   TERRIER_ASSERT(c_id >= 1 && c_id <= 3000, "Invalid c_id read from the Customer table.");
 
   const auto c_balance =
-      *reinterpret_cast<double *>(customer_select_tuple->AccessWithNullCheck(c_balance_select_pr_offset));
+      *reinterpret_cast<double *>(customer_select_tuple->AccessWithNullCheck(c_balance_select_pr_offset_));
   const auto c_ytd_payment =
-      *reinterpret_cast<double *>(customer_select_tuple->AccessWithNullCheck(c_ytd_payment_select_pr_offset));
+      *reinterpret_cast<double *>(customer_select_tuple->AccessWithNullCheck(c_ytd_payment_select_pr_offset_));
   const auto c_payment_cnt =
-      *reinterpret_cast<int16_t *>(customer_select_tuple->AccessWithNullCheck(c_payment_cnt_select_pr_offset));
+      *reinterpret_cast<int16_t *>(customer_select_tuple->AccessWithNullCheck(c_payment_cnt_select_pr_offset_));
   const auto c_credit =
-      *reinterpret_cast<storage::VarlenEntry *>(customer_select_tuple->AccessWithNullCheck(c_credit_select_pr_offset));
+      *reinterpret_cast<storage::VarlenEntry *>(customer_select_tuple->AccessWithNullCheck(c_credit_select_pr_offset_));
   const auto c_data =
-      *reinterpret_cast<storage::VarlenEntry *>(customer_select_tuple->AccessWithNullCheck(c_data_select_pr_offset));
+      *reinterpret_cast<storage::VarlenEntry *>(customer_select_tuple->AccessWithNullCheck(c_data_select_pr_offset_));
 
   // Update customer
   auto *const customer_update_redo =
-      txn->StageWrite(db->db_oid_, db->customer_table_oid_, customer_update_pr_initializer);
+      txn->StageWrite(db->db_oid_, db->customer_table_oid_, customer_update_pr_initializer_);
   auto *const customer_update_tuple = customer_update_redo->Delta();
-  *reinterpret_cast<double *>(customer_update_tuple->AccessForceNotNull(c_balance_update_pr_offset)) =
-      c_balance - args.h_amount;
-  *reinterpret_cast<double *>(customer_update_tuple->AccessForceNotNull(c_ytd_payment_update_pr_offset)) =
-      c_ytd_payment + args.h_amount;
-  *reinterpret_cast<int16_t *>(customer_update_tuple->AccessForceNotNull(c_payment_cnt_update_pr_offset)) =
+  *reinterpret_cast<double *>(customer_update_tuple->AccessForceNotNull(c_balance_update_pr_offset_)) =
+      c_balance - args.h_amount_;
+  *reinterpret_cast<double *>(customer_update_tuple->AccessForceNotNull(c_ytd_payment_update_pr_offset_)) =
+      c_ytd_payment + args.h_amount_;
+  *reinterpret_cast<int16_t *>(customer_update_tuple->AccessForceNotNull(c_payment_cnt_update_pr_offset_)) =
       static_cast<int16_t>(c_payment_cnt + 1);
   customer_update_redo->SetTupleSlot(customer_slot);
   result = db->customer_table_->Update(txn, customer_update_redo);
@@ -156,15 +156,15 @@ bool Payment::Execute(transaction::TransactionManager *const txn_manager, Databa
   TERRIER_ASSERT(c_credit_str.compare("BC") == 0 || c_credit_str.compare("GC") == 0,
                  "Invalid c_credit read from the Customer table.");
   if (c_credit_str.compare("BC") == 0) {
-    auto *const c_data_update_redo = txn->StageWrite(db->db_oid_, db->customer_table_oid_, c_data_pr_initializer);
+    auto *const c_data_update_redo = txn->StageWrite(db->db_oid_, db->customer_table_oid_, c_data_pr_initializer_);
 
     const auto c_data_str = c_data.StringView();
     auto new_c_data = std::to_string(c_id);
-    new_c_data.append(std::to_string(args.c_d_id));
-    new_c_data.append(std::to_string(args.c_w_id));
-    new_c_data.append(std::to_string(args.d_id));
-    new_c_data.append(std::to_string(args.w_id));
-    new_c_data.append(std::to_string(args.h_amount));
+    new_c_data.append(std::to_string(args.c_d_id_));
+    new_c_data.append(std::to_string(args.c_w_id_));
+    new_c_data.append(std::to_string(args.d_id_));
+    new_c_data.append(std::to_string(args.w_id_));
+    new_c_data.append(std::to_string(args.h_amount_));
     new_c_data.append(c_data_str);
     const auto new_c_data_length = std::min(new_c_data.length(), static_cast<std::size_t>(500));
     auto *const varlen = common::AllocationUtil::AllocateAligned(new_c_data_length);
@@ -187,16 +187,18 @@ bool Payment::Execute(transaction::TransactionManager *const txn_manager, Databa
   const auto h_data = storage::VarlenEntry::Create(varlen, static_cast<uint32_t>(h_data_length), true);
 
   // Insert in History table
-  auto *const history_insert_redo = txn->StageWrite(db->db_oid_, db->history_table_oid_, history_insert_pr_initializer);
+  auto *const history_insert_redo =
+      txn->StageWrite(db->db_oid_, db->history_table_oid_, history_insert_pr_initializer_);
   auto *const history_insert_tuple = history_insert_redo->Delta();
-  *reinterpret_cast<int32_t *>(history_insert_tuple->AccessForceNotNull(h_c_id_insert_pr_offset)) = c_id;
-  *reinterpret_cast<int8_t *>(history_insert_tuple->AccessForceNotNull(h_c_d_id_insert_pr_offset)) = args.c_d_id;
-  *reinterpret_cast<int8_t *>(history_insert_tuple->AccessForceNotNull(h_c_w_id_insert_pr_offset)) = args.c_w_id;
-  *reinterpret_cast<int8_t *>(history_insert_tuple->AccessForceNotNull(h_d_id_insert_pr_offset)) = args.d_id;
-  *reinterpret_cast<int8_t *>(history_insert_tuple->AccessForceNotNull(h_w_id_insert_pr_offset)) = args.w_id;
-  *reinterpret_cast<uint64_t *>(history_insert_tuple->AccessForceNotNull(h_date_insert_pr_offset)) = args.h_date;
-  *reinterpret_cast<double *>(history_insert_tuple->AccessForceNotNull(h_amount_insert_pr_offset)) = args.h_amount;
-  *reinterpret_cast<storage::VarlenEntry *>(history_insert_tuple->AccessForceNotNull(h_data_insert_pr_offset)) = h_data;
+  *reinterpret_cast<int32_t *>(history_insert_tuple->AccessForceNotNull(h_c_id_insert_pr_offset_)) = c_id;
+  *reinterpret_cast<int8_t *>(history_insert_tuple->AccessForceNotNull(h_c_d_id_insert_pr_offset_)) = args.c_d_id_;
+  *reinterpret_cast<int8_t *>(history_insert_tuple->AccessForceNotNull(h_c_w_id_insert_pr_offset_)) = args.c_w_id_;
+  *reinterpret_cast<int8_t *>(history_insert_tuple->AccessForceNotNull(h_d_id_insert_pr_offset_)) = args.d_id_;
+  *reinterpret_cast<int8_t *>(history_insert_tuple->AccessForceNotNull(h_w_id_insert_pr_offset_)) = args.w_id_;
+  *reinterpret_cast<uint64_t *>(history_insert_tuple->AccessForceNotNull(h_date_insert_pr_offset_)) = args.h_date_;
+  *reinterpret_cast<double *>(history_insert_tuple->AccessForceNotNull(h_amount_insert_pr_offset_)) = args.h_amount_;
+  *reinterpret_cast<storage::VarlenEntry *>(history_insert_tuple->AccessForceNotNull(h_data_insert_pr_offset_)) =
+      h_data;
 
   db->history_table_->Insert(txn, history_insert_redo);
 

--- a/test/util/tpcc/workload.cpp
+++ b/test/util/tpcc/workload.cpp
@@ -12,7 +12,7 @@ void Workload(const int8_t worker_id, Database *const tpcc_db, transaction::Tran
   auto stock_level = StockLevel(tpcc_db);
 
   for (const auto &txn_args : precomputed_args[worker_id]) {
-    switch (txn_args.type) {
+    switch (txn_args.type_) {
       case TransactionType::NewOrder: {
         new_order.Execute(txn_manager, tpcc_db, &((*workers)[worker_id]), txn_args);
         break;
@@ -42,9 +42,9 @@ void Workload(const int8_t worker_id, Database *const tpcc_db, transaction::Tran
 void CleanUpVarlensInPrecomputedArgs(const std::vector<std::vector<TransactionArgs>> *const precomputed_args) {
   for (const auto &worker_id : *precomputed_args) {
     for (const auto &args : worker_id) {
-      if ((args.type == TransactionType::Payment || args.type == TransactionType::OrderStatus) && args.use_c_last &&
-          !args.c_last.IsInlined()) {
-        delete[] args.c_last.Content();
+      if ((args.type_ == TransactionType::Payment || args.type_ == TransactionType::OrderStatus) && args.use_c_last_ &&
+          !args.c_last_.IsInlined()) {
+        delete[] args.c_last_.Content();
       }
     }
   }

--- a/test/util/transaction_test_util.cpp
+++ b/test/util/transaction_test_util.cpp
@@ -43,7 +43,7 @@ void RandomWorkloadTransaction::RandomUpdate(Random *generator) {
   updates_[updated] = update;
 
   // TODO(Tianyu): Hardly efficient, but will do for testing.
-  auto *record = txn_->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, initializer);
+  auto *record = txn_->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, initializer);
   record->SetTupleSlot(updated);
   std::memcpy(reinterpret_cast<void *>(record->Delta()), update, update->Size());
   auto result = test_object_->table_.Update(txn_, updated, *update);
@@ -166,7 +166,7 @@ void LargeTransactionTestObject::PopulateInitialTable(uint32_t num_tuples, Rando
     storage::TupleSlot inserted = table_.Insert(initial_txn_, *redo);
     // TODO(Tianyu): Hardly efficient, but will do for testing.
     auto *record =
-        initial_txn_->StageWrite(CatalogTestUtil::test_db_oid, CatalogTestUtil::test_table_oid, row_initializer_);
+        initial_txn_->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, row_initializer_);
     record->SetTupleSlot(inserted);
     std::memcpy(reinterpret_cast<void *>(record->Delta()), redo, redo->Size());
     last_checked_version_.emplace_back(inserted, redo);


### PR DESCRIPTION
Fix #523.

These are the enabled checks:
```
CheckOptions:
  - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
  - { key: readability-identifier-naming.EnumCase,            value: CamelCase  }
  - { key: readability-identifier-naming.FunctionCase,        value: CamelCase  }
  - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
  - { key: readability-identifier-naming.MemberCase,          value: lower_case }
  - { key: readability-identifier-naming.MemberSuffix,        value: _          }
  - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
  - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
  - { key: readability-identifier-naming.UnionCase,           value: CamelCase  }
  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
```

Also modified bad_words.txt to disallow underscores in namespaces.

Lastly, fixed the codebase to make it compliant.