### PR TITLE
Update LLVM_DIR path for llvm@8 Homebrew package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         - NAME="macos-10.14/AppleClang-1001.0.46.4 (Debug/packages.sh)" CMAKE_BUILD_TYPE=debug
       install:
         - echo 'y' | ./script/installation/packages.sh
-        - export LLVM_DIR=/usr/local/Cellar/llvm/8.0.1
+        - export LLVM_DIR=/usr/local/Cellar/llvm@8/8.0.1
     - os: linux
       dist: trusty
       env:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
-                        LLVM_DIR="/usr/local/Cellar/llvm/8.0.1"
+                        LLVM_DIR="/usr/local/Cellar/llvm@8/8.0.1"
                     }
                     steps {
                         sh 'echo $NODE_NAME'
@@ -71,7 +71,7 @@ pipeline {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
-                        LLVM_DIR="/usr/local/Cellar/llvm/8.0.1"
+                        LLVM_DIR="/usr/local/Cellar/llvm@8/8.0.1"
                     }
                     steps {
                         sh 'echo $NODE_NAME'

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -72,7 +72,7 @@ install_mac() {
   brew ls --versions jemalloc || brew install jemalloc
   brew ls --versions libevent || brew install libevent
   brew ls --versions libpqxx || brew install libpqxx
-  (brew ls --versions llvm | grep 8) || brew install llvm@8
+  (brew ls --versions llvm@8 | grep 8) || brew install llvm@8
   brew ls --versions openssl || brew install openssl
   brew ls --versions postgresql || brew install postgresql
   brew ls --versions tbb || brew install tbb


### PR DESCRIPTION
The `llvm` Homebrew package now defaults to 9. We don't want that yet (all the clang-tools and LLVM are untested with the repo right now), so we need to specify 8.