### PR TITLE
Update LLVM_DIR for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         - NAME="macos-10.14/AppleClang-1001.0.46.4 (Debug/packages.sh)" CMAKE_BUILD_TYPE=debug
       install:
         - echo 'y' | ./script/installation/packages.sh
-        - export LLVM_DIR=/usr/local/Cellar/llvm@8/8.0.1
+        - export LLVM_DIR=/usr/local/Cellar/llvm@8/8.0.1_1
     - os: linux
       dist: trusty
       env:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
-                        LLVM_DIR="/usr/local/Cellar/llvm@8/8.0.1"
+                        LLVM_DIR="/usr/local/Cellar/llvm@8/8.0.1_1"
                     }
                     steps {
                         sh 'echo $NODE_NAME'
@@ -107,7 +107,7 @@ pipeline {
                     agent { label 'macos' }
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
-                        LLVM_DIR="/usr/local/Cellar/llvm@8/8.0.1"
+                        LLVM_DIR="/usr/local/Cellar/llvm@8/8.0.1_1"
                     }
                     steps {
                         sh 'echo $NODE_NAME'


### PR DESCRIPTION
Homebrew changed the path of the `llvm@8` package, so we need to update our CI to reflect that.