### PR TITLE
DDL lock in DatabaseCatalog

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -64,8 +64,6 @@ install_mac() {
   fi
   # Update Homebrew.
   brew update
-  brew upgrade
-  brew cleanup
   # Install packages.
   brew ls --versions cmake || brew install cmake
   brew ls --versions coreutils || brew install coreutils

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -64,6 +64,8 @@ install_mac() {
   fi
   # Update Homebrew.
   brew update
+  brew upgrade
+  brew cleanup
   # Install packages.
   brew ls --versions cmake || brew install cmake
   brew ls --versions coreutils || brew install coreutils

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1786,14 +1786,14 @@ Column DatabaseCatalog::MakeColumn(storage::ProjectedRow *const pr, const storag
 
 bool DatabaseCatalog::TryLock(transaction::TransactionContext *const txn) {
   auto current_val = write_lock_.load();
-  if (current_val == txn->StartTime()) return true;  // already hold the lock
+  if (current_val == txn->FinishTime()) return true;  // already hold the lock
 
   if (transaction::TransactionUtil::NewerThan(txn->StartTime(), current_val) &&
-      write_lock_.compare_exchange_strong(current_val, txn->StartTime())) {
+      write_lock_.compare_exchange_strong(current_val, txn->FinishTime())) {
     auto *const write_lock = &write_lock_;
     auto release = [=]() -> void {
-      auto txn_start = txn->StartTime();
-      const auto result = write_lock->compare_exchange_strong(txn_start, txn->FinishTime());
+      auto txn_finish = txn->StartTime();
+      const auto result = write_lock->compare_exchange_strong(txn_finish, txn->StartTime());
       TERRIER_ASSERT(result, "Failed to release the lock.");
     };
     txn->RegisterCommitAction(release);

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -349,6 +349,16 @@ class DatabaseCatalog {
   friend class postgres::Builder;
   friend class storage::RecoveryManager;
 
+  /**
+   * Internal function to DatabaseCatalog to disallow concurrent DDL changes. This also disallows older txns to enact
+   * DDL chances after a newer transaction has committed one. This effectively follows the same timestamp ordering logic
+   * as the version pointer MVCC stuff in the storage layer.
+   * @param txn Requesting txn. This is used to inspect the timestamp and register commit/abort events to release the
+   * lock if it is acquired.
+   * @return true if lock was acquired, false otherwise
+   * @warning this requires that commit and abort actions be performed after the commit time is stored in the
+   * TransactionContext's FinishTime.
+   */
   bool TryLock(transaction::TransactionContext *txn);
 
   /**

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -335,10 +335,11 @@ class DatabaseCatalog {
   storage::index::Index *constraints_foreigntable_index_;
 
   std::atomic<uint32_t> next_oid_;
+  std::atomic<transaction::timestamp_t> write_lock_;
 
   const db_oid_t db_oid_;
 
-  explicit DatabaseCatalog(db_oid_t oid) : db_oid_(oid) {}
+  explicit DatabaseCatalog(db_oid_t oid) : write_lock_(transaction::INITIAL_TXN_TIMESTAMP), db_oid_(oid) {}
 
   void TearDown(transaction::TransactionContext *txn);
   bool CreateTableEntry(transaction::TransactionContext *txn, table_oid_t table_oid, namespace_oid_t ns_oid,
@@ -347,6 +348,8 @@ class DatabaseCatalog {
   friend class Catalog;
   friend class postgres::Builder;
   friend class storage::RecoveryManager;
+
+  bool TryLock(transaction::TransactionContext *txn);
 
   /**
    * Atomically updates the next oid counter to the max of the current count and the provided next oid

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -351,12 +351,12 @@ class DatabaseCatalog {
 
   /**
    * Internal function to DatabaseCatalog to disallow concurrent DDL changes. This also disallows older txns to enact
-   * DDL chances after a newer transaction has committed one. This effectively follows the same timestamp ordering logic
-   * as the version pointer MVCC stuff in the storage layer.
+   * DDL changes after a newer transaction has committed one. This effectively follows the same timestamp ordering logic
+   * as the version pointer MVCC stuff in the storage layer. It also serializes all DDL within a database.
    * @param txn Requesting txn. This is used to inspect the timestamp and register commit/abort events to release the
    * lock if it is acquired.
    * @return true if lock was acquired, false otherwise
-   * @warning this requires that commit and abort actions be performed after the commit time is stored in the
+   * @warning this requires that commit actions be performed after the commit time is stored in the
    * TransactionContext's FinishTime.
    */
   bool TryLock(transaction::TransactionContext *txn);

--- a/src/include/storage/recovery/recovery_manager.h
+++ b/src/include/storage/recovery/recovery_manager.h
@@ -207,6 +207,8 @@ class RecoveryManager : public common::DedicatedThreadOwner {
                                                                       catalog::db_oid_t db_oid) {
     auto db_catalog_ptr = catalog_->GetDatabaseCatalog(txn, db_oid);
     TERRIER_ASSERT(db_catalog_ptr != nullptr, "No catalog for given database oid");
+    auto result UNUSED_ATTRIBUTE = db_catalog_ptr->TryLock(txn);
+    TERRIER_ASSERT(result, "There should not be concurrent DDL changes during recovery.");
     return db_catalog_ptr;
   }
 

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -30,7 +30,6 @@ void TransactionManager::LogCommit(TransactionContext *const txn, const timestam
                                    const callback_fn commit_callback, void *const commit_callback_arg,
                                    const timestamp_t oldest_active_txn) {
   txn->finish_time_.store(commit_time);
-
   if (log_manager_ != DISABLED) {
     // At this point the commit has already happened for the rest of the system.
     // Here we will manually add a commit record and flush the buffer to ensure the logger

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -29,7 +29,6 @@ TransactionContext *TransactionManager::BeginTransaction() {
 void TransactionManager::LogCommit(TransactionContext *const txn, const timestamp_t commit_time,
                                    const callback_fn commit_callback, void *const commit_callback_arg,
                                    const timestamp_t oldest_active_txn) {
-  txn->finish_time_.store(commit_time);
   if (log_manager_ != DISABLED) {
     // At this point the commit has already happened for the rest of the system.
     // Here we will manually add a commit record and flush the buffer to ensure the logger
@@ -83,6 +82,9 @@ timestamp_t TransactionManager::Commit(TransactionContext *const txn, transactio
         "This txn was marked that it must abort. Set a breakpoint at TransactionContext::MustAbort() to see a "
         "stack trace for when this flag is getting tripped.");
     result = txn->IsReadOnly() ? timestamp_manager_->CheckOutTimestamp() : UpdatingCommitCriticalSection(txn);
+
+    txn->finish_time_.store(result);
+
     while (!txn->commit_actions_.empty()) {
       TERRIER_ASSERT(deferred_action_manager_ != DISABLED, "No deferred action manager exists to process actions");
       txn->commit_actions_.front()(deferred_action_manager_);
@@ -142,13 +144,6 @@ void TransactionManager::LogAbort(TransactionContext *const txn) {
 }
 
 timestamp_t TransactionManager::Abort(TransactionContext *const txn) {
-  // Immediately clear the abort actions stack
-  while (!txn->abort_actions_.empty()) {
-    TERRIER_ASSERT(deferred_action_manager_ != DISABLED, "No deferred action manager exists to process actions");
-    txn->abort_actions_.front()(deferred_action_manager_);
-    txn->abort_actions_.pop_front();
-  }
-
   // We need to beware not to rollback a version chain multiple times, as that is just wasted computation
   std::unordered_set<storage::TupleSlot> slots_rolled_back;
   for (auto &record : txn->undo_buffer_) {
@@ -172,6 +167,13 @@ timestamp_t TransactionManager::Abort(TransactionContext *const txn) {
   // The last update might not have been installed, and thus Rollback would miss it if it contains a
   // varlen entry whose memory content needs to be freed. We have to check for this case manually.
   GCLastUpdateOnAbort(txn);
+
+  // Immediately clear the abort actions stack
+  while (!txn->abort_actions_.empty()) {
+    TERRIER_ASSERT(deferred_action_manager_ != DISABLED, "No deferred action manager exists to process actions");
+    txn->abort_actions_.front()(deferred_action_manager_);
+    txn->abort_actions_.pop_front();
+  }
 
   LogAbort(txn);
 

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -507,71 +507,67 @@ TEST_F(CatalogTests, GetIndexObjectsTest) {
  */
 // NOLINTNEXTLINE
 TEST_F(CatalogTests, DDLLockTest) {
-  // txn2 is used to verify that older txns can't acquire the lock
-  auto *txn2 = txn_manager_->BeginTransaction();
-  // txn5 is used to verify that older txns can't acquire the lock
-  auto *txn5 = txn_manager_->BeginTransaction();
-
-  // txn0 is used to verify conflict scenarios and that commits release the lock
+  // txn0 is used to verify that older concurrent txns can't acquire lock
   auto *txn0 = txn_manager_->BeginTransaction();
-  // txn6 is used to verify that newer txns (than holding txn, older than lock acquisition) can't acquire the lock
-  auto *txn6 = txn_manager_->BeginTransaction();
-
   auto accessor0 = catalog_->GetAccessor(txn0, db_);
-  EXPECT_NE(accessor0, nullptr);
-  auto ns_oid = accessor0->CreateNamespace("test_namespace0");  // Should succeed as txn0 acquires the lock
-  EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);
-  VerifyCatalogTables(*accessor0);  // Check visibility to me
-
-  ns_oid = accessor0->CreateNamespace("test_namespace4");  // Should work since txn0 already holds lock
-  EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);
-  VerifyCatalogTables(*accessor0);  // Check visibility to me
-
-  // txn1 is used to verify that concurrent txns cannot acquire lock, even if a newer timestamp
+  // txn1 is used to verify that older concurrent txns can't acquire the lock
   auto *txn1 = txn_manager_->BeginTransaction();
   auto accessor1 = catalog_->GetAccessor(txn1, db_);
-  ns_oid = accessor1->CreateNamespace("test_namespace1");
-  EXPECT_EQ(ns_oid, catalog::INVALID_NAMESPACE_OID);  // Should fail to get the lock because txn0 holds it (txn1 > txn0)
-  txn_manager_->Abort(txn1);
 
+  // txn2 is used to verify that commit releases the lock
+  auto *txn2 = txn_manager_->BeginTransaction();
   auto accessor2 = catalog_->GetAccessor(txn2, db_);
-  ns_oid = accessor2->CreateNamespace("test_namespace2");
-  EXPECT_EQ(ns_oid, catalog::INVALID_NAMESPACE_OID);  // Should fail to get the lock because txn0 holds it (txn2 < txn0)
-  txn_manager_->Abort(txn2);
-
-  txn_manager_->Commit(txn0, transaction::TransactionUtil::EmptyCallback, nullptr);  // txn0 releases the lock
-
-  auto accessor5 = catalog_->GetAccessor(txn5, db_);
-  ns_oid = accessor5->CreateNamespace("test_namespace5");
-  EXPECT_EQ(ns_oid,
-            catalog::INVALID_NAMESPACE_OID);  // Should fail to get the lock because txn0 committed (txn5 < txn0)
-  txn_manager_->Abort(txn5);
-
-  auto accessor6 = catalog_->GetAccessor(txn6, db_);
-  ns_oid = accessor6->CreateNamespace("test_namespace6");
-  EXPECT_EQ(ns_oid,
-            catalog::INVALID_NAMESPACE_OID);  // Should fail to get the lock because txn0 committed ( < )
-  txn_manager_->Abort(txn6);
-
-  // txn4 is used to verify that older txns can acquire the lock after an abort
-  auto *txn4 = txn_manager_->BeginTransaction();
-
-  // txn3 is used to verify that aborts release the lock
+  // txn3 is used to verify that newer txns (than holder)
   auto *txn3 = txn_manager_->BeginTransaction();
   auto accessor3 = catalog_->GetAccessor(txn3, db_);
-  ns_oid = accessor3->CreateNamespace("test_namespace3");
-  EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);  // Should succeed as txn3 acquires the lock
-  txn_manager_->Abort(txn3);                          // txn3 releases the lock
 
+  auto ns_oid = accessor2->CreateNamespace("txn2_ns");  // succeeds, txn2 acquires lock
+  EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);
+
+  ns_oid = accessor2->CreateNamespace("txn2_ns2");  // succeeds, txn2 already holds lock
+  EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);
+
+  // txn4 is used to verify that newer concurrent transactions can't acquire lock
+  auto *txn4 = txn_manager_->BeginTransaction();
   auto accessor4 = catalog_->GetAccessor(txn4, db_);
-  EXPECT_NE(accessor4, nullptr);
-  VerifyCatalogTables(*accessor4);  // Check visibility to me
-  ns_oid = accessor4->GetNamespaceOid(
-      "test_namespace0");  // Should succeed as txn4 acquires the lock (txn4 < txn3) but txn3 aborted
-  EXPECT_TRUE(accessor4->DropNamespace(ns_oid));
-  ns_oid = accessor4->GetNamespaceOid("test_namespace0");
+  ns_oid = accessor4->CreateNamespace("txn4_ns");
+  EXPECT_EQ(ns_oid,
+            catalog::INVALID_NAMESPACE_OID);  // fails, txn2 holds lock (txn4 > txn2)
+  txn_manager_->Abort(txn4);
+
+  ns_oid = accessor0->CreateNamespace("txn0_ns");
+  EXPECT_EQ(ns_oid,
+            catalog::INVALID_NAMESPACE_OID);  // fails, txn2 holds lock (txn0 < txn2)
+  txn_manager_->Abort(txn0);
+
+  txn_manager_->Commit(txn2, transaction::TransactionUtil::EmptyCallback, nullptr);  // txn2 releases the lock
+
+  ns_oid = accessor1->CreateNamespace("txn1_ns");
+  EXPECT_EQ(ns_oid,
+            catalog::INVALID_NAMESPACE_OID);  // fails, txn2 committed changes (txn1 < txn2)
+  txn_manager_->Abort(txn1);
+
+  ns_oid = accessor3->CreateNamespace("txn3_ns");
+  EXPECT_EQ(ns_oid,
+            catalog::INVALID_NAMESPACE_OID);  // fails, txn2 committed changes (txn3 > txn2, but txn3 < txn2 commit)
+  txn_manager_->Abort(txn3);
+
+  // txn5 is used to verify that older concurrent transactions can acquire lock after abort
+  auto *txn5 = txn_manager_->BeginTransaction();
+  auto accessor5 = catalog_->GetAccessor(txn5, db_);
+
+  // txn6 is used to verify that abort releases the lock
+  auto *txn6 = txn_manager_->BeginTransaction();
+  auto accessor6 = catalog_->GetAccessor(txn6, db_);
+  ns_oid = accessor6->CreateNamespace("txn6_ns");
+  EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);  // succeeds, txn6 acquires lock
+  txn_manager_->Abort(txn6);                          // txn6 releases the lock
+
+  ns_oid = accessor5->GetNamespaceOid("txn2_ns");  // succeeds, txn5 acquires lock (txn5 < txn6)
+  EXPECT_TRUE(accessor5->DropNamespace(ns_oid));
+  ns_oid = accessor5->GetNamespaceOid("txn2_ns");
   EXPECT_EQ(ns_oid, catalog::INVALID_NAMESPACE_OID);
-  txn_manager_->Commit(txn4, transaction::TransactionUtil::EmptyCallback, nullptr);  // txn4 releases the lock
+  txn_manager_->Commit(txn5, transaction::TransactionUtil::EmptyCallback, nullptr);  // txn5 releases the lock
 }
 
 }  // namespace terrier

--- a/test/test_util/tpcc/builder.cpp
+++ b/test/test_util/tpcc/builder.cpp
@@ -51,11 +51,7 @@ Database *Builder::Build(const storage::index::IndexType index_type) {
   TERRIER_ASSERT(order_table_oid != catalog::INVALID_TABLE_OID, "Failed to create table.");
   TERRIER_ASSERT(order_line_table_oid != catalog::INVALID_TABLE_OID, "Failed to create table.");
 
-  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-
   // get the schemas from the catalog
-  txn = txn_manager_->BeginTransaction();
-  accessor = catalog_->GetAccessor(txn, db_oid);
 
   item_schema = accessor->GetSchema(item_table_oid);
   warehouse_schema = accessor->GetSchema(warehouse_table_oid);
@@ -67,11 +63,7 @@ Database *Builder::Build(const storage::index::IndexType index_type) {
   order_schema = accessor->GetSchema(order_table_oid);
   order_line_schema = accessor->GetSchema(order_line_table_oid);
 
-  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-
   // instantiate and set the table pointers in the catalog
-  txn = txn_manager_->BeginTransaction();
-  accessor = catalog_->GetAccessor(txn, db_oid);
 
   auto result UNUSED_ATTRIBUTE = accessor->SetTablePointer(item_table_oid, new storage::SqlTable(store_, item_schema));
   TERRIER_ASSERT(result, "Failed to set table pointer.");
@@ -217,11 +209,7 @@ Database *Builder::Build(const storage::index::IndexType index_type) {
   TERRIER_ASSERT(item_primary_index_oid != catalog::INVALID_INDEX_OID, "Failed to create index.");
   TERRIER_ASSERT(stock_primary_index_oid != catalog::INVALID_INDEX_OID, "Failed to create index.");
 
-  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-
   // get the schemas from the catalog
-  txn = txn_manager_->BeginTransaction();
-  accessor = catalog_->GetAccessor(txn, db_oid);
 
   warehouse_primary_index_schema = accessor->GetIndexSchema(warehouse_primary_index_oid);
   district_primary_index_schema = accessor->GetIndexSchema(district_primary_index_oid);
@@ -234,11 +222,7 @@ Database *Builder::Build(const storage::index::IndexType index_type) {
   item_primary_index_schema = accessor->GetIndexSchema(item_primary_index_oid);
   stock_primary_index_schema = accessor->GetIndexSchema(stock_primary_index_oid);
 
-  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
-
   // instantiate and set the index pointers in the catalog
-  txn = txn_manager_->BeginTransaction();
-  accessor = catalog_->GetAccessor(txn, db_oid);
 
   result = accessor->SetIndexPointer(warehouse_primary_index_oid, BuildIndex(warehouse_primary_index_schema));
   TERRIER_ASSERT(result, "Failed to set index pointer.");


### PR DESCRIPTION
This is a quick way to avoid write skew anomalies in the catalog when we have concurrent DDL changes that won't trigger write-write conflicts in the storage layer. Any transactions attempting to perform DDL changes must first acquire the database-level lock.

Long term this could be handled with more robust solutions like precision locking (see HyPer paper) but this will save us for now. In the meantime, any DDL change implementations added to the catalog should make sure to honor these semantics and acquire the lock first.

This will allow me to implement DROP SCHEMA (namespace) without worrying about another transaction adding objects to that namespace at the same time.