### PR TITLE
Fix InputPacket::Clear() to reset extended_ flag

### DIFF
--- a/src/include/network/network_defs.h
+++ b/src/include/network/network_defs.h
@@ -170,6 +170,7 @@ struct InputPacket {
     len_ = 0;
     buf_ = nullptr;
     header_parsed_ = false;
+    extended_ = false;
   }
 };
 

--- a/src/include/network/protocol_interpreter.h
+++ b/src/include/network/protocol_interpreter.h
@@ -95,6 +95,9 @@ class ProtocolInterpreter {
       throw NETWORK_PROCESS_EXCEPTION("Packet too large");
     }
 
+    TERRIER_ASSERT(!curr_input_packet_.extended_,
+                   "InputPacket shouldn't already be extended before beginning parsing of the body.");
+
     // Extend the buffer as needed
     if (curr_input_packet_.len_ > in->Capacity()) {
       // Allocate a larger buffer and copy bytes off from the I/O layer's buffer
@@ -127,6 +130,9 @@ class ProtocolInterpreter {
     // copy bytes only if the packet is longer than the read buffer,
     // otherwise we can use the read buffer to save space
     if (curr_input_packet_.extended_) {
+      TERRIER_ASSERT(curr_input_packet_.len_ == curr_input_packet_.buf_->Capacity(),
+                     "The buffer should have been extended to support the packet length. Otherwise, there's a mismatch "
+                     "between the extended_ flag.");
       curr_input_packet_.buf_->FillBufferFrom(*in, can_read);
     }
 


### PR DESCRIPTION
Found a bug while refactoring some shared_ptrs in the network layer, turns out this was causing headaches for @GustavoAngulo's replication stuff.

I'm not thrilled with the test, but without the fix it at least trips the two asserts that I added.