### PR TITLE
Cascading DROP logic for table and namespace

### DIFF
--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -276,8 +276,8 @@ class DatabaseCatalog {
    * @param ns being queried
    * @return vector of OIDs for all of the objects on this namespace
    */
-  std::vector<std::pair<uint32_t, postgres::ClassKind>> GetNamespaceObjectOids(transaction::TransactionContext *txn,
-                                                                               namespace_oid_t ns_oid);
+  std::vector<std::pair<uint32_t, postgres::ClassKind>> GetNamespaceClassOids(transaction::TransactionContext *txn,
+                                                                              namespace_oid_t ns_oid);
 
   /**
    * Delete entries from pg_attribute

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -276,7 +276,7 @@ class DatabaseCatalog {
    * @return vector of OIDs for all of the tables on this namespace
    */
   std::vector<std::pair<uint32_t, postgres::ClassKind>> GetNamespaceObjectOids(transaction::TransactionContext *txn,
-                                                                            namespace_oid_t ns_oid);
+                                                                               namespace_oid_t ns_oid);
 
   /**
    * Delete entries from pg_attribute

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -270,6 +270,15 @@ class DatabaseCatalog {
   std::vector<Column> GetColumns(transaction::TransactionContext *txn, ClassOid class_oid);
 
   /**
+   * A list of all tables on the given namespace
+   * @param txn for the operation
+   * @param ns being queried
+   * @return vector of OIDs for all of the tables on this namespace
+   */
+  std::vector<std::pair<uint32_t, postgres::ClassKind>> GetNamespaceObjectOids(transaction::TransactionContext *txn,
+                                                                            namespace_oid_t ns_oid);
+
+  /**
    * Delete entries from pg_attribute
    * @tparam Column type of columns
    * @param txn txn to use
@@ -385,6 +394,15 @@ class DatabaseCatalog {
    */
   bool CreateIndexEntry(transaction::TransactionContext *txn, namespace_oid_t ns_oid, table_oid_t table_oid,
                         index_oid_t index_oid, const std::string &name, const IndexSchema &schema);
+
+  /**
+   * Delete an index.  Any constraints that utilize this index must be deleted
+   * or transitioned to a different index prior to deleting an index.
+   * @param txn for the operation
+   * @param table to remove all indexes for
+   * @return true if the deletion succeeded, otherwise false.
+   */
+  bool DeleteIndexes(transaction::TransactionContext *txn, table_oid_t table);
 
   /**
    * Bootstraps the built-in types found in type::Type

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -270,10 +270,11 @@ class DatabaseCatalog {
   std::vector<Column> GetColumns(transaction::TransactionContext *txn, ClassOid class_oid);
 
   /**
-   * A list of all tables on the given namespace
+   * A list of all oids and their postgres::ClassKind from pg_class on the given namespace. This is currently designed
+   * as an internal function, though could be exposed via the CatalogAccessor if desired in the future.
    * @param txn for the operation
    * @param ns being queried
-   * @return vector of OIDs for all of the tables on this namespace
+   * @return vector of OIDs for all of the objects on this namespace
    */
   std::vector<std::pair<uint32_t, postgres::ClassKind>> GetNamespaceObjectOids(transaction::TransactionContext *txn,
                                                                                namespace_oid_t ns_oid);
