### PR TITLE
 More GCC 8+ fixes

### DIFF
--- a/benchmark/storage/tuple_access_strategy_benchmark.cpp
+++ b/benchmark/storage/tuple_access_strategy_benchmark.cpp
@@ -61,7 +61,8 @@ BENCHMARK_DEFINE_F(TupleAccessStrategyBenchmark, SimpleInsert)(benchmark::State 
       // Get a Block, zero it, and initialize
       storage::RawBlock *raw_block = block_store_.Get();
       raw_blocks_.emplace_back(raw_block);
-      std::memset(raw_block, 0, sizeof(storage::RawBlock));
+      // Recast raw_block as a -Wclass-memaccess workaround
+      std::memset(static_cast<void *>(raw_block), 0, sizeof(storage::RawBlock));
       tested.InitializeRawBlock(nullptr, raw_block, storage::layout_version_t(0));
       for (uint32_t j = 0; j < layout_.NumSlots(); j++) {
         storage::TupleSlot slot;

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -546,7 +546,7 @@ std::vector<Column> DatabaseCatalog::GetColumns(transaction::TransactionContext 
   // Finish
   delete[] buffer;
   delete[] key_buffer;
-  return std::move(cols);
+  return cols;
 }
 
 // TODO(Matt): we need a DeleteColumn()

--- a/src/execution/vm/bytecode_emitter.cpp
+++ b/src/execution/vm/bytecode_emitter.cpp
@@ -75,7 +75,7 @@ void BytecodeEmitter::Bind(BytecodeLabel *label) {
     auto &jump_locations = label->ReferrerOffsets();
 
     for (const auto &jump_location : jump_locations) {
-      TERRIER_ASSERT((curr_offset - jump_location) < std::numeric_limits<int32_t>::max(),
+      TERRIER_ASSERT((curr_offset - jump_location) < static_cast<size_t>(std::numeric_limits<int32_t>::max()),
                      "Jump delta exceeds 32-bit value for jump offsets!");
 
       auto delta = static_cast<int32_t>(curr_offset - jump_location);
@@ -101,7 +101,8 @@ void BytecodeEmitter::EmitJump(BytecodeLabel *label) {
     TERRIER_ASSERT(label->Offset() <= curr_offset,
                    "Label for backwards jump cannot be beyond current bytecode position");
     std::size_t delta = curr_offset - label->Offset();
-    TERRIER_ASSERT(delta < std::numeric_limits<int32_t>::max(), "Jump delta exceeds 32-bit value for jump offsets!");
+    TERRIER_ASSERT(delta < static_cast<size_t>(std::numeric_limits<int32_t>::max()),
+            "Jump delta exceeds 32-bit value for jump offsets!");
 
     // Immediately emit the delta
     EmitScalarValue(-static_cast<int32_t>(delta));

--- a/src/include/execution/sql/concise_hash_table.h
+++ b/src/include/execution/sql/concise_hash_table.h
@@ -179,7 +179,7 @@ inline void ConciseHashTable::Insert(HashTableEntry *entry, const hash_t hash) {
   const uint64_t slot_idx = hash & slot_mask_;
   const uint64_t group_idx = slot_idx >> K_LOG_SLOTS_PER_GROUP;
   const uint64_t num_bits_to_group = group_idx << K_LOG_SLOTS_PER_GROUP;
-  auto *group_bits = reinterpret_cast<uint32_t *>(&slot_groups_[group_idx].bits_);
+  auto *group_bits = reinterpret_cast<uint32_t *>(&slot_groups_[group_idx] + offsetof(SlotGroup, bits_));
 
   auto bit_idx = static_cast<uint32_t>(slot_idx & K_GROUP_BIT_MASK);
   uint32_t max_bit_idx = std::min(63u, bit_idx + probe_limit_);

--- a/src/include/storage/index/generic_key.h
+++ b/src/include/storage/index/generic_key.h
@@ -76,7 +76,8 @@ class GenericKey {
       TERRIER_ASSERT(
           reinterpret_cast<uintptr_t>(GetProjectedRow()) + from.Size() <= reinterpret_cast<uintptr_t>(this) + KeySize,
           "ProjectedRow will access out of bounds.");
-      std::memcpy(GetProjectedRow(), &from, from.Size());
+      // We recast GetProjectedRow() as a workaround for -Wclass-memaccess
+      std::memcpy(static_cast<void *>(GetProjectedRow()), &from, from.Size());
     }
   }
 

--- a/src/storage/block_compactor.cpp
+++ b/src/storage/block_compactor.cpp
@@ -159,7 +159,8 @@ bool BlockCompactor::MoveTuple(CompactionGroup *cg, TupleSlot from, TupleSlot to
   // own special operators that takes physical locations instead of predicates, but it should share logic with the rest
   // of the system when it comes to index updates and such.
   RedoRecord *record = cg->txn_->StageWrite(catalog::db_oid_t(0), catalog::table_oid_t(0), cg->all_cols_initializer_);
-  std::memcpy(record->Delta(), cg->read_buffer_, cg->all_cols_initializer_.ProjectedRowSize());
+  // We recast record->Delta() as a workaround for -Wclass-memaccess
+  std::memcpy(static_cast<void *>(record->Delta()), cg->read_buffer_, cg->all_cols_initializer_.ProjectedRowSize());
 
   // Because the GC will assume all varlen pointers are unique and deallocate the same underlying
   // varlen for every update record, we need to mark subsequent records that reference the same

--- a/test/execution/projected_columns_iterator_test.cpp
+++ b/test/execution/projected_columns_iterator_test.cpp
@@ -117,7 +117,8 @@ class ProjectedColumnsIteratorTest : public SqlBasedTest {
       projected_columns_->SetNumTuples(num_tuples);
       if (nulls != nullptr) {
         // Fill up the null bitmap.
-        std::memcpy(projected_columns_->ColumnNullBitmap(col_offset), nulls.get(),
+        // We recast ColumnNullBitmap as a workaround for -Wclass-memaccess
+        std::memcpy(static_cast<void *>(projected_columns_->ColumnNullBitmap(col_offset)), nulls.get(),
                     num_tuples / common::Constants::K_BITS_PER_BYTE);
         // Because the storage layer treats 1 as non-null, we have to flip the
         // bits.
@@ -126,7 +127,8 @@ class ProjectedColumnsIteratorTest : public SqlBasedTest {
         }
       } else {
         // Set all rows to non-null.
-        std::memset(projected_columns_->ColumnNullBitmap(col_offset), 0,
+        // Recast ColumnNullBitmap again as a -Wclass-memaccess workaround
+        std::memset(static_cast<void *>(projected_columns_->ColumnNullBitmap(col_offset)), 0,
                     num_tuples / common::Constants::K_BITS_PER_BYTE);
       }
       // Fill up the values.

--- a/test/optimizer/logical_operator_test.cpp
+++ b/test/optimizer/logical_operator_test.cpp
@@ -27,7 +27,7 @@ TEST(OperatorTests, LogicalInsertTest) {
   parser::AbstractExpression *raw_values[] = {
       new parser::ConstantValueExpression(type::TransientValueFactory::GetTinyInt(1)),
       new parser::ConstantValueExpression(type::TransientValueFactory::GetTinyInt(9))};
-  std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> *values = new std::vector(
+  auto *values = new std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(
       {std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values))});
 
   // Check that all of our GET methods work as expected
@@ -52,7 +52,7 @@ TEST(OperatorTests, LogicalInsertTest) {
 
   // For this last check, we are going to give it more rows to insert
   // This will make sure that our hash is going deep into the vectors
-  std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> *other_values = new std::vector{
+  auto *other_values = new std::vector{
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values)),
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values))};
   Operator op3 = LogicalInsert::Make(
@@ -70,7 +70,7 @@ TEST(OperatorTests, LogicalInsertTest) {
       new parser::ConstantValueExpression(type::TransientValueFactory::GetTinyInt(1)),
       new parser::ConstantValueExpression(type::TransientValueFactory::GetTinyInt(2)),
       new parser::ConstantValueExpression(type::TransientValueFactory::GetTinyInt(3))};
-  std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> *bad_values = new std::vector(
+  auto *bad_values = new std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(
       {std::vector<common::ManagedPointer<parser::AbstractExpression>>(bad_raw_values, std::end(bad_raw_values))});
   EXPECT_DEATH(LogicalInsert::Make(
                    database_oid, namespace_oid, table_oid, std::vector<catalog::col_oid_t>(columns, std::end(columns)),

--- a/test/storage/index_key_test.cpp
+++ b/test/storage/index_key_test.cpp
@@ -774,8 +774,8 @@ TEST_F(IndexKeyTests, RandomCompactIntsKeyTest) {
       float probabilities[] = {0.0, 0.5, 1.0};
 
       for (float prob : probabilities) {
-        // have B copy A
-        std::memcpy(pr_b, pr_a, initializer.ProjectedRowSize());
+        // have B copy A. Recast pr_b to workaround -Wclass-memaccess.
+        std::memcpy(static_cast<void *>(pr_b), pr_a, initializer.ProjectedRowSize());
         auto *data_b = new byte[key_size];
         std::memcpy(data_b, data_a, key_size);
 

--- a/third_party/madoka/sketch.cc
+++ b/third_party/madoka/sketch.cc
@@ -883,7 +883,8 @@ void Sketch::hash(const void *key_addr, std::size_t key_size,
 
 void Sketch::copy_(const Sketch &src, const char *path, int flags) {
   create_(src.width(), src.max_value(), path, flags, src.seed());
-  std::memcpy(random_, src.random_, sizeof(Random));
+  // We recast random_ as a workaround for -Wclass-memaccess
+  std::memcpy(static_cast<void *>(random_), src.random_, sizeof(Random));
   std::memcpy(table_, src.table_, static_cast<std::size_t>(table_size()));
 }
 
@@ -976,7 +977,8 @@ void Sketch::shrink_(const Sketch &src, UInt64 width,
   MADOKA_THROW_IF((src.width() % width) != 0);
 
   create_(width, max_value, path, flags, src.seed());
-  std::memcpy(random_, src.random_, sizeof(Random));
+  // We recast random_ as a workaround for -Wclass-memaccess
+  std::memcpy(static_cast<void *>(random_), src.random_, sizeof(Random));
 
   width = this->width();
   max_value = this->max_value();


### PR DESCRIPTION
This changeset allows for compilation under GCC9 with LLVM 9 libraries. 



This is not-for-merge for a variety of reasons, including but not limited to:



1. ~~The Wclass-memaccess workaround is a bit cludgy (though, interestingly, RocksDB did the same thing I'm doing here when they switched to GCC9)~~ Still somewhat cludgy, but I think that adding comments has resolved most of the issue here.


2. I'm not convinced there's any interest in a PR regarding toolchain updates at the moment


3. Code review is of course still needed.




The specific changes that have been made are: 

1. Fixing a misleading part of the build configuration that mandates that the LLVM version be exactly 8.0 (and not greater), while stating that it wants an LLVM version greater than *or equal to* 8. This can be made into its own PR.


2.  Fix seemingly erroneous use of std::move, which is something that newer versions of GCC throw warnings for. This can also be brought into its own PR.


3. A workaround for -Waddress-of-packed-member. There's a potentially unaligned read that GCC9 warns (and with -Werror, errors) about. 


4. Patches surrounding various type-related checks that are new in GCC8 and 9. I'm not a fan of the solution used to address the new -Wclass-memaccess checks, but I went with the approach seen here for a few reasons: (1) other large projects like RocksDB did it, so surely it can't be that bad; and, (2) addressing it "properly" would require tweaking ProjectedRow, RawBlock, and Random, which might introduce more complexity than would be optimal. ~~A middle-ground between clearer code and more code might be to add comments clarifying why I'm re-casting to `void*`~~ Edit: Comments have been added. 