### PR TITLE
Fix CMake goof on macOS

### DIFF
--- a/cmake_modules/SetupCxxFlags.cmake
+++ b/cmake_modules/SetupCxxFlags.cmake
@@ -24,7 +24,7 @@ include(CheckCXXCompilerFlag)
 # compiler flags that are common across debug/release builds
 set(CXX_COMMON_FLAGS "-Wall -Werror -Wno-c++98-compat -Wno-c++98-compat-pedantic")
 if (APPLE)
-    set(CXX_COMMON_FLAGS "-Wno-braced-scalar-init") # AppleClang needs this while upstream Clang and GCC are reasonable
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-braced-scalar-init") # AppleClang needs this while upstream Clang and GCC are reasonable
 endif()
 set(CXX_ONLY_FLAGS "-std=c++17 -fPIC -mcx16 -march=native -fvisibility=hidden")
 


### PR DESCRIPTION
It accidentally got messed up today and we lost some compiler flags on Apple.

Noticed it now while playing around with `-ftime-trace`.