@@ -396,8 +397,8 @@ class DatabaseCatalog {
                         index_oid_t index_oid, const std::string &name, const IndexSchema &schema);
 
   /**
-   * Delete an index.  Any constraints that utilize this index must be deleted
-   * or transitioned to a different index prior to deleting an index.
+   * Delete all of the indexes for a given table. This is currently designed as an internal function, though could be
+   * exposed via the CatalogAccessor if desired in the future.
    * @param txn for the operation
    * @param table to remove all indexes for
    * @return true if the deletion succeeded, otherwise false.

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -402,8 +402,8 @@ TEST_F(CatalogTests, CascadingDropNamespaceTest) {
 }
 
 /*
- * Create a user table in one namespace and an index on that table in another namespace. Verify that index gets dropped
- * correctly in second namespace.
+ * Create a user table in default namespace and an index on that table in a user namespace. Verify that index gets
+ * dropped correctly when dropping the user namespace, but the table remains.
  */
 // NOLINTNEXTLINE
 TEST_F(CatalogTests, CascadingDropNamespaceWithIndexOnOtherNamespaceTest) {
@@ -458,15 +458,19 @@ TEST_F(CatalogTests, CascadingDropNamespaceWithIndexOnOtherNamespaceTest) {
   accessor = catalog_->GetAccessor(txn, db_);
   EXPECT_NE(accessor, nullptr);
 
+  // Table is in default namespace, index is in user namespace
   VerifyTablePresent(*accessor, accessor->GetDefaultNamespace(), "test_table");
   idx_oid = accessor->GetIndexOid(ns_oid, "test_index");
   EXPECT_NE(idx_oid, catalog::INVALID_INDEX_OID);
 
+  // Table is not in user namespace (obvious), index is not in user namespace
   VerifyTableAbsent(*accessor, ns_oid, "test_table");
   idx_oid = accessor->GetIndexOid(accessor->GetDefaultNamespace(), "test_index");
   EXPECT_EQ(idx_oid, catalog::INVALID_INDEX_OID);
 
   EXPECT_TRUE(accessor->DropNamespace(ns_oid));
+
+  // Table is in default namespace, index is not in user namespace
   VerifyTablePresent(*accessor, accessor->GetDefaultNamespace(), "test_table");
   idx_oid = accessor->GetIndexOid(ns_oid, "test_index");
   EXPECT_EQ(idx_oid, catalog::INVALID_INDEX_OID);

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -223,7 +223,7 @@ TEST_F(CatalogTests, UserTableTest) {
 }
 
 /*
- *
+ * Create and delete a user index.
  */
 // NOLINTNEXTLINE
 TEST_F(CatalogTests, UserIndexTest) {
@@ -270,6 +270,131 @@ TEST_F(CatalogTests, UserIndexTest) {
   EXPECT_NE(idx_oid, catalog::INVALID_INDEX_OID);
   EXPECT_TRUE(accessor->DropIndex(idx_oid));
   idx_oid = accessor->GetIndexOid("test_table_index_mabobberwithareallylongnamethatstillneedsmore");
+  EXPECT_EQ(idx_oid, catalog::INVALID_INDEX_OID);
+  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+}
+
+/*
+ * Create a user table and index. Drop them both by dropping the table using cascading drop logic.
+ */
+// NOLINTNEXTLINE
+TEST_F(CatalogTests, CascadingDropTableTest) {
+  auto txn = txn_manager_->BeginTransaction();
+  auto accessor = catalog_->GetAccessor(txn, db_);
+  EXPECT_NE(accessor, nullptr);
+
+  // Create the column definition (no OIDs)
+  std::vector<catalog::Schema::Column> cols;
+  cols.emplace_back("id", type::TypeId::INTEGER, false,
+                    parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::INTEGER)));
+  cols.emplace_back("user_col_1", type::TypeId::INTEGER, false,
+                    parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::INTEGER)));
+  auto tmp_schema = catalog::Schema(cols);
+
+  auto table_oid = accessor->CreateTable(accessor->GetDefaultNamespace(), "test_table", tmp_schema);
+  auto schema = accessor->GetSchema(table_oid);
+  auto table = new storage::SqlTable(&block_store_, schema);
+
+  EXPECT_TRUE(accessor->SetTablePointer(table_oid, table));
+  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+
+  // Create the index
+  txn = txn_manager_->BeginTransaction();
+  accessor = catalog_->GetAccessor(txn, db_);
+  EXPECT_NE(accessor, nullptr);
+  std::vector<catalog::IndexSchema::Column> key_cols{catalog::IndexSchema::Column{
+      "id", type::TypeId::INTEGER, false, parser::ColumnValueExpression(db_, table_oid, schema.GetColumn("id").Oid())}};
+  auto index_schema = catalog::IndexSchema(key_cols, storage::index::IndexType::BWTREE, true, true, false, true);
+  auto idx_oid = accessor->CreateIndex(accessor->GetDefaultNamespace(), table_oid, "test_index", index_schema);
+  EXPECT_NE(idx_oid, catalog::INVALID_INDEX_OID);
+  auto true_schema = accessor->GetIndexSchema(idx_oid);
+
+  storage::index::IndexBuilder index_builder;
+  index_builder.SetKeySchema(true_schema);
+  auto index = index_builder.Build();
+
+  EXPECT_TRUE(accessor->SetIndexPointer(idx_oid, index));
+  EXPECT_EQ(common::ManagedPointer(index), accessor->GetIndex(idx_oid));
+  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+
+  // Get an accessor into the database and validate the catalog tables exist
+  // then delete it and verify an invalid OID is now returned for the lookup
+  txn = txn_manager_->BeginTransaction();
+  accessor = catalog_->GetAccessor(txn, db_);
+  EXPECT_NE(accessor, nullptr);
+
+  VerifyTablePresent(*accessor, accessor->GetDefaultNamespace(), "test_table");
+  idx_oid = accessor->GetIndexOid("test_index");
+  EXPECT_NE(idx_oid, catalog::INVALID_INDEX_OID);
+  EXPECT_TRUE(accessor->DropTable(table_oid));
+  VerifyTableAbsent(*accessor, accessor->GetDefaultNamespace(), "test_table");
+  idx_oid = accessor->GetIndexOid("test_index");
+  EXPECT_EQ(idx_oid, catalog::INVALID_INDEX_OID);
+  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+}
+
+/*
+ * Create a user table and index. Drop them all by dropping the namespace using cascading drop logic.
+ */
+// NOLINTNEXTLINE
+TEST_F(CatalogTests, CascadingDropNamespaceTest) {
+  auto txn = txn_manager_->BeginTransaction();
+  auto accessor = catalog_->GetAccessor(txn, db_);
+  EXPECT_NE(accessor, nullptr);
+  auto ns_oid = accessor->CreateNamespace("test_namespace");
+  EXPECT_NE(ns_oid, catalog::INVALID_NAMESPACE_OID);
+  VerifyCatalogTables(*accessor);  // Check visibility to me
+  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+
+  // Create the column definition (no OIDs)
+  std::vector<catalog::Schema::Column> cols;
+  cols.emplace_back("id", type::TypeId::INTEGER, false,
+                    parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::INTEGER)));
+  cols.emplace_back("user_col_1", type::TypeId::INTEGER, false,
+                    parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::INTEGER)));
+  auto tmp_schema = catalog::Schema(cols);
+
+  txn = txn_manager_->BeginTransaction();
+  accessor = catalog_->GetAccessor(txn, db_);
+  EXPECT_NE(accessor, nullptr);
+  auto table_oid = accessor->CreateTable(ns_oid, "test_table", tmp_schema);
+  auto schema = accessor->GetSchema(table_oid);
+  auto table = new storage::SqlTable(&block_store_, schema);
+
+  EXPECT_TRUE(accessor->SetTablePointer(table_oid, table));
+  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+
+  // Create the index
+  txn = txn_manager_->BeginTransaction();
+  accessor = catalog_->GetAccessor(txn, db_);
+  EXPECT_NE(accessor, nullptr);
+  std::vector<catalog::IndexSchema::Column> key_cols{catalog::IndexSchema::Column{
+      "id", type::TypeId::INTEGER, false, parser::ColumnValueExpression(db_, table_oid, schema.GetColumn("id").Oid())}};
+  auto index_schema = catalog::IndexSchema(key_cols, storage::index::IndexType::BWTREE, true, true, false, true);
+  auto idx_oid = accessor->CreateIndex(ns_oid, table_oid, "test_index", index_schema);
+  EXPECT_NE(idx_oid, catalog::INVALID_INDEX_OID);
+  auto true_schema = accessor->GetIndexSchema(idx_oid);
+
+  storage::index::IndexBuilder index_builder;
+  index_builder.SetKeySchema(true_schema);
+  auto index = index_builder.Build();
+
+  EXPECT_TRUE(accessor->SetIndexPointer(idx_oid, index));
+  EXPECT_EQ(common::ManagedPointer(index), accessor->GetIndex(idx_oid));
+  txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+
+  // Get an accessor into the database and validate the catalog tables exist
+  // then delete it and verify an invalid OID is now returned for the lookup
+  txn = txn_manager_->BeginTransaction();
+  accessor = catalog_->GetAccessor(txn, db_);
+  EXPECT_NE(accessor, nullptr);
+
+  VerifyTablePresent(*accessor, ns_oid, "test_table");
+  idx_oid = accessor->GetIndexOid(ns_oid, "test_index");
+  EXPECT_NE(idx_oid, catalog::INVALID_INDEX_OID);
+  EXPECT_TRUE(accessor->DropNamespace(ns_oid));
+  VerifyTableAbsent(*accessor, ns_oid, "test_table");
+  idx_oid = accessor->GetIndexOid(ns_oid, "test_index");
   EXPECT_EQ(idx_oid, catalog::INVALID_INDEX_OID);
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 }

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -1,9 +1,11 @@
 #include "catalog/catalog.h"
+
 #include <algorithm>
 #include <random>
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_accessor.h"
 #include "catalog/catalog_defs.h"
 #include "catalog/postgres/pg_namespace.h"


### PR DESCRIPTION
- `DatabaseCatalog::DeleteTable()` now drops any indexes on the table being dropped. Documentation already said it did this, so no change there.
- `DatabaseCatalog::DeleteNamespace()` now drops any tables and indexes on the namespace being dropped. Documentation already said it did this, so no change there.
- Added a couple of internal functions to make it easier, though these could be exposed via `CatalogAccessor` if desired in the future.
- Test cases.