### PR TITLE
Add `make clean` as final step of Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
                         sh 'cd build && gtimeout 1h make unittest'
                         sh 'cd build && gtimeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
+                        sh 'cd build && make clean'
                     }
                 }
 
@@ -41,6 +42,7 @@ pipeline {
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
+                        sh 'cd build && make clean'
                     }
                 }
 
@@ -74,6 +76,7 @@ pipeline {
                         sh 'cd build && curl -s https://codecov.io/bash > ./codecov.sh'
                         sh 'cd build && chmod a+x ./codecov.sh'
                         sh 'cd build && /bin/bash ./codecov.sh -X gcov'
+                        sh 'cd build && make clean'
                     }
                 }
 
@@ -97,6 +100,7 @@ pipeline {
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
+                        sh 'cd build && make clean'
                     }
                 }
 
@@ -114,6 +118,7 @@ pipeline {
                         sh 'cd build && gtimeout 1h make unittest'
                         sh 'cd build && gtimeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
+                        sh 'cd build && make clean'
                     }
                 }
 
@@ -131,6 +136,7 @@ pipeline {
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
+                        sh 'cd build && make clean'
                     }
                 }
 
@@ -152,6 +158,7 @@ pipeline {
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
+                        sh 'cd build && make clean'
                     }
                 }
 
@@ -166,6 +173,7 @@ pipeline {
                         sh 'cd script/micro_bench && timeout 1h ./run_micro_bench.py'
                         archiveArtifacts 'script/micro_bench/*.json'
                         junit 'script/micro_bench/*.xml'
+                        sh 'cd build && make clean'
                     }
                 }
             }


### PR DESCRIPTION
This should reduce the archived size of builds.