### PR TITLE
Fix hashing DropTriggerPlanNode and UpdatePlanNode

### DIFF
--- a/src/optimizer/physical_operators.cpp
+++ b/src/optimizer/physical_operators.cpp
@@ -126,10 +126,10 @@ common::hash_t IndexScan::Hash() const {
     else
       hash = common::HashUtil::SumHashes(hash, BaseOperatorNode::Hash());
   }
-  for (auto &col_oid : key_column_oid_list_)
-    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(&col_oid));
-  for (auto &expr_type : expr_type_list_)
-    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(&expr_type));
+  for (const auto &col_oid : key_column_oid_list_)
+    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(col_oid));
+  for (const auto &expr_type : expr_type_list_)
+    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(expr_type));
   for (auto &val : value_list_) hash = common::HashUtil::CombineHashes(hash, val.Hash());
   return hash;
 }

--- a/src/planner/plannodes/drop_trigger_plan_node.cpp
+++ b/src/planner/plannodes/drop_trigger_plan_node.cpp
@@ -17,11 +17,11 @@ common::hash_t DropTriggerPlanNode::Hash() const {
 
   // Hash trigger_oid
   auto trigger_oid = GetTriggerOid();
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(&trigger_oid));
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(trigger_oid));
 
   // Hash if_exists_
   auto if_exist = IsIfExists();
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(&if_exist));
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(if_exist));
 
   return hash;
 }

--- a/src/planner/plannodes/update_plan_node.cpp
+++ b/src/planner/plannodes/update_plan_node.cpp
@@ -22,7 +22,7 @@ common::hash_t UpdatePlanNode::Hash() const {
 
   // Hash update_primary_key
   auto is_update_primary_key = GetUpdatePrimaryKey();
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(&is_update_primary_key));
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(is_update_primary_key));
 
   return hash;
 }


### PR DESCRIPTION
We were hashing the pointers of fields in a couple of the plan nodes. That's not good. We want to hash the actual values.

Somehow this didn't break on our existing toolchain (maybe the stack addresses ended up exactly the same for the fields on back-to-back calls to `Hash()`) but this week's AppleClang release caused a failure. Go figure.