### PR TITLE
Binder namespace binding refactor

### DIFF
--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -143,7 +143,8 @@ void BindNodeVisitor::Visit(parser::DeleteStatement *node, parser::ParseResult *
   context_ = new BinderContext(nullptr);
   node->GetDeletionTable()->TryBindDatabaseName(default_database_name_);
   auto table = node->GetDeletionTable();
-  context_->AddRegularTable(catalog_accessor_, table->GetDatabaseName(), table->GetTableName(), table->GetTableName());
+  context_->AddRegularTable(catalog_accessor_, table->GetDatabaseName(), table->GetNamespaceName(),
+                            table->GetTableName(), table->GetTableName());
 
   if (node->GetDeleteCondition() != nullptr) {
     node->GetDeleteCondition()->Accept(this, parse_result);
@@ -193,7 +194,8 @@ void BindNodeVisitor::Visit(parser::InsertStatement *node, parser::ParseResult *
   node->GetInsertionTable()->TryBindDatabaseName(default_database_name_);
 
   auto table = node->GetInsertionTable();
-  context_->AddRegularTable(catalog_accessor_, table->GetDatabaseName(), table->GetTableName(), table->GetTableName());
+  context_->AddRegularTable(catalog_accessor_, table->GetDatabaseName(), table->GetNamespaceName(),
+                            table->GetTableName(), table->GetTableName());
   if (node->GetSelect() != nullptr) node->GetSelect()->Accept(this, parse_result);
 
   delete context_;

--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -25,8 +25,20 @@ void BinderContext::AddRegularTable(const std::unique_ptr<catalog::CatalogAccess
                                     const std::string &db_name, const std::string &namespace_name,
                                     const std::string &table_name, const std::string &table_alias) {
   auto db_id = accessor->GetDatabaseOid(db_name);
+  if (db_id == catalog::INVALID_DATABASE_OID) {
+    throw BINDER_EXCEPTION(("Unknown database name " + db_name).c_str());
+  }
+
   auto namespace_id = accessor->GetNamespaceOid(namespace_name);
+  if (namespace_id == catalog::INVALID_NAMESPACE_OID) {
+    throw BINDER_EXCEPTION(("Unknown namespace name " + namespace_name).c_str());
+  }
+
   auto table_id = accessor->GetTableOid(namespace_id, table_name);
+  if (table_id == catalog::INVALID_TABLE_OID) {
+    throw BINDER_EXCEPTION(("Unknown table name " + table_name).c_str());
+  }
+
   auto schema = accessor->GetSchema(table_id);
 
   if (nested_table_alias_map_.find(table_alias) != nested_table_alias_map_.end()) {

--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -17,14 +17,16 @@ namespace terrier::binder {
 
 void BinderContext::AddRegularTable(const std::unique_ptr<catalog::CatalogAccessor> &accessor,
                                     parser::TableRef *table_ref) {
-  AddRegularTable(accessor, table_ref->GetDatabaseName(), table_ref->GetTableName(), table_ref->GetAlias());
+  AddRegularTable(accessor, table_ref->GetDatabaseName(), table_ref->GetNamespaceName(), table_ref->GetTableName(),
+                  table_ref->GetAlias());
 }
 
 void BinderContext::AddRegularTable(const std::unique_ptr<catalog::CatalogAccessor> &accessor,
-                                    const std::string &db_name, const std::string &table_name,
-                                    const std::string &table_alias) {
+                                    const std::string &db_name, const std::string &namespace_name,
+                                    const std::string &table_name, const std::string &table_alias) {
   auto db_id = accessor->GetDatabaseOid(db_name);
-  auto table_id = accessor->GetTableOid(table_name);
+  auto namespace_id = accessor->GetNamespaceOid(namespace_name);
+  auto table_id = accessor->GetTableOid(namespace_id, table_name);
   auto schema = accessor->GetSchema(table_id);
 
   if (nested_table_alias_map_.find(table_alias) != nested_table_alias_map_.end()) {

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -31,6 +31,7 @@ void CatalogAccessor::SetSearchPath(std::vector<namespace_oid_t> namespaces) {
 }
 
 namespace_oid_t CatalogAccessor::GetNamespaceOid(std::string name) const {
+  if (name.empty()) return catalog::postgres::NAMESPACE_DEFAULT_NAMESPACE_OID;
   NormalizeObjectName(&name);
   return dbc_->GetNamespaceOid(txn_, name);
 }

--- a/src/include/binder/binder_context.h
+++ b/src/include/binder/binder_context.h
@@ -55,11 +55,13 @@ class BinderContext {
    * Update the table alias map given a table reference (in the from clause)
    * @param accessor Pointer to the catalog accessor object
    * @param db_name Name of the database
+   * @param namespace_name Name of the namespace
    * @param table_name Name of the table
    * @param table_alias Alias of the table
    */
   void AddRegularTable(const std::unique_ptr<catalog::CatalogAccessor> &accessor, const std::string &db_name,
-                       const std::string &table_name, const std::string &table_alias);
+                       const std::string &namespace_name, const std::string &table_name,
+                       const std::string &table_alias);
 
   /**
    * Update the nested table alias map

--- a/src/include/parser/expression/column_value_expression.h
+++ b/src/include/parser/expression/column_value_expression.h
@@ -23,17 +23,12 @@ class ColumnValueExpression : public AbstractExpression {
   /**
    * This constructor is called only in postgresparser, setting the column name,
    * and optionally setting the table name and alias.
-   * Namespace name is always set to empty string, as the postgresparser does not know the namespace name.
-   * Parameter namespace name is included so that the program can differentiate this constructor from
-   * another constructor that sets the namespace name, table name. and column name.
-   * @param namespace_name namespace name
    * @param table_name table name
    * @param col_name column name
    * @param alias alias of the expression
    */
-  ColumnValueExpression(std::string namespace_name, std::string table_name, std::string col_name, std::string alias)
+  ColumnValueExpression(std::string table_name, std::string col_name, std::string alias)
       : AbstractExpression(ExpressionType::COLUMN_VALUE, type::TypeId::INVALID, std::move(alias), {}),
-        namespace_name_(std::move(namespace_name)),
         table_name_(std::move(table_name)),
         column_name_(std::move(col_name)) {}
 
@@ -43,17 +38,6 @@ class ColumnValueExpression : public AbstractExpression {
    */
   ColumnValueExpression(std::string table_name, std::string col_name)
       : AbstractExpression(ExpressionType::COLUMN_VALUE, type::TypeId::INVALID, {}),
-        table_name_(std::move(table_name)),
-        column_name_(std::move(col_name)) {}
-
-  /**
-   * @param namespace_name namespace name
-   * @param table_name table name
-   * @param col_name column name
-   */
-  ColumnValueExpression(std::string namespace_name, std::string table_name, std::string col_name)
-      : AbstractExpression(ExpressionType::COLUMN_VALUE, type::TypeId::INVALID, {}),
-        namespace_name_(std::move(namespace_name)),
         table_name_(std::move(table_name)),
         column_name_(std::move(col_name)) {}
 
@@ -70,9 +54,6 @@ class ColumnValueExpression : public AbstractExpression {
 
   /** Default constructor for deserialization. */
   ColumnValueExpression() = default;
-
-  /** @return namespace name */
-  std::string GetNamespaceName() const { return namespace_name_; }
 
   /** @return table name */
   std::string GetTableName() const { return table_name_; }
@@ -92,7 +73,6 @@ class ColumnValueExpression : public AbstractExpression {
   std::unique_ptr<AbstractExpression> Copy() const override {
     auto expr = std::make_unique<ColumnValueExpression>(GetDatabaseOid(), GetTableOid(), GetColumnOid());
     expr->SetMutableStateForCopy(*this);
-    expr->namespace_name_ = this->namespace_name_;
     expr->table_name_ = this->table_name_;
     expr->column_name_ = this->column_name_;
     expr->SetDatabaseOID(this->database_oid_);
@@ -103,7 +83,6 @@ class ColumnValueExpression : public AbstractExpression {
 
   common::hash_t Hash() const override {
     common::hash_t hash = AbstractExpression::Hash();
-    hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(namespace_name_));
     hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(table_name_));
     hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(column_name_));
     hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
@@ -117,7 +96,6 @@ class ColumnValueExpression : public AbstractExpression {
     auto const &other = dynamic_cast<const ColumnValueExpression &>(rhs);
     if (GetColumnName() != other.GetColumnName()) return false;
     if (GetTableName() != other.GetTableName()) return false;
-    if (GetNamespaceName() != other.GetNamespaceName()) return false;
     if (GetColumnOid() != other.GetColumnOid()) return false;
     if (GetTableOid() != other.GetTableOid()) return false;
     return GetDatabaseOid() == other.GetDatabaseOid();
@@ -137,7 +115,6 @@ class ColumnValueExpression : public AbstractExpression {
    */
   nlohmann::json ToJson() const override {
     nlohmann::json j = AbstractExpression::ToJson();
-    j["namespace_name"] = namespace_name_;
     j["table_name"] = table_name_;
     j["column_name"] = column_name_;
     j["database_oid"] = database_oid_;
@@ -153,7 +130,6 @@ class ColumnValueExpression : public AbstractExpression {
     std::vector<std::unique_ptr<AbstractExpression>> exprs;
     auto e1 = AbstractExpression::FromJson(j);
     exprs.insert(exprs.end(), std::make_move_iterator(e1.begin()), std::make_move_iterator(e1.end()));
-    namespace_name_ = j.at("namespace_name").get<std::string>();
     table_name_ = j.at("table_name").get<std::string>();
     column_name_ = j.at("column_name").get<std::string>();
     database_oid_ = j.at("database_oid").get<catalog::db_oid_t>();
@@ -175,8 +151,6 @@ class ColumnValueExpression : public AbstractExpression {
   /** @param column_oid Column OID to be assigned to this expression */
   void SetColumnName(const std::string &col_name) { column_name_ = std::string(col_name); }
 
-  /** Namespace name. */
-  std::string namespace_name_;
   /** Table name. */
   std::string table_name_;
   /** Column name. */

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -77,7 +77,7 @@ struct TableInfo {
   std::vector<std::unique_ptr<AbstractExpression>> FromJson(const nlohmann::json &j) {
     std::vector<std::unique_ptr<AbstractExpression>> exprs;
     table_name_ = j.at("table_name").get<std::string>();
-    namespace_name_ = j.at("namespace_name_").get<std::string>();
+    namespace_name_ = j.at("namespace_name").get<std::string>();
     database_name_ = j.at("database_name").get<std::string>();
     return exprs;
   }
@@ -185,9 +185,9 @@ class TableRefStatement : public SQLStatement {
   virtual std::string GetTableName() const { return table_info_->GetTableName(); }
 
   /**
-   * @return table schema name (aka namespace)
+   * @return namespace name
    */
-  virtual std::string GetSchemaName() const { return table_info_->GetNamespaceName(); }
+  virtual std::string GetNamespaceName() const { return table_info_->GetNamespaceName(); }
 
   /**
    * @return database name

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -23,17 +23,17 @@ class ParseResult;
 class AbstractExpression;
 
 /**
- * Table location information (Database, Schema, Table).
+ * Table location information (Database, Namespace, Table).
  */
 struct TableInfo {
   /**
    * @param table_name table name
-   * @param schema_name schema name
+   * @param namespace_name namespace name
    * @param database_name database name
    */
-  TableInfo(std::string table_name, std::string schema_name, std::string database_name)
+  TableInfo(std::string table_name, std::string namespace_name, std::string database_name)
       : table_name_(std::move(table_name)),
-        schema_name_(std::move(schema_name)),
+        namespace_name_(std::move(namespace_name)),
         database_name_(std::move(database_name)) {}
 
   TableInfo() = default;
@@ -42,7 +42,7 @@ struct TableInfo {
    * @return a copy of the table location information
    */
   std::unique_ptr<TableInfo> Copy() {
-    return std::make_unique<TableInfo>(GetTableName(), GetSchemaName(), GetDatabaseName());
+    return std::make_unique<TableInfo>(GetTableName(), GetNamespaceName(), GetDatabaseName());
   }
 
   /**
@@ -51,9 +51,9 @@ struct TableInfo {
   std::string GetTableName() { return table_name_; }
 
   /**
-   * @return schema name
+   * @return namespace name
    */
-  std::string GetSchemaName() { return schema_name_; }
+  std::string GetNamespaceName() { return namespace_name_; }
 
   /**
    * @return database name
@@ -66,7 +66,7 @@ struct TableInfo {
   nlohmann::json ToJson() const {
     nlohmann::json j;
     j["table_name"] = table_name_;
-    j["schema_name"] = schema_name_;
+    j["namespace_name"] = namespace_name_;
     j["database_name"] = database_name_;
     return j;
   }
@@ -77,7 +77,7 @@ struct TableInfo {
   std::vector<std::unique_ptr<AbstractExpression>> FromJson(const nlohmann::json &j) {
     std::vector<std::unique_ptr<AbstractExpression>> exprs;
     table_name_ = j.at("table_name").get<std::string>();
-    schema_name_ = j.at("schema_name").get<std::string>();
+    namespace_name_ = j.at("namespace_name_").get<std::string>();
     database_name_ = j.at("database_name").get<std::string>();
     return exprs;
   }
@@ -86,7 +86,7 @@ struct TableInfo {
   friend class TableRefStatement;
   friend class TableRef;
   std::string table_name_;
-  std::string schema_name_;
+  std::string namespace_name_;
   std::string database_name_;
 
   /**
@@ -187,7 +187,7 @@ class TableRefStatement : public SQLStatement {
   /**
    * @return table schema name (aka namespace)
    */
-  virtual std::string GetSchemaName() const { return table_info_->GetSchemaName(); }
+  virtual std::string GetSchemaName() const { return table_info_->GetNamespaceName(); }
 
   /**
    * @return database name

--- a/src/include/parser/table_ref.h
+++ b/src/include/parser/table_ref.h
@@ -182,8 +182,8 @@ class TableRef {
   /** @return table name */
   std::string GetTableName() { return table_info_->GetTableName(); }
 
-  /** @return schema name */
-  std::string GetSchemaName() { return table_info_->GetSchemaName(); }
+  /** @return namespace name */
+  std::string GetNamespaceName() { return table_info_->GetNamespaceName(); }
 
   /** @return database name */
   std::string GetDatabaseName() { return table_info_->GetDatabaseName(); }

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -536,9 +536,9 @@ std::unique_ptr<AbstractExpression> PostgresParser::ColumnRefTransform(ParseResu
       }
 
       if (alias != nullptr)
-        result = std::make_unique<ColumnValueExpression>("", table_name, col_name, std::string(alias));
+        result = std::make_unique<ColumnValueExpression>(table_name, col_name, std::string(alias));
       else
-        result = std::make_unique<ColumnValueExpression>("", table_name, col_name);
+        result = std::make_unique<ColumnValueExpression>(table_name, col_name);
       break;
     }
     case T_A_Star: {

--- a/test/parser/expression_test.cpp
+++ b/test/parser/expression_test.cpp
@@ -745,20 +745,18 @@ TEST(ExpressionTests, ParameterValueExpressionJsonTest) {
 
 // NOLINTNEXTLINE
 TEST(ExpressionTests, ColumnValueExpressionTest) {
-  auto tve1 = new ColumnValueExpression("", "table_name", "column_name", "alias");
-  auto tve2 = new ColumnValueExpression("", "table_name", "column_name", "alias");
-  auto tve3 = new ColumnValueExpression("", "table_name2", "column_name", "alias");
-  auto tve4 = new ColumnValueExpression("", "table_name", "column_name2", "alias");
-  auto tve5 = new ColumnValueExpression("", "table_name", "column_name", "alias2");
+  auto tve1 = new ColumnValueExpression("table_name", "column_name", "alias");
+  auto tve2 = new ColumnValueExpression("table_name", "column_name", "alias");
+  auto tve3 = new ColumnValueExpression("table_name2", "column_name", "alias");
+  auto tve4 = new ColumnValueExpression("table_name", "column_name2", "alias");
+  auto tve5 = new ColumnValueExpression("table_name", "column_name", "alias2");
   auto tve6 = new ColumnValueExpression("table_name", "column_name");
   auto tve7 = new ColumnValueExpression(catalog::db_oid_t(1), catalog::table_oid_t(2), catalog::col_oid_t(3));
   auto tve8 = new ColumnValueExpression(catalog::db_oid_t(1), catalog::table_oid_t(2), catalog::col_oid_t(3));
   auto tve9 = new ColumnValueExpression(catalog::db_oid_t(1), catalog::table_oid_t(4), catalog::col_oid_t(3));
   auto tve10 = new ColumnValueExpression(catalog::db_oid_t(1), catalog::table_oid_t(2), catalog::col_oid_t(4));
   auto tve14 = new ColumnValueExpression(catalog::db_oid_t(4), catalog::table_oid_t(2), catalog::col_oid_t(3));
-  auto tve11 = new ColumnValueExpression("namespace_name", "table_name", "column_name");
-  auto tve12 = new ColumnValueExpression("namespace_name", "table_name", "column_name");
-  auto tve13 = new ColumnValueExpression("namespace_name2", "table_name", "column_name");
+  auto tve11 = new ColumnValueExpression("table_name", "column_name");
 
   EXPECT_TRUE(*tve1 == *tve2);
   EXPECT_FALSE(*tve1 == *tve3);
@@ -770,9 +768,7 @@ TEST(ExpressionTests, ColumnValueExpressionTest) {
   EXPECT_FALSE(*tve7 == *tve10);
   EXPECT_FALSE(*tve7 == *tve1);
   EXPECT_FALSE(*tve7 == *tve14);
-  EXPECT_TRUE(*tve11 == *tve12);
-  EXPECT_FALSE(*tve11 == *tve13);
-  EXPECT_FALSE(*tve11 == *tve6);
+  EXPECT_TRUE(*tve11 == *tve6);
 
   EXPECT_EQ(tve1->Hash(), tve2->Hash());
   EXPECT_NE(tve1->Hash(), tve3->Hash());
@@ -784,23 +780,17 @@ TEST(ExpressionTests, ColumnValueExpressionTest) {
   EXPECT_NE(tve7->Hash(), tve10->Hash());
   EXPECT_NE(tve7->Hash(), tve1->Hash());
   EXPECT_NE(tve7->Hash(), tve14->Hash());
-  EXPECT_EQ(tve11->Hash(), tve12->Hash());
-  EXPECT_NE(tve11->Hash(), tve13->Hash());
-  EXPECT_NE(tve11->Hash(), tve6->Hash());
+  EXPECT_EQ(tve11->Hash(), tve6->Hash());
 
   EXPECT_EQ(tve1->GetExpressionType(), ExpressionType::COLUMN_VALUE);
   EXPECT_EQ(tve1->GetReturnValueType(), type::TypeId::INVALID);
   EXPECT_EQ(tve1->GetAlias(), "alias");
-  EXPECT_EQ(tve1->GetNamespaceName(), "");
   EXPECT_EQ(tve1->GetTableName(), "table_name");
   EXPECT_EQ(tve1->GetColumnName(), "column_name");
   // Uninitialized OIDs set to 0; TODO(Ling): change to INVALID_*_OID after catalog completion
   EXPECT_EQ(tve1->GetTableOid(), catalog::INVALID_TABLE_OID);
   EXPECT_EQ(tve1->GetDatabaseOid(), catalog::INVALID_DATABASE_OID);
   EXPECT_EQ(tve1->GetColumnOid(), catalog::INVALID_COLUMN_OID);
-  EXPECT_EQ(tve1->GetNamespaceName(), "");
-
-  EXPECT_EQ(tve11->GetNamespaceName(), "namespace_name");
 
   EXPECT_EQ(tve11->GetAlias(), "");
   EXPECT_EQ(tve7->GetTableName(), "");
@@ -827,8 +817,6 @@ TEST(ExpressionTests, ColumnValueExpressionTest) {
   delete tve9;
   delete tve10;
   delete tve11;
-  delete tve12;
-  delete tve13;
   delete tve14;
 }
 
@@ -836,7 +824,7 @@ TEST(ExpressionTests, ColumnValueExpressionTest) {
 TEST(ExpressionTests, ColumnValueExpressionJsonTest) {
   // Create expression
   std::unique_ptr<ColumnValueExpression> original_expr =
-      std::make_unique<ColumnValueExpression>("", "table_name", "column_name", "alias");
+      std::make_unique<ColumnValueExpression>("table_name", "column_name", "alias");
 
   EXPECT_EQ(*original_expr, *(original_expr->Copy()));
 
@@ -848,7 +836,6 @@ TEST(ExpressionTests, ColumnValueExpressionJsonTest) {
   auto deserialized = DeserializeExpression(json);
   auto deserialized_expr = common::ManagedPointer(deserialized.result_).CastManagedPointerTo<ColumnValueExpression>();
   EXPECT_EQ(*original_expr, *deserialized_expr);
-  EXPECT_EQ(original_expr->GetNamespaceName(), deserialized_expr->GetNamespaceName());
   EXPECT_EQ(original_expr->GetColumnName(), deserialized_expr->GetColumnName());
   EXPECT_EQ(original_expr->GetTableName(), deserialized_expr->GetTableName());
   EXPECT_EQ(original_expr->GetAlias(), deserialized_expr->GetAlias());
@@ -866,14 +853,13 @@ TEST(ExpressionTests, ColumnValueExpressionJsonTest) {
   auto deserialized_expr_2 =
       common::ManagedPointer(deserialized_2.result_).CastManagedPointerTo<ColumnValueExpression>();
   EXPECT_EQ(*original_expr_2, *deserialized_expr_2);
-  EXPECT_EQ(original_expr_2->GetNamespaceName(), deserialized_expr_2->GetNamespaceName());
   EXPECT_EQ(original_expr_2->GetAlias(), deserialized_expr_2->GetAlias());
   EXPECT_EQ(original_expr_2->GetColumnName(), deserialized_expr_2->GetColumnName());
   EXPECT_EQ(original_expr_2->GetTableName(), deserialized_expr_2->GetTableName());
 
   // Create expression
   std::unique_ptr<ColumnValueExpression> original_expr_3 =
-      std::make_unique<ColumnValueExpression>("namespace_name", "table_name", "column_name");
+      std::make_unique<ColumnValueExpression>("table_name", "column_name");
 
   // Serialize expression
   auto json_3 = original_expr_3->ToJson();
@@ -884,7 +870,6 @@ TEST(ExpressionTests, ColumnValueExpressionJsonTest) {
   auto deserialized_expr_3 =
       common::ManagedPointer(deserialized_3.result_).CastManagedPointerTo<ColumnValueExpression>();
   EXPECT_EQ(*original_expr_3, *deserialized_expr_3);
-  EXPECT_EQ(original_expr_3->GetNamespaceName(), deserialized_expr_3->GetNamespaceName());
   EXPECT_EQ(original_expr_3->GetAlias(), deserialized_expr_3->GetAlias());
   EXPECT_EQ(original_expr_3->GetColumnName(), deserialized_expr_3->GetColumnName());
   EXPECT_EQ(original_expr_3->GetTableName(), deserialized_expr_3->GetTableName());

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -296,7 +296,7 @@ TEST_F(ParserTestBase, DropSchemaTest) {
 
   auto drop_stmt = result.GetStatement(0).CastManagedPointerTo<DropStatement>();
   EXPECT_EQ(drop_stmt->GetDropType(), DropStatement::DropType::kSchema);
-  EXPECT_EQ(drop_stmt->GetSchemaName(), "foo");
+  EXPECT_EQ(drop_stmt->GetNamespaceName(), "foo");
   EXPECT_TRUE(drop_stmt->IsCascade());
   EXPECT_TRUE(drop_stmt->IsIfExists());
 }
@@ -1330,13 +1330,13 @@ TEST_F(ParserTestBase, OldCreateSchemaTest) {
   std::string query = "CREATE SCHEMA tt";
   auto result = pgparser_.BuildParseTree(query);
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
-  EXPECT_EQ("tt", create_stmt->GetSchemaName());
+  EXPECT_EQ("tt", create_stmt->GetNamespaceName());
 
   // Test default schema name
   query = "CREATE SCHEMA AUTHORIZATION joe";
   result = pgparser_.BuildParseTree(query);
   create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
-  EXPECT_EQ("joe", create_stmt->GetSchemaName());
+  EXPECT_EQ("joe", create_stmt->GetNamespaceName());
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
This PR does the following:

1. Look up table OID based on namespace (return DEFAULT NAMESPACE if namespace name is unspecified), this will allow prepared statements to be resolved in similar ways
2. Rename SchemaName -> Namespace Name in TableRef
3. Remove unused field "namespace_name_" in ColumnValueExpression