### PR TITLE
Remove shared_ptr from the network layer

### DIFF
--- a/src/include/network/connection_handle.h
+++ b/src/include/network/connection_handle.h
@@ -91,7 +91,7 @@ class ConnectionHandle {
     } else {
       t = Transition ::WAKEUP;
     }
-    state_machine_.Accept(t, *this);
+    state_machine_.Accept(t, common::ManagedPointer<ConnectionHandle>(this));
   }
 
   /* State Machine Actions */
@@ -180,7 +180,7 @@ class ConnectionHandle {
    */
   class StateMachine {
    public:
-    using action = Transition (*)(ConnectionHandle &);
+    using action = Transition (*)(const common::ManagedPointer<ConnectionHandle>);
     using transition_result = std::pair<ConnState, action>;
     /**
      * Runs the internal state machine, starting from the symbol given, until no
@@ -202,10 +202,7 @@ class ConnectionHandle {
      * @param action starting symbol
      * @param connection the network connection object to apply actions to
      */
-    void Accept(Transition action, ConnectionHandle &connection);  // NOLINT
-    // clang-tidy is suppressed here as it complains about the reference param having
-    // no const qualifier as this must be casted into a (void*) to pass as an argument to METHOD_AS_CALLBACK
-    // in the forward dependencies of Accept in the state_machine
+    void Accept(Transition action, common::ManagedPointer<ConnectionHandle> connection);
 
    private:
     /**

--- a/src/include/network/connection_handle.h
+++ b/src/include/network/connection_handle.h
@@ -221,7 +221,6 @@ class ConnectionHandle {
   friend class ConnectionHandleFactory;
 
   std::unique_ptr<NetworkIoWrapper> io_wrapper_;
-  // A raw pointer is used here because references cannot be rebound.
   common::ManagedPointer<ConnectionHandlerTask> conn_handler_;
   common::ManagedPointer<trafficcop::TrafficCop> traffic_cop_;
   std::unique_ptr<ProtocolInterpreter> protocol_interpreter_;

--- a/src/include/network/itp/itp_command_factory.h
+++ b/src/include/network/itp/itp_command_factory.h
@@ -3,7 +3,7 @@
 #include "network/itp/itp_network_commands.h"
 
 #define MAKE_ITP_COMMAND(type) \
-  std::unique_ptr<ITPNetworkCommand>(static_cast<ITPNetworkCommand *>(std::make_unique<type>(packet).release()))
+  std::unique_ptr<ITPNetworkCommand>(reinterpret_cast<ITPNetworkCommand *>(new type(packet)))
 
 namespace terrier::network {
 
@@ -18,7 +18,7 @@ class ITPCommandFactory {
    * @param packet the Postgres input packet
    * @return a unique_ptr to the converted command
    */
-  virtual std::unique_ptr<ITPNetworkCommand> PacketToCommand(InputPacket *packet);
+  virtual std::unique_ptr<ITPNetworkCommand> PacketToCommand(const common::ManagedPointer<InputPacket> packet);
 
   virtual ~ITPCommandFactory() = default;
 };

--- a/src/include/network/itp/itp_command_factory.h
+++ b/src/include/network/itp/itp_command_factory.h
@@ -18,7 +18,7 @@ class ITPCommandFactory {
    * @param packet the Postgres input packet
    * @return a unique_ptr to the converted command
    */
-  virtual std::unique_ptr<ITPNetworkCommand> PacketToCommand(const common::ManagedPointer<InputPacket> packet);
+  virtual std::unique_ptr<ITPNetworkCommand> PacketToCommand(common::ManagedPointer<InputPacket> packet);
 
   virtual ~ITPCommandFactory() = default;
 };

--- a/src/include/network/itp/itp_network_commands.h
+++ b/src/include/network/itp/itp_network_commands.h
@@ -5,7 +5,7 @@
 #define DEFINE_ITP_COMMAND(name, flush)                                                                                \
   class name : public ITPNetworkCommand {                                                                              \
    public:                                                                                                             \
-    explicit name(InputPacket *in) : ITPNetworkCommand(in, flush) {}                                                   \
+    explicit name(const common::ManagedPointer<InputPacket> in) : ITPNetworkCommand(in, flush) {}                      \
     Transition Exec(common::ManagedPointer<ProtocolInterpreter> interpreter,                                           \
                     common::ManagedPointer<ITPPacketWriter> out, common::ManagedPointer<trafficcop::TrafficCop> t_cop, \
                     common::ManagedPointer<ConnectionContext> connection, NetworkCallback callback) override;          \
@@ -38,7 +38,8 @@ class ITPNetworkCommand : public NetworkCommand {
    * @param in The input packets to this command
    * @param flush Whether or not to flush the output packets on completion
    */
-  ITPNetworkCommand(InputPacket *in, bool flush) : NetworkCommand(in, flush), in_len_(in->len_) {}
+  ITPNetworkCommand(const common::ManagedPointer<InputPacket> in, bool flush)
+      : NetworkCommand(in, flush), in_len_(in->len_) {}
 
   /**
    * Size of the input packet

--- a/src/include/network/itp/itp_packet_writer.h
+++ b/src/include/network/itp/itp_packet_writer.h
@@ -16,7 +16,7 @@ class ITPPacketWriter : public PacketWriter {
   /**
    * Instantiates a new ITPPacketWriter backed by the given WriteQueue
    */
-  explicit ITPPacketWriter(const std::shared_ptr<WriteQueue> &write_queue) : PacketWriter(write_queue) {}
+  explicit ITPPacketWriter(common::ManagedPointer<WriteQueue> write_queue) : PacketWriter(write_queue) {}
 
   /**
    * Create a Replication command

--- a/src/include/network/itp/itp_protocol_interpreter.h
+++ b/src/include/network/itp/itp_protocol_interpreter.h
@@ -57,7 +57,7 @@ class ITPProtocolInterpreter : public ProtocolInterpreter {
    * @param callback The callback function to trigger on completion
    * @return
    */
-  Transition Process(std::shared_ptr<ReadBuffer> in, std::shared_ptr<WriteQueue> out,
+  Transition Process(common::ManagedPointer<ReadBuffer> in, common::ManagedPointer<WriteQueue> out,
                      common::ManagedPointer<trafficcop::TrafficCop> t_cop,
                      common::ManagedPointer<ConnectionContext> context, NetworkCallback callback) override;
 
@@ -65,7 +65,7 @@ class ITPProtocolInterpreter : public ProtocolInterpreter {
    * Writes result to the client
    * @param out WriteQueue to flush message to client
    */
-  void GetResult(std::shared_ptr<WriteQueue> out) override;
+  void GetResult(common::ManagedPointer<WriteQueue> out) override;
 
  protected:
   /**
@@ -78,7 +78,7 @@ class ITPProtocolInterpreter : public ProtocolInterpreter {
    * @see ProtocolInterpreter::SetPacketMessageType
    * @param in ReadBuffer to read input from
    */
-  void SetPacketMessageType(const std::shared_ptr<ReadBuffer> &in) override;
+  void SetPacketMessageType(common::ManagedPointer<ReadBuffer> in) override;
 
  private:
   common::ManagedPointer<ITPCommandFactory> command_factory_;

--- a/src/include/network/network_command.h
+++ b/src/include/network/network_command.h
@@ -33,7 +33,8 @@ class NetworkCommand {
    * @param in The input packets to this command
    * @param flush Whether or not to flush the outuput packets on completion
    */
-  NetworkCommand(InputPacket *in, bool flush) : in_(in->buf_->ReadIntoView(in->len_)), flush_on_complete_(flush) {}
+  NetworkCommand(const common::ManagedPointer<InputPacket> in, bool flush)
+      : in_(in->buf_->ReadIntoView(in->len_)), flush_on_complete_(flush) {}
 
   /**
    * The ReadBufferView to read input packets from

--- a/src/include/network/network_defs.h
+++ b/src/include/network/network_defs.h
@@ -112,53 +112,6 @@ enum class NetworkMessageType : unsigned char {
 // Network packet defs
 //===--------------------------------------------------------------------===//
 
-/**
- * Encapsulates an input packet
- */
-struct InputPacket {
-  ~InputPacket() {
-    if (extended_) delete buf_;
-  }
-
-  /**
-   * Type of message this packet encodes
-   */
-  NetworkMessageType msg_type_ = NetworkMessageType::NULL_COMMAND;
-
-  /**
-   * Length of this packet's contents
-   */
-  size_t len_ = 0;
-
-  /**
-   * ReadBuffer containing this packet's contents
-   */
-  ReadBuffer *buf_;
-
-  /**
-   * Whether or not this packet's header has been parsed yet
-   */
-  bool header_parsed_ = false;
-
-  /**
-   * Whether or not this packet's buffer was extended
-   */
-  bool extended_ = false;
-
-  /**
-   * Clears the packet's contents
-   */
-  virtual void Clear() {
-    msg_type_ = NetworkMessageType::NULL_COMMAND;
-    len_ = 0;
-
-    if (extended_) delete buf_;
-    buf_ = nullptr;
-    header_parsed_ = false;
-    extended_ = false;
-  }
-};
-
 //===--------------------------------------------------------------------===//
 // Describe Message Types
 //===--------------------------------------------------------------------===//

--- a/src/include/network/network_io_utils.h
+++ b/src/include/network/network_io_utils.h
@@ -21,13 +21,12 @@ namespace terrier::network {
  */
 class Buffer {
  public:
+  Buffer() { buf_.resize(capacity_); }
+
   /**
    * Instantiates a new buffer and reserve capacity many bytes.
    */
-  explicit Buffer(size_t capacity) : capacity_(capacity) {
-    // TODO(tanujnay112) this used to be reserve but nothing was actually getting allocated
-    buf_.resize(capacity);
-  }
+  explicit Buffer(size_t capacity) : capacity_(capacity) { buf_.resize(capacity_); }
 
   /**
    * Reset the buffer pointer and clears content
@@ -91,7 +90,7 @@ class Buffer {
   /**
    * Capacity of the buffer
    */
-  size_t capacity_;
+  const size_t capacity_ = SOCKET_BUFFER_CAPACITY;
 
   /**
    * Actual character buffer where bytes are held
@@ -303,7 +302,6 @@ class ReadBuffer : public Buffer {
  */
 class WriteBuffer : public Buffer {
  public:
-
   /**
    * Write as many bytes as possible using Posix write to fd
    * @param fd File descriptor to write out to
@@ -386,7 +384,7 @@ class WriteQueue {
     offset_ = 0;
     flush_ = false;
     if (buffers_[0] == nullptr)
-      buffers_[0] = std::make_shared<WriteBuffer>();
+      buffers_[0] = std::make_unique<WriteBuffer>();
     else
       buffers_[0]->Reset();
   }
@@ -394,8 +392,8 @@ class WriteQueue {
   /**
    * @return The head of the WriteQueue
    */
-  std::shared_ptr<WriteBuffer> FlushHead() {
-    if (buffers_.size() > offset_) return buffers_[offset_];
+  common::ManagedPointer<WriteBuffer> FlushHead() {
+    if (buffers_.size() > offset_) return common::ManagedPointer(buffers_[offset_]);
     return nullptr;
   }
 
@@ -435,7 +433,7 @@ class WriteQueue {
       // Only write partially if we are allowed to
       size_t written = breakup ? tail.RemainingCapacity() : 0;
       tail.AppendRaw(src, written);
-      buffers_.push_back(std::make_shared<WriteBuffer>());
+      buffers_.push_back(std::make_unique<WriteBuffer>());
       BufferWriteRaw(reinterpret_cast<const uchar *>(src) + written, len - written);
     }
   }
@@ -456,9 +454,56 @@ class WriteQueue {
 
  private:
   friend class PacketWriter;
-  std::vector<std::shared_ptr<WriteBuffer>> buffers_;
+  std::vector<std::unique_ptr<WriteBuffer>> buffers_;
   size_t offset_ = 0;
   bool flush_ = false;
+};
+
+/**
+ * Encapsulates an input packet
+ */
+struct InputPacket {
+  ~InputPacket() {
+    if (extended_) delete buf_;
+  }
+
+  /**
+   * Type of message this packet encodes
+   */
+  NetworkMessageType msg_type_ = NetworkMessageType::NULL_COMMAND;
+
+  /**
+   * Length of this packet's contents
+   */
+  size_t len_ = 0;
+
+  /**
+   * ReadBuffer containing this packet's contents
+   */
+  ReadBuffer *buf_;
+
+  /**
+   * Whether or not this packet's header has been parsed yet
+   */
+  bool header_parsed_ = false;
+
+  /**
+   * Whether or not this packet's buffer was extended
+   */
+  bool extended_ = false;
+
+  /**
+   * Clears the packet's contents
+   */
+  virtual void Clear() {
+    msg_type_ = NetworkMessageType::NULL_COMMAND;
+    len_ = 0;
+
+    if (extended_) delete buf_;
+    buf_ = nullptr;
+    header_parsed_ = false;
+    extended_ = false;
+  }
 };
 
 }  // namespace terrier::network

--- a/src/include/network/network_io_utils.h
+++ b/src/include/network/network_io_utils.h
@@ -303,10 +303,6 @@ class ReadBuffer : public Buffer {
  */
 class WriteBuffer : public Buffer {
  public:
-  /**
-   * Instantiates a new buffer and reserve capacity many bytes.
-   */
-  explicit WriteBuffer(size_t capacity = SOCKET_BUFFER_CAPACITY) : Buffer(capacity) {}
 
   /**
    * Write as many bytes as possible using Posix write to fd

--- a/src/include/network/network_io_utils.h
+++ b/src/include/network/network_io_utils.h
@@ -246,8 +246,8 @@ class ReadBuffer : public Buffer {
    * @param other The other buffer to read from
    * @param size Number of bytes to read
    */
-  void FillBufferFrom(ReadBuffer &other, size_t size) {  // NOLINT
-    FillBufferFrom(other.ReadIntoView(size), size);
+  void FillBufferFrom(const common::ManagedPointer<ReadBuffer> other, const size_t size) {
+    FillBufferFrom(other->ReadIntoView(size), size);
   }
 
   /**

--- a/src/include/network/network_io_wrapper.h
+++ b/src/include/network/network_io_wrapper.h
@@ -33,8 +33,6 @@ class NetworkIoWrapper {
   /**
    * @brief Constructor for a PosixSocketIoWrapper
    * @param sock_fd The fd this IoWrapper communicates on
-   * @param in The ReadBuffer this NetworkIOWrapper uses for reads
-   * @param out The WriteQueue this NetworkIOWrapper uses for writes
    */
   explicit NetworkIoWrapper(const int sock_fd)
       : sock_fd_(sock_fd), in_(std::make_unique<ReadBuffer>()), out_(std::make_unique<WriteQueue>()) {

--- a/src/include/network/network_io_wrapper.h
+++ b/src/include/network/network_io_wrapper.h
@@ -36,11 +36,8 @@ class NetworkIoWrapper {
    * @param in The ReadBuffer this NetworkIOWrapper uses for reads
    * @param out The WriteQueue this NetworkIOWrapper uses for writes
    */
-  explicit NetworkIoWrapper(int sock_fd, std::shared_ptr<ReadBuffer> in = std::make_shared<ReadBuffer>(),
-                            std::shared_ptr<WriteQueue> out = std::make_shared<WriteQueue>())
-      : sock_fd_(sock_fd), in_(std::move(in)), out_(std::move(out)) {
-    in_->Reset();
-    out_->Reset();
+  explicit NetworkIoWrapper(const int sock_fd)
+      : sock_fd_(sock_fd), in_(std::make_unique<ReadBuffer>()), out_(std::make_unique<WriteQueue>()) {
     RestartState();
   }
 
@@ -87,27 +84,27 @@ class NetworkIoWrapper {
   void Restart();
 
   /**
-   * @return The socket file descriptor this IOWrapper communciates on
+   * @return The socket file descriptor this IOWrapper communicates on
    */
   int GetSocketFd() { return sock_fd_; }
 
   /**
    * @return The ReadBuffer for this IOWrapper
    */
-  std::shared_ptr<ReadBuffer> GetReadBuffer() { return in_; }
+  common::ManagedPointer<ReadBuffer> GetReadBuffer() { return common::ManagedPointer<ReadBuffer>(in_); }
 
   /**
    * @return The WriteQueue for this IOWrapper
    */
-  std::shared_ptr<WriteQueue> GetWriteQueue() { return out_; }
+  common::ManagedPointer<WriteQueue> GetWriteQueue() { return common::ManagedPointer<WriteQueue>(out_); }
 
  private:
   // The file descriptor associated with this NetworkIoWrapper
-  int sock_fd_;
+  const int sock_fd_;
   // The ReadBuffer associated with this NetworkIoWrapper
-  std::shared_ptr<ReadBuffer> in_;
+  std::unique_ptr<ReadBuffer> in_;
   // The WriteQueue associated with this NetworkIoWrapper
-  std::shared_ptr<WriteQueue> out_;
+  std::unique_ptr<WriteQueue> out_;
 
   void RestartState();
 };

--- a/src/include/network/network_io_wrapper.h
+++ b/src/include/network/network_io_wrapper.h
@@ -59,7 +59,7 @@ class NetworkIoWrapper {
    * @brief Flushes the write buffer of this IOWrapper to the assigned fd
    * @return The next transition for this client's state machine
    */
-  Transition FlushWriteBuffer(WriteBuffer *wbuf);
+  Transition FlushWriteBuffer(common::ManagedPointer<WriteBuffer> wbuf);
 
   /**
    * @brief Flushes all writes to this IOWrapper

--- a/src/include/network/packet_writer.h
+++ b/src/include/network/packet_writer.h
@@ -151,7 +151,7 @@ class PacketWriter {
     for (const auto &entry : error_status) AppendRawValue(entry.first).AppendString(entry.second);
 
     // Nul-terminate packet
-    AppendRawValue<byte>(static_cast<byte>(0)).EndPacket();
+    AppendRawValue<uchar>(0).EndPacket();
   }
 
   /**
@@ -194,7 +194,7 @@ class PacketWriter {
     // Build header, assume minor version is always 0
     BeginPacket(NetworkMessageType::NO_HEADER).AppendValue<int16_t>(major_version).AppendValue<int16_t>(0);
     for (const auto &pair : config) AppendString(pair.first).AppendString(pair.second);
-    AppendRawValue<byte>(static_cast<byte>(0));  // Startup message should have (byte+1) length
+    AppendRawValue<uchar>(0);  // Startup message should have (byte+1) length
     EndPacket();
   }
 

--- a/src/include/network/postgres/postgres_command_factory.h
+++ b/src/include/network/postgres/postgres_command_factory.h
@@ -2,7 +2,8 @@
 #include <memory>
 #include "network/postgres/postgres_network_commands.h"
 
-#define MAKE_POSTGRES_COMMAND(type) reinterpret_cast<PostgresNetworkCommand *>(new type(packet))
+#define MAKE_POSTGRES_COMMAND(type) \
+  std::unique_ptr<PostgresNetworkCommand>(reinterpret_cast<PostgresNetworkCommand *>(new type(packet)))
 
 namespace terrier::network {
 
@@ -17,7 +18,7 @@ class PostgresCommandFactory {
    * @param packet the Postgres input packet
    * @return a raw pointer to the converted command
    */
-  virtual PostgresNetworkCommand *PacketToCommand(InputPacket *packet);
+  virtual std::unique_ptr<PostgresNetworkCommand> PacketToCommand(common::ManagedPointer<InputPacket> packet);
 
   virtual ~PostgresCommandFactory() = default;
 };

--- a/src/include/network/postgres/postgres_command_factory.h
+++ b/src/include/network/postgres/postgres_command_factory.h
@@ -2,8 +2,7 @@
 #include <memory>
 #include "network/postgres/postgres_network_commands.h"
 
-#define MAKE_POSTGRES_COMMAND(type) \
-  std::static_pointer_cast<PostgresNetworkCommand, type>(std::make_shared<type>(packet))
+#define MAKE_POSTGRES_COMMAND(type) reinterpret_cast<PostgresNetworkCommand *>(new type(packet))
 
 namespace terrier::network {
 
@@ -18,7 +17,7 @@ class PostgresCommandFactory {
    * @param packet the Postgres input packet
    * @return a shared_ptr to the converted command
    */
-  virtual std::shared_ptr<PostgresNetworkCommand> PacketToCommand(InputPacket *packet);
+  virtual PostgresNetworkCommand *PacketToCommand(InputPacket *packet);
 
   virtual ~PostgresCommandFactory() = default;
 };

--- a/src/include/network/postgres/postgres_command_factory.h
+++ b/src/include/network/postgres/postgres_command_factory.h
@@ -15,7 +15,7 @@ class PostgresCommandFactory {
   /**
    * Convert a Postgres packet to command.
    * @param packet the Postgres input packet
-   * @return a shared_ptr to the converted command
+   * @return a raw pointer to the converted command
    */
   virtual PostgresNetworkCommand *PacketToCommand(InputPacket *packet);
 

--- a/src/include/network/postgres/postgres_network_commands.h
+++ b/src/include/network/postgres/postgres_network_commands.h
@@ -4,7 +4,7 @@
 #define DEFINE_POSTGRES_COMMAND(name, flush)                                                                  \
   class name : public PostgresNetworkCommand {                                                                \
    public:                                                                                                    \
-    explicit name(InputPacket *in) : PostgresNetworkCommand(in, flush) {}                                     \
+    explicit name(const common::ManagedPointer<InputPacket> in) : PostgresNetworkCommand(in, flush) {}        \
     Transition Exec(common::ManagedPointer<ProtocolInterpreter> interpreter,                                  \
                     common::ManagedPointer<PostgresPacketWriter> out,                                         \
                     common::ManagedPointer<trafficcop::TrafficCop> t_cop,                                     \
@@ -38,7 +38,7 @@ class PostgresNetworkCommand : public NetworkCommand {
    * @param in The input packets to this command
    * @param flush Whether or not to flush the output packets on completion
    */
-  PostgresNetworkCommand(InputPacket *in, bool flush) : NetworkCommand(in, flush) {}
+  PostgresNetworkCommand(const common::ManagedPointer<InputPacket> in, bool flush) : NetworkCommand(in, flush) {}
 };
 
 // Set all to force flush for now

--- a/src/include/network/postgres/postgres_packet_writer.h
+++ b/src/include/network/postgres/postgres_packet_writer.h
@@ -16,7 +16,7 @@ class PostgresPacketWriter : public PacketWriter {
   /**
    * Instantiates a new PostgresPacketWriter backed by the given WriteQueue
    */
-  explicit PostgresPacketWriter(const std::shared_ptr<WriteQueue> &write_queue) : PacketWriter(write_queue) {}
+  explicit PostgresPacketWriter(const common::ManagedPointer<WriteQueue> write_queue) : PacketWriter(write_queue) {}
 
   /**
    * Write out a packet with a single type that is associated with SSL.

--- a/src/include/network/postgres/postgres_protocol_interpreter.h
+++ b/src/include/network/postgres/postgres_protocol_interpreter.h
@@ -58,7 +58,7 @@ class PostgresProtocolInterpreter : public ProtocolInterpreter {
    * @param context the connection context
    * @return
    */
-  Transition Process(std::shared_ptr<ReadBuffer> in, std::shared_ptr<WriteQueue> out,
+  Transition Process(common::ManagedPointer<ReadBuffer> in, common::ManagedPointer<WriteQueue> out,
                      common::ManagedPointer<trafficcop::TrafficCop> t_cop,
                      common::ManagedPointer<ConnectionContext> context, NetworkCallback callback) override;
 
@@ -67,20 +67,9 @@ class PostgresProtocolInterpreter : public ProtocolInterpreter {
    *
    * @param out
    */
-  void GetResult(std::shared_ptr<WriteQueue> out) override {
+  void GetResult(const common::ManagedPointer<WriteQueue> out) override {
     PostgresPacketWriter writer(out);
     ExecQueryMessageGetResult(&writer, ResultType::SUCCESS);
-    // TODO(Tianyu): This looks wrong. JDBC and PSQL should be united under one wire protocol. This field was set
-    // statically for all connections before I removed it. Also, the difference between these two methods look
-    // superficial. Some one should dig deeper to figure out what's going on here.
-    //    switch (protocol_type_) {
-    //      case NetworkProtocolType::POSTGRES_JDBC:NETWORK_LOG_TRACE("JDBC result");
-    //        ExecExecuteMessageGetResult(&writer, ResultType::SUCCESS);
-    //        break;
-    //      case NetworkProtocolType::POSTGRES_PSQL:NETWORK_LOG_TRACE("PSQL result");
-    //        ExecQueryMessageGetResult(&writer, ResultType::SUCCESS);
-    //      default:throw NETWORK_PROCESS_EXCEPTION("Unsupported protocol type");
-    //    }
   }
 
   /**
@@ -89,7 +78,7 @@ class PostgresProtocolInterpreter : public ProtocolInterpreter {
    * @param out
    * @return
    */
-  Transition ProcessStartup(const std::shared_ptr<ReadBuffer> &in, const std::shared_ptr<WriteQueue> &out);
+  Transition ProcessStartup(common::ManagedPointer<ReadBuffer> in, common::ManagedPointer<WriteQueue> out);
 
   /**
    *
@@ -124,7 +113,7 @@ class PostgresProtocolInterpreter : public ProtocolInterpreter {
   /**
    * @see ProtocolInterpreter::SetPacketMessageType
    */
-  void SetPacketMessageType(const std::shared_ptr<ReadBuffer> &in) override;
+  void SetPacketMessageType(common::ManagedPointer<ReadBuffer> in) override;
 
  private:
   bool startup_ = true;

--- a/src/include/network/protocol_interpreter.h
+++ b/src/include/network/protocol_interpreter.h
@@ -101,11 +101,11 @@ class ProtocolInterpreter {
     // Extend the buffer as needed
     if (curr_input_packet_.len_ > in->Capacity()) {
       // Allocate a larger buffer and copy bytes off from the I/O layer's buffer
-      curr_input_packet_.buf_ = std::make_unique<ReadBuffer>(curr_input_packet_.len_);
+      curr_input_packet_.buf_ = new ReadBuffer(curr_input_packet_.len_);
       NETWORK_LOG_TRACE("Extended Buffer size required for packet of size {0}", curr_input_packet_.len_);
       curr_input_packet_.extended_ = true;
     } else {
-      curr_input_packet_.buf_ = in;
+      curr_input_packet_.buf_ = in.Get();
     }
 
     curr_input_packet_.header_parsed_ = true;

--- a/src/include/network/protocol_interpreter.h
+++ b/src/include/network/protocol_interpreter.h
@@ -40,7 +40,7 @@ class ProtocolInterpreter {
    * @param callback The callback function to trigger on completion
    * @return The next transition for the client's associated state machine
    */
-  virtual Transition Process(std::shared_ptr<ReadBuffer> in, std::shared_ptr<WriteQueue> out,
+  virtual Transition Process(common::ManagedPointer<ReadBuffer> in, common::ManagedPointer<WriteQueue> out,
                              common::ManagedPointer<trafficcop::TrafficCop> t_cop,
                              common::ManagedPointer<ConnectionContext> context, NetworkCallback callback) = 0;
 
@@ -48,7 +48,7 @@ class ProtocolInterpreter {
    * Sends a result
    * @param out The WriteQueue to communicate with the client through
    */
-  virtual void GetResult(std::shared_ptr<WriteQueue> out) = 0;
+  virtual void GetResult(common::ManagedPointer<WriteQueue> out) = 0;
 
   /**
    * Default destructor for ProtocolInterpreter
@@ -71,14 +71,14 @@ class ProtocolInterpreter {
    * Sets the message type of the current packet
    * @param in ReadBuffer to read input from
    */
-  virtual void SetPacketMessageType(const std::shared_ptr<ReadBuffer> &in) = 0;
+  virtual void SetPacketMessageType(common::ManagedPointer<ReadBuffer> in) = 0;
 
   /**
    * Reads the header of the packet to see if it is valid
    * @param in The ReadBuffer to read input from
    * @return whether the packet header is valid or not
    */
-  bool TryReadPacketHeader(const std::shared_ptr<ReadBuffer> &in) {
+  bool TryReadPacketHeader(const common::ManagedPointer<ReadBuffer> in) {
     if (curr_input_packet_.header_parsed_) return true;
 
     // Header format: 1 byte message type (only if non-startup)
@@ -101,7 +101,7 @@ class ProtocolInterpreter {
     // Extend the buffer as needed
     if (curr_input_packet_.len_ > in->Capacity()) {
       // Allocate a larger buffer and copy bytes off from the I/O layer's buffer
-      curr_input_packet_.buf_ = std::make_shared<ReadBuffer>(curr_input_packet_.len_);
+      curr_input_packet_.buf_ = std::make_unique<ReadBuffer>(curr_input_packet_.len_);
       NETWORK_LOG_TRACE("Extended Buffer size required for packet of size {0}", curr_input_packet_.len_);
       curr_input_packet_.extended_ = true;
     } else {
@@ -117,7 +117,7 @@ class ProtocolInterpreter {
    * @param in The ReadBuffer to read input from
    * @return whether the packet is valid or not
    */
-  bool TryBuildPacket(const std::shared_ptr<ReadBuffer> &in) {
+  bool TryBuildPacket(const common::ManagedPointer<ReadBuffer> in) {
     if (!TryReadPacketHeader(in)) return false;
 
     size_t size_needed = curr_input_packet_.extended_

--- a/src/include/network/protocol_interpreter.h
+++ b/src/include/network/protocol_interpreter.h
@@ -133,7 +133,7 @@ class ProtocolInterpreter {
       TERRIER_ASSERT(curr_input_packet_.len_ == curr_input_packet_.buf_->Capacity(),
                      "The buffer should have been extended to support the packet length. Otherwise, there's a mismatch "
                      "between the extended_ flag.");
-      curr_input_packet_.buf_->FillBufferFrom(*in, can_read);
+      curr_input_packet_.buf_->FillBufferFrom(in, can_read);
     }
 
     return remaining_bytes <= 0;

--- a/src/network/connection_handle.cpp
+++ b/src/network/connection_handle.cpp
@@ -57,33 +57,33 @@
   {                     \
     ConnState::s,
 #define AND_INVOKE(m)                         \
-  ([](ConnectionHandle &w) { return w.m(); }) \
+  ([](const common::ManagedPointer<ConnectionHandle> w) { return w->m(); }) \
   };                                          // NOLINT
 
 #define AND_WAIT_ON_READ                      \
-  ([](ConnectionHandle &w) {                  \
-    w.UpdateEventFlags(EV_READ | EV_PERSIST); \
+  ([](const common::ManagedPointer<ConnectionHandle> w) {                  \
+    w->UpdateEventFlags(EV_READ | EV_PERSIST); \
     return Transition::NONE;                  \
   })                                          \
   };                                          // NOLINT
 
 #define AND_WAIT_ON_WRITE                      \
-  ([](ConnectionHandle &w) {                   \
-    w.UpdateEventFlags(EV_WRITE | EV_PERSIST); \
+  ([](const common::ManagedPointer<ConnectionHandle> w) {                   \
+    w->UpdateEventFlags(EV_WRITE | EV_PERSIST); \
     return Transition::NONE;                   \
   })                                           \
   };                                            // NOLINT
 
 #define AND_WAIT_ON_TERRIER        \
-  ([](ConnectionHandle &w) {       \
-    w.StopReceivingNetworkEvent(); \
+  ([](const common::ManagedPointer<ConnectionHandle> w) {       \
+    w->StopReceivingNetworkEvent(); \
     return Transition::NONE;       \
   })                               \
   };                               // NOLINT
 
 #define AND_WAIT_ON_READ_TIMEOUT        \
-  ([](ConnectionHandle &w) {       \
-    w.UpdateEventFlags(EV_READ | EV_PERSIST | EV_TIMEOUT, READ_TIMEOUT); \
+  ([](const common::ManagedPointer<ConnectionHandle> w) {       \
+    w->UpdateEventFlags(EV_READ | EV_PERSIST | EV_TIMEOUT, READ_TIMEOUT); \
     return Transition::NONE;       \
   })                               \
   };                               // NOLINT
@@ -144,7 +144,8 @@ DEF_TRANSITION_GRAPH
 END_DEF
     // clang-format on
 
-    void ConnectionHandle::StateMachine::Accept(Transition action, ConnectionHandle &connection) {
+    void ConnectionHandle::StateMachine::Accept(Transition action,
+                                                const common::ManagedPointer<ConnectionHandle> connection) {
   Transition next = action;
   while (next != Transition::NONE) {
     transition_result result = Delta(current_state_, next);

--- a/src/network/itp/itp_command_factory.cpp
+++ b/src/network/itp/itp_command_factory.cpp
@@ -2,7 +2,8 @@
 #include <memory>
 namespace terrier::network {
 
-std::unique_ptr<ITPNetworkCommand> ITPCommandFactory::PacketToCommand(InputPacket *packet) {
+std::unique_ptr<ITPNetworkCommand> ITPCommandFactory::PacketToCommand(
+    const common::ManagedPointer<InputPacket> packet) {
   switch (packet->msg_type_) {
     case NetworkMessageType::ITP_REPLICATION_COMMAND:
       return MAKE_ITP_COMMAND(ReplicationCommand);

--- a/src/network/itp/itp_protocol_interpreter.cpp
+++ b/src/network/itp/itp_protocol_interpreter.cpp
@@ -20,7 +20,7 @@ Transition ITPProtocolInterpreter::Process(common::ManagedPointer<ReadBuffer> in
     NETWORK_LOG_ERROR("Encountered exception {0} when parsing packet", e.what());
     return Transition::TERMINATE;
   }
-  std::unique_ptr<ITPNetworkCommand> command = command_factory_->PacketToCommand(&curr_input_packet_);
+  auto command = command_factory_->PacketToCommand(common::ManagedPointer(&curr_input_packet_));
   ITPPacketWriter writer(out);
   if (command->FlushOnComplete()) out->ForceFlush();
   Transition ret = command->Exec(common::ManagedPointer<ProtocolInterpreter>(this),

--- a/src/network/itp/itp_protocol_interpreter.cpp
+++ b/src/network/itp/itp_protocol_interpreter.cpp
@@ -9,7 +9,8 @@
 #include "network/terrier_server.h"
 
 namespace terrier::network {
-Transition ITPProtocolInterpreter::Process(std::shared_ptr<ReadBuffer> in, std::shared_ptr<WriteQueue> out,
+Transition ITPProtocolInterpreter::Process(common::ManagedPointer<ReadBuffer> in,
+                                           common::ManagedPointer<WriteQueue> out,
                                            common::ManagedPointer<trafficcop::TrafficCop> t_cop,
                                            common::ManagedPointer<ConnectionContext> context,
                                            NetworkCallback callback) {
@@ -28,14 +29,14 @@ Transition ITPProtocolInterpreter::Process(std::shared_ptr<ReadBuffer> in, std::
   return ret;
 }
 
-void ITPProtocolInterpreter::GetResult(std::shared_ptr<WriteQueue> out) {
+void ITPProtocolInterpreter::GetResult(const common::ManagedPointer<WriteQueue> out) {
   ITPPacketWriter writer(out);
   writer.WriteCommandComplete();
 }
 
 size_t ITPProtocolInterpreter::GetPacketHeaderSize() { return 1 + sizeof(uint32_t); }
 
-void ITPProtocolInterpreter::SetPacketMessageType(const std::shared_ptr<ReadBuffer> &in) {
+void ITPProtocolInterpreter::SetPacketMessageType(const common::ManagedPointer<ReadBuffer> in) {
   curr_input_packet_.msg_type_ = in->ReadValue<NetworkMessageType>();
 }
 

--- a/src/network/postgres/postgres_command_factory.cpp
+++ b/src/network/postgres/postgres_command_factory.cpp
@@ -2,7 +2,8 @@
 #include <memory>
 namespace terrier::network {
 
-PostgresNetworkCommand *PostgresCommandFactory::PacketToCommand(InputPacket *packet) {
+std::unique_ptr<PostgresNetworkCommand> PostgresCommandFactory::PacketToCommand(
+    const common::ManagedPointer<InputPacket> packet) {
   switch (packet->msg_type_) {
     case NetworkMessageType::PG_SIMPLE_QUERY_COMMAND:
       return MAKE_POSTGRES_COMMAND(SimpleQueryCommand);

--- a/src/network/postgres/postgres_command_factory.cpp
+++ b/src/network/postgres/postgres_command_factory.cpp
@@ -2,7 +2,7 @@
 #include <memory>
 namespace terrier::network {
 
-std::shared_ptr<PostgresNetworkCommand> PostgresCommandFactory::PacketToCommand(InputPacket *packet) {
+PostgresNetworkCommand *PostgresCommandFactory::PacketToCommand(InputPacket *packet) {
   switch (packet->msg_type_) {
     case NetworkMessageType::PG_SIMPLE_QUERY_COMMAND:
       return MAKE_POSTGRES_COMMAND(SimpleQueryCommand);

--- a/src/network/postgres/postgres_protocol_interpreter.cpp
+++ b/src/network/postgres/postgres_protocol_interpreter.cpp
@@ -29,7 +29,7 @@ Transition PostgresProtocolInterpreter::Process(common::ManagedPointer<ReadBuffe
     curr_input_packet_.Clear();
     return ProcessStartup(in, out);
   }
-  std::shared_ptr<PostgresNetworkCommand> command = command_factory_->PacketToCommand(&curr_input_packet_);
+  std::unique_ptr<PostgresNetworkCommand> command(command_factory_->PacketToCommand(&curr_input_packet_));
   PostgresPacketWriter writer(out);
   if (command->FlushOnComplete()) out->ForceFlush();
   Transition ret = command->Exec(common::ManagedPointer<ProtocolInterpreter>(this),

--- a/src/network/postgres/postgres_protocol_interpreter.cpp
+++ b/src/network/postgres/postgres_protocol_interpreter.cpp
@@ -12,7 +12,7 @@
 #define PROTO_MAJOR_VERSION(x) ((x) >> 16)
 
 namespace terrier::network {
-Transition PostgresProtocolInterpreter::Process(std::shared_ptr<ReadBuffer> in, std::shared_ptr<WriteQueue> out,
+Transition PostgresProtocolInterpreter::Process(common::ManagedPointer<ReadBuffer> in, common::ManagedPointer<WriteQueue> out,
                                                 common::ManagedPointer<trafficcop::TrafficCop> t_cop,
                                                 common::ManagedPointer<ConnectionContext> context,
                                                 NetworkCallback callback) {
@@ -37,8 +37,8 @@ Transition PostgresProtocolInterpreter::Process(std::shared_ptr<ReadBuffer> in, 
   return ret;
 }
 
-Transition PostgresProtocolInterpreter::ProcessStartup(const std::shared_ptr<ReadBuffer> &in,
-                                                       const std::shared_ptr<WriteQueue> &out) {
+Transition PostgresProtocolInterpreter::ProcessStartup(const common::ManagedPointer<ReadBuffer> in,
+                                                       const common::ManagedPointer<WriteQueue> out) {
   PostgresPacketWriter writer(out);
   auto proto_version = in->ReadValue<uint32_t>();
   NETWORK_LOG_TRACE("protocol version: {0}", proto_version);
@@ -76,7 +76,7 @@ Transition PostgresProtocolInterpreter::ProcessStartup(const std::shared_ptr<Rea
 
 size_t PostgresProtocolInterpreter::GetPacketHeaderSize() { return startup_ ? sizeof(uint32_t) : 1 + sizeof(uint32_t); }
 
-void PostgresProtocolInterpreter::SetPacketMessageType(const std::shared_ptr<ReadBuffer> &in) {
+void PostgresProtocolInterpreter::SetPacketMessageType(const common::ManagedPointer<ReadBuffer> in) {
   if (!startup_) curr_input_packet_.msg_type_ = in->ReadValue<NetworkMessageType>();
 }
 

--- a/src/network/postgres/postgres_protocol_interpreter.cpp
+++ b/src/network/postgres/postgres_protocol_interpreter.cpp
@@ -12,7 +12,8 @@
 #define PROTO_MAJOR_VERSION(x) ((x) >> 16)
 
 namespace terrier::network {
-Transition PostgresProtocolInterpreter::Process(common::ManagedPointer<ReadBuffer> in, common::ManagedPointer<WriteQueue> out,
+Transition PostgresProtocolInterpreter::Process(common::ManagedPointer<ReadBuffer> in,
+                                                common::ManagedPointer<WriteQueue> out,
                                                 common::ManagedPointer<trafficcop::TrafficCop> t_cop,
                                                 common::ManagedPointer<ConnectionContext> context,
                                                 NetworkCallback callback) {

--- a/src/network/postgres/postgres_protocol_interpreter.cpp
+++ b/src/network/postgres/postgres_protocol_interpreter.cpp
@@ -29,7 +29,7 @@ Transition PostgresProtocolInterpreter::Process(common::ManagedPointer<ReadBuffe
     curr_input_packet_.Clear();
     return ProcessStartup(in, out);
   }
-  std::unique_ptr<PostgresNetworkCommand> command(command_factory_->PacketToCommand(&curr_input_packet_));
+  auto command = command_factory_->PacketToCommand(common::ManagedPointer<InputPacket>(&curr_input_packet_));
   PostgresPacketWriter writer(out);
   if (command->FlushOnComplete()) out->ForceFlush();
   Transition ret = command->Exec(common::ManagedPointer<ProtocolInterpreter>(this),

--- a/src/network/postgres/postgres_protocol_utils.cpp
+++ b/src/network/postgres/postgres_protocol_utils.cpp
@@ -1,4 +1,5 @@
 #include "network/postgres/postgres_protocol_utils.h"
+#include "loggers/main_logger.h"
 
 namespace terrier::network {
 

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -26,8 +26,9 @@ namespace terrier::network {
  * So, in network tests, we use a fake command factory to return empty results for every query.
  */
 class FakeCommandFactory : public PostgresCommandFactory {
-  PostgresNetworkCommand *PacketToCommand(InputPacket *packet) override {
-    return reinterpret_cast<PostgresNetworkCommand *>(new EmptyCommand(packet));
+  std::unique_ptr<PostgresNetworkCommand> PacketToCommand(const common::ManagedPointer<InputPacket> packet) override {
+    return std::unique_ptr<PostgresNetworkCommand>(
+        reinterpret_cast<PostgresNetworkCommand *>(new EmptyCommand(packet)));
   }
 };
 

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -26,8 +26,8 @@ namespace terrier::network {
  * So, in network tests, we use a fake command factory to return empty results for every query.
  */
 class FakeCommandFactory : public PostgresCommandFactory {
-  std::shared_ptr<PostgresNetworkCommand> PacketToCommand(InputPacket *packet) override {
-    return std::static_pointer_cast<PostgresNetworkCommand, EmptyCommand>(std::make_shared<EmptyCommand>(packet));
+  PostgresNetworkCommand *PacketToCommand(InputPacket *packet) override {
+    return reinterpret_cast<PostgresNetworkCommand *>(new EmptyCommand(packet));
   }
 };
 


### PR DESCRIPTION
Needed for #401. This clears up the ownership in the network layer.

I still want to make a pass adding some comments now that I understand the behavior a bit better,  but I can at least see how it does in CI.