### PR TITLE
CREATE/DROP plan node cleanup and executors

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -261,11 +261,12 @@ DatabaseCatalog *Catalog::DeleteDatabaseEntry(transaction::TransactionContext *t
   *(reinterpret_cast<db_oid_t *>(pr->AccessForceNotNull(0))) = db;
 
   databases_oid_index_->ScanKey(*txn, *pr, &index_results);
-  if (index_results.empty()) {
-    delete[] buffer;
-    return nullptr;
-  }
-  TERRIER_ASSERT(index_results.size() == 1, "Database OID not unique in index");
+  TERRIER_ASSERT(
+      index_results.size() == 1,
+      "Incorrect number of results from index scan. Expect 1 because it's a unique index. 0 implies that "
+      "function was called with an oid that doesn't exist in the Catalog, but binding somehow succeeded. That doesn't "
+      "make sense. Was a DROP plan node reused twice? IF EXISTS should be handled in the Binder, rather than "
+      "pushing logic here.");
 
   pr = delete_database_entry_pri_.InitializeRow(buffer);
   const auto UNUSED_ATTRIBUTE result = databases_->Select(txn, index_results[0], pr);

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -745,7 +745,7 @@ std::pair<uint32_t, postgres::ClassKind> DatabaseCatalog::GetClassOidKind(transa
   if (index_results.empty()) {
     delete[] buffer;
     // If the OID is invalid, we don't care the class kind and return a random one.
-    return std::make_pair(0, postgres::ClassKind::REGULAR_TABLE);
+    return std::make_pair(catalog::NULL_OID, postgres::ClassKind::REGULAR_TABLE);
   }
   TERRIER_ASSERT(index_results.size() == 1, "name not unique in classes_name_index_");
 
@@ -768,7 +768,7 @@ std::pair<uint32_t, postgres::ClassKind> DatabaseCatalog::GetClassOidKind(transa
 table_oid_t DatabaseCatalog::GetTableOid(transaction::TransactionContext *const txn, const namespace_oid_t ns,
                                          const std::string &name) {
   const auto oid_pair = GetClassOidKind(txn, ns, name);
-  if (oid_pair.second != postgres::ClassKind::REGULAR_TABLE) {
+  if (oid_pair.first == catalog::NULL_OID || oid_pair.second != postgres::ClassKind::REGULAR_TABLE) {
     // User called GetTableOid on an object that doesn't have type REGULAR_TABLE
     return INVALID_TABLE_OID;
   }
@@ -1076,7 +1076,7 @@ common::ManagedPointer<storage::index::Index> DatabaseCatalog::GetIndex(transact
 index_oid_t DatabaseCatalog::GetIndexOid(transaction::TransactionContext *txn, namespace_oid_t ns,
                                          const std::string &name) {
   const auto oid_pair = GetClassOidKind(txn, ns, name);
-  if (oid_pair.second != postgres::ClassKind::INDEX) {
+  if (oid_pair.first == NULL_OID || oid_pair.second != postgres::ClassKind::INDEX) {
     // User called GetIndexOid on an object that doesn't have type INDEX
     return INVALID_INDEX_OID;
   }

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -345,12 +345,11 @@ bool DatabaseCatalog::DeleteNamespace(transaction::TransactionContext *const txn
   // Scan index
   std::vector<storage::TupleSlot> index_results;
   namespaces_oid_index_->ScanKey(*txn, *pr, &index_results);
-  if (index_results.empty()) {
-    // oid not found in the index, so namespace doesn't exist. Free the buffer and return false to indicate failure
-    delete[] buffer;
-    return false;
-  }
-  TERRIER_ASSERT(index_results.size() == 1, "Namespace OID not unique in index");
+  TERRIER_ASSERT(
+      index_results.size() == 1,
+      "Incorrect number of results from index scan. Expect 1 because it's a unique index. 0 implies that function was "
+      "called with an oid that doesn't exist in the Catalog, but binding somehow succeeded. That doesn't make sense. "
+      "Was a DROP plan node reused twice? IF EXISTS should be handled in the Binder, rather than pushing logic here.");
   const auto tuple_slot = index_results[0];
 
   // Step 2: Select from the table to get the name
@@ -524,12 +523,9 @@ std::vector<Column> DatabaseCatalog::GetColumns(transaction::TransactionContext 
   std::vector<storage::TupleSlot> index_results;
   columns_oid_index_->ScanAscending(*txn, *pr, *pr_high, &index_results);
 
-  if (index_results.empty()) {
-    // class not found in the index, so class doesn't exist. Free the buffer and return nullptr to indicate failure
-    delete[] buffer;
-    delete[] key_buffer;
-    return {};
-  }
+  TERRIER_ASSERT(!index_results.empty(),
+                 "Incorrect number of results from index scan. empty() implies that function was called with an oid "
+                 "that doesn't exist in the Catalog, but binding somehow succeeded. That doesn't make sense.");
 
   // Step 2: Scan the table to get the columns
   std::vector<Column> cols;
@@ -577,10 +573,9 @@ bool DatabaseCatalog::DeleteColumns(transaction::TransactionContext *const txn, 
   std::vector<storage::TupleSlot> index_results;
   columns_oid_index_->ScanAscending(*txn, *pr, *key_pr, &index_results);
 
-  if (index_results.empty()) {
-    delete[] buffer;
-    return false;
-  }
+  TERRIER_ASSERT(!index_results.empty(),
+                 "Incorrect number of results from index scan. empty() implies that function was called with an oid "
+                 "that doesn't exist in the Catalog, but binding somehow succeeded. That doesn't make sense.");
 
   // TODO(Matt): do we have any way to assert that we got the number of attributes we expect? From another attribute in
   // another catalog table maybe?
@@ -652,14 +647,11 @@ bool DatabaseCatalog::DeleteTable(transaction::TransactionContext *const txn, co
   *(reinterpret_cast<table_oid_t *>(key_pr->AccessForceNotNull(0))) = table;
   std::vector<storage::TupleSlot> index_results;
   classes_oid_index_->ScanKey(*txn, *key_pr, &index_results);
-  if (index_results.empty()) {
-    // TODO(Matt): we should verify what postgres does in this case
-    // Index scan didn't find anything. This seems weird since we were able to enter this function with a table_oid.
-    // That implies that it was visible to us. Maybe the table was dropped or renamed twice by the same txn?
-    delete[] buffer;
-    return false;
-  }
-  TERRIER_ASSERT(index_results.size() == 1, "You got more than one result from a unique index. How did you do that?");
+  TERRIER_ASSERT(
+      index_results.size() == 1,
+      "Incorrect number of results from index scan. Expect 1 because it's a unique index. 0 implies that function was "
+      "called with an oid that doesn't exist in the Catalog, but binding somehow succeeded. That doesn't make sense. "
+      "Was a DROP plan node reused twice? IF EXISTS should be handled in the Binder, rather than pushing logic here.");
 
   // Select the tuple out of the table before deletion. We need the attributes to do index deletions later
   auto *const table_pr = pg_class_all_cols_pri_.InitializeRow(buffer);
@@ -893,14 +885,11 @@ bool DatabaseCatalog::DeleteIndex(transaction::TransactionContext *txn, index_oi
   *(reinterpret_cast<index_oid_t *>(key_pr->AccessForceNotNull(0))) = index;
   std::vector<storage::TupleSlot> index_results;
   classes_oid_index_->ScanKey(*txn, *key_pr, &index_results);
-  if (index_results.empty()) {
-    // TODO(Matt): we should verify what postgres does in this case
-    // Index scan didn't find anything. This seems weird since we were able to enter this function with an index_oid.
-    // That implies that it was visible to us. Maybe the index was dropped or renamed twice by the same txn?
-    delete[] buffer;
-    return false;
-  }
-  TERRIER_ASSERT(index_results.size() == 1, "You got more than one result from a unique index. How did you do that?");
+  TERRIER_ASSERT(
+      index_results.size() == 1,
+      "Incorrect number of results from index scan. Expect 1 because it's a unique index. 0 implies that function was "
+      "called with an oid that doesn't exist in the Catalog, but binding somehow succeeded. That doesn't make sense. "
+      "Was a DROP plan node reused twice? IF EXISTS should be handled in the Binder, rather than pushing logic here.");
 
   // Select the tuple out of the table before deletion. We need the attributes to do index deletions later
   auto *table_pr = pg_class_all_cols_pri_.InitializeRow(buffer);
@@ -964,14 +953,10 @@ bool DatabaseCatalog::DeleteIndex(transaction::TransactionContext *txn, index_oi
   key_pr = index_oid_pr.InitializeRow(buffer);
   *(reinterpret_cast<index_oid_t *>(key_pr->AccessForceNotNull(0))) = index;
   indexes_oid_index_->ScanKey(*txn, *key_pr, &index_results);
-  if (index_results.empty()) {
-    // TODO(Matt): we should verify what postgres does in this case
-    // Index scan didn't find anything. This seems weird since we were able to enter this function with an index_oid.
-    // That implies that it was visible to us. Maybe the index was dropped or renamed twice by the same txn?
-    delete[] buffer;
-    return false;
-  }
-  TERRIER_ASSERT(index_results.size() == 1, "You got more than one result from a unique index. How did you do that?");
+  TERRIER_ASSERT(index_results.size() == 1,
+                 "Incorrect number of results from index scan. Expect 1 because it's a unique index. size() of 0 "
+                 "implies an error in Catalog state because scanning pg_class worked, but it doesn't exist in "
+                 "pg_index. Something broke.");
 
   // Select the tuple out of pg_index before deletion. We need the attributes to do index deletions later
   table_pr = delete_index_pri_.InitializeRow(buffer);
@@ -1049,14 +1034,11 @@ bool DatabaseCatalog::SetClassPointer(transaction::TransactionContext *const txn
   *(reinterpret_cast<ClassOid *>(key_pr->AccessForceNotNull(0))) = oid;
   std::vector<storage::TupleSlot> index_results;
   classes_oid_index_->ScanKey(*txn, *key_pr, &index_results);
-  if (index_results.empty()) {
-    // TODO(Matt): we should verify what postgres does in this case
-    // Index scan didn't find anything. This seems weird since we were able to enter this function with an oid.
-    // That implies that it was visible to us. Maybe the object was dropped or renamed twice by the same txn?
-    delete[] buffer;
-    return false;
-  }
-  TERRIER_ASSERT(index_results.size() == 1, "You got more than one result from a unique index. How did you do that?");
+  TERRIER_ASSERT(
+      index_results.size() == 1,
+      "Incorrect number of results from index scan. Expect 1 because it's a unique index. 0 implies that function was "
+      "called with an oid that doesn't exist in the Catalog, which implies a programmer error. There's no reasonable "
+      "code path for this to be called on an oid that isn't present.");
 
   auto &initializer =
       (class_col == catalog::postgres::REL_PTR_COL_OID) ? set_class_pointer_pri_ : set_class_schema_pri_;
@@ -1153,15 +1135,10 @@ std::vector<std::pair<common::ManagedPointer<storage::index::Index>, const Index
     // Find the entry using the index
     *(reinterpret_cast<uint32_t *>(class_key_pr->AccessForceNotNull(0))) = static_cast<uint32_t>(index_oid);
     classes_oid_index_->ScanKey(*txn, *class_key_pr, &index_scan_results);
-    if (index_scan_results.empty()) {
-      // TODO(Matt): we should verify what postgres does in this case
-      // Index scan didn't find anything. This seems weird since we were able to enter this function with an oid.
-      // That implies that it was visible to us. Maybe the object was dropped or renamed twice by the same txn?
-      delete[] buffer;
-      return {};
-    }
     TERRIER_ASSERT(index_scan_results.size() == 1,
-                   "You got more than one result from a unique index. How did you do that?");
+                   "Incorrect number of results from index scan. Expect 1 because it's a unique index. size() of 0 "
+                   "implies an error in Catalog state because scanning pg_index returned the index oid, but it doesn't "
+                   "exist in pg_class. Something broke.");
     class_tuple_slots.push_back(index_scan_results[0]);
     index_scan_results.clear();
   }
@@ -1683,14 +1660,10 @@ std::pair<void *, postgres::ClassKind> DatabaseCatalog::GetClassPtrKind(transact
   auto *key_pr = oid_pri.InitializeRow(buffer);
   *(reinterpret_cast<uint32_t *>(key_pr->AccessForceNotNull(0))) = oid;
   classes_oid_index_->ScanKey(*txn, *key_pr, &index_results);
-  if (index_results.empty()) {
-    // TODO(Matt): we should verify what postgres does in this case
-    // Index scan didn't find anything. This seems weird since we were able to enter this function with an oid.
-    // That implies that it was visible to us. Maybe the object was dropped or renamed twice by the same txn?
-    delete[] buffer;
-    return {nullptr, postgres::ClassKind::REGULAR_TABLE};
-  }
-  TERRIER_ASSERT(index_results.size() == 1, "You got more than one result from a unique index. How did you do that?");
+  TERRIER_ASSERT(
+      index_results.size() == 1,
+      "Incorrect number of results from index scan. Expect 1 because it's a unique index. 0 implies that function was "
+      "called with an oid that doesn't exist in the Catalog, but binding somehow succeeded. That doesn't make sense.");
 
   auto *select_pr = get_class_pointer_kind_pri_.InitializeRow(buffer);
   const auto result UNUSED_ATTRIBUTE = classes_->Select(txn, index_results[0], select_pr);
@@ -1726,14 +1699,10 @@ std::pair<void *, postgres::ClassKind> DatabaseCatalog::GetClassSchemaPtrKind(tr
   auto *key_pr = oid_pri.InitializeRow(buffer);
   *(reinterpret_cast<uint32_t *>(key_pr->AccessForceNotNull(0))) = oid;
   classes_oid_index_->ScanKey(*txn, *key_pr, &index_results);
-  if (index_results.empty()) {
-    // TODO(Matt): we should verify what postgres does in this case
-    // Index scan didn't find anything. This seems weird since we were able to enter this function with an oid.
-    // That implies that it was visible to us. Maybe the object was dropped or renamed twice by the same txn?
-    delete[] buffer;
-    return {nullptr, postgres::ClassKind::REGULAR_TABLE};
-  }
-  TERRIER_ASSERT(index_results.size() == 1, "You got more than one result from a unique index. How did you do that?");
+  TERRIER_ASSERT(
+      index_results.size() == 1,
+      "Incorrect number of results from index scan. Expect 1 because it's a unique index. 0 implies that function was "
+      "called with an oid that doesn't exist in the Catalog, but binding somehow succeeded. That doesn't make sense.");
 
   auto *select_pr = get_class_schema_pointer_kind_pri_.InitializeRow(buffer);
   const auto result UNUSED_ATTRIBUTE = classes_->Select(txn, index_results[0], select_pr);

--- a/src/execution/sql/ddl_executors.cpp
+++ b/src/execution/sql/ddl_executors.cpp
@@ -1,0 +1,139 @@
+#include "execution/sql/ddl_executors.h"
+#include <memory>
+#include <string>
+#include <vector>
+#include "catalog/catalog_accessor.h"
+#include "common/macros.h"
+#include "execution/exec/execution_context.h"
+#include "parser/expression/column_value_expression.h"
+#include "planner/plannodes/create_database_plan_node.h"
+#include "planner/plannodes/create_index_plan_node.h"
+#include "planner/plannodes/create_namespace_plan_node.h"
+#include "planner/plannodes/create_table_plan_node.h"
+#include "planner/plannodes/drop_database_plan_node.h"
+#include "planner/plannodes/drop_index_plan_node.h"
+#include "planner/plannodes/drop_namespace_plan_node.h"
+#include "planner/plannodes/drop_table_plan_node.h"
+#include "storage/index/index_builder.h"
+#include "storage/sql_table.h"
+
+namespace terrier::execution::sql {
+
+bool DDLExecutors::CreateDatabaseExecutor(const common::ManagedPointer<planner::CreateDatabasePlanNode> node,
+                                          const common::ManagedPointer<exec::ExecutionContext> context) {
+  auto *const accessor = context->GetAccessor();
+  // Request permission from the Catalog to see if this a valid database name
+  return accessor->CreateDatabase(node->GetDatabaseName()) != catalog::INVALID_DATABASE_OID;
+}
+
+bool DDLExecutors::CreateNamespaceExecutor(const common::ManagedPointer<planner::CreateNamespacePlanNode> node,
+                                           const common::ManagedPointer<exec::ExecutionContext> context) {
+  auto *const accessor = context->GetAccessor();
+  // Request permission from the Catalog to see if this a valid namespace name
+  return accessor->CreateNamespace(node->GetNamespaceName()) != catalog::INVALID_NAMESPACE_OID;
+}
+
+bool DDLExecutors::CreateTableExecutor(const common::ManagedPointer<planner::CreateTablePlanNode> node,
+                                       const common::ManagedPointer<exec::ExecutionContext> context) {
+  auto *const accessor = context->GetAccessor();
+  // Request permission from the Catalog to see if this a valid namespace and table name
+  const auto table_oid = accessor->CreateTable(node->GetNamespaceOid(), node->GetTableName(), *(node->GetSchema()));
+  if (table_oid == catalog::INVALID_TABLE_OID) {
+    // Catalog wasn't able to proceed, txn must now abort
+    return false;
+  }
+  // Get the canonical Schema from the Catalog now that column oids have been assigned
+  const auto &schema = accessor->GetSchema(table_oid);
+  // Instantiate a SqlTable and update the pointer in the Catalog
+  auto *const table = new storage::SqlTable(node->GetBlockStore().Get(), schema);
+  bool result UNUSED_ATTRIBUTE = accessor->SetTablePointer(table_oid, table);
+  TERRIER_ASSERT(result, "CreateTable succeeded, SetTablePointer must also succeed.");
+
+  if (node->HasPrimaryKey()) {
+    // Create the IndexSchema Columns by referencing the Columns in the canonical table Schema from the Catalog
+    std::vector<catalog::IndexSchema::Column> key_cols;
+    const auto &primary_key_info = node->GetPrimaryKey();
+    key_cols.reserve(primary_key_info.primary_key_cols_.size());
+    for (const auto &parser_col : primary_key_info.primary_key_cols_) {
+      const auto &table_col = schema.GetColumn(parser_col);
+      if (table_col.Type() == type::TypeId::VARCHAR || table_col.Type() == type::TypeId::VARBINARY) {
+        key_cols.emplace_back(table_col.Name(), table_col.Type(), table_col.MaxVarlenSize(), table_col.Nullable(),
+                              parser::ColumnValueExpression(context->DBOid(), table_oid, table_col.Oid()));
+
+      } else {
+        key_cols.emplace_back(table_col.Name(), table_col.Type(), table_col.Nullable(),
+                              parser::ColumnValueExpression(context->DBOid(), table_oid, table_col.Oid()));
+      }
+    }
+    catalog::IndexSchema index_schema(key_cols, storage::index::IndexType::BWTREE, true, true, false, true);
+
+    // Create the index, and use its return value as overall success result
+    return CreateIndex(context, node->GetNamespaceOid(), primary_key_info.constraint_name_, table_oid, index_schema);
+  }
+
+  // TODO(Matt): interpret other fields in CreateTablePlanNode when we support them in the Catalog:
+  // foreign_keys_, con_uniques_, con_checks_,
+
+  return true;
+}
+
+bool DDLExecutors::CreateIndexExecutor(const common::ManagedPointer<planner::CreateIndexPlanNode> node,
+                                       const common::ManagedPointer<exec::ExecutionContext> context) {
+  return CreateIndex(context, node->GetNamespaceOid(), node->GetIndexName(), node->GetTableOid(), *(node->GetSchema()));
+}
+
+bool DDLExecutors::DropDatabaseExecutor(const common::ManagedPointer<planner::DropDatabasePlanNode> node,
+                                        const common::ManagedPointer<exec::ExecutionContext> context) {
+  TERRIER_ASSERT(context->DBOid() != node->GetDatabaseOid(),
+                 "This command cannot be executed while connected to the target database. This should be checked in "
+                 "the binder.");
+  auto *const accessor = context->GetAccessor();
+  const bool result = accessor->DropDatabase(node->GetDatabaseOid());
+  return result;
+}
+
+bool DDLExecutors::DropNamespaceExecutor(const common::ManagedPointer<planner::DropNamespacePlanNode> node,
+                                         const common::ManagedPointer<exec::ExecutionContext> context) {
+  auto *const accessor = context->GetAccessor();
+  const bool result = accessor->DropNamespace(node->GetNamespaceOid());
+  // TODO(Matt): CASCADE?
+  return result;
+}
+
+bool DDLExecutors::DropTableExecutor(const common::ManagedPointer<planner::DropTablePlanNode> node,
+                                     const common::ManagedPointer<exec::ExecutionContext> context) {
+  auto *const accessor = context->GetAccessor();
+  const bool result = accessor->DropTable(node->GetTableOid());
+  // TODO(Matt): CASCADE?
+  return result;
+}
+
+bool DDLExecutors::DropIndexExecutor(const common::ManagedPointer<planner::DropIndexPlanNode> node,
+                                     const common::ManagedPointer<exec::ExecutionContext> context) {
+  auto *const accessor = context->GetAccessor();
+  const bool result = accessor->DropIndex(node->GetIndexOid());
+  // TODO(Matt): CASCADE?
+  return result;
+}
+
+bool DDLExecutors::CreateIndex(const common::ManagedPointer<exec::ExecutionContext> context,
+                               const catalog::namespace_oid_t ns, const std::string &name,
+                               const catalog::table_oid_t table, const catalog::IndexSchema &input_schema) {
+  auto *const accessor = context->GetAccessor();
+  // Request permission from the Catalog to see if this a valid namespace and table name
+  const auto index_oid = accessor->CreateIndex(ns, table, name, input_schema);
+  if (index_oid == catalog::INVALID_INDEX_OID) {
+    // Catalog wasn't able to proceed, txn must now abort
+    return false;
+  }
+  // Get the canonical IndexSchema from the Catalog now that column oids have been assigned
+  const auto &schema = accessor->GetIndexSchema(index_oid);
+  // Instantiate an Index and update the pointer in the Catalog
+  storage::index::IndexBuilder index_builder;
+  index_builder.SetKeySchema(schema);
+  auto *const index = index_builder.Build();
+  bool result UNUSED_ATTRIBUTE = accessor->SetIndexPointer(index_oid, index);
+  TERRIER_ASSERT(result, "CreateIndex succeeded, SetIndexPointer must also succeed.");
+  return true;
+}
+}  // namespace terrier::execution::sql

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -86,7 +86,8 @@ class CatalogAccessor {
 
   /**
    * Drop all entries in the catalog that belong to the namespace, including the namespace entry
-   * @param ns the OID of the namespace to drop
+   * @param ns the OID of the namespace to drop, this must be a valid oid from GetNamespaceOid. Invalid input will
+   * trigger an assert
    * @return true, unless there was no namespace entry with the given OID
    */
   bool DropNamespace(namespace_oid_t ns) const;
@@ -135,15 +136,15 @@ class CatalogAccessor {
 
   /**
    * Drop the table and all corresponding indices from the catalog.
-   * @param table the OID of the table to drop
-   * @return true, unless there was no table entry for the given OID or the entry
-   *         was write-locked by a different transaction
+   * @param table the OID of the table to drop, this must be a valid oid from GetTableOid. Invalid input will trigger an
+   * assert
+   * @return true, unless the entry was write-locked by a different transaction
    */
   bool DropTable(table_oid_t table) const;
 
   /**
    * Inform the catalog of where the underlying storage for a table is
-   * @param table OID in the catalog
+   * @param table OID in the catalog, this must be a valid oid from GetTableOid. Invalid input will trigger an assert
    * @param table_ptr to the memory where the storage is
    * @return whether the operation was successful
    * @warning The table pointer that is passed in must be on the heap as the
@@ -154,7 +155,8 @@ class CatalogAccessor {
 
   /**
    * Obtain the storage pointer for a SQL table
-   * @param table to which we want the storage object
+   * @param table to which we want the storage object, this must be a valid oid from GetTableOid. Invalid input will
+   * trigger an assert
    * @return the storage object corresponding to the passed OID
    */
   common::ManagedPointer<storage::SqlTable> GetTable(table_oid_t table) const;
@@ -166,24 +168,22 @@ class CatalogAccessor {
    * @param table OID of the modified table
    * @param new_schema object describing the table after modification
    * @return true if the operation succeeded, false otherwise
-   * @warning The catalog accessor assumes it takes ownership of the schema object
-   * that is passed.  As such, there is no guarantee that the pointer is still
-   * valid when this function returns.  If the caller needs to reference the
-   * schema object after this call, they should use the GetSchema function to
-   * obtain the authoritative schema for this table.
+   * @warning If the caller needs to reference the schema object after this call, they should use the GetSchema function
+   * to obtain the authoritative schema for this table.
    */
   bool UpdateSchema(table_oid_t table, Schema *new_schema) const;
 
   /**
    * Get the visible schema describing the table.
-   * @param table corresponding to the requested schema
+   * @param table corresponding to the requested schema, this must be a valid oid from GetTableOid. Invalid input will
+   * trigger an assert
    * @return the visible schema object for the identified table
    */
   const Schema &GetSchema(table_oid_t table) const;
 
   /**
    * A list of all constraints on this table
-   * @param table being queried
+   * @param table being queried, this must be a valid oid from GetTableOid. Invalid input will trigger an assert
    * @return vector of OIDs for all of the constraints that apply to this table
    */
   std::vector<constraint_oid_t> GetConstraints(table_oid_t table) const;
@@ -198,7 +198,8 @@ class CatalogAccessor {
   /**
    * Returns index pointers and schemas for every index on a table. Provides much better performance than individual
    * calls to GetIndex and GetIndexSchema
-   * @param table table to get index objects for
+   * @param table table to get index objects for, this must be a valid oid from GetTableOid. Invalid input will trigger
+   * an assert
    * @return vector of pairs of index pointers and their corresponding schemas
    */
   std::vector<std::pair<common::ManagedPointer<storage::index::Index>, const IndexSchema &>> GetIndexes(
@@ -231,21 +232,22 @@ class CatalogAccessor {
 
   /**
    * Gets the schema that was used to define the index
-   * @param index corresponding to the requested key schema
+   * @param index corresponding to the requested key schema, this must be a valid oid from GetIndexOid. Invalid input
+   * will trigger an assert
    * @return the key schema for this index
    */
   const IndexSchema &GetIndexSchema(index_oid_t index) const;
 
   /**
    * Drop the corresponding index from the catalog.
-   * @param index to be dropped
+   * @param index to be dropped, this must be a valid oid from GetIndexOid. Invalid input will trigger an assert
    * @return whether the operation succeeded
    */
   bool DropIndex(index_oid_t index) const;
 
   /**
    * Inform the catalog of where the underlying implementation of the index is
-   * @param index OID in the catalog
+   * @param index OID in the catalog, this must be a valid oid from GetIndexOid. Invalid input will trigger an assert
    * @param index_ptr to the memory where the index is
    * @return whether the operation was successful
    * @warning The index pointer that is passed in must be on the heap as the
@@ -256,7 +258,8 @@ class CatalogAccessor {
 
   /**
    * Obtain the pointer to the index
-   * @param index to which we want a pointer
+   * @param index to which we want a pointer, this must be a valid oid from GetIndexOid. Invalid input will trigger an
+   * assert
    * @return the pointer to the index
    */
   common::ManagedPointer<storage::index::Index> GetIndex(index_oid_t index) const;

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -252,11 +251,14 @@ class Schema {
    * @throw std::out_of_range if the column doesn't exist.
    */
   const Column &GetColumn(const std::string &name) const {
-    const auto find_fn = [&](const Column &c) { return c.Name() == name; };
-    TERRIER_ASSERT(std::count_if(columns_.cbegin(), columns_.cend(), find_fn) > 0,
-                   "column name does not exist in this Schema");
-    const auto it = std::find_if(columns_.cbegin(), columns_.cend(), find_fn);
-    return *it;
+    for (const auto &c : columns_) {
+      if (c.Name() == name) {
+        return c;
+      }
+    }
+    // TODO(John): Should this be a TERRIER_ASSERT to have the same semantics
+    // as the other accessor methods above?
+    throw std::out_of_range("Column name doesn't exist");
   }
   /**
    * @return description of this SQL table's schema as a collection of Columns

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -251,14 +252,11 @@ class Schema {
    * @throw std::out_of_range if the column doesn't exist.
    */
   const Column &GetColumn(const std::string &name) const {
-    for (const auto &c : columns_) {
-      if (c.Name() == name) {
-        return c;
-      }
-    }
-    // TODO(John): Should this be a TERRIER_ASSERT to have the same semantics
-    // as the other accessor methods above?
-    throw std::out_of_range("Column name doesn't exist");
+    const auto find_fn = [&](const Column &c) { return c.Name() == name; };
+    TERRIER_ASSERT(std::count_if(columns_.cbegin(), columns_.cend(), find_fn) > 0,
+                   "column name does not exist in this Schema");
+    const auto it = std::find_if(columns_.cbegin(), columns_.cend(), find_fn);
+    return *it;
   }
   /**
    * @return description of this SQL table's schema as a collection of Columns

--- a/src/include/execution/sql/ddl_executors.h
+++ b/src/include/execution/sql/ddl_executors.h
@@ -24,6 +24,20 @@ class DDLExecutors {
  public:
   DDLExecutors() = delete;
 
+  static bool CreateDatabaseExecutor(const common::ManagedPointer<planner::CreateDatabasePlanNode> node,
+                                     const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    // Request permission from the Catalog to see if this a valid database name
+    return accessor->CreateDatabase(node->GetDatabaseName()) != catalog::INVALID_DATABASE_OID;
+  }
+
+  static bool CreateNamespaceExecutor(const common::ManagedPointer<planner::CreateNamespacePlanNode> node,
+                                      const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    // Request permission from the Catalog to see if this a valid namespace name
+    return accessor->CreateNamespace(node->GetNamespaceName()) != catalog::INVALID_NAMESPACE_OID;
+  }
+
   static bool CreateTableExecutor(const common::ManagedPointer<planner::CreateTablePlanNode> node,
                                   const common::ManagedPointer<exec::ExecutionContext> context) {
     auto *const accessor = context->GetAccessor();
@@ -74,36 +88,6 @@ class DDLExecutors {
                        *(node->GetSchema()));
   }
 
-  static bool CreateDatabaseExecutor(const common::ManagedPointer<planner::CreateDatabasePlanNode> node,
-                                     const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    // Request permission from the Catalog to see if this a valid database name
-    return accessor->CreateDatabase(node->GetDatabaseName()) != catalog::INVALID_DATABASE_OID;
-  }
-
-  static bool CreateNamespaceExecutor(const common::ManagedPointer<planner::CreateNamespacePlanNode> node,
-                                      const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    // Request permission from the Catalog to see if this a valid namespace name
-    return accessor->CreateNamespace(node->GetNamespaceName()) != catalog::INVALID_NAMESPACE_OID;
-  }
-
-  static bool DropTableExecutor(const common::ManagedPointer<planner::DropTablePlanNode> node,
-                                const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    const bool result = accessor->DropTable(node->GetTableOid());
-    // TODO(Matt): CASCADE?
-    return result;
-  }
-
-  static bool DropIndexExecutor(const common::ManagedPointer<planner::DropIndexPlanNode> node,
-                                const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    const bool result = accessor->DropIndex(node->GetIndexOid());
-    // TODO(Matt): CASCADE?
-    return result;
-  }
-
   static bool DropDatabaseExecutor(const common::ManagedPointer<planner::DropDatabasePlanNode> node,
                                    const common::ManagedPointer<exec::ExecutionContext> context) {
     TERRIER_ASSERT(context->DBOid() != node->GetDatabaseOid(),
@@ -118,6 +102,22 @@ class DDLExecutors {
                                     const common::ManagedPointer<exec::ExecutionContext> context) {
     auto *const accessor = context->GetAccessor();
     const bool result = accessor->DropNamespace(node->GetNamespaceOid());
+    // TODO(Matt): CASCADE?
+    return result;
+  }
+
+  static bool DropTableExecutor(const common::ManagedPointer<planner::DropTablePlanNode> node,
+                                const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    const bool result = accessor->DropTable(node->GetTableOid());
+    // TODO(Matt): CASCADE?
+    return result;
+  }
+
+  static bool DropIndexExecutor(const common::ManagedPointer<planner::DropIndexPlanNode> node,
+                                const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    const bool result = accessor->DropIndex(node->GetIndexOid());
     // TODO(Matt): CASCADE?
     return result;
   }

--- a/src/include/execution/sql/ddl_executors.h
+++ b/src/include/execution/sql/ddl_executors.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 #include "catalog/catalog_accessor.h"

--- a/src/include/execution/sql/ddl_executors.h
+++ b/src/include/execution/sql/ddl_executors.h
@@ -1,148 +1,103 @@
 #pragma once
 
-#include <memory>
 #include <string>
-#include <utility>
-#include <vector>
-#include "catalog/catalog_accessor.h"
-#include "common/macros.h"
-#include "execution/exec/execution_context.h"
-#include "parser/expression/column_value_expression.h"
-#include "planner/plannodes/create_database_plan_node.h"
-#include "planner/plannodes/create_index_plan_node.h"
-#include "planner/plannodes/create_namespace_plan_node.h"
-#include "planner/plannodes/create_table_plan_node.h"
-#include "planner/plannodes/drop_database_plan_node.h"
-#include "planner/plannodes/drop_index_plan_node.h"
-#include "planner/plannodes/drop_namespace_plan_node.h"
-#include "planner/plannodes/drop_table_plan_node.h"
-#include "storage/index/index_builder.h"
-#include "storage/sql_table.h"
+#include "catalog/catalog_defs.h"
+#include "common/managed_pointer.h"
+namespace terrier::planner {
+class CreateDatabasePlanNode;
+class CreateNamespacePlanNode;
+class CreateTablePlanNode;
+class CreateIndexPlanNode;
+class DropDatabasePlanNode;
+class DropNamespacePlanNode;
+class DropTablePlanNode;
+class DropIndexPlanNode;
+}  // namespace terrier::planner
 
-namespace terrier::execution {
+namespace terrier::execution::exec {
+class ExecutionContext;
+}
 
+namespace terrier::catalog {
+class IndexSchema;
+}
+
+namespace terrier::execution::sql {
+
+/**
+ * static utility class to execute DDL plan nodes, can be called directly by C++ or eventually through TPL builtins
+ */
 class DDLExecutors {
  public:
   DDLExecutors() = delete;
 
-  static bool CreateDatabaseExecutor(const common::ManagedPointer<planner::CreateDatabasePlanNode> node,
-                                     const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    // Request permission from the Catalog to see if this a valid database name
-    return accessor->CreateDatabase(node->GetDatabaseName()) != catalog::INVALID_DATABASE_OID;
-  }
+  /**
+   * @param node node to executed
+   * @param context context to use for execution
+   * @return true if operation succeeded, false otherwise
+   */
+  static bool CreateDatabaseExecutor(common::ManagedPointer<planner::CreateDatabasePlanNode> node,
+                                     common::ManagedPointer<exec::ExecutionContext> context);
 
-  static bool CreateNamespaceExecutor(const common::ManagedPointer<planner::CreateNamespacePlanNode> node,
-                                      const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    // Request permission from the Catalog to see if this a valid namespace name
-    return accessor->CreateNamespace(node->GetNamespaceName()) != catalog::INVALID_NAMESPACE_OID;
-  }
+  /**
+   * @param node node to executed
+   * @param context context to use for execution
+   * @return true if operation succeeded, false otherwise
+   */
+  static bool CreateNamespaceExecutor(common::ManagedPointer<planner::CreateNamespacePlanNode> node,
+                                      common::ManagedPointer<exec::ExecutionContext> context);
 
-  static bool CreateTableExecutor(const common::ManagedPointer<planner::CreateTablePlanNode> node,
-                                  const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    // Request permission from the Catalog to see if this a valid namespace and table name
-    const auto table_oid = accessor->CreateTable(node->GetNamespaceOid(), node->GetTableName(), *(node->GetSchema()));
-    if (table_oid == catalog::INVALID_TABLE_OID) {
-      // Catalog wasn't able to proceed, txn must now abort
-      return false;
-    }
-    // Get the canonical Schema from the Catalog now that column oids have been assigned
-    const auto &schema = accessor->GetSchema(table_oid);
-    // Instantiate a SqlTable and update the pointer in the Catalog
-    auto *const table = new storage::SqlTable(node->GetBlockStore().Get(), schema);
-    bool result UNUSED_ATTRIBUTE = accessor->SetTablePointer(table_oid, table);
-    TERRIER_ASSERT(result, "CreateTable succeeded, SetTablePointer must also succeed.");
+  /**
+   * @param node node to executed
+   * @param context context to use for execution
+   * @return true if operation succeeded, false otherwise
+   */
+  static bool CreateTableExecutor(common::ManagedPointer<planner::CreateTablePlanNode> node,
+                                  common::ManagedPointer<exec::ExecutionContext> context);
 
-    if (node->HasPrimaryKey()) {
-      // Create the IndexSchema Columns by referencing the Columns in the canonical table Schema from the Catalog
-      std::vector<catalog::IndexSchema::Column> key_cols;
-      const auto &primary_key_info = node->GetPrimaryKey();
-      key_cols.reserve(primary_key_info.primary_key_cols_.size());
-      for (const auto &parser_col : primary_key_info.primary_key_cols_) {
-        const auto &table_col = schema.GetColumn(parser_col);
-        if (table_col.Type() == type::TypeId::VARCHAR || table_col.Type() == type::TypeId::VARBINARY) {
-          key_cols.emplace_back(table_col.Name(), table_col.Type(), table_col.MaxVarlenSize(), table_col.Nullable(),
-                                parser::ColumnValueExpression(context->DBOid(), table_oid, table_col.Oid()));
+  /**
+   * @param node node to executed
+   * @param context context to use for execution
+   * @return true if operation succeeded, false otherwise
+   */
+  static bool CreateIndexExecutor(common::ManagedPointer<planner::CreateIndexPlanNode> node,
+                                  common::ManagedPointer<exec::ExecutionContext> context);
 
-        } else {
-          key_cols.emplace_back(table_col.Name(), table_col.Type(), table_col.Nullable(),
-                                parser::ColumnValueExpression(context->DBOid(), table_oid, table_col.Oid()));
-        }
-      }
-      catalog::IndexSchema index_schema(key_cols, storage::index::IndexType::BWTREE, true, true, false, true);
+  /**
+   * @param node node to executed
+   * @param context context to use for execution
+   * @return true if operation succeeded, false otherwise
+   */
+  static bool DropDatabaseExecutor(common::ManagedPointer<planner::DropDatabasePlanNode> node,
+                                   common::ManagedPointer<exec::ExecutionContext> context);
 
-      // Create the index, and use its return value as overall success result
-      return CreateIndex(context, node->GetNamespaceOid(), primary_key_info.constraint_name_, table_oid, index_schema);
-    }
+  /**
+   * @param node node to executed
+   * @param context context to use for execution
+   * @return true if operation succeeded, false otherwise
+   */
+  static bool DropNamespaceExecutor(common::ManagedPointer<planner::DropNamespacePlanNode> node,
+                                    common::ManagedPointer<exec::ExecutionContext> context);
 
-    // TODO(Matt): interpret other fields in CreateTablePlanNode when we support them in the Catalog:
-    // foreign_keys_, con_uniques_, con_checks_,
+  /**
+   * @param node node to executed
+   * @param context context to use for execution
+   * @return true if operation succeeded, false otherwise
+   */
+  static bool DropTableExecutor(common::ManagedPointer<planner::DropTablePlanNode> node,
+                                common::ManagedPointer<exec::ExecutionContext> context);
 
-    return true;
-  }
-
-  static bool CreateIndexExecutor(const common::ManagedPointer<planner::CreateIndexPlanNode> node,
-                                  const common::ManagedPointer<exec::ExecutionContext> context) {
-    return CreateIndex(context, node->GetNamespaceOid(), node->GetIndexName(), node->GetTableOid(),
-                       *(node->GetSchema()));
-  }
-
-  static bool DropDatabaseExecutor(const common::ManagedPointer<planner::DropDatabasePlanNode> node,
-                                   const common::ManagedPointer<exec::ExecutionContext> context) {
-    TERRIER_ASSERT(context->DBOid() != node->GetDatabaseOid(),
-                   "This command cannot be executed while connected to the target database. This should be checked in "
-                   "the binder.");
-    auto *const accessor = context->GetAccessor();
-    const bool result = accessor->DropDatabase(node->GetDatabaseOid());
-    return result;
-  }
-
-  static bool DropNamespaceExecutor(const common::ManagedPointer<planner::DropNamespacePlanNode> node,
-                                    const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    const bool result = accessor->DropNamespace(node->GetNamespaceOid());
-    // TODO(Matt): CASCADE?
-    return result;
-  }
-
-  static bool DropTableExecutor(const common::ManagedPointer<planner::DropTablePlanNode> node,
-                                const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    const bool result = accessor->DropTable(node->GetTableOid());
-    // TODO(Matt): CASCADE?
-    return result;
-  }
-
-  static bool DropIndexExecutor(const common::ManagedPointer<planner::DropIndexPlanNode> node,
-                                const common::ManagedPointer<exec::ExecutionContext> context) {
-    auto *const accessor = context->GetAccessor();
-    const bool result = accessor->DropIndex(node->GetIndexOid());
-    // TODO(Matt): CASCADE?
-    return result;
-  }
+  /**
+   * @param node node to executed
+   * @param context context to use for execution
+   * @return true if operation succeeded, false otherwise
+   */
+  static bool DropIndexExecutor(common::ManagedPointer<planner::DropIndexPlanNode> node,
+                                common::ManagedPointer<exec::ExecutionContext> context);
 
  private:
-  static bool CreateIndex(const common::ManagedPointer<exec::ExecutionContext> context,
-                          const catalog::namespace_oid_t ns, const std::string &name, const catalog::table_oid_t table,
-                          const catalog::IndexSchema &input_schema) {
-    auto *const accessor = context->GetAccessor();
-    // Request permission from the Catalog to see if this a valid namespace and table name
-    const auto index_oid = accessor->CreateIndex(ns, table, name, input_schema);
-    if (index_oid == catalog::INVALID_INDEX_OID) {
-      // Catalog wasn't able to proceed, txn must now abort
-      return false;
-    }
-    // Get the canonical IndexSchema from the Catalog now that column oids have been assigned
-    const auto &schema = accessor->GetIndexSchema(index_oid);
-    // Instantiate an Index and update the pointer in the Catalog
-    storage::index::IndexBuilder index_builder;
-    index_builder.SetKeySchema(schema);
-    auto *const index = index_builder.Build();
-    bool result UNUSED_ATTRIBUTE = accessor->SetIndexPointer(index_oid, index);
-    TERRIER_ASSERT(result, "CreateIndex succeeded, SetIndexPointer must also succeed.");
-    return true;
-  }
+  static bool CreateIndex(common::ManagedPointer<exec::ExecutionContext> context, catalog::namespace_oid_t ns,
+                          const std::string &name, catalog::table_oid_t table,
+                          const catalog::IndexSchema &input_schema);
 };
-}  // namespace terrier::execution
+}  // namespace terrier::execution::sql

--- a/src/include/execution/sql/ddl_executors.h
+++ b/src/include/execution/sql/ddl_executors.h
@@ -92,7 +92,7 @@ class DDLExecutors {
                                 const common::ManagedPointer<exec::ExecutionContext> context) {
     auto *const accessor = context->GetAccessor();
     const bool result = accessor->DropTable(node->GetTableOid());
-    // TODO(Matt): drop all indexes, constraints, etc.?
+    // TODO(Matt): CASCADE?
     return result;
   }
 
@@ -100,6 +100,7 @@ class DDLExecutors {
                                 const common::ManagedPointer<exec::ExecutionContext> context) {
     auto *const accessor = context->GetAccessor();
     const bool result = accessor->DropIndex(node->GetIndexOid());
+    // TODO(Matt): CASCADE?
     return result;
   }
 
@@ -110,7 +111,6 @@ class DDLExecutors {
                    "the binder.");
     auto *const accessor = context->GetAccessor();
     const bool result = accessor->DropDatabase(node->GetDatabaseOid());
-    // TODO(Matt): drop all namespaces?
     return result;
   }
 
@@ -118,7 +118,7 @@ class DDLExecutors {
                                     const common::ManagedPointer<exec::ExecutionContext> context) {
     auto *const accessor = context->GetAccessor();
     const bool result = accessor->DropNamespace(node->GetNamespaceOid());
-    // TODO(Matt): drop all tables?
+    // TODO(Matt): CASCADE?
     return result;
   }
 

--- a/src/include/execution/sql/ddl_util.h
+++ b/src/include/execution/sql/ddl_util.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "catalog/catalog_accessor.h"
+#include "common/macros.h"
+#include "execution/exec/execution_context.h"
+#include "parser/expression/column_value_expression.h"
+#include "planner/plannodes/create_database_plan_node.h"
+#include "planner/plannodes/create_index_plan_node.h"
+#include "planner/plannodes/create_namespace_plan_node.h"
+#include "planner/plannodes/create_table_plan_node.h"
+#include "planner/plannodes/drop_database_plan_node.h"
+#include "planner/plannodes/drop_index_plan_node.h"
+#include "planner/plannodes/drop_namespace_plan_node.h"
+#include "planner/plannodes/drop_table_plan_node.h"
+#include "storage/index/index_builder.h"
+#include "storage/sql_table.h"
+
+namespace terrier::execution {
+
+class DDLUtil {
+ public:
+  DDLUtil() = delete;
+
+  static bool CreateTableExecutor(const common::ManagedPointer<planner::CreateTablePlanNode> node,
+                                  const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    // Request permission from the Catalog to see if this a valid namespace and table name
+    const auto table_oid = accessor->CreateTable(node->GetNamespaceOid(), node->GetTableName(), *(node->GetSchema()));
+    if (table_oid == catalog::INVALID_TABLE_OID) {
+      // Catalog wasn't able to proceed, txn must now abort
+      return false;
+    }
+    // Get the canonical Schema from the Catalog now that column oids have been assigned
+    const auto &schema = accessor->GetSchema(table_oid);
+    // Instantiate a SqlTable and update the pointer in the Catalog
+    auto *const table = new storage::SqlTable(node->GetBlockStore().Get(), schema);
+    bool result UNUSED_ATTRIBUTE = accessor->SetTablePointer(table_oid, table);
+    TERRIER_ASSERT(result, "CreateTable succeeded, SetTablePointer must also succeed.");
+
+    if (node->HasPrimaryKey()) {
+      // Create the IndexSchema Columns by referencing the Columns in the canonical table Schema from the Catalog
+      std::vector<catalog::IndexSchema::Column> key_cols;
+      const auto &primary_key_info = node->GetPrimaryKey();
+      key_cols.reserve(primary_key_info.primary_key_cols_.size());
+      for (const auto &parser_col : primary_key_info.primary_key_cols_) {
+        const auto &table_col = schema.GetColumn(parser_col);
+        if (table_col.Type() == type::TypeId::VARCHAR || table_col.Type() == type::TypeId::VARBINARY) {
+          key_cols.emplace_back(
+              table_col.Name(), table_col.Type(), table_col.MaxVarlenSize(), table_col.Nullable(),
+              parser::ColumnValueExpression(context->DBOid(), table_oid,
+                                            table_col.Oid()));  // TODO(Matt): is table_col.Name() right?
+
+        } else {
+          key_cols.emplace_back(
+              table_col.Name(), table_col.Type(), table_col.Nullable(),
+              parser::ColumnValueExpression(context->DBOid(), table_oid,
+                                            table_col.Oid()));  // TODO(Matt): is table_col.Name() right?
+        }
+      }
+      auto index_schema =
+          std::make_unique<catalog::IndexSchema>(key_cols, storage::index::IndexType::BWTREE, true, true, false, true);
+
+      planner::CreateIndexPlanNode::Builder builder;
+      builder.SetDatabaseOid(context->DBOid())
+          .SetNamespaceOid(node->GetNamespaceOid())
+          .SetTableOid(table_oid)
+          .SetIndexName(primary_key_info.constraint_name_)
+          .SetSchema(std::move(index_schema));
+
+      auto create_index_node = builder.Build();
+
+      return CreateIndexExecutor(common::ManagedPointer<planner::CreateIndexPlanNode>(create_index_node), context);
+    }
+
+    return true;
+  }
+
+  static bool CreateIndexExecutor(const common::ManagedPointer<planner::CreateIndexPlanNode> node,
+                                  const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    // Request permission from the Catalog to see if this a valid namespace and table name
+    const auto index_oid =
+        accessor->CreateIndex(node->GetNamespaceOid(), node->GetTableOid(), node->GetIndexName(), *(node->GetSchema()));
+    if (index_oid == catalog::INVALID_INDEX_OID) {
+      // Catalog wasn't able to proceed, txn must now abort
+      return false;
+    }
+    // Get the canonical IndexSchema from the Catalog now that column oids have been assigned
+    const auto &schema = accessor->GetIndexSchema(index_oid);
+    // Instantiate an Index and update the pointer in the Catalog
+    storage::index::IndexBuilder index_builder;
+    index_builder.SetKeySchema(schema);
+    auto *const index = index_builder.Build();
+    bool result UNUSED_ATTRIBUTE = accessor->SetIndexPointer(index_oid, index);
+    TERRIER_ASSERT(result, "CreateIndex succeeded, SetIndexPointer must also succeed.");
+    return true;
+  }
+
+  static bool CreateDatabaseExecutor(const common::ManagedPointer<planner::CreateDatabasePlanNode> node,
+                                     const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    // Request permission from the Catalog to see if this a valid database name
+    return accessor->CreateDatabase(node->GetDatabaseName()) != catalog::INVALID_DATABASE_OID;
+  }
+
+  static bool CreateNamespaceExecutor(const common::ManagedPointer<planner::CreateNamespacePlanNode> node,
+                                      const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    // Request permission from the Catalog to see if this a valid namespace name
+    return accessor->CreateNamespace(node->GetNamespaceName()) != catalog::INVALID_NAMESPACE_OID;
+  }
+
+  static bool DropTableExecutor(const common::ManagedPointer<planner::DropTablePlanNode> node,
+                                const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    const bool result = accessor->DropTable(node->GetTableOid());
+    return result;
+  }
+
+  static bool DropIndexExecutor(const common::ManagedPointer<planner::DropIndexPlanNode> node,
+                                const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    const bool result = accessor->DropIndex(node->GetIndexOid());
+    return result;
+  }
+
+  static bool DropDatabaseExecutor(const common::ManagedPointer<planner::DropDatabasePlanNode> node,
+                                   const common::ManagedPointer<exec::ExecutionContext> context) {
+    TERRIER_ASSERT(context->DBOid() != node->GetDatabaseOid(),
+                   "This command cannot be executed while connected to the target database. This should be checked in "
+                   "the binder.");
+    auto *const accessor = context->GetAccessor();
+    const bool result = accessor->DropDatabase(node->GetDatabaseOid());
+    return result;
+  }
+
+  static bool DropNamespaceExecutor(const common::ManagedPointer<planner::DropNamespacePlanNode> node,
+                                    const common::ManagedPointer<exec::ExecutionContext> context) {
+    auto *const accessor = context->GetAccessor();
+    const bool result = accessor->DropNamespace(node->GetNamespaceOid());
+    return result;
+  }
+};
+}  // namespace terrier::execution

--- a/src/include/parser/parser_defs.h
+++ b/src/include/parser/parser_defs.h
@@ -60,8 +60,9 @@ enum class IndexType {
   INVALID = INVALID_TYPE_ID,  // invalid index type
   BWTREE = 1,                 // bwtree
   HASH = 2,                   // hash
-  SKIPLIST = 3,               // skiplist
-  ART = 4,                    // ART
+  // TODO(Matt) are we ever gonna support these again? if not we should remove them
+  //  SKIPLIST = 3,               // skiplist
+  //  ART = 4,                    // ART
 };
 
 enum class InsertType {

--- a/src/include/parser/parser_defs.h
+++ b/src/include/parser/parser_defs.h
@@ -60,9 +60,6 @@ enum class IndexType {
   INVALID = INVALID_TYPE_ID,  // invalid index type
   BWTREE = 1,                 // bwtree
   HASH = 2,                   // hash
-  // TODO(Matt) are we ever gonna support these again? if not we should remove them
-  //  SKIPLIST = 3,               // skiplist
-  //  ART = 4,                    // ART
 };
 
 enum class InsertType {

--- a/src/include/planner/plannodes/create_database_plan_node.h
+++ b/src/include/planner/plannodes/create_database_plan_node.h
@@ -40,17 +40,6 @@ class CreateDatabasePlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param create_stmt the SQL CREATE statement
-     * @return builder object
-     */
-    Builder &SetFromCreateStatement(parser::CreateStatement *create_stmt) {
-      if (create_stmt->GetCreateType() == parser::CreateStatement::CreateType::kDatabase) {
-        database_name_ = std::string(create_stmt->GetDatabaseName());
-      }
-      return *this;
-    }
-
-    /**
      * Build the create database plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/create_function_plan_node.h
+++ b/src/include/planner/plannodes/create_function_plan_node.h
@@ -118,27 +118,6 @@ class CreateFunctionPlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param create_func_stmt the SQL CREATE FUNCTION statement
-     * @return builder object
-     */
-    Builder &SetFromCreateFuncStatement(parser::CreateFunctionStatement *create_func_stmt) {
-      language_ = create_func_stmt->GetPLType();
-      function_body_ = create_func_stmt->GetFuncBody();
-      is_replace_ = create_func_stmt->ShouldReplace();
-      function_name_ = create_func_stmt->GetFuncName();
-
-      for (const auto &col : create_func_stmt->GetFuncParameters()) {
-        function_param_names_.push_back(col->GetParamName());
-        param_count_++;
-        function_param_types_.push_back(col->GetDataType());
-      }
-
-      auto ret_type_obj = *(create_func_stmt->GetFuncReturnType());
-      return_type_ = ret_type_obj.GetDataType();
-      return *this;
-    }
-
-    /**
      * Build the create function plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/create_index_plan_node.h
+++ b/src/include/planner/plannodes/create_index_plan_node.h
@@ -4,7 +4,9 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "catalog/index_schema.h"
 #include "parser/create_statement.h"
+#include "parser/expression/column_value_expression.h"
 #include "planner/plannodes/abstract_plan_node.h"
 
 namespace terrier::planner {
@@ -62,55 +64,8 @@ class CreateIndexPlanNode : public AbstractPlanNode {
       return *this;
     }
 
-    /**
-     * @param unique_index true if index should be unique
-     * @return builder object
-     */
-    Builder &SetUniqueIndex(bool unique_index) {
-      unique_index_ = unique_index;
-      return *this;
-    }
-
-    /**
-     * @param index_attrs index attributes
-     * @return builder object
-     */
-    Builder &SetIndexAttrs(std::vector<std::string> &&index_attrs) {
-      index_attrs_ = std::move(index_attrs);
-      return *this;
-    }
-
-    /**
-     * @param key_attrs key attributes
-     * @return builder object
-     */
-    Builder &SetKeyAttrs(std::vector<std::string> &&key_attrs) {
-      key_attrs_ = key_attrs;
-      return *this;
-    }
-
-    /**
-     * @param create_stmt the SQL CREATE statement
-     * @return builder object
-     */
-    Builder &SetFromCreateStatement(parser::CreateStatement *create_stmt) {
-      if (create_stmt->GetCreateType() == parser::CreateStatement::CreateType::kIndex) {
-        index_name_ = std::string(create_stmt->GetIndexName());
-
-        // This holds the attribute names.
-        std::vector<std::string> index_attrs_holder;
-
-        for (auto &attr : create_stmt->GetIndexAttributes()) {
-          // TODO(WAN/WEN): Wen, all yours. Note that it either has a name or an expression, not both.
-          index_attrs_holder.push_back(attr.GetName());
-        }
-
-        index_attrs_ = index_attrs_holder;
-
-        index_type_ = create_stmt->GetIndexType();
-
-        unique_index_ = create_stmt->IsUniqueIndex();
-      }
+    Builder &SetSchema(std::unique_ptr<catalog::IndexSchema> schema) {
+      schema_ = std::move(schema);
       return *this;
     }
 
@@ -119,9 +74,9 @@ class CreateIndexPlanNode : public AbstractPlanNode {
      * @return plan node
      */
     std::unique_ptr<CreateIndexPlanNode> Build() {
-      return std::unique_ptr<CreateIndexPlanNode>(new CreateIndexPlanNode(
-          std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_, table_oid_, index_type_,
-          unique_index_, std::move(index_name_), std::move(index_attrs_), std::move(key_attrs_)));
+      return std::unique_ptr<CreateIndexPlanNode>(
+          new CreateIndexPlanNode(std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_,
+                                  table_oid_, std::move(index_name_)));
     }
 
    protected:
@@ -145,25 +100,7 @@ class CreateIndexPlanNode : public AbstractPlanNode {
      */
     std::string index_name_;
 
-    /**
-     * Index type
-     */
-    parser::IndexType index_type_ = parser::IndexType::INVALID;
-
-    /**
-     * True if the index is unique
-     */
-    bool unique_index_ = false;
-
-    /**
-     * Index attributes
-     */
-    std::vector<std::string> index_attrs_;
-
-    /**
-     * Attributes that are part of the index key
-     */
-    std::vector<std::string> key_attrs_;
+    std::unique_ptr<catalog::IndexSchema> schema_;
   };
 
  private:
@@ -177,23 +114,15 @@ class CreateIndexPlanNode : public AbstractPlanNode {
    * @param index_type type of index to create
    * @param unique_index true if index should be unique
    * @param index_name name of index to be created
-   * @param index_attrs index attributes
-   * @param key_attrs key attributes
    */
   CreateIndexPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
                       std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
-                      catalog::namespace_oid_t namespace_oid, catalog::table_oid_t table_oid,
-                      parser::IndexType index_type, bool unique_index, std::string index_name,
-                      std::vector<std::string> &&index_attrs, std::vector<std::string> &&key_attrs)
+                      catalog::namespace_oid_t namespace_oid, catalog::table_oid_t table_oid, std::string index_name)
       : AbstractPlanNode(std::move(children), std::move(output_schema)),
         database_oid_(database_oid),
         namespace_oid_(namespace_oid),
         table_oid_(table_oid),
-        index_type_(index_type),
-        unique_index_(unique_index),
-        index_name_(std::move(index_name)),
-        index_attrs_(std::move(index_attrs)),
-        key_attrs_(std::move(key_attrs)) {}
+        index_name_(std::move(index_name)) {}
 
  public:
   /**
@@ -229,24 +158,9 @@ class CreateIndexPlanNode : public AbstractPlanNode {
   const std::string &GetIndexName() const { return index_name_; }
 
   /**
-   * @return true if index should be unique
+   * @return pointer to the schema
    */
-  bool IsUniqueIndex() const { return unique_index_; }
-
-  /**
-   * @return index type
-   */
-  parser::IndexType GetIndexType() const { return index_type_; }
-
-  /**
-   * @return index attributes
-   */
-  const std::vector<std::string> &GetIndexAttributes() const { return index_attrs_; }
-
-  /**
-   * @return name of key attributes
-   */
-  const std::vector<std::string> &GetKeyAttrs() const { return key_attrs_; }
+  common::ManagedPointer<catalog::IndexSchema> GetSchema() const { return common::ManagedPointer(schema_); }
 
   /**
    * @return the hashed value of this plan node
@@ -259,45 +173,11 @@ class CreateIndexPlanNode : public AbstractPlanNode {
   std::vector<std::unique_ptr<parser::AbstractExpression>> FromJson(const nlohmann::json &j) override;
 
  private:
-  /**
-   * OID of the database
-   */
   catalog::db_oid_t database_oid_;
-
-  /**
-   * OID of namespace
-   */
   catalog::namespace_oid_t namespace_oid_;
-
-  /**
-   * OID of the table to create index on
-   */
   catalog::table_oid_t table_oid_;
-
-  /**
-   * Index type
-   */
-  parser::IndexType index_type_ = parser::IndexType::INVALID;
-
-  /**
-   * True if the index is unique
-   */
-  bool unique_index_ = false;
-
-  /**
-   * Name of the Index
-   */
   std::string index_name_;
-
-  /**
-   * Index attributes
-   */
-  std::vector<std::string> index_attrs_;
-
-  /**
-   * Attributes that are part of the index key
-   */
-  std::vector<std::string> key_attrs_;
+  std::unique_ptr<catalog::IndexSchema> schema_;
 };
 
 DEFINE_JSON_DECLARATIONS(CreateIndexPlanNode);

--- a/src/include/planner/plannodes/create_index_plan_node.h
+++ b/src/include/planner/plannodes/create_index_plan_node.h
@@ -66,12 +66,11 @@ class CreateIndexPlanNode : public AbstractPlanNode {
      */
     std::unique_ptr<CreateIndexPlanNode> Build() {
       return std::unique_ptr<CreateIndexPlanNode>(
-          new CreateIndexPlanNode(std::move(children_), std::move(output_schema_), namespace_oid_,
-                                  table_oid_, std::move(index_name_)));
+          new CreateIndexPlanNode(std::move(children_), std::move(output_schema_), namespace_oid_, table_oid_,
+                                  std::move(index_name_), std::move(schema_)));
     }
 
    protected:
-
     /**
      * OID of namespace
      */
@@ -103,12 +102,14 @@ class CreateIndexPlanNode : public AbstractPlanNode {
    * @param index_name name of index to be created
    */
   CreateIndexPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                      std::unique_ptr<OutputSchema> output_schema,
-                      catalog::namespace_oid_t namespace_oid, catalog::table_oid_t table_oid, std::string index_name)
+                      std::unique_ptr<OutputSchema> output_schema, catalog::namespace_oid_t namespace_oid,
+                      catalog::table_oid_t table_oid, std::string index_name,
+                      std::unique_ptr<catalog::IndexSchema> schema)
       : AbstractPlanNode(std::move(children), std::move(output_schema)),
         namespace_oid_(namespace_oid),
         table_oid_(table_oid),
-        index_name_(std::move(index_name)) {}
+        index_name_(std::move(index_name)),
+        schema_(std::move(schema)) {}
 
  public:
   /**

--- a/src/include/planner/plannodes/create_index_plan_node.h
+++ b/src/include/planner/plannodes/create_index_plan_node.h
@@ -29,15 +29,6 @@ class CreateIndexPlanNode : public AbstractPlanNode {
     DISALLOW_COPY_AND_MOVE(Builder);
 
     /**
-     * @param database_oid  OID of the database
-     * @return builder object
-     */
-    Builder &SetDatabaseOid(catalog::db_oid_t database_oid) {
-      database_oid_ = database_oid;
-      return *this;
-    }
-
-    /**
      * @param namespace_oid OID of the namespace
      * @return builder object
      */
@@ -75,15 +66,11 @@ class CreateIndexPlanNode : public AbstractPlanNode {
      */
     std::unique_ptr<CreateIndexPlanNode> Build() {
       return std::unique_ptr<CreateIndexPlanNode>(
-          new CreateIndexPlanNode(std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_,
+          new CreateIndexPlanNode(std::move(children_), std::move(output_schema_), namespace_oid_,
                                   table_oid_, std::move(index_name_)));
     }
 
    protected:
-    /**
-     * OID of the database
-     */
-    catalog::db_oid_t database_oid_;
 
     /**
      * OID of namespace
@@ -116,10 +103,9 @@ class CreateIndexPlanNode : public AbstractPlanNode {
    * @param index_name name of index to be created
    */
   CreateIndexPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                      std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
+                      std::unique_ptr<OutputSchema> output_schema,
                       catalog::namespace_oid_t namespace_oid, catalog::table_oid_t table_oid, std::string index_name)
       : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
         namespace_oid_(namespace_oid),
         table_oid_(table_oid),
         index_name_(std::move(index_name)) {}
@@ -136,11 +122,6 @@ class CreateIndexPlanNode : public AbstractPlanNode {
    * @return the type of this plan node
    */
   PlanNodeType GetPlanNodeType() const override { return PlanNodeType::CREATE_INDEX; }
-
-  /**
-   * @return OID of the database
-   */
-  catalog::db_oid_t GetDatabaseOid() const { return database_oid_; }
 
   /**
    * @return OID of the namespace
@@ -173,7 +154,6 @@ class CreateIndexPlanNode : public AbstractPlanNode {
   std::vector<std::unique_ptr<parser::AbstractExpression>> FromJson(const nlohmann::json &j) override;
 
  private:
-  catalog::db_oid_t database_oid_;
   catalog::namespace_oid_t namespace_oid_;
   catalog::table_oid_t table_oid_;
   std::string index_name_;

--- a/src/include/planner/plannodes/create_index_plan_node.h
+++ b/src/include/planner/plannodes/create_index_plan_node.h
@@ -55,6 +55,10 @@ class CreateIndexPlanNode : public AbstractPlanNode {
       return *this;
     }
 
+    /**
+     * @param schema table schema, node takes ownership
+     * @return builder object
+     */
     Builder &SetSchema(std::unique_ptr<catalog::IndexSchema> schema) {
       schema_ = std::move(schema);
       return *this;
@@ -86,6 +90,9 @@ class CreateIndexPlanNode : public AbstractPlanNode {
      */
     std::string index_name_;
 
+    /**
+     * table schema
+     */
     std::unique_ptr<catalog::IndexSchema> schema_;
   };
 

--- a/src/include/planner/plannodes/create_namespace_plan_node.h
+++ b/src/include/planner/plannodes/create_namespace_plan_node.h
@@ -46,17 +46,6 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param create_stmt the SQL CREATE statement
-     * @return builder object
-     */
-    Builder &SetFromCreateStatement(parser::CreateStatement *create_stmt) {
-      if (create_stmt->GetCreateType() == parser::CreateStatement::CreateType::kSchema) {
-        namespace_name_ = std::string(create_stmt->GetSchemaName());
-      }
-      return *this;
-    }
-
-    /**
      * Build the create namespace plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/create_namespace_plan_node.h
+++ b/src/include/planner/plannodes/create_namespace_plan_node.h
@@ -28,15 +28,6 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
     DISALLOW_COPY_AND_MOVE(Builder);
 
     /**
-     * @param database_oid  of the database
-     * @return builder object
-     */
-    Builder &SetDatabaseOid(catalog::db_oid_t database_oid) {
-      database_oid_ = database_oid;
-      return *this;
-    }
-
-    /**
      * @param namespace_name name of the namespace
      * @return builder object
      */
@@ -51,14 +42,10 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
      */
     std::unique_ptr<CreateNamespacePlanNode> Build() {
       return std::unique_ptr<CreateNamespacePlanNode>(new CreateNamespacePlanNode(
-          std::move(children_), std::move(output_schema_), database_oid_, std::move(namespace_name_)));
+          std::move(children_), std::move(output_schema_), std::move(namespace_name_)));
     }
 
    protected:
-    /**
-     * OID of the database
-     */
-    catalog::db_oid_t database_oid_;
 
     /**
      * Namespace name
@@ -74,7 +61,7 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
    * @param namespace_name name of the namespace
    */
   CreateNamespacePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                          std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
+                          std::unique_ptr<OutputSchema> output_schema,
                           std::string namespace_name)
       : AbstractPlanNode(std::move(children), std::move(output_schema)), namespace_name_(std::move(namespace_name)) {}
 
@@ -92,11 +79,6 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
   PlanNodeType GetPlanNodeType() const override { return PlanNodeType::CREATE_NAMESPACE; }
 
   /**
-   * @return OID of the database
-   */
-  catalog::db_oid_t GetDatabaseOid() const { return database_oid_; }
-
-  /**
    * @return name of the namespace
    */
   const std::string &GetNamespaceName() const { return namespace_name_; }
@@ -112,10 +94,6 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
   std::vector<std::unique_ptr<parser::AbstractExpression>> FromJson(const nlohmann::json &j) override;
 
  private:
-  /**
-   * OID of the database
-   */
-  catalog::db_oid_t database_oid_;
 
   /**
    * Namespace name

--- a/src/include/planner/plannodes/create_namespace_plan_node.h
+++ b/src/include/planner/plannodes/create_namespace_plan_node.h
@@ -41,12 +41,11 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
      * @return plan node
      */
     std::unique_ptr<CreateNamespacePlanNode> Build() {
-      return std::unique_ptr<CreateNamespacePlanNode>(new CreateNamespacePlanNode(
-          std::move(children_), std::move(output_schema_), std::move(namespace_name_)));
+      return std::unique_ptr<CreateNamespacePlanNode>(
+          new CreateNamespacePlanNode(std::move(children_), std::move(output_schema_), std::move(namespace_name_)));
     }
 
    protected:
-
     /**
      * Namespace name
      */
@@ -61,8 +60,7 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
    * @param namespace_name name of the namespace
    */
   CreateNamespacePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                          std::unique_ptr<OutputSchema> output_schema,
-                          std::string namespace_name)
+                          std::unique_ptr<OutputSchema> output_schema, std::string namespace_name)
       : AbstractPlanNode(std::move(children), std::move(output_schema)), namespace_name_(std::move(namespace_name)) {}
 
  public:
@@ -94,7 +92,6 @@ class CreateNamespacePlanNode : public AbstractPlanNode {
   std::vector<std::unique_ptr<parser::AbstractExpression>> FromJson(const nlohmann::json &j) override;
 
  private:
-
   /**
    * Namespace name
    */

--- a/src/include/planner/plannodes/create_table_plan_node.h
+++ b/src/include/planner/plannodes/create_table_plan_node.h
@@ -574,6 +574,9 @@ class CreateTablePlanNode : public AbstractPlanNode {
      */
     std::unique_ptr<catalog::Schema> table_schema_;
 
+    /**
+     * block store to be used when constructing this table
+     */
     common::ManagedPointer<storage::BlockStore> block_store_;
 
     /**
@@ -657,6 +660,9 @@ class CreateTablePlanNode : public AbstractPlanNode {
    */
   const std::string &GetTableName() const { return table_name_; }
 
+  /**
+   * @return block store to be used when constructing this table
+   */
   common::ManagedPointer<storage::BlockStore> GetBlockStore() const { return block_store_; }
 
   /**

--- a/src/include/planner/plannodes/create_trigger_plan_node.h
+++ b/src/include/planner/plannodes/create_trigger_plan_node.h
@@ -110,31 +110,6 @@ class CreateTriggerPlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param create_stmt the SQL CREATE statement
-     * @return builder object
-     */
-    Builder &SetFromCreateStatement(parser::CreateStatement *create_stmt) {
-      if (create_stmt->GetCreateType() == parser::CreateStatement::CreateType::kTrigger) {
-        trigger_name_ = std::string(create_stmt->GetTriggerName());
-
-        if (create_stmt->GetTriggerWhen()) {
-          trigger_when_ = create_stmt->GetTriggerWhen()->Copy();
-        } else {
-          trigger_when_ = nullptr;
-        }
-        trigger_type_ = create_stmt->GetTriggerType();
-
-        for (auto &s : create_stmt->GetTriggerFuncNames()) {
-          trigger_funcnames_.push_back(s);
-        }
-        for (auto &s : create_stmt->GetTriggerArgs()) {
-          trigger_args_.push_back(s);
-        }
-      }
-      return *this;
-    }
-
-    /**
      * Build the create trigger plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/create_view_plan_node.h
+++ b/src/include/planner/plannodes/create_view_plan_node.h
@@ -64,18 +64,6 @@ class CreateViewPlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param create_stmt the SQL CREATE statement
-     * @return builder object
-     */
-    Builder &SetFromCreateStatement(parser::CreateStatement *create_stmt) {
-      // TODO(Gus,Wen) Need to implement
-      /* if (create_stmt->GetCreateType() == parser::CreateStatement::kView) {
-
-      }*/
-      return *this;
-    }
-
-    /**
      * Build the create view plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/drop_database_plan_node.h
+++ b/src/include/planner/plannodes/drop_database_plan_node.h
@@ -45,17 +45,6 @@ class DropDatabasePlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param drop_stmt the SQL DROP statement
-     * @return builder object
-     */
-    Builder &SetFromDropStatement(parser::DropStatement *drop_stmt) {
-      if (drop_stmt->GetDropType() == parser::DropStatement::DropType::kDatabase) {
-        if_exists_ = drop_stmt->IsIfExists();
-      }
-      return *this;
-    }
-
-    /**
      * Build the drop database plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/drop_database_plan_node.h
+++ b/src/include/planner/plannodes/drop_database_plan_node.h
@@ -50,7 +50,7 @@ class DropDatabasePlanNode : public AbstractPlanNode {
      */
     std::unique_ptr<DropDatabasePlanNode> Build() {
       return std::unique_ptr<DropDatabasePlanNode>(
-          new DropDatabasePlanNode(std::move(children_), std::move(output_schema_), database_oid_, if_exists_));
+          new DropDatabasePlanNode(std::move(children_), std::move(output_schema_), database_oid_));
     }
 
    protected:
@@ -72,10 +72,8 @@ class DropDatabasePlanNode : public AbstractPlanNode {
    * @param database_oid OID of the database to drop
    */
   DropDatabasePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                       std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid, bool if_exists)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        if_exists_(if_exists) {}
+                       std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid)
+      : AbstractPlanNode(std::move(children), std::move(output_schema)), database_oid_(database_oid) {}
 
  public:
   /**
@@ -96,11 +94,6 @@ class DropDatabasePlanNode : public AbstractPlanNode {
   catalog::db_oid_t GetDatabaseOid() const { return database_oid_; }
 
   /**
-   * @return true if "IF EXISTS" was used
-   */
-  bool IsIfExists() const { return if_exists_; }
-
-  /**
    * @return the hashed value of this plan node
    */
   common::hash_t Hash() const override;
@@ -111,15 +104,7 @@ class DropDatabasePlanNode : public AbstractPlanNode {
   std::vector<std::unique_ptr<parser::AbstractExpression>> FromJson(const nlohmann::json &j) override;
 
  private:
-  /**
-   * OID of the database to drop
-   */
   catalog::db_oid_t database_oid_;
-
-  /**
-   * Whether "IF EXISTS" was used
-   */
-  bool if_exists_;
 };
 
 DEFINE_JSON_DECLARATIONS(DropDatabasePlanNode);

--- a/src/include/planner/plannodes/drop_database_plan_node.h
+++ b/src/include/planner/plannodes/drop_database_plan_node.h
@@ -36,15 +36,6 @@ class DropDatabasePlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param if_exists true if "IF EXISTS" was used
-     * @return builder object
-     */
-    Builder &SetIfExist(bool if_exists) {
-      if_exists_ = if_exists;
-      return *this;
-    }
-
-    /**
      * Build the drop database plan node
      * @return plan node
      */
@@ -58,11 +49,6 @@ class DropDatabasePlanNode : public AbstractPlanNode {
      * OID of the database to drop
      */
     catalog::db_oid_t database_oid_;
-
-    /**
-     * Whether "IF EXISTS" was used
-     */
-    bool if_exists_;
   };
 
  private:

--- a/src/include/planner/plannodes/drop_index_plan_node.h
+++ b/src/include/planner/plannodes/drop_index_plan_node.h
@@ -63,17 +63,6 @@ class DropIndexPlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param drop_stmt the SQL DROP statement
-     * @return builder object
-     */
-    Builder &SetFromDropStatement(parser::DropStatement *drop_stmt) {
-      if (drop_stmt->GetDropType() == parser::DropStatement::DropType::kDatabase) {
-        if_exists_ = drop_stmt->IsIfExists();
-      }
-      return *this;
-    }
-
-    /**
      * Build the drop index plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/drop_index_plan_node.h
+++ b/src/include/planner/plannodes/drop_index_plan_node.h
@@ -27,24 +27,6 @@ class DropIndexPlanNode : public AbstractPlanNode {
     DISALLOW_COPY_AND_MOVE(Builder);
 
     /**
-     * @param database_oid the OID of the database
-     * @return builder object
-     */
-    Builder &SetDatabaseOid(catalog::db_oid_t database_oid) {
-      database_oid_ = database_oid;
-      return *this;
-    }
-
-    /**
-     * @param namespace_oid OID of the namespace
-     * @return builder object
-     */
-    Builder &SetNamespaceOid(catalog::namespace_oid_t namespace_oid) {
-      namespace_oid_ = namespace_oid;
-      return *this;
-    }
-
-    /**
      * @param index_oid the OID of the index to drop
      * @return builder object
      */
@@ -54,43 +36,19 @@ class DropIndexPlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param if_exists true if "IF EXISTS" was used
-     * @return builder object
-     */
-    Builder &SetIfExist(bool if_exists) {
-      if_exists_ = if_exists;
-      return *this;
-    }
-
-    /**
      * Build the drop index plan node
      * @return plan node
      */
     std::unique_ptr<DropIndexPlanNode> Build() {
-      return std::unique_ptr<DropIndexPlanNode>(new DropIndexPlanNode(
-          std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_, index_oid_, if_exists_));
+      return std::unique_ptr<DropIndexPlanNode>(
+          new DropIndexPlanNode(std::move(children_), std::move(output_schema_), index_oid_));
     }
 
    protected:
     /**
-     * OID of the database
-     */
-    catalog::db_oid_t database_oid_;
-
-    /**
-     * OID of namespace
-     */
-    catalog::namespace_oid_t namespace_oid_;
-
-    /**
      * OID of the index to drop
      */
     catalog::index_oid_t index_oid_;
-
-    /**
-     * Whether "IF EXISTS" was used
-     */
-    bool if_exists_;
   };
 
  private:
@@ -102,13 +60,8 @@ class DropIndexPlanNode : public AbstractPlanNode {
    * @param index_oid OID of the index to drop
    */
   DropIndexPlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                    std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
-                    catalog::namespace_oid_t namespace_oid, catalog::index_oid_t index_oid, bool if_exists)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        namespace_oid_(namespace_oid),
-        index_oid_(index_oid),
-        if_exists_(if_exists) {}
+                    std::unique_ptr<OutputSchema> output_schema, catalog::index_oid_t index_oid)
+      : AbstractPlanNode(std::move(children), std::move(output_schema)), index_oid_(index_oid) {}
 
  public:
   /**
@@ -124,24 +77,9 @@ class DropIndexPlanNode : public AbstractPlanNode {
   PlanNodeType GetPlanNodeType() const override { return PlanNodeType::DROP_INDEX; }
 
   /**
-   * @return OID of the database
-   */
-  catalog::db_oid_t GetDatabaseOid() const { return database_oid_; }
-
-  /**
-   * @return OID of the namespace
-   */
-  catalog::namespace_oid_t GetNamespaceOid() const { return namespace_oid_; }
-
-  /**
    * @return OID of the index to drop
    */
   catalog::index_oid_t GetIndexOid() const { return index_oid_; }
-
-  /**
-   * @return true if "IF EXISTS" was used
-   */
-  bool IsIfExists() const { return if_exists_; }
 
   /**
    * @return the hashed value of this plan node
@@ -155,24 +93,9 @@ class DropIndexPlanNode : public AbstractPlanNode {
 
  private:
   /**
-   * OID of the database
-   */
-  catalog::db_oid_t database_oid_;
-
-  /**
-   * OID of namespace
-   */
-  catalog::namespace_oid_t namespace_oid_;
-
-  /**
    * OID of the index to drop
    */
   catalog::index_oid_t index_oid_;
-
-  /**
-   * Whether "IF EXISTS" was used
-   */
-  bool if_exists_;
 };
 
 DEFINE_JSON_DECLARATIONS(DropIndexPlanNode);

--- a/src/include/planner/plannodes/drop_namespace_plan_node.h
+++ b/src/include/planner/plannodes/drop_namespace_plan_node.h
@@ -27,15 +27,6 @@ class DropNamespacePlanNode : public AbstractPlanNode {
     DISALLOW_COPY_AND_MOVE(Builder);
 
     /**
-     * @param database_oid the OID of the database
-     * @return builder object
-     */
-    Builder &SetDatabaseOid(catalog::db_oid_t database_oid) {
-      database_oid_ = database_oid;
-      return *this;
-    }
-
-    /**
      * @param namespace_oid the OID of the namespace to drop
      * @return builder object
      */
@@ -45,38 +36,19 @@ class DropNamespacePlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param if_exists true if "IF EXISTS" was used
-     * @return builder object
-     */
-    Builder &SetIfExist(bool if_exists) {
-      if_exists_ = if_exists;
-      return *this;
-    }
-
-    /**
      * Build the drop namespace plan node
      * @return plan node
      */
     std::unique_ptr<DropNamespacePlanNode> Build() {
-      return std::unique_ptr<DropNamespacePlanNode>(new DropNamespacePlanNode(
-          std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_, if_exists_));
+      return std::unique_ptr<DropNamespacePlanNode>(
+          new DropNamespacePlanNode(std::move(children_), std::move(output_schema_), namespace_oid_));
     }
 
    protected:
     /**
-     * OID of the database
-     */
-    catalog::db_oid_t database_oid_;
-
-    /**
      * OID of the namespace to drop
      */
     catalog::namespace_oid_t namespace_oid_;
-
-    /**
-     * Whether "IF EXISTS" was used
-     */
-    bool if_exists_;
   };
 
  private:
@@ -87,12 +59,8 @@ class DropNamespacePlanNode : public AbstractPlanNode {
    * @param namespace_oid OID of the namespace to drop
    */
   DropNamespacePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                        std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
-                        catalog::namespace_oid_t namespace_oid, bool if_exists)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        namespace_oid_(namespace_oid),
-        if_exists_(if_exists) {}
+                        std::unique_ptr<OutputSchema> output_schema, catalog::namespace_oid_t namespace_oid)
+      : AbstractPlanNode(std::move(children), std::move(output_schema)), namespace_oid_(namespace_oid) {}
 
  public:
   /**
@@ -108,19 +76,9 @@ class DropNamespacePlanNode : public AbstractPlanNode {
   PlanNodeType GetPlanNodeType() const override { return PlanNodeType::DROP_NAMESPACE; }
 
   /**
-   * @return OID of the database
-   */
-  catalog::db_oid_t GetDatabaseOid() const { return database_oid_; }
-
-  /**
    * @return OID of the namespace to drop
    */
   catalog::namespace_oid_t GetNamespaceOid() const { return namespace_oid_; }
-
-  /**
-   * @return true if "IF EXISTS" was used
-   */
-  bool IsIfExists() const { return if_exists_; }
 
   /**
    * @return the hashed value of this plan node
@@ -134,19 +92,9 @@ class DropNamespacePlanNode : public AbstractPlanNode {
 
  private:
   /**
-   * OID of the database
-   */
-  catalog::db_oid_t database_oid_;
-
-  /**
    * OID of the namespace to drop
    */
   catalog::namespace_oid_t namespace_oid_;
-
-  /**
-   * Whether "IF EXISTS" was used
-   */
-  bool if_exists_;
 };
 
 DEFINE_JSON_DECLARATIONS(DropNamespacePlanNode);

--- a/src/include/planner/plannodes/drop_namespace_plan_node.h
+++ b/src/include/planner/plannodes/drop_namespace_plan_node.h
@@ -54,17 +54,6 @@ class DropNamespacePlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param drop_stmt the SQL DROP statement
-     * @return builder object
-     */
-    Builder &SetFromDropStatement(parser::DropStatement *drop_stmt) {
-      if (drop_stmt->GetDropType() == parser::DropStatement::DropType::kDatabase) {
-        if_exists_ = drop_stmt->IsIfExists();
-      }
-      return *this;
-    }
-
-    /**
      * Build the drop namespace plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/drop_table_plan_node.h
+++ b/src/include/planner/plannodes/drop_table_plan_node.h
@@ -27,24 +27,6 @@ class DropTablePlanNode : public AbstractPlanNode {
     DISALLOW_COPY_AND_MOVE(Builder);
 
     /**
-     * @param database_oid the OID of the database
-     * @return builder object
-     */
-    Builder &SetDatabaseOid(catalog::db_oid_t database_oid) {
-      database_oid_ = database_oid;
-      return *this;
-    }
-
-    /**
-     * @param namespace_oid OID of the namespace
-     * @return builder object
-     */
-    Builder &SetNamespaceOid(catalog::namespace_oid_t namespace_oid) {
-      namespace_oid_ = namespace_oid;
-      return *this;
-    }
-
-    /**
      * @param table_oid the OID of the table to drop
      * @return builder object
      */
@@ -54,43 +36,19 @@ class DropTablePlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param if_exists true if "IF EXISTS" was used
-     * @return builder object
-     */
-    Builder &SetIfExist(bool if_exists) {
-      if_exists_ = if_exists;
-      return *this;
-    }
-
-    /**
      * Build the drop table plan node
      * @return plan node
      */
     std::unique_ptr<DropTablePlanNode> Build() {
-      return std::unique_ptr<DropTablePlanNode>(new DropTablePlanNode(
-          std::move(children_), std::move(output_schema_), database_oid_, namespace_oid_, table_oid_, if_exists_));
+      return std::unique_ptr<DropTablePlanNode>(
+          new DropTablePlanNode(std::move(children_), std::move(output_schema_), table_oid_));
     }
 
    protected:
     /**
-     * OID of the database
-     */
-    catalog::db_oid_t database_oid_;
-
-    /**
-     * OID of namespace
-     */
-    catalog::namespace_oid_t namespace_oid_;
-
-    /**
      * OID of the table to drop
      */
     catalog::table_oid_t table_oid_;
-
-    /**
-     * Whether "IF EXISTS" was used
-     */
-    bool if_exists_;
   };
 
  private:
@@ -102,13 +60,8 @@ class DropTablePlanNode : public AbstractPlanNode {
    * @param table_oid OID of the table to drop
    */
   DropTablePlanNode(std::vector<std::unique_ptr<AbstractPlanNode>> &&children,
-                    std::unique_ptr<OutputSchema> output_schema, catalog::db_oid_t database_oid,
-                    catalog::namespace_oid_t namespace_oid, catalog::table_oid_t table_oid, bool if_exists)
-      : AbstractPlanNode(std::move(children), std::move(output_schema)),
-        database_oid_(database_oid),
-        namespace_oid_(namespace_oid),
-        table_oid_(table_oid),
-        if_exists_(if_exists) {}
+                    std::unique_ptr<OutputSchema> output_schema, catalog::table_oid_t table_oid)
+      : AbstractPlanNode(std::move(children), std::move(output_schema)), table_oid_(table_oid) {}
 
  public:
   /**
@@ -124,24 +77,9 @@ class DropTablePlanNode : public AbstractPlanNode {
   PlanNodeType GetPlanNodeType() const override { return PlanNodeType::DROP_TABLE; }
 
   /**
-   * @return OID of the database
-   */
-  catalog::db_oid_t GetDatabaseOid() const { return database_oid_; }
-
-  /**
-   * @return OID of the namespace
-   */
-  catalog::namespace_oid_t GetNamespaceOid() const { return namespace_oid_; }
-
-  /**
    * @return OID of the table to drop
    */
   catalog::table_oid_t GetTableOid() const { return table_oid_; }
-
-  /**
-   * @return true if "IF EXISTS" was used
-   */
-  bool IsIfExists() const { return if_exists_; }
 
   /**
    * @return the hashed value of this plan node
@@ -154,25 +92,7 @@ class DropTablePlanNode : public AbstractPlanNode {
   std::vector<std::unique_ptr<parser::AbstractExpression>> FromJson(const nlohmann::json &j) override;
 
  private:
-  /**
-   * OID of the database
-   */
-  catalog::db_oid_t database_oid_;
-
-  /**
-   * OID of namespace
-   */
-  catalog::namespace_oid_t namespace_oid_;
-
-  /**
-   * OID of the table to drop
-   */
   catalog::table_oid_t table_oid_;
-
-  /**
-   * Whether "IF EXISTS" was used
-   */
-  bool if_exists_;
 };
 
 DEFINE_JSON_DECLARATIONS(DropTablePlanNode);

--- a/src/include/planner/plannodes/drop_table_plan_node.h
+++ b/src/include/planner/plannodes/drop_table_plan_node.h
@@ -63,17 +63,6 @@ class DropTablePlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param drop_stmt the SQL DROP statement
-     * @return builder object
-     */
-    Builder &SetFromDropStatement(parser::DropStatement *drop_stmt) {
-      if (drop_stmt->GetDropType() == parser::DropStatement::DropType::kDatabase) {
-        if_exists_ = drop_stmt->IsIfExists();
-      }
-      return *this;
-    }
-
-    /**
      * Build the drop table plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/drop_trigger_plan_node.h
+++ b/src/include/planner/plannodes/drop_trigger_plan_node.h
@@ -63,17 +63,6 @@ class DropTriggerPlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param drop_stmt the SQL DROP statement
-     * @return builder object
-     */
-    Builder &SetFromDropStatement(parser::DropStatement *drop_stmt) {
-      if (drop_stmt->GetDropType() == parser::DropStatement::DropType::kDatabase) {
-        if_exists_ = drop_stmt->IsIfExists();
-      }
-      return *this;
-    }
-
-    /**
      * Build the drop trigger plan node
      * @return plan node
      */

--- a/src/include/planner/plannodes/drop_view_plan_node.h
+++ b/src/include/planner/plannodes/drop_view_plan_node.h
@@ -63,17 +63,6 @@ class DropViewPlanNode : public AbstractPlanNode {
     }
 
     /**
-     * @param drop_stmt the SQL DROP statement
-     * @return builder object
-     */
-    Builder &SetFromDropStatement(parser::DropStatement *drop_stmt) {
-      if (drop_stmt->GetDropType() == parser::DropStatement::DropType::kDatabase) {
-        if_exists_ = drop_stmt->IsIfExists();
-      }
-      return *this;
-    }
-
-    /**
      * Build the drop view plan node
      * @return plan node
      */

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1314,11 +1314,6 @@ std::unique_ptr<SQLStatement> PostgresParser::CreateIndexTransform(ParseResult *
     index_type = IndexType::BWTREE;
   } else if (strcmp(access_method, "hash") == 0) {
     index_type = IndexType::HASH;
-    // TODO(Matt) are we ever gonna support these again? if not we should remove them
-    //  } else if (strcmp(access_method, "skiplist") == 0) {
-    //    index_type = IndexType::SKIPLIST;
-    //  } else if (strcmp(access_method, "art") == 0) {
-    //    index_type = IndexType::ART;
   } else {
     PARSER_LOG_DEBUG("CreateIndexTransform: IndexType {} not supported", access_method);
     throw NOT_IMPLEMENTED_EXCEPTION("CreateIndexTransform error");

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1314,10 +1314,11 @@ std::unique_ptr<SQLStatement> PostgresParser::CreateIndexTransform(ParseResult *
     index_type = IndexType::BWTREE;
   } else if (strcmp(access_method, "hash") == 0) {
     index_type = IndexType::HASH;
-  } else if (strcmp(access_method, "skiplist") == 0) {
-    index_type = IndexType::SKIPLIST;
-  } else if (strcmp(access_method, "art") == 0) {
-    index_type = IndexType::ART;
+    // TODO(Matt) are we ever gonna support these again? if not we should remove them
+    //  } else if (strcmp(access_method, "skiplist") == 0) {
+    //    index_type = IndexType::SKIPLIST;
+    //  } else if (strcmp(access_method, "art") == 0) {
+    //    index_type = IndexType::ART;
   } else {
     PARSER_LOG_DEBUG("CreateIndexTransform: IndexType {} not supported", access_method);
     throw NOT_IMPLEMENTED_EXCEPTION("CreateIndexTransform error");

--- a/src/planner/plannodes/create_database_plan_node.cpp
+++ b/src/planner/plannodes/create_database_plan_node.cpp
@@ -20,8 +20,7 @@ bool CreateDatabasePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const CreateDatabasePlanNode &>(rhs);
 
-  // Database name
-  return (database_name_ == other.database_name_);
+  return database_name_ == other.database_name_;
 }
 
 nlohmann::json CreateDatabasePlanNode::ToJson() const {

--- a/src/planner/plannodes/create_index_plan_node.cpp
+++ b/src/planner/plannodes/create_index_plan_node.cpp
@@ -18,17 +18,7 @@ common::hash_t CreateIndexPlanNode::Hash() const {
   // Hash table_oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(table_oid_));
 
-  // Hash index_type
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(index_type_));
-
-  // Hash index_attrs
-  hash = common::HashUtil::CombineHashInRange(hash, index_attrs_.begin(), index_attrs_.end());
-
-  // Hash key_attrs
-  hash = common::HashUtil::CombineHashInRange(hash, key_attrs_.begin(), key_attrs_.end());
-
-  // Hash unique_index
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(unique_index_));
+  // TODO(Gus,Wen) Hash catalog::IndexSchema
 
   // Hash index_name
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(index_name_));
@@ -50,17 +40,7 @@ bool CreateIndexPlanNode::operator==(const AbstractPlanNode &rhs) const {
   // Table OID
   if (table_oid_ != other.table_oid_) return false;
 
-  // Index type
-  if (index_type_ != other.index_type_) return false;
-
-  // Index attrs
-  if (index_attrs_ != other.index_attrs_) return false;
-
-  // Key attrs
-  if (key_attrs_ != other.key_attrs_) return false;
-
-  // Unique index
-  if (unique_index_ != other.unique_index_) return false;
+  // TODO(Gus,Wen) Compare catalog::IndexSchema
 
   // Index name
   if (index_name_ != other.index_name_) return false;
@@ -73,11 +53,7 @@ nlohmann::json CreateIndexPlanNode::ToJson() const {
   j["database_oid"] = database_oid_;
   j["namespace_oid"] = namespace_oid_;
   j["table_oid"] = table_oid_;
-  j["index_type"] = index_type_;
-  j["unique_index"] = unique_index_;
   j["index_name"] = index_name_;
-  j["index_attrs"] = index_attrs_;
-  j["key_attrs"] = key_attrs_;
   return j;
 }
 
@@ -88,11 +64,7 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> CreateIndexPlanNode::Fr
   database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
   namespace_oid_ = j.at("namespace_oid").get<catalog::namespace_oid_t>();
   table_oid_ = j.at("table_oid").get<catalog::table_oid_t>();
-  index_type_ = j.at("index_type").get<parser::IndexType>();
-  unique_index_ = j.at("unique_index").get<bool>();
   index_name_ = j.at("index_name").get<std::string>();
-  index_attrs_ = j.at("index_attrs").get<std::vector<std::string>>();
-  key_attrs_ = j.at("key_attrs").get<std::vector<std::string>>();
   return exprs;
 }
 

--- a/src/planner/plannodes/create_index_plan_node.cpp
+++ b/src/planner/plannodes/create_index_plan_node.cpp
@@ -9,9 +9,6 @@ namespace terrier::planner {
 common::hash_t CreateIndexPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Hash database_oid
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
-
   // Hash namespace oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(namespace_oid_));
 
@@ -31,9 +28,6 @@ bool CreateIndexPlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const CreateIndexPlanNode &>(rhs);
 
-  // Database OID
-  if (database_oid_ != other.database_oid_) return false;
-
   // Namespace OID
   if (namespace_oid_ != other.namespace_oid_) return false;
 
@@ -50,7 +44,6 @@ bool CreateIndexPlanNode::operator==(const AbstractPlanNode &rhs) const {
 
 nlohmann::json CreateIndexPlanNode::ToJson() const {
   nlohmann::json j = AbstractPlanNode::ToJson();
-  j["database_oid"] = database_oid_;
   j["namespace_oid"] = namespace_oid_;
   j["table_oid"] = table_oid_;
   j["index_name"] = index_name_;
@@ -61,7 +54,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> CreateIndexPlanNode::Fr
   std::vector<std::unique_ptr<parser::AbstractExpression>> exprs;
   auto e1 = AbstractPlanNode::FromJson(j);
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
-  database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
   namespace_oid_ = j.at("namespace_oid").get<catalog::namespace_oid_t>();
   table_oid_ = j.at("table_oid").get<catalog::table_oid_t>();
   index_name_ = j.at("index_name").get<std::string>();

--- a/src/planner/plannodes/create_namespace_plan_node.cpp
+++ b/src/planner/plannodes/create_namespace_plan_node.cpp
@@ -10,9 +10,6 @@ namespace terrier::planner {
 common::hash_t CreateNamespacePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Hash database_oid
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
-
   // Hash namespace_name
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(namespace_name_));
 
@@ -24,9 +21,6 @@ bool CreateNamespacePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const CreateNamespacePlanNode &>(rhs);
 
-  // Database OID
-  if (database_oid_ != other.database_oid_) return false;
-
   // Schema name
   if (GetNamespaceName() != other.GetNamespaceName()) return false;
 
@@ -35,7 +29,6 @@ bool CreateNamespacePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
 nlohmann::json CreateNamespacePlanNode::ToJson() const {
   nlohmann::json j = AbstractPlanNode::ToJson();
-  j["database_oid"] = database_oid_;
   j["namespace_name"] = namespace_name_;
   return j;
 }
@@ -44,7 +37,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> CreateNamespacePlanNode
   std::vector<std::unique_ptr<parser::AbstractExpression>> exprs;
   auto e1 = AbstractPlanNode::FromJson(j);
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
-  database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
   namespace_name_ = j.at("namespace_name").get<std::string>();
   return exprs;
 }

--- a/src/planner/plannodes/create_namespace_plan_node.cpp
+++ b/src/planner/plannodes/create_namespace_plan_node.cpp
@@ -22,9 +22,7 @@ bool CreateNamespacePlanNode::operator==(const AbstractPlanNode &rhs) const {
   auto &other = dynamic_cast<const CreateNamespacePlanNode &>(rhs);
 
   // Schema name
-  if (GetNamespaceName() != other.GetNamespaceName()) return false;
-
-  return true;
+  return namespace_name_ == other.namespace_name_;
 }
 
 nlohmann::json CreateNamespacePlanNode::ToJson() const {

--- a/src/planner/plannodes/create_table_plan_node.cpp
+++ b/src/planner/plannodes/create_table_plan_node.cpp
@@ -3,7 +3,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include "parser/parser_defs.h"
 
 namespace terrier::planner {
 

--- a/src/planner/plannodes/create_table_plan_node.cpp
+++ b/src/planner/plannodes/create_table_plan_node.cpp
@@ -9,9 +9,6 @@ namespace terrier::planner {
 common::hash_t CreateTablePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Database OID
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
-
   // Namespace OI
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(namespace_oid_));
 
@@ -51,9 +48,6 @@ bool CreateTablePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const CreateTablePlanNode &>(rhs);
 
-  // Database OID
-  if (database_oid_ != other.database_oid_) return false;
-
   // Namespace OID
   if (namespace_oid_ != other.namespace_oid_) return false;
 
@@ -82,7 +76,6 @@ bool CreateTablePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
 nlohmann::json CreateTablePlanNode::ToJson() const {
   nlohmann::json j = AbstractPlanNode::ToJson();
-  j["database_oid"] = database_oid_;
   j["namespace_oid"] = namespace_oid_;
   j["table_name"] = table_name_;
   j["table_schema"] = table_schema_->ToJson();
@@ -102,7 +95,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> CreateTablePlanNode::Fr
   std::vector<std::unique_ptr<parser::AbstractExpression>> exprs;
   auto e1 = AbstractPlanNode::FromJson(j);
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
-  database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
   namespace_oid_ = j.at("namespace_oid").get<catalog::namespace_oid_t>();
   table_name_ = j.at("table_name").get<std::string>();
 

--- a/src/planner/plannodes/drop_database_plan_node.cpp
+++ b/src/planner/plannodes/drop_database_plan_node.cpp
@@ -11,6 +11,7 @@ common::hash_t DropDatabasePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
 
   return hash;
 }
@@ -20,7 +21,7 @@ bool DropDatabasePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const DropDatabasePlanNode &>(rhs);
 
-  return database_oid_ != other.database_oid_;
+  return database_oid_ == other.database_oid_;
 }
 
 nlohmann::json DropDatabasePlanNode::ToJson() const {

--- a/src/planner/plannodes/drop_database_plan_node.cpp
+++ b/src/planner/plannodes/drop_database_plan_node.cpp
@@ -10,7 +10,6 @@ namespace terrier::planner {
 common::hash_t DropDatabasePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Database Oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
 
   return hash;
@@ -21,10 +20,7 @@ bool DropDatabasePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const DropDatabasePlanNode &>(rhs);
 
-  // Database OID
-  if (database_oid_ != other.database_oid_) return false;
-
-  return true;
+  return database_oid_ != other.database_oid_;
 }
 
 nlohmann::json DropDatabasePlanNode::ToJson() const {

--- a/src/planner/plannodes/drop_database_plan_node.cpp
+++ b/src/planner/plannodes/drop_database_plan_node.cpp
@@ -13,9 +13,6 @@ common::hash_t DropDatabasePlanNode::Hash() const {
   // Database Oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
 
-  // If Exists
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(if_exists_));
-
   return hash;
 }
 
@@ -27,16 +24,12 @@ bool DropDatabasePlanNode::operator==(const AbstractPlanNode &rhs) const {
   // Database OID
   if (database_oid_ != other.database_oid_) return false;
 
-  // If exists
-  if (if_exists_ != other.if_exists_) return false;
-
   return true;
 }
 
 nlohmann::json DropDatabasePlanNode::ToJson() const {
   nlohmann::json j = AbstractPlanNode::ToJson();
   j["database_oid"] = database_oid_;
-  j["if_exists"] = if_exists_;
   return j;
 }
 
@@ -45,7 +38,6 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> DropDatabasePlanNode::F
   auto e1 = AbstractPlanNode::FromJson(j);
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
   database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
-  if_exists_ = j.at("if_exists").get<bool>();
   return exprs;
 }
 

--- a/src/planner/plannodes/drop_index_plan_node.cpp
+++ b/src/planner/plannodes/drop_index_plan_node.cpp
@@ -20,7 +20,7 @@ bool DropIndexPlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const DropIndexPlanNode &>(rhs);
 
-  return index_oid_ != other.index_oid_;
+  return index_oid_ == other.index_oid_;
 }
 
 nlohmann::json DropIndexPlanNode::ToJson() const {

--- a/src/planner/plannodes/drop_index_plan_node.cpp
+++ b/src/planner/plannodes/drop_index_plan_node.cpp
@@ -10,7 +10,6 @@ namespace terrier::planner {
 common::hash_t DropIndexPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Hash index_oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(index_oid_));
 
   return hash;
@@ -21,10 +20,7 @@ bool DropIndexPlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const DropIndexPlanNode &>(rhs);
 
-  // Index OID
-  if (index_oid_ != other.index_oid_) return false;
-
-  return true;
+  return index_oid_ != other.index_oid_;
 }
 
 nlohmann::json DropIndexPlanNode::ToJson() const {

--- a/src/planner/plannodes/drop_index_plan_node.cpp
+++ b/src/planner/plannodes/drop_index_plan_node.cpp
@@ -10,17 +10,8 @@ namespace terrier::planner {
 common::hash_t DropIndexPlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Hash databse_oid
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
-
-  // Hash namespace oid
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(namespace_oid_));
-
   // Hash index_oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(index_oid_));
-
-  // Hash if_exists_
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(if_exists_));
 
   return hash;
 }
@@ -30,27 +21,15 @@ bool DropIndexPlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const DropIndexPlanNode &>(rhs);
 
-  // Database OID
-  if (database_oid_ != other.database_oid_) return false;
-
-  // Namespace OID
-  if (namespace_oid_ != other.namespace_oid_) return false;
-
   // Index OID
   if (index_oid_ != other.index_oid_) return false;
-
-  // If exists
-  if (if_exists_ != other.if_exists_) return false;
 
   return true;
 }
 
 nlohmann::json DropIndexPlanNode::ToJson() const {
   nlohmann::json j = AbstractPlanNode::ToJson();
-  j["database_oid"] = database_oid_;
-  j["namespace_oid"] = namespace_oid_;
   j["index_oid"] = index_oid_;
-  j["if_exists"] = if_exists_;
   return j;
 }
 
@@ -58,10 +37,7 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> DropIndexPlanNode::From
   std::vector<std::unique_ptr<parser::AbstractExpression>> exprs;
   auto e1 = AbstractPlanNode::FromJson(j);
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
-  database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
-  namespace_oid_ = j.at("namespace_oid").get<catalog::namespace_oid_t>();
   index_oid_ = j.at("index_oid").get<catalog::index_oid_t>();
-  if_exists_ = j.at("if_exists").get<bool>();
   return exprs;
 }
 

--- a/src/planner/plannodes/drop_namespace_plan_node.cpp
+++ b/src/planner/plannodes/drop_namespace_plan_node.cpp
@@ -10,7 +10,6 @@ namespace terrier::planner {
 common::hash_t DropNamespacePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Hash namespace_oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(namespace_oid_));
 
   return hash;
@@ -21,10 +20,7 @@ bool DropNamespacePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const DropNamespacePlanNode &>(rhs);
 
-  // Namespace OID
-  if (namespace_oid_ != other.namespace_oid_) return false;
-
-  return true;
+  return namespace_oid_ == other.namespace_oid_;
 }
 
 nlohmann::json DropNamespacePlanNode::ToJson() const {

--- a/src/planner/plannodes/drop_namespace_plan_node.cpp
+++ b/src/planner/plannodes/drop_namespace_plan_node.cpp
@@ -10,14 +10,8 @@ namespace terrier::planner {
 common::hash_t DropNamespacePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Hash databse_oid
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
-
   // Hash namespace_oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(namespace_oid_));
-
-  // Hash if_exists_
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(if_exists_));
 
   return hash;
 }
@@ -27,23 +21,15 @@ bool DropNamespacePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const DropNamespacePlanNode &>(rhs);
 
-  // Database OID
-  if (database_oid_ != other.database_oid_) return false;
-
   // Namespace OID
   if (namespace_oid_ != other.namespace_oid_) return false;
-
-  // If exists
-  if (if_exists_ != other.if_exists_) return false;
 
   return true;
 }
 
 nlohmann::json DropNamespacePlanNode::ToJson() const {
   nlohmann::json j = AbstractPlanNode::ToJson();
-  j["database_oid"] = database_oid_;
   j["namespace_oid"] = namespace_oid_;
-  j["if_exists"] = if_exists_;
   return j;
 }
 
@@ -51,9 +37,7 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> DropNamespacePlanNode::
   std::vector<std::unique_ptr<parser::AbstractExpression>> exprs;
   auto e1 = AbstractPlanNode::FromJson(j);
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
-  database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
   namespace_oid_ = j.at("namespace_oid").get<catalog::namespace_oid_t>();
-  if_exists_ = j.at("if_exists").get<bool>();
   return exprs;
 }
 

--- a/src/planner/plannodes/drop_table_plan_node.cpp
+++ b/src/planner/plannodes/drop_table_plan_node.cpp
@@ -10,17 +10,8 @@ namespace terrier::planner {
 common::hash_t DropTablePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Hash database_oid
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
-
-  // Hash namespace oid
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(namespace_oid_));
-
   // Hash table_oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(table_oid_));
-
-  // Hash if_exists_
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(if_exists_));
 
   return hash;
 }
@@ -30,27 +21,15 @@ bool DropTablePlanNode::operator==(const AbstractPlanNode &rhs) const {
 
   auto &other = dynamic_cast<const DropTablePlanNode &>(rhs);
 
-  // Database OID
-  if (database_oid_ != other.database_oid_) return false;
-
-  // Namespace OID
-  if (namespace_oid_ != other.namespace_oid_) return false;
-
   // Table OID
   if (table_oid_ != other.table_oid_) return false;
-
-  // If exists
-  if (IsIfExists() != other.IsIfExists()) return false;
 
   return true;
 }
 
 nlohmann::json DropTablePlanNode::ToJson() const {
   nlohmann::json j = AbstractPlanNode::ToJson();
-  j["database_oid"] = database_oid_;
-  j["namespace_oid"] = namespace_oid_;
   j["table_oid"] = table_oid_;
-  j["if_exists"] = if_exists_;
   return j;
 }
 
@@ -58,10 +37,7 @@ std::vector<std::unique_ptr<parser::AbstractExpression>> DropTablePlanNode::From
   std::vector<std::unique_ptr<parser::AbstractExpression>> exprs;
   auto e1 = AbstractPlanNode::FromJson(j);
   exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
-  database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
-  namespace_oid_ = j.at("namespace_oid").get<catalog::namespace_oid_t>();
   table_oid_ = j.at("table_oid").get<catalog::table_oid_t>();
-  if_exists_ = j.at("if_exists").get<bool>();
   return exprs;
 }
 

--- a/src/planner/plannodes/drop_table_plan_node.cpp
+++ b/src/planner/plannodes/drop_table_plan_node.cpp
@@ -10,7 +10,6 @@ namespace terrier::planner {
 common::hash_t DropTablePlanNode::Hash() const {
   common::hash_t hash = AbstractPlanNode::Hash();
 
-  // Hash table_oid
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(table_oid_));
 
   return hash;
@@ -22,9 +21,7 @@ bool DropTablePlanNode::operator==(const AbstractPlanNode &rhs) const {
   auto &other = dynamic_cast<const DropTablePlanNode &>(rhs);
 
   // Table OID
-  if (table_oid_ != other.table_oid_) return false;
-
-  return true;
+  return table_oid_ == other.table_oid_;
 }
 
 nlohmann::json DropTablePlanNode::ToJson() const {

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -170,7 +170,8 @@ TEST_F(CatalogTests, NamespaceTest) {
 
   txn = txn_manager_->BeginTransaction();
   accessor = catalog_->GetAccessor(txn, db_);
-  EXPECT_FALSE(accessor->DropNamespace(ns_oid));
+  ns_oid = accessor->GetNamespaceOid("test_namespace");
+  EXPECT_EQ(ns_oid, catalog::INVALID_NAMESPACE_OID);
   txn_manager_->Abort(txn);
 }
 

--- a/test/execution/ddl_executors_test.cpp
+++ b/test/execution/ddl_executors_test.cpp
@@ -2,34 +2,213 @@
 #include <memory>
 #include <vector>
 
-#include "execution/sql_test.h"
-
+#include "catalog/catalog.h"
+#include "catalog/catalog_accessor.h"
 #include "catalog/catalog_defs.h"
+#include "execution/exec/execution_context.h"
 #include "execution/sql/ddl_executors.h"
+#include "planner/plannodes/create_database_plan_node.h"
+#include "planner/plannodes/create_index_plan_node.h"
+#include "planner/plannodes/create_namespace_plan_node.h"
+#include "planner/plannodes/create_table_plan_node.h"
+#include "planner/plannodes/drop_database_plan_node.h"
+#include "planner/plannodes/drop_index_plan_node.h"
+#include "planner/plannodes/drop_namespace_plan_node.h"
+#include "planner/plannodes/drop_table_plan_node.h"
+#include "test_util/catalog_test_util.h"
+#include "test_util/test_harness.h"
+#include "transaction/transaction_manager.h"
+#include "transaction/transaction_util.h"
 
 namespace terrier::execution::sql::test {
 
-class DDLUtilTests : public SqlBasedTest {
-  void SetUp() override {
-    // Create the test tables
-    SqlBasedTest::SetUp();
-    exec_ctx_ = MakeExecCtx();
-    GenerateTestTables(exec_ctx_.get());
-  }
-
+class DDLExecutorsTests : public TerrierTest {
  public:
-  parser::ConstantValueExpression DummyExpr() {
-    return parser::ConstantValueExpression(type::TransientValueFactory::GetInteger(0));
+  void SetUp() override {
+    TerrierTest::SetUp();
+
+    // Initialize the transaction manager and GC
+    timestamp_manager_ = std::make_unique<transaction::TimestampManager>();
+    deferred_action_manager_ = std::make_unique<transaction::DeferredActionManager>(timestamp_manager_.get());
+    txn_manager_ = std::make_unique<transaction::TransactionManager>(
+        timestamp_manager_.get(), deferred_action_manager_.get(), &buffer_pool_, true, DISABLED);
+    gc_ = std::make_unique<storage::GarbageCollector>(timestamp_manager_.get(), deferred_action_manager_.get(),
+                                                      txn_manager_.get(), nullptr);
+
+    // Build out the catalog and commit so that it is visible to other transactions
+    catalog_ = std::make_unique<catalog::Catalog>(txn_manager_.get(), &block_store_);
+
+    auto *txn = txn_manager_->BeginTransaction();
+    db_ = catalog_->CreateDatabase(txn, "terrier", true);
+    EXPECT_NE(db_, catalog::INVALID_DATABASE_OID);
+    txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+
+    // Run the GC to flush it down to a clean system
+    gc_->PerformGarbageCollection();
+    gc_->PerformGarbageCollection();
+
+    auto col = catalog::Schema::Column(
+        "attribute", type::TypeId::INTEGER, false,
+        parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::INTEGER)));
+    StorageTestUtil::ForceOid(&(col), catalog::col_oid_t(1));
+    table_schema_ = std::make_unique<catalog::Schema>(std::vector<catalog::Schema::Column>{col});
+
+    std::vector<catalog::IndexSchema::Column> keycols;
+    keycols.emplace_back("", type::TypeId::INTEGER, false,
+                         parser::ColumnValueExpression(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID,
+                                                       catalog::col_oid_t(1)));
+    StorageTestUtil::ForceOid(&(keycols[0]), catalog::indexkeycol_oid_t(1));
+    unique_schema_ =
+        std::make_unique<catalog::IndexSchema>(keycols, storage::index::IndexType::BWTREE, true, true, false, true);
+    default_schema_ =
+        std::make_unique<catalog::IndexSchema>(keycols, storage::index::IndexType::BWTREE, false, false, false, true);
   }
 
- protected:
-  /**
-   * Execution context to use for the test
-   */
-  std::unique_ptr<exec::ExecutionContext> exec_ctx_;
+  void TearDown() override {
+    catalog_->TearDown();
+    // Run the GC to clean up transactions
+    gc_->PerformGarbageCollection();
+    gc_->PerformGarbageCollection();
+    gc_->PerformGarbageCollection();
+
+    TerrierTest::TearDown();
+  }
+
+  std::unique_ptr<catalog::Catalog> catalog_;
+  storage::RecordBufferSegmentPool buffer_pool_{100, 100};
+  storage::BlockStore block_store_{100, 100};
+  std::unique_ptr<storage::GarbageCollector> gc_;
+  std::unique_ptr<transaction::TransactionManager> txn_manager_;
+  std::unique_ptr<transaction::DeferredActionManager> deferred_action_manager_;
+  std::unique_ptr<transaction::TimestampManager> timestamp_manager_;
+
+  catalog::db_oid_t db_;
+
+  std::unique_ptr<catalog::Schema> table_schema_;
+  std::unique_ptr<catalog::IndexSchema> unique_schema_;
+  std::unique_ptr<catalog::IndexSchema> default_schema_;
+
+  auto CreateExecutionContext() const {
+    auto *txn = txn_manager_->BeginTransaction();
+    auto accessor = catalog_->GetAccessor(txn, db_);
+    return std::make_unique<execution::exec::ExecutionContext>(db_, txn, nullptr, nullptr, std::move(accessor));
+  }
 };
 
 // NOLINTNEXTLINE
-TEST_F(DDLUtilTests, BasicTest) {}
+TEST_F(DDLExecutorsTests, CreateTablePlanNode) {
+  planner::CreateTablePlanNode::Builder builder;
+  auto create_table_node = builder.SetNamespaceOid(CatalogTestUtil::TEST_NAMESPACE_OID)
+                               .SetTableSchema(std::move(table_schema_))
+                               .SetTableName("foo")
+                               .SetBlockStore(common::ManagedPointer<storage::BlockStore>(&block_store_))
+                               .Build();
+  auto exec_ctx = CreateExecutionContext();
+  auto accessor = exec_ctx->GetAccessor();
+  EXPECT_TRUE(execution::DDLExecutors::CreateTableExecutor(
+      common::ManagedPointer<planner::CreateTablePlanNode>(create_table_node),
+      common::ManagedPointer<exec::ExecutionContext>(exec_ctx)));
+  auto table_oid = accessor->GetTableOid(CatalogTestUtil::TEST_NAMESPACE_OID, "foo");
+  EXPECT_NE(table_oid, catalog::INVALID_TABLE_OID);
+  auto table_ptr = accessor->GetTable(table_oid);
+  EXPECT_NE(table_ptr, nullptr);
+  txn_manager_->Commit(exec_ctx->GetTxn(), transaction::TransactionUtil::EmptyCallback, nullptr);
+}
+
+// NOLINTNEXTLINE
+TEST_F(DDLExecutorsTests, CreateTablePlanNodeAbort) {
+  planner::CreateTablePlanNode::Builder builder;
+  auto create_table_node = builder.SetNamespaceOid(CatalogTestUtil::TEST_NAMESPACE_OID)
+                               .SetTableSchema(std::move(table_schema_))
+                               .SetTableName("foo")
+                               .SetBlockStore(common::ManagedPointer<storage::BlockStore>(&block_store_))
+                               .Build();
+  auto exec_ctx = CreateExecutionContext();
+  auto accessor = exec_ctx->GetAccessor();
+  EXPECT_TRUE(execution::DDLExecutors::CreateTableExecutor(
+      common::ManagedPointer<planner::CreateTablePlanNode>(create_table_node),
+      common::ManagedPointer<exec::ExecutionContext>(exec_ctx)));
+  auto table_oid = accessor->GetTableOid(CatalogTestUtil::TEST_NAMESPACE_OID, "foo");
+  EXPECT_NE(table_oid, catalog::INVALID_TABLE_OID);
+  auto table_ptr = accessor->GetTable(table_oid);
+  EXPECT_NE(table_ptr, nullptr);
+  txn_manager_->Abort(exec_ctx->GetTxn());
+}
+
+// NOLINTNEXTLINE
+TEST_F(DDLExecutorsTests, CreateTablePlanNodeNameConflict) {
+  planner::CreateTablePlanNode::Builder builder;
+  auto create_table_node = builder.SetNamespaceOid(CatalogTestUtil::TEST_NAMESPACE_OID)
+                               .SetTableSchema(std::move(table_schema_))
+                               .SetTableName("foo")
+                               .SetBlockStore(common::ManagedPointer<storage::BlockStore>(&block_store_))
+                               .Build();
+  auto exec_ctx = CreateExecutionContext();
+  auto accessor = exec_ctx->GetAccessor();
+  EXPECT_TRUE(execution::DDLExecutors::CreateTableExecutor(
+      common::ManagedPointer<planner::CreateTablePlanNode>(create_table_node),
+      common::ManagedPointer<exec::ExecutionContext>(exec_ctx)));
+  auto table_oid = accessor->GetTableOid(CatalogTestUtil::TEST_NAMESPACE_OID, "foo");
+  EXPECT_NE(table_oid, catalog::INVALID_TABLE_OID);
+  auto table_ptr = accessor->GetTable(table_oid);
+  EXPECT_NE(table_ptr, nullptr);
+  EXPECT_FALSE(execution::DDLExecutors::CreateTableExecutor(
+      common::ManagedPointer<planner::CreateTablePlanNode>(create_table_node),
+      common::ManagedPointer<exec::ExecutionContext>(exec_ctx)));
+  txn_manager_->Abort(exec_ctx->GetTxn());
+}
+
+// NOLINTNEXTLINE
+TEST_F(DDLExecutorsTests, CreateTablePlanNodeWriteWriteConflict) {
+  planner::CreateTablePlanNode::Builder builder;
+  auto create_table_node = builder.SetNamespaceOid(CatalogTestUtil::TEST_NAMESPACE_OID)
+                               .SetTableSchema(std::move(table_schema_))
+                               .SetTableName("foo")
+                               .SetBlockStore(common::ManagedPointer<storage::BlockStore>(&block_store_))
+                               .Build();
+  auto exec_ctx = CreateExecutionContext();
+  auto accessor = exec_ctx->GetAccessor();
+  EXPECT_TRUE(execution::DDLExecutors::CreateTableExecutor(
+      common::ManagedPointer<planner::CreateTablePlanNode>(create_table_node),
+      common::ManagedPointer<exec::ExecutionContext>(exec_ctx)));
+  auto table_oid = accessor->GetTableOid(CatalogTestUtil::TEST_NAMESPACE_OID, "foo");
+  EXPECT_NE(table_oid, catalog::INVALID_TABLE_OID);
+  auto table_ptr = accessor->GetTable(table_oid);
+  EXPECT_NE(table_ptr, nullptr);
+
+  auto other_ctx = CreateExecutionContext();
+  EXPECT_FALSE(execution::DDLExecutors::CreateTableExecutor(
+      common::ManagedPointer<planner::CreateTablePlanNode>(create_table_node),
+      common::ManagedPointer<exec::ExecutionContext>(other_ctx)));
+  txn_manager_->Commit(exec_ctx->GetTxn(), transaction::TransactionUtil::EmptyCallback, nullptr);
+  txn_manager_->Abort(other_ctx->GetTxn());
+}
+
+// NOLINTNEXTLINE
+TEST_F(DDLExecutorsTests, DropTablePlanNode) {
+  planner::CreateTablePlanNode::Builder create_builder;
+  auto create_table_node = create_builder.SetNamespaceOid(CatalogTestUtil::TEST_NAMESPACE_OID)
+                               .SetTableSchema(std::move(table_schema_))
+                               .SetTableName("foo")
+                               .SetBlockStore(common::ManagedPointer<storage::BlockStore>(&block_store_))
+                               .Build();
+  auto exec_ctx = CreateExecutionContext();
+  auto accessor = exec_ctx->GetAccessor();
+  EXPECT_TRUE(execution::DDLExecutors::CreateTableExecutor(
+      common::ManagedPointer<planner::CreateTablePlanNode>(create_table_node),
+      common::ManagedPointer<exec::ExecutionContext>(exec_ctx)));
+  auto table_oid = accessor->GetTableOid(CatalogTestUtil::TEST_NAMESPACE_OID, "foo");
+  EXPECT_NE(table_oid, catalog::INVALID_TABLE_OID);
+  auto table_ptr = accessor->GetTable(table_oid);
+  EXPECT_NE(table_ptr, nullptr);
+
+  planner::DropTablePlanNode::Builder drop_builder;
+  auto drop_table_node = drop_builder.SetTableOid(table_oid).Build();
+  EXPECT_TRUE(
+      execution::DDLExecutors::DropTableExecutor(common::ManagedPointer<planner::DropTablePlanNode>(drop_table_node),
+                                                 common::ManagedPointer<exec::ExecutionContext>(exec_ctx)));
+
+  txn_manager_->Commit(exec_ctx->GetTxn(), transaction::TransactionUtil::EmptyCallback, nullptr);
+}
 
 }  // namespace terrier::execution::sql::test

--- a/test/execution/ddl_executors_test.cpp
+++ b/test/execution/ddl_executors_test.cpp
@@ -5,7 +5,7 @@
 #include "execution/sql_test.h"
 
 #include "catalog/catalog_defs.h"
-#include "execution/sql/ddl_util.h"
+#include "execution/sql/ddl_executors.h"
 
 namespace terrier::execution::sql::test {
 

--- a/test/execution/ddl_util_test.cpp
+++ b/test/execution/ddl_util_test.cpp
@@ -1,0 +1,35 @@
+#include <array>
+#include <memory>
+#include <vector>
+
+#include "execution/sql_test.h"
+
+#include "catalog/catalog_defs.h"
+#include "execution/sql/ddl_util.h"
+
+namespace terrier::execution::sql::test {
+
+class DDLUtilTests : public SqlBasedTest {
+  void SetUp() override {
+    // Create the test tables
+    SqlBasedTest::SetUp();
+    exec_ctx_ = MakeExecCtx();
+    GenerateTestTables(exec_ctx_.get());
+  }
+
+ public:
+  parser::ConstantValueExpression DummyExpr() {
+    return parser::ConstantValueExpression(type::TransientValueFactory::GetInteger(0));
+  }
+
+ protected:
+  /**
+   * Execution context to use for the test
+   */
+  std::unique_ptr<exec::ExecutionContext> exec_ctx_;
+};
+
+// NOLINTNEXTLINE
+TEST_F(DDLUtilTests, BasicTest) {}
+
+}  // namespace terrier::execution::sql::test

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -1276,13 +1276,13 @@ TEST_F(ParserTestBase, OldCreateIndexTest) {
   EXPECT_EQ(create_stmt->GetIndexAttributes()[0].GetName(), "o_w_id");
   EXPECT_EQ(create_stmt->GetIndexAttributes()[1].GetName(), "o_d_id");
 
-  query = "CREATE INDEX ii ON t USING SKIPLIST (col);";
+  query = "CREATE INDEX ii ON t USING HASH (col);";
   result = pgparser_.BuildParseTree(query);
   create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   // Check attributes
   EXPECT_EQ(create_stmt->GetCreateType(), CreateStatement::kIndex);
-  EXPECT_EQ(create_stmt->GetIndexType(), IndexType::SKIPLIST);
+  EXPECT_EQ(create_stmt->GetIndexType(), IndexType::HASH);
   EXPECT_EQ(create_stmt->GetIndexName(), "ii");
   EXPECT_EQ(create_stmt->GetTableName(), "t");
 

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -516,11 +516,7 @@ TEST(PlanNodeJsonTest, DropDatabasePlanNodeTest) {
 TEST(PlanNodeJsonTest, DropIndexPlanNodeTest) {
   // Construct DropIndexPlanNode
   DropIndexPlanNode::Builder builder;
-  auto plan_node = builder.SetDatabaseOid(catalog::db_oid_t(7))
-                       .SetNamespaceOid(catalog::namespace_oid_t(0))
-                       .SetIndexOid(catalog::index_oid_t(8))
-                       .SetIfExist(true)
-                       .Build();
+  auto plan_node = builder.SetIndexOid(catalog::index_oid_t(8)).Build();
 
   // Serialize to Json
   auto json = plan_node->ToJson();
@@ -539,10 +535,7 @@ TEST(PlanNodeJsonTest, DropIndexPlanNodeTest) {
 TEST(PlanNodeJsonTest, DropNamespacePlanNodeTest) {
   // Construct DropNamespacePlanNode
   DropNamespacePlanNode::Builder builder;
-  auto plan_node = builder.SetDatabaseOid(catalog::db_oid_t(8))
-                       .SetNamespaceOid(catalog::namespace_oid_t(9))
-                       .SetIfExist(true)
-                       .Build();
+  auto plan_node = builder.SetNamespaceOid(catalog::namespace_oid_t(9)).Build();
 
   // Serialize to Json
   auto json = plan_node->ToJson();
@@ -561,11 +554,7 @@ TEST(PlanNodeJsonTest, DropNamespacePlanNodeTest) {
 TEST(PlanNodeJsonTest, DropTablePlanNodeTest) {
   // Construct DropTablePlanNode
   DropTablePlanNode::Builder builder;
-  auto plan_node = builder.SetDatabaseOid(catalog::db_oid_t(9))
-                       .SetNamespaceOid(catalog::namespace_oid_t(0))
-                       .SetTableOid(catalog::table_oid_t(10))
-                       .SetIfExist(true)
-                       .Build();
+  auto plan_node = builder.SetTableOid(catalog::table_oid_t(10)).Build();
 
   // Serialize to Json
   auto json = plan_node->ToJson();

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -220,7 +220,7 @@ TEST(PlanNodeJsonTest, CreateFunctionPlanNodeTest) {
 TEST(PlanNodeJsonTest, CreateIndexPlanNodeTest) {
   // Construct CreateIndexPlanNode
   CreateIndexPlanNode::Builder builder;
-  auto plan_node = builder.SetDatabaseOid(catalog::db_oid_t(1))
+  auto plan_node = builder
                        .SetNamespaceOid(catalog::namespace_oid_t(0))
                        .SetTableOid(catalog::table_oid_t(2))
                        .SetIndexName("test_index")
@@ -243,7 +243,7 @@ TEST(PlanNodeJsonTest, CreateIndexPlanNodeTest) {
 TEST(PlanNodeJsonTest, CreateNamespacePlanNodeTest) {
   // Construct CreateNamespacePlanNode
   CreateNamespacePlanNode::Builder builder;
-  auto plan_node = builder.SetDatabaseOid(catalog::db_oid_t(2)).SetNamespaceName("test_namespace").Build();
+  auto plan_node = builder.SetNamespaceName("test_namespace").Build();
 
   // Serialize to Json
   auto json = plan_node->ToJson();
@@ -316,7 +316,7 @@ TEST(PlanNodeJsonTest, CreateTablePlanNodeTest) {
 
   // Construct CreateTablePlanNode (1 with PK and 1 without PK)
   CreateTablePlanNode::Builder builder;
-  auto pk_plan_node = builder.SetDatabaseOid(catalog::db_oid_t(1))
+  auto pk_plan_node = builder
                           .SetNamespaceOid(catalog::namespace_oid_t(2))
                           .SetTableName("test_tbl")
                           .SetTableSchema(get_schema())
@@ -327,7 +327,7 @@ TEST(PlanNodeJsonTest, CreateTablePlanNodeTest) {
                           .SetCheckConstraints(get_check_info())
                           .Build();
 
-  auto no_pk_plan_node = builder.SetDatabaseOid(catalog::db_oid_t(1))
+  auto no_pk_plan_node = builder
                              .SetNamespaceOid(catalog::namespace_oid_t(2))
                              .SetTableName("test_tbl")
                              .SetTableSchema(get_schema())

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -220,8 +220,7 @@ TEST(PlanNodeJsonTest, CreateFunctionPlanNodeTest) {
 TEST(PlanNodeJsonTest, CreateIndexPlanNodeTest) {
   // Construct CreateIndexPlanNode
   CreateIndexPlanNode::Builder builder;
-  auto plan_node = builder
-                       .SetNamespaceOid(catalog::namespace_oid_t(0))
+  auto plan_node = builder.SetNamespaceOid(catalog::namespace_oid_t(0))
                        .SetTableOid(catalog::table_oid_t(2))
                        .SetIndexName("test_index")
                        .Build();
@@ -316,8 +315,7 @@ TEST(PlanNodeJsonTest, CreateTablePlanNodeTest) {
 
   // Construct CreateTablePlanNode (1 with PK and 1 without PK)
   CreateTablePlanNode::Builder builder;
-  auto pk_plan_node = builder
-                          .SetNamespaceOid(catalog::namespace_oid_t(2))
+  auto pk_plan_node = builder.SetNamespaceOid(catalog::namespace_oid_t(2))
                           .SetTableName("test_tbl")
                           .SetTableSchema(get_schema())
                           .SetHasPrimaryKey(true)
@@ -327,8 +325,7 @@ TEST(PlanNodeJsonTest, CreateTablePlanNodeTest) {
                           .SetCheckConstraints(get_check_info())
                           .Build();
 
-  auto no_pk_plan_node = builder
-                             .SetNamespaceOid(catalog::namespace_oid_t(2))
+  auto no_pk_plan_node = builder.SetNamespaceOid(catalog::namespace_oid_t(2))
                              .SetTableName("test_tbl")
                              .SetTableSchema(get_schema())
                              .SetHasPrimaryKey(false)

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -484,7 +484,7 @@ TEST(PlanNodeJsonTest, DeletePlanNodeTest) {
 TEST(PlanNodeJsonTest, DropDatabasePlanNodeTest) {
   // Construct DropDatabasePlanNode
   DropDatabasePlanNode::Builder builder;
-  auto plan_node = builder.SetDatabaseOid(catalog::db_oid_t(7)).SetIfExist(true).Build();
+  auto plan_node = builder.SetDatabaseOid(catalog::db_oid_t(7)).Build();
 
   // Serialize to Json
   auto json = plan_node->ToJson();
@@ -500,7 +500,7 @@ TEST(PlanNodeJsonTest, DropDatabasePlanNodeTest) {
 
   // Sanity check to make sure that it actually fails if the plan nodes are truly different
   DropDatabasePlanNode::Builder builder2;
-  auto plan_node2 = builder2.SetDatabaseOid(catalog::db_oid_t(9999)).SetIfExist(true).Build();
+  auto plan_node2 = builder2.SetDatabaseOid(catalog::db_oid_t(9999)).Build();
   auto json2 = plan_node2->ToJson();
   auto deserialized2 = DeserializePlanNode(json2);
   auto deserialized_plan2 = common::ManagedPointer(deserialized2.result_).CastManagedPointerTo<DropDatabasePlanNode>();

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -224,9 +224,6 @@ TEST(PlanNodeJsonTest, CreateIndexPlanNodeTest) {
                        .SetNamespaceOid(catalog::namespace_oid_t(0))
                        .SetTableOid(catalog::table_oid_t(2))
                        .SetIndexName("test_index")
-                       .SetUniqueIndex(true)
-                       .SetIndexAttrs({"a", "foo"})
-                       .SetKeyAttrs({"a", "bar"})
                        .Build();
 
   // Serialize to Json

--- a/test/planner/plan_node_test.cpp
+++ b/test/planner/plan_node_test.cpp
@@ -97,56 +97,6 @@ TEST(PlanNodeTest, AnalyzePlanTest) {
   }
 }
 
-// NOLINTNEXTLINE
-TEST(PlanNodeTest, CreateDatabasePlanTest) {
-  parser::PostgresParser pgparser;
-  auto result = pgparser.BuildParseTree("CREATE DATABASE test");
-  EXPECT_EQ(1, result.GetStatements().size());
-  auto *create_stmt = static_cast<parser::CreateStatement *>(result.TakeStatementsOwnership()[0].release());
-
-  CreateDatabasePlanNode::Builder builder;
-  auto plan = builder.SetFromCreateStatement(create_stmt).Build();
-
-  EXPECT_TRUE(plan != nullptr);
-  EXPECT_STREQ("test", plan->GetDatabaseName().c_str());
-  EXPECT_EQ(PlanNodeType::CREATE_DATABASE, plan->GetPlanNodeType());
-  delete create_stmt;
-}
-
-// NOLINTNEXTLINE
-TEST(PlanNodeTest, DropDatabasePlanTest) {
-  parser::PostgresParser pgparser;
-  auto result = pgparser.BuildParseTree("DROP DATABASE test");
-  EXPECT_EQ(1, result.GetStatements().size());
-  auto *drop_stmt = static_cast<parser::DropStatement *>(result.TakeStatementsOwnership()[0].release());
-
-  DropDatabasePlanNode::Builder builder;
-  auto plan = builder.SetDatabaseOid(catalog::db_oid_t(0)).SetFromDropStatement(drop_stmt).Build();
-
-  EXPECT_TRUE(plan != nullptr);
-  EXPECT_EQ(catalog::db_oid_t(0), plan->GetDatabaseOid());
-  EXPECT_FALSE(plan->IsIfExists());
-  EXPECT_EQ(PlanNodeType::DROP_DATABASE, plan->GetPlanNodeType());
-  delete drop_stmt;
-}
-
-// NOLINTNEXTLINE
-TEST(PlanNodeTest, DropDatabasePlanIfExistsTest) {
-  parser::PostgresParser pgparser;
-  auto result = pgparser.BuildParseTree("DROP DATABASE IF EXISTS test");
-  EXPECT_EQ(1, result.GetStatements().size());
-  auto *drop_stmt = static_cast<parser::DropStatement *>(result.TakeStatementsOwnership()[0].release());
-
-  DropDatabasePlanNode::Builder builder;
-  auto plan = builder.SetDatabaseOid(catalog::db_oid_t(0)).SetFromDropStatement(drop_stmt).Build();
-
-  EXPECT_TRUE(plan != nullptr);
-  EXPECT_EQ(catalog::db_oid_t(0), plan->GetDatabaseOid());
-  EXPECT_TRUE(plan->IsIfExists());
-  EXPECT_EQ(PlanNodeType::DROP_DATABASE, plan->GetPlanNodeType());
-  delete drop_stmt;
-}
-
 // Test creation of simple two table join.
 // We construct the plan for the following query: SELECT table1.col1 FROM table1, table2 WHERE table1.col1 =
 // table2.col2; NOLINTNEXTLINE

--- a/test/storage/recovery_test.cpp
+++ b/test/storage/recovery_test.cpp
@@ -359,7 +359,6 @@ TEST_F(RecoveryTests, DropTableTest) {
 
   // Assert the table we deleted doesn't exist
   EXPECT_EQ(catalog::INVALID_TABLE_OID, db_catalog->GetTableOid(txn, namespace_oid, table_name));
-  EXPECT_FALSE(db_catalog->GetTable(txn, table_oid));
   recovery_txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 }
 
@@ -402,7 +401,6 @@ TEST_F(RecoveryTests, DropIndexTest) {
 
   // Assert the index we deleted doesn't exist
   EXPECT_EQ(0, db_catalog->GetIndexOids(txn, table_oid).size());
-  EXPECT_FALSE(db_catalog->GetIndex(txn, index_oid));
   recovery_txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 }
 
@@ -662,7 +660,6 @@ TEST_F(RecoveryTests, ConcurrentDDLChangesTest) {
 
   // Assert the table we deleted doesn't exist
   EXPECT_EQ(catalog::INVALID_TABLE_OID, db_catalog->GetTableOid(txn, namespace_oid, table_name));
-  EXPECT_FALSE(db_catalog->GetTable(txn, table_oid));
   recovery_txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 }
 


### PR DESCRIPTION
Overview of changes:

- There's a static util class in `execution/sql` that can take in `CREATE` or `DROP` plan nodes along with an `ExecutionContext` and perform the operation. Is this the API we want? Names are undecided and easy to change. I'm not happy with them right now.
- I gutted any fields that weren't required to execute these plan nodes. Note: I did not remove fields that we would eventually want to support (i.e. constraints for CREATE TABLE).  I only removed fields that legitimately seemed redundant.
- Removed `SetFromCreateStatement` and `SetFromDropStatement` methods on plan node Builders. These were used for a few contrived tests, but represent a special case code path that will not be used in the real system. All plan nodes will be generated by going through the parser, binder, and optimizer.
- Removed references to skiplist and ART indexes from `PostgresParser`. I'm not a fan of dead code coming over from Peloton.
- Typing up #635 pretty much convinced me that `IF EXISTS` should not be in physical plan nodes so I removed that field, but that issue exists to discuss it.