### PR TITLE
Update openssl Homebrew package to 1.1 for macOS

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -73,7 +73,7 @@ install_mac() {
   brew ls --versions libevent || brew install libevent
   brew ls --versions libpqxx || brew install libpqxx
   (brew ls --versions llvm@8 | grep 8) || brew install llvm@8
-  brew ls --versions openssl || brew install openssl
+  brew ls --versions openssl@1.1 || brew install openssl@1.1
   brew ls --versions postgresql || brew install postgresql
   brew ls --versions tbb || brew install tbb
   brew ls --versions ant || brew install ant


### PR DESCRIPTION
Not convinced this dependency is even used right now, but this should fix macOS builds breaking in CI after https://github.com/Homebrew/homebrew-core/pull/46876