### PR TITLE
Remove dead code

### DIFF
--- a/src/include/storage/tuple_access_strategy.h
+++ b/src/include/storage/tuple_access_strategy.h
@@ -76,14 +76,6 @@ class TupleAccessStrategy {
       return reinterpret_cast<MiniBlock *>(head);
     }
 
-    // return reference to num_slots. Use as a member.
-    uint32_t &NumSlots() { return *reinterpret_cast<uint32_t *>(block_.content_); }
-
-    // return reference to num_attrs. Use as a member.
-    uint16_t &NumAttrs(const BlockLayout &layout) {
-      return *reinterpret_cast<uint16_t *>(AttrOffsets(layout) + layout.NumColumns());
-    }
-
     RawBlock block_;
   };
 


### PR DESCRIPTION
There are a couple of leftover functions that are not used any more in tuple access strategy. (They are also no longer correct, but again, not used)