### PR TITLE
Static PostgresParser

### DIFF
--- a/benchmark/parser/parser_benchmark.cpp
+++ b/benchmark/parser/parser_benchmark.cpp
@@ -14,7 +14,7 @@ namespace terrier {
  */
 #define PARSER_BENCHMARK_EXECUTE(QUERIES, TYPE)                                                                    \
   for (const auto &sql : QUERIES) {                                                                                \
-    auto result = parser_.BuildParseTree(sql);                                                                     \
+    auto result = parser::PostgresParser::BuildParseTree(sql);                                                     \
     TERRIER_ASSERT(result.GetStatement(0).CastManagedPointerTo<TYPE>() != nullptr, "Failed to get ##TYPE object"); \
   }
 
@@ -120,7 +120,6 @@ class ParserBenchmark : public benchmark::Fixture {
     // Nothing to do, nothing to see...
   }
 
-  parser::PostgresParser parser_;
   std::vector<std::string> selects_simple_;
   std::vector<std::string> selects_complex_;
   std::vector<std::string> updates_simple_;
@@ -207,7 +206,7 @@ BENCHMARK_DEFINE_F(ParserBenchmark, DeletesComplex)(benchmark::State &state) {
 BENCHMARK_DEFINE_F(ParserBenchmark, NOOPs)(benchmark::State &state) {
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    auto result = parser_.BuildParseTree(";");
+    auto result = parser::PostgresParser::BuildParseTree(";");
     TERRIER_ASSERT(result.GetStatements().empty(), "Unexpected return result for NOOP");
   }
   state.SetItemsProcessed(state.iterations());

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -4,12 +4,12 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "libpg_query/pg_query.h"
 #include "parser/parsenodes.h"
 #include "parser/statements.h"
 
-namespace terrier {
-namespace parser {
+namespace terrier::parser {
 
 /**
  * ParseResult is the parser's output to the binder. It allows you to obtain non-owning managed pointers to the
@@ -100,15 +100,14 @@ class PostgresParser {
    */
 
  public:
-  PostgresParser();
-  ~PostgresParser();
+  PostgresParser() = delete;
 
   /**
    * Builds the parse tree for the given query string.
    * @param query_string query string to be parsed
    * @return unique pointer to parse tree
    */
-  ParseResult BuildParseTree(const std::string &query_string);
+  static ParseResult BuildParseTree(const std::string &query_string);
 
  private:
   static FKConstrActionType CharToActionType(const char &type) {
@@ -287,5 +286,4 @@ class PostgresParser {
   static std::unique_ptr<UpdateStatement> UpdateTransform(ParseResult *parse_result, UpdateStmt *update_stmt);
 };
 
-}  // namespace parser
-}  // namespace terrier
+}  // namespace terrier::parser

--- a/src/include/planner/plannodes/index_scan_plan_node.h
+++ b/src/include/planner/plannodes/index_scan_plan_node.h
@@ -6,6 +6,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "catalog/schema.h"
 #include "common/hash_util.h"
@@ -367,7 +368,7 @@ class IndexScanPlanNode : public AbstractScanPlanNode {
 
   /**
    * Collect all column oids in this expression
-   * @warn slow!
+   * @warning slow!
    * @return the vector of unique columns oids
    */
   std::vector<catalog::col_oid_t> CollectInputOids() const {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1,3 +1,5 @@
+#include "parser/postgresparser.h"
+
 #include <algorithm>
 #include <cstdio>
 #include <memory>
@@ -7,12 +9,9 @@
 #include <vector>
 
 #include "common/exception.h"
-
 #include "libpg_query/pg_list.h"
 #include "libpg_query/pg_query.h"
-
 #include "loggers/parser_logger.h"
-
 #include "parser/expression/aggregate_expression.h"
 #include "parser/expression/case_expression.h"
 #include "parser/expression/column_value_expression.h"
@@ -27,7 +26,6 @@
 #include "parser/expression/subquery_expression.h"
 #include "parser/expression/type_cast_expression.h"
 #include "parser/pg_trigger.h"
-#include "parser/postgresparser.h"
 #include "type/transient_value_factory.h"
 
 /**
@@ -41,10 +39,6 @@
   throw PARSER_EXCEPTION(#FN_NAME ":" #TYPE_MSG " unsupported")
 
 namespace terrier::parser {
-
-PostgresParser::PostgresParser() = default;
-
-PostgresParser::~PostgresParser() = default;
 
 ParseResult PostgresParser::BuildParseTree(const std::string &query_string) {
   auto text = query_string.c_str();

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -33,7 +33,6 @@ class BinderCorrectnessTest : public TerrierTest {
   catalog::db_oid_t db_oid_;
   catalog::table_oid_t table_a_oid_;
   catalog::table_oid_t table_b_oid_;
-  parser::PostgresParser parser_;
   common::ManagedPointer<transaction::TransactionManager> txn_manager_;
   common::ManagedPointer<catalog::Catalog> catalog_;
   transaction::TransactionContext *txn_;
@@ -115,7 +114,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementInvalidTableTest) {
   BINDER_LOG_DEBUG("Parsing sql query");
   std::string select_sql = "SELECT a1 FROM c;";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   EXPECT_THROW(binder_->BindNameToNode(statement, &parse_tree), BinderException);
 }
@@ -126,7 +125,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementInvalidColumnTest) {
   BINDER_LOG_DEBUG("Parsing sql query");
   std::string select_sql = "SELECT a8 FROM a;";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   EXPECT_THROW(binder_->BindNameToNode(statement, &parse_tree), BinderException);
 }
@@ -139,7 +138,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementComplexTest) {
       "SELECT A.A1, B.B2 FROM A INNER JOIN b ON a.a1 = b.b1 WHERE a1 < 100 "
       "GROUP BY A.a1, B.b2 HAVING a1 > 50 ORDER BY a1";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -236,7 +235,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementStarTest) {
   BINDER_LOG_DEBUG("Checking STAR expression in select and sub-select");
 
   std::string select_sql = "SELECT * FROM A LEFT OUTER JOIN B ON A.A1 < B.B1";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -300,7 +299,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementStarNestedSelectTest) {
 
   std::string select_sql =
       "SELECT * FROM A LEFT OUTER JOIN (SELECT * FROM B INNER JOIN A ON B1 = A1) AS C ON C.B2 = a.A1";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -481,7 +480,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementNestedColumnTest) {
   BINDER_LOG_DEBUG("Checking nested select columns.");
 
   std::string select_sql = "SELECT A1, (SELECT B2 FROM B where B2 IS NULL LIMIT 1) FROM A";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -529,7 +528,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementDupAliasTest) {
   BINDER_LOG_DEBUG("Checking duplicate alias and table name.");
 
   std::string select_sql = "SELECT * FROM A, B as A";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto select_stmt = parse_tree.GetStatements()[0];
   EXPECT_THROW(binder_->BindNameToNode(select_stmt, &parse_tree), BinderException);
 }
@@ -538,7 +537,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementDupAliasTest) {
 TEST_F(BinderCorrectnessTest, SelectStatementDiffTableSameSchemaTest) {
   // Test select from different table instances from the same physical schema
   std::string select_sql = "SELECT * FROM A, A as AA where A.a1 = AA.a2";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -560,7 +559,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementSelectListAliasTest) {
   BINDER_LOG_DEBUG("Checking select_list and table alias binding");
 
   std::string select_sql = "SELECT AA.a1, b2 FROM A as AA, B WHERE AA.a1 = B.b1";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -578,7 +577,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementSelectListAliasTest) {
 // NOLINTNEXTLINE
 TEST_F(BinderCorrectnessTest, UpdateStatementSimpleTest) {
   std::string update_sql = "UPDATE A SET A1 = 999 WHERE A1 >= 1";
-  auto parse_tree = parser_.BuildParseTree(update_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(update_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto update_stmt = statement.CastManagedPointerTo<parser::UpdateStatement>();
@@ -600,7 +599,7 @@ TEST_F(BinderCorrectnessTest, UpdateStatementSimpleTest) {
 // NOLINTNEXTLINE
 TEST_F(BinderCorrectnessTest, DeleteStatementWhereTest) {
   std::string delete_sql = "DELETE FROM b WHERE 1 = b1 AND b2 = 'str'";
-  auto parse_tree = parser_.BuildParseTree(delete_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(delete_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto delete_stmt = statement.CastManagedPointerTo<parser::DeleteStatement>();
@@ -626,7 +625,7 @@ TEST_F(BinderCorrectnessTest, AggregateSimpleTest) {
   BINDER_LOG_DEBUG("Checking simple aggregate select.");
 
   std::string select_sql = "SELECT MAX(b1) FROM B;";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -650,7 +649,7 @@ TEST_F(BinderCorrectnessTest, AggregateComplexTest) {
   BINDER_LOG_DEBUG("Checking aggregate in subselect.");
 
   std::string select_sql = "SELECT A.a1 FROM A WHERE A.a1 IN (SELECT MAX(b1) FROM B);";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -677,7 +676,7 @@ TEST_F(BinderCorrectnessTest, OperatorComplexTest) {
   BINDER_LOG_DEBUG("Checking if operator expressions are correctly parsed.");
 
   std::string select_sql = "SELECT A.a1 FROM A WHERE 2 * A.a1 IN (SELECT b1+1 FROM B);";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -717,7 +716,7 @@ TEST_F(BinderCorrectnessTest, BindDepthTest) {
   std::string select_sql =
       "SELECT A.a1 FROM A WHERE A.a1 IN (SELECT b1 FROM B WHERE b1 = 2 AND "
       "b2 > (SELECT a1 FROM A WHERE a2 > 0)) AND EXISTS (SELECT b1 FROM B WHERE B.b1 = A.a1)";
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto select_stmt = statement.CastManagedPointerTo<parser::SelectStatement>();
@@ -822,7 +821,7 @@ TEST_F(BinderCorrectnessTest, CreateDatabaseTest) {
   BINDER_LOG_DEBUG("Checking create database.");
 
   std::string create_sql = "CREATE DATABASE C;";
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   EXPECT_NO_THROW(binder_->BindNameToNode(statement, &parse_tree));
 }
@@ -834,7 +833,7 @@ TEST_F(BinderCorrectnessTest, CreateTableTest) {
   std::string create_sql =
       "CREATE TABLE C ( C1 int NOT NULL, C2 varchar(255) NOT NULL UNIQUE, C3 INT REFERENCES A(A1), C4 INT DEFAULT 14 "
       "CHECK (C4<100), PRIMARY KEY(C1));";
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
 
@@ -854,7 +853,7 @@ TEST_F(BinderCorrectnessTest, CreateTableSimpleForeignTest) {
   std::string create_sql =
       "CREATE TABLE D ( D1 int NOT NULL, D2 varchar(255) NOT NULL UNIQUE, D3 INT UNIQUE, D4 VARCHAR(20) UNIQUE, "
       "PRIMARY KEY(D1, D2), FOREIGN KEY(D3, D4) REFERENCES A(A1, A2));";
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   EXPECT_NO_THROW(binder_->BindNameToNode(statement, &parse_tree));
 }
@@ -866,7 +865,7 @@ TEST_F(BinderCorrectnessTest, CreateTableSimpleForeignViolateTest) {
   std::string create_sql =
       "CREATE TABLE D ( D1 int NOT NULL, D2 varchar(255) NOT NULL UNIQUE, D3 INT UNIQUE, D4 INT UNIQUE, PRIMARY "
       "KEY(D1, D2), FOREIGN KEY(D4, D3) REFERENCES A(A1, A2));";
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   EXPECT_THROW(binder_->BindNameToNode(statement, &parse_tree), BinderException);
 }
@@ -876,7 +875,7 @@ TEST_F(BinderCorrectnessTest, CreateIndexTest) {
   BINDER_LOG_DEBUG("Checking create index");
 
   std::string create_sql = "CREATE UNIQUE INDEX idx_d ON A (lower(A2), A1);";
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   EXPECT_NO_THROW(binder_->BindNameToNode(statement, &parse_tree));
 }
@@ -891,7 +890,7 @@ TEST_F(BinderCorrectnessTest, CreateTriggerTest) {
       "FOR EACH ROW "
       "WHEN (OLD.a1 <> NEW.a1) "
       "EXECUTE PROCEDURE check_account_update(update_date);";
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   auto create_stmt = statement.CastManagedPointerTo<parser::CreateStatement>();
   EXPECT_NO_THROW(binder_->BindNameToNode(statement, &parse_tree));
@@ -909,7 +908,7 @@ TEST_F(BinderCorrectnessTest, CreateTriggerTest) {
 TEST_F(BinderCorrectnessTest, CreateViewTest) {
   std::string create_sql = "CREATE VIEW a_view AS SELECT * FROM a WHERE a1 = 4;";
 
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
 

--- a/test/optimizer/operator_transformer_test.cpp
+++ b/test/optimizer/operator_transformer_test.cpp
@@ -37,7 +37,6 @@ class OperatorTransformerTest : public TerrierTest {
   catalog::table_oid_t table_a_oid_;
   catalog::table_oid_t table_b_oid_;
   catalog::index_oid_t a_index_oid_;
-  parser::PostgresParser parser_;
   common::ManagedPointer<transaction::TransactionManager> txn_manager_;
   common::ManagedPointer<catalog::Catalog> catalog_;
   transaction::TransactionContext *txn_;
@@ -165,7 +164,7 @@ TEST_F(OperatorTransformerTest, SelectStatementSimpleTest) {
 
   std::string ref = R"({"Op":"LogicalGet",})";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -189,7 +188,7 @@ TEST_F(OperatorTransformerTest, InsertStatementSimpleTest) {
 
   std::string ref = R"({"Op":"LogicalInsert",})";
 
-  auto parse_tree = parser_.BuildParseTree(insert_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(insert_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -227,7 +226,7 @@ TEST_F(OperatorTransformerTest, InsertStatementSelectTest) {
       "[{\"Op\":\"LogicalFilter\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(insert_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(insert_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -265,7 +264,7 @@ TEST_F(OperatorTransformerTest, UpdateStatementSimpleTest) {
       "{\"Op\":\"LogicalUpdate\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",}]}";
 
-  auto parse_tree = parser_.BuildParseTree(update_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(update_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -302,7 +301,7 @@ TEST_F(OperatorTransformerTest, SelectStatementAggregateTest) {
       "{\"Op\":\"LogicalAggregateAndGroupBy\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -336,7 +335,7 @@ TEST_F(OperatorTransformerTest, SelectStatementDistinctTest) {
       "[{\"Op\":\"LogicalFilter\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -368,7 +367,7 @@ TEST_F(OperatorTransformerTest, SelectStatementOrderByTest) {
       "{\"Op\":\"LogicalLimit\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -406,7 +405,7 @@ TEST_F(OperatorTransformerTest, SelectStatementLeftJoinTest) {
       "{\"Op\":\"LogicalLeftJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -444,7 +443,7 @@ TEST_F(OperatorTransformerTest, SelectStatementRightJoinTest) {
       "{\"Op\":\"LogicalRightJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -482,7 +481,7 @@ TEST_F(OperatorTransformerTest, SelectStatementInnerJoinTest) {
       "{\"Op\":\"LogicalInnerJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -520,7 +519,7 @@ TEST_F(OperatorTransformerTest, SelectStatementOuterJoinTest) {
       "{\"Op\":\"LogicalOuterJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -563,7 +562,7 @@ TEST_F(OperatorTransformerTest, SelectStatementComplexTest) {
       "[{\"Op\":\"LogicalInnerJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}]}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -585,7 +584,7 @@ TEST_F(OperatorTransformerTest, SelectStatementMarkJoinTest) {
       "[{\"Op\":\"LogicalMarkJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}]}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -609,7 +608,7 @@ TEST_F(OperatorTransformerTest, SelectStatementStarNestedSelectTest) {
       "[{\"Op\":\"LogicalInnerJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -628,7 +627,7 @@ TEST_F(OperatorTransformerTest, SelectStatementNestedColumnTest) {
 
   std::string ref = R"({"Op":"LogicalGet",})";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -648,7 +647,7 @@ TEST_F(OperatorTransformerTest, SelectStatementDiffTableSameSchemaTest) {
       "[{\"Op\":\"LogicalInnerJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -669,7 +668,7 @@ TEST_F(OperatorTransformerTest, SelectStatementSelectListAliasTest) {
       "[{\"Op\":\"LogicalInnerJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -687,7 +686,7 @@ TEST_F(OperatorTransformerTest, DeleteStatementWhereTest) {
       "{\"Op\":\"LogicalDelete\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",}]}";
 
-  auto parse_tree = parser_.BuildParseTree(delete_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(delete_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -727,7 +726,7 @@ TEST_F(OperatorTransformerTest, AggregateComplexTest) {
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalAggregateAndGroupBy\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",}]}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -749,7 +748,7 @@ TEST_F(OperatorTransformerTest, OperatorComplexTest) {
       "[{\"Op\":\"LogicalMarkJoin\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",},{\"Op\":\"LogicalGet\",}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto default_namespace_oid = accessor_->GetDefaultNamespace();
@@ -795,7 +794,7 @@ TEST_F(OperatorTransformerTest, SubqueryComplexTest) {
       "[{\"Op\":\"LogicalGet\",}]}]}]}]},{\"Op\":\"LogicalFilter\",\"Children\":"
       "[{\"Op\":\"LogicalGet\",}]}]}]}";
 
-  auto parse_tree = parser_.BuildParseTree(select_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(select_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -811,7 +810,7 @@ TEST_F(OperatorTransformerTest, CreateDatabaseTest) {
 
   std::string ref = R"({"Op":"LogicalCreateDatabase",})";
 
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -833,7 +832,7 @@ TEST_F(OperatorTransformerTest, CreateTableTest) {
 
   std::string ref = R"({"Op":"LogicalCreateTable",})";
 
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto ns_oid = accessor_->GetDefaultNamespace();
@@ -856,7 +855,7 @@ TEST_F(OperatorTransformerTest, CreateIndexTest) {
   std::string create_sql = "CREATE UNIQUE INDEX idx_d ON A (lower(A2), A1);";
   std::string ref = R"({"Op":"LogicalCreateIndex",})";
 
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto ns_oid = accessor_->GetDefaultNamespace();
@@ -905,7 +904,7 @@ TEST_F(OperatorTransformerTest, CreateFunctionTest) {
 
   std::string ref = R"({"Op":"LogicalCreateFunction",})";
 
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto ns_oid = accessor_->GetDefaultNamespace();
@@ -940,7 +939,7 @@ TEST_F(OperatorTransformerTest, CreateNamespaceTest) {
 
   std::string ref = R"({"Op":"LogicalCreateNamespace",})";
 
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -960,7 +959,7 @@ TEST_F(OperatorTransformerTest, CreateViewTest) {
 
   std::string ref = R"({"Op":"LogicalCreateView",})";
 
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto ns_oid = accessor_->GetDefaultNamespace();
@@ -987,7 +986,7 @@ TEST_F(OperatorTransformerTest, CreateTriggerTest) {
       "EXECUTE PROCEDURE check_account_update(update_date);";
   std::string ref = R"({"Op":"LogicalCreateTrigger",})";
 
-  auto parse_tree = parser_.BuildParseTree(create_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(create_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   auto ns_oid = accessor_->GetDefaultNamespace();
@@ -1026,7 +1025,7 @@ TEST_F(OperatorTransformerTest, DropDatabaseTest) {
 
   std::string ref = R"({"Op":"LogicalDropDatabase",})";
 
-  auto parse_tree = parser_.BuildParseTree(drop_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(drop_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -1046,7 +1045,7 @@ TEST_F(OperatorTransformerTest, DropTableTest) {
 
   std::string ref = R"({"Op":"LogicalDropTable",})";
 
-  auto parse_tree = parser_.BuildParseTree(drop_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(drop_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -1065,7 +1064,7 @@ TEST_F(OperatorTransformerTest, DropIndexTest) {
   std::string drop_sql = "DROP index a_index ;";
   std::string ref = R"({"Op":"LogicalDropIndex",})";
 
-  auto parse_tree = parser_.BuildParseTree(drop_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(drop_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));
@@ -1084,7 +1083,7 @@ TEST_F(OperatorTransformerTest, DropNamespaceIfExistsTest) {
   std::string drop_sql = "DROP SCHEMA IF EXISTS foo CASCADE;";
   std::string ref = R"({"Op":"LogicalDropNamespace",})";
 
-  auto parse_tree = parser_.BuildParseTree(drop_sql);
+  auto parse_tree = parser::PostgresParser::BuildParseTree(drop_sql);
   auto statement = parse_tree.GetStatements()[0];
   binder_->BindNameToNode(statement, &parse_tree);
   operator_transformer_ = std::make_unique<optimizer::QueryToOperatorTransformer>(common::ManagedPointer(accessor_));

--- a/test/parser/expression_test.cpp
+++ b/test/parser/expression_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-
 #include "parser/expression/conjunction_expression.h"
 #include "parser/expression/constant_value_expression.h"
 // TODO(Tianyu): They are included here so they will get compiled and statically analyzed despite not being used
@@ -23,7 +22,6 @@
 #include "parser/expression/type_cast_expression.h"
 #include "parser/parameter.h"
 #include "parser/postgresparser.h"
-
 #include "type/transient_value.h"
 #include "type/transient_value_factory.h"
 #include "type/type_id.h"
@@ -1008,8 +1006,7 @@ TEST(ExpressionTests, SubqueryExpressionTest) {
   // Current implementation of subquery expression's ==operator and Hash() function
   // only handles: all fields inherited from abstract expression class and
   // subselect's select columns, where condition, and distinct flag
-  PostgresParser pgparser;
-  auto stmts0 = pgparser.BuildParseTree(
+  auto stmts0 = parser::PostgresParser::BuildParseTree(
       "SELECT * FROM foo INNER JOIN bar ON foo.a = bar.a WHERE foo.a > 0 GROUP BY foo.b ORDER BY bar.b ASC LIMIT 5;");
   EXPECT_EQ(stmts0.GetStatements().size(), 1);
   EXPECT_EQ(stmts0.GetStatement(0)->GetType(), StatementType::SELECT);
@@ -1018,14 +1015,14 @@ TEST(ExpressionTests, SubqueryExpressionTest) {
       reinterpret_cast<SelectStatement *>(stmts0.TakeStatementsOwnership()[0].release()));
   auto subselect_expr0 = new SubqueryExpression(std::move(select0));
 
-  auto stmts1 = pgparser.BuildParseTree(
+  auto stmts1 = parser::PostgresParser::BuildParseTree(
       "SELECT * FROM foo INNER JOIN bar ON foo.a = bar.a WHERE foo.a > 0 GROUP BY foo.b ORDER BY bar.b ASC LIMIT 5;");
   auto select1 = std::unique_ptr<SelectStatement>(
       reinterpret_cast<SelectStatement *>(stmts1.TakeStatementsOwnership()[0].release()));
   auto subselect_expr1 = new SubqueryExpression(std::move(select1));
 
   // different in select columns
-  auto stmts2 = pgparser.BuildParseTree(
+  auto stmts2 = parser::PostgresParser::BuildParseTree(
       "SELECT a, b FROM foo INNER JOIN bar ON foo.a = bar.a WHERE foo.a > 0 GROUP BY foo.b ORDER BY bar.b ASC LIMIT "
       "5;");
   auto select2 = std::unique_ptr<SelectStatement>(
@@ -1033,7 +1030,7 @@ TEST(ExpressionTests, SubqueryExpressionTest) {
   auto subselect_expr2 = new SubqueryExpression(std::move(select2));
 
   // different in distinct flag
-  auto stmts3 = pgparser.BuildParseTree(
+  auto stmts3 = parser::PostgresParser::BuildParseTree(
       "SELECT DISTINCT a, b FROM foo INNER JOIN bar ON foo.a = bar.a WHERE foo.a > 0 GROUP BY foo.b ORDER BY bar.b ASC "
       "LIMIT 5;");
   auto select3 = std::unique_ptr<SelectStatement>(
@@ -1041,14 +1038,14 @@ TEST(ExpressionTests, SubqueryExpressionTest) {
   auto subselect_expr3 = new SubqueryExpression(std::move(select3));
 
   // different in where
-  auto stmts4 = pgparser.BuildParseTree(
+  auto stmts4 = parser::PostgresParser::BuildParseTree(
       "SELECT * FROM foo INNER JOIN bar ON foo.b = bar.a WHERE foo.b > 0 GROUP BY foo.b ORDER BY bar.b ASC LIMIT 5;");
   auto select4 = std::unique_ptr<SelectStatement>(
       reinterpret_cast<SelectStatement *>(stmts4.TakeStatementsOwnership()[0].release()));
   auto subselect_expr4 = new SubqueryExpression(std::move(select4));
 
   // different in where
-  auto stmts5 = pgparser.BuildParseTree("SELECT * FROM foo INNER JOIN bar ON foo.b = bar.a;");
+  auto stmts5 = parser::PostgresParser::BuildParseTree("SELECT * FROM foo INNER JOIN bar ON foo.b = bar.a;");
   auto select5 = std::unique_ptr<SelectStatement>(
       reinterpret_cast<SelectStatement *>(stmts5.TakeStatementsOwnership()[0].release()));
   auto subselect_expr5 = new SubqueryExpression(std::move(select5));
@@ -1079,8 +1076,7 @@ TEST(ExpressionTests, SubqueryExpressionTest) {
 // NOLINTNEXTLINE
 TEST(ExpressionTests, SimpleSubqueryExpressionJsonTest) {
   // Create expression
-  PostgresParser pgparser;
-  auto result = pgparser.BuildParseTree("SELECT * FROM foo;");
+  auto result = parser::PostgresParser::BuildParseTree("SELECT * FROM foo;");
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::SELECT);
 
@@ -1111,8 +1107,7 @@ TEST(ExpressionTests, SimpleSubqueryExpressionJsonTest) {
 // NOLINTNEXTLINE
 TEST(ExpressionTests, ComplexSubqueryExpressionJsonTest) {
   // Create expression
-  PostgresParser pgparser;
-  auto result = pgparser.BuildParseTree(
+  auto result = parser::PostgresParser::BuildParseTree(
       "SELECT * FROM foo INNER JOIN bar ON foo.a = bar.a GROUP BY foo.b ORDER BY bar.b ASC LIMIT 5;");
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatements()[0]->GetType(), StatementType::SELECT);

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -34,8 +34,6 @@ class ParserTestBase : public TerrierTest {
   void CheckTable(const std::unique_ptr<TableInfo> &table_info, const std::string &table_name) {
     EXPECT_EQ(table_info->GetTableName(), table_name);
   }
-
-  PostgresParser pgparser_;
 };
 
 // NOLINTNEXTLINE
@@ -49,7 +47,7 @@ TEST_F(ParserTestBase, AnalyzeTest) {
    * ANALYZE table_name (column_name, ...) : (segfaults)
    */
 
-  auto result = pgparser_.BuildParseTree("ANALYZE table_name;");
+  auto result = parser::PostgresParser::BuildParseTree("ANALYZE table_name;");
   auto analyze_stmt = result.GetStatement(0).CastManagedPointerTo<AnalyzeStatement>();
   EXPECT_EQ(analyze_stmt->GetType(), StatementType::ANALYZE);
   EXPECT_EQ(analyze_stmt->GetAnalyzeTable()->GetTableName(), "table_name");
@@ -57,13 +55,13 @@ TEST_F(ParserTestBase, AnalyzeTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, NOOPTest) {
-  auto result = pgparser_.BuildParseTree(";");
+  auto result = parser::PostgresParser::BuildParseTree(";");
   EXPECT_EQ(result.GetStatements().size(), 0);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, CastTest) {
-  auto result = pgparser_.BuildParseTree("SELECT CAST('100' AS INTEGER);");
+  auto result = parser::PostgresParser::BuildParseTree("SELECT CAST('100' AS INTEGER);");
   auto cast_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
   EXPECT_EQ(cast_stmt->GetType(), StatementType::SELECT);
   EXPECT_EQ(cast_stmt->GetSelectColumns().at(0)->GetExpressionType(), ExpressionType::OPERATOR_CAST);
@@ -72,7 +70,7 @@ TEST_F(ParserTestBase, CastTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, CopyTest) {
-  auto result = pgparser_.BuildParseTree("COPY foo FROM STDIN WITH BINARY;");
+  auto result = parser::PostgresParser::BuildParseTree("COPY foo FROM STDIN WITH BINARY;");
   auto copy_stmt = result.GetStatement(0).CastManagedPointerTo<CopyStatement>();
   EXPECT_EQ(copy_stmt->GetType(), StatementType::COPY);
   EXPECT_EQ(copy_stmt->GetExternalFileFormat(), ExternalFileFormat::BINARY);
@@ -88,7 +86,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
         " RETURNS DOUBLE AS $$ "
         " BEGIN RETURN i + 1; END; $$ "
         "LANGUAGE plpgsql;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto stmt = result.GetStatement(0).CastManagedPointerTo<CreateFunctionStatement>();
     auto func_params = stmt->GetFuncParameters();
     EXPECT_EQ(stmt->GetFuncName(), "increment");
@@ -105,7 +103,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
         " RETURNS DOUBLE AS $$ "
         " BEGIN RETURN i + j; END; $$ "
         "LANGUAGE plpgsql;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto stmt = result.GetStatement(0).CastManagedPointerTo<CreateFunctionStatement>();
     auto func_params = stmt->GetFuncParameters();
     EXPECT_EQ(stmt->GetFuncName(), "increment1");
@@ -124,7 +122,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
         " RETURNS INT AS $$ "
         "BEGIN RETURN i + 1; END; $$ "
         "LANGUAGE plpgsql;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto stmt = result.GetStatement(0).CastManagedPointerTo<CreateFunctionStatement>();
     auto func_params = stmt->GetFuncParameters();
     EXPECT_EQ(stmt->GetFuncName(), "increment2");
@@ -143,7 +141,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
         " RETURNS VARCHAR AS $$ "
         "BEGIN RETURN 'foo'; END; $$ "
         "LANGUAGE plpgsql;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto stmt = result.GetStatement(0).CastManagedPointerTo<CreateFunctionStatement>();
     auto func_params = stmt->GetFuncParameters();
     EXPECT_EQ(stmt->GetFuncName(), "return_varchar");
@@ -160,7 +158,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
         " RETURNS TEXT AS $$ "
         "BEGIN RETURN 'foo'; END; $$ "
         "LANGUAGE plpgsql;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto stmt = result.GetStatement(0).CastManagedPointerTo<CreateFunctionStatement>();
     auto func_params = stmt->GetFuncParameters();
     EXPECT_EQ(stmt->GetFuncName(), "return_text");
@@ -177,7 +175,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
         " RETURNS BOOL AS $$ "
         "BEGIN RETURN false; END; $$ "
         "LANGUAGE plpgsql;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto stmt = result.GetStatement(0).CastManagedPointerTo<CreateFunctionStatement>();
     auto func_params = stmt->GetFuncParameters();
     EXPECT_EQ(stmt->GetFuncName(), "return_bool");
@@ -190,7 +188,7 @@ TEST_F(ParserTestBase, CreateFunctionTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, CreateIndexTest) {
   std::string query = "CREATE INDEX IDX_ORDER ON oorder ((O_W_ID - 2), (O + W + O));";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   EXPECT_EQ(create_stmt->GetCreateType(), CreateStatement::kIndex);
@@ -236,15 +234,15 @@ TEST_F(ParserTestBase, CreateTableTest) {
       "PRIMARY KEY (id),"
       "FOREIGN KEY (c_id) REFERENCES country (cid));";
 
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
 
   query = "CREATE TABLE Foo (id BAZ, PRIMARY KEY (id));";
-  EXPECT_THROW(pgparser_.BuildParseTree(query), ParserException);
+  EXPECT_THROW(parser::PostgresParser::BuildParseTree(query), ParserException);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, CreateViewTest) {
-  auto result = pgparser_.BuildParseTree("CREATE VIEW foo AS SELECT * FROM bar WHERE baz = 1;");
+  auto result = parser::PostgresParser::BuildParseTree("CREATE VIEW foo AS SELECT * FROM bar WHERE baz = 1;");
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   EXPECT_EQ(create_stmt->GetViewName(), "foo");
@@ -267,7 +265,7 @@ TEST_F(ParserTestBase, CreateViewTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, DropDBTest) {
-  auto result = pgparser_.BuildParseTree("DROP DATABASE test_db;");
+  auto result = parser::PostgresParser::BuildParseTree("DROP DATABASE test_db;");
   EXPECT_EQ(result.GetStatements().size(), 1);
 
   auto drop_stmt = result.GetStatement(0).CastManagedPointerTo<DropStatement>();
@@ -277,7 +275,7 @@ TEST_F(ParserTestBase, DropDBTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, DropIndexTest) {
-  auto result = pgparser_.BuildParseTree("DROP INDEX foo;");
+  auto result = parser::PostgresParser::BuildParseTree("DROP INDEX foo;");
   EXPECT_EQ(result.GetStatements().size(), 1);
 
   auto drop_stmt = result.GetStatement(0).CastManagedPointerTo<DropStatement>();
@@ -287,7 +285,7 @@ TEST_F(ParserTestBase, DropIndexTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, DropSchemaTest) {
-  auto result = pgparser_.BuildParseTree("DROP SCHEMA IF EXISTS foo CASCADE;");
+  auto result = parser::PostgresParser::BuildParseTree("DROP SCHEMA IF EXISTS foo CASCADE;");
   EXPECT_EQ(result.GetStatements().size(), 1);
 
   auto drop_stmt = result.GetStatement(0).CastManagedPointerTo<DropStatement>();
@@ -299,7 +297,7 @@ TEST_F(ParserTestBase, DropSchemaTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, DropTableTest) {
-  auto result = pgparser_.BuildParseTree("DROP TABLE test_db;");
+  auto result = parser::PostgresParser::BuildParseTree("DROP TABLE test_db;");
   EXPECT_EQ(result.GetStatements().size(), 1);
 
   auto drop_stmt = result.GetStatement(0).CastManagedPointerTo<DropStatement>();
@@ -309,36 +307,36 @@ TEST_F(ParserTestBase, DropTableTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, ExecuteTest) {
-  auto result = pgparser_.BuildParseTree("EXECUTE prepared_statement_name;");
+  auto result = parser::PostgresParser::BuildParseTree("EXECUTE prepared_statement_name;");
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::EXECUTE);
 
-  result = pgparser_.BuildParseTree("EXECUTE prepared_statement_name(1, 2.0)");
+  result = parser::PostgresParser::BuildParseTree("EXECUTE prepared_statement_name(1, 2.0)");
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::EXECUTE);
 
-  result = pgparser_.BuildParseTree("EXECUTE prepared_statement_name(1, 'arg_2', 3.0)");
+  result = parser::PostgresParser::BuildParseTree("EXECUTE prepared_statement_name(1, 'arg_2', 3.0)");
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::EXECUTE);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, ExplainTest) {
-  auto result = pgparser_.BuildParseTree("EXPLAIN SELECT * FROM foo;");
+  auto result = parser::PostgresParser::BuildParseTree("EXPLAIN SELECT * FROM foo;");
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::EXPLAIN);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, GarbageTest) {
-  EXPECT_THROW(pgparser_.BuildParseTree("blarglesnarf"), ParserException);
-  EXPECT_THROW(pgparser_.BuildParseTree("SELECT;"), ParserException);
+  EXPECT_THROW(parser::PostgresParser::BuildParseTree("blarglesnarf"), ParserException);
+  EXPECT_THROW(parser::PostgresParser::BuildParseTree("SELECT;"), ParserException);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, InsertTest) {
-  auto result = pgparser_.BuildParseTree("INSERT INTO foo VALUES (1, 2, 3), (4, 5, 6);");
+  auto result = parser::PostgresParser::BuildParseTree("INSERT INTO foo VALUES (1, 2, 3), (4, 5, 6);");
   auto insert_stmt = result.GetStatement(0).CastManagedPointerTo<InsertStatement>();
   EXPECT_EQ(insert_stmt->GetInsertionTable()->GetTableName(), "foo");
   EXPECT_EQ(insert_stmt->GetInsertColumns()->size(), 0);
 
-  result = pgparser_.BuildParseTree("INSERT INTO foo (id,bar,entry) VALUES (DEFAULT, 2, 3);");
+  result = parser::PostgresParser::BuildParseTree("INSERT INTO foo (id,bar,entry) VALUES (DEFAULT, 2, 3);");
   insert_stmt = result.GetStatement(0).CastManagedPointerTo<InsertStatement>();
   EXPECT_EQ(insert_stmt->GetInsertionTable()->GetTableName(), "foo");
   EXPECT_EQ(insert_stmt->GetInsertColumns()->size(), 3);
@@ -348,7 +346,7 @@ TEST_F(ParserTestBase, InsertTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, PrepareTest) {
   {
-    auto result = pgparser_.BuildParseTree("PREPARE insert_plan AS INSERT INTO table_name VALUES($1);");
+    auto result = parser::PostgresParser::BuildParseTree("PREPARE insert_plan AS INSERT INTO table_name VALUES($1);");
     EXPECT_EQ(result.GetStatements().size(), 1);
     EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::PREPARE);
     auto prepare_stmt = result.GetStatement(0).CastManagedPointerTo<PrepareStatement>();
@@ -359,7 +357,8 @@ TEST_F(ParserTestBase, PrepareTest) {
   }
 
   {
-    auto result = pgparser_.BuildParseTree("PREPARE insert_plan (INT) AS INSERT INTO table_name VALUES($1);");
+    auto result =
+        parser::PostgresParser::BuildParseTree("PREPARE insert_plan (INT) AS INSERT INTO table_name VALUES($1);");
     EXPECT_EQ(result.GetStatements().size(), 1);
     EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::PREPARE);
     auto prepare_stmt = result.GetStatement(0).CastManagedPointerTo<PrepareStatement>();
@@ -371,8 +370,8 @@ TEST_F(ParserTestBase, PrepareTest) {
   }
 
   {
-    auto result =
-        pgparser_.BuildParseTree("PREPARE select_stmt_plan (INT) AS SELECT column_name FROM table_name WHERE id=$1;");
+    auto result = parser::PostgresParser::BuildParseTree(
+        "PREPARE select_stmt_plan (INT) AS SELECT column_name FROM table_name WHERE id=$1;");
     EXPECT_EQ(result.GetStatements().size(), 1);
     EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::PREPARE);
     auto prepare_stmt = result.GetStatement(0).CastManagedPointerTo<PrepareStatement>();
@@ -386,7 +385,7 @@ TEST_F(ParserTestBase, PrepareTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, SelectTest) {
-  auto result = pgparser_.BuildParseTree("SELECT * FROM foo;");
+  auto result = parser::PostgresParser::BuildParseTree("SELECT * FROM foo;");
 
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::SELECT);
@@ -396,7 +395,7 @@ TEST_F(ParserTestBase, SelectTest) {
   // CheckTable(select_stmt->from_->table_info_, std::string("foo"));
   EXPECT_EQ(select_stmt->GetSelectColumns()[0]->GetExpressionType(), ExpressionType::STAR);
 
-  auto result2 = pgparser_.BuildParseTree("SELECT id FROM foo LIMIT 1 OFFSET 1;");
+  auto result2 = parser::PostgresParser::BuildParseTree("SELECT id FROM foo LIMIT 1 OFFSET 1;");
   EXPECT_EQ(result2.GetStatement(0)->GetType(), StatementType::SELECT);
   auto select_stmt_2 = result2.GetStatement(0).CastManagedPointerTo<SelectStatement>();
   EXPECT_EQ(select_stmt_2->GetSelectLimit()->GetLimit(), 1);
@@ -408,28 +407,29 @@ TEST_F(ParserTestBase, SelectTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, SelectUnionTest) {
-  auto result = pgparser_.BuildParseTree("SELECT * FROM foo UNION SELECT * FROM bar;");
+  auto result = parser::PostgresParser::BuildParseTree("SELECT * FROM foo UNION SELECT * FROM bar;");
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::SELECT);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, SetTest) {
-  auto result = pgparser_.BuildParseTree("SET var_name TO 1;");
+  auto result = parser::PostgresParser::BuildParseTree("SET var_name TO 1;");
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::VARIABLE_SET);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, SubqueryTest) {
-  auto result = pgparser_.BuildParseTree("SELECT * FROM foo WHERE id IN (SELECT id FROM foo WHERE x > 400)");
+  auto result =
+      parser::PostgresParser::BuildParseTree("SELECT * FROM foo WHERE id IN (SELECT id FROM foo WHERE x > 400)");
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::SELECT);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, TruncateTest) {
-  auto result = pgparser_.BuildParseTree("TRUNCATE TABLE test_db;");
+  auto result = parser::PostgresParser::BuildParseTree("TRUNCATE TABLE test_db;");
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::DELETE);
 
@@ -440,7 +440,7 @@ TEST_F(ParserTestBase, TruncateTest) {
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, UpdateTest) {
-  auto result = pgparser_.BuildParseTree("UPDATE students SET grade = 1.0;");
+  auto result = parser::PostgresParser::BuildParseTree("UPDATE students SET grade = 1.0;");
 
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::UPDATE);
@@ -455,7 +455,7 @@ TEST_F(ParserTestBase, UpdateTest) {
 TEST_F(ParserTestBase, OperatorTest) {
   {
     std::string query = "SELECT 10+10 AS Addition;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectColumns().at(0);
@@ -464,7 +464,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 15-721 AS Subtraction;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectColumns().at(0);
@@ -473,7 +473,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 5*7 AS Multiplication;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectColumns().at(0);
@@ -482,7 +482,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 1/2 AS Division;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectColumns().at(0);
@@ -491,7 +491,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 15||213 AS Concatenation;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectColumns().at(0);
@@ -500,7 +500,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT 4%2 AS Mod;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectColumns().at(0);
@@ -509,7 +509,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT CAST('100' AS INTEGER) AS Casting;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectColumns().at(0);
@@ -519,7 +519,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE NOT id = 1;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
@@ -528,7 +528,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE id IS NULL;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
@@ -539,7 +539,7 @@ TEST_F(ParserTestBase, OperatorTest) {
   {
     // Coverage for NullNodeTransform
     std::string query = "SELECT * FROM foo WHERE 0 IS NULL;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
@@ -548,14 +548,14 @@ TEST_F(ParserTestBase, OperatorTest) {
     EXPECT_EQ(expr->GetChild(0)->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
 
     query = "SELECT * FROM foo WHERE 0*1 IS NULL;";
-    result = pgparser_.BuildParseTree(query);
+    result = parser::PostgresParser::BuildParseTree(query);
     select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     expr = select_stmt->GetSelectCondition();
     EXPECT_EQ(expr->GetExpressionType(), ExpressionType::OPERATOR_IS_NULL);
     EXPECT_EQ(expr->GetReturnValueType(), type::TypeId::BOOLEAN);
 
     query = "SELECT * FROM foo WHERE ? IS NULL;";
-    result = pgparser_.BuildParseTree(query);
+    result = parser::PostgresParser::BuildParseTree(query);
     select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     expr = select_stmt->GetSelectCondition();
     EXPECT_EQ(expr->GetExpressionType(), ExpressionType::OPERATOR_IS_NULL);
@@ -565,7 +565,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE EXISTS (SELECT * from bar);";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
     EXPECT_EQ(expr->GetExpressionType(), ExpressionType::OPERATOR_EXISTS);
@@ -577,7 +577,7 @@ TEST_F(ParserTestBase, OperatorTest) {
 TEST_F(ParserTestBase, CompareTest) {
   {
     std::string query = "SELECT * FROM foo WHERE id < 10;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
@@ -587,7 +587,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE id <= 10;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
@@ -597,7 +597,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE id >= 10;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
@@ -607,7 +607,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE str ~~ '%test%';";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
@@ -617,7 +617,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE str !~~ '%test%';";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
@@ -627,7 +627,7 @@ TEST_F(ParserTestBase, CompareTest) {
 
   {
     std::string query = "SELECT * FROM foo WHERE str IS DISTINCT FROM 'test';";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
     auto expr = select_stmt->GetSelectCondition();
@@ -646,7 +646,7 @@ TEST_F(ParserTestBase, CompareTest) {
 TEST_F(ParserTestBase, OldBasicTest) {
   std::string query = "SELECT * FROM foo;";
 
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   EXPECT_EQ(1, result.GetStatements().size());
   EXPECT_EQ(StatementType::SELECT, result.GetStatement(0)->GetType());
 
@@ -662,7 +662,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT COUNT(*) FROM foo;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     EXPECT_EQ(1, result.GetStatements().size());
     EXPECT_EQ(StatementType::SELECT, result.GetStatement(0)->GetType());
 
@@ -673,7 +673,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT COUNT(DISTINCT id) FROM foo;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
 
     EXPECT_EQ(1, result.GetStatements().size());
     EXPECT_EQ(StatementType::SELECT, result.GetStatement(0)->GetType());
@@ -690,7 +690,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT MAX(*) FROM foo;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     EXPECT_EQ(1, result.GetStatements().size());
     EXPECT_EQ(StatementType::SELECT, result.GetStatement(0)->GetType());
 
@@ -701,7 +701,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT MIN(*) FROM foo;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     EXPECT_EQ(1, result.GetStatements().size());
     EXPECT_EQ(StatementType::SELECT, result.GetStatement(0)->GetType());
 
@@ -712,7 +712,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 
   {
     query = "SELECT AVG(*) FROM foo;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     EXPECT_EQ(1, result.GetStatements().size());
     EXPECT_EQ(StatementType::SELECT, result.GetStatement(0)->GetType());
 
@@ -726,7 +726,7 @@ TEST_F(ParserTestBase, OldAggTest) {
 TEST_F(ParserTestBase, OldGroupByTest) {
   // Select with group by clause
   std::string query = "SELECT * FROM foo GROUP BY id, name HAVING id > 10;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
 
   auto statement = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
   auto columns = statement->GetSelectGroupBy()->GetColumns();
@@ -747,7 +747,7 @@ TEST_F(ParserTestBase, OldGroupByTest) {
   EXPECT_EQ(type::TypeId::INTEGER, value_exp->GetValue().Type());
   EXPECT_EQ(10, type::TransientValuePeeker::PeekInteger(value_exp->GetValue()));
 
-  auto result2 = pgparser_.BuildParseTree(query);
+  auto result2 = parser::PostgresParser::BuildParseTree(query);
   auto statement_2 = result2.GetStatement(0).CastManagedPointerTo<SelectStatement>();
   EXPECT_TRUE(*statement == *statement_2);
   EXPECT_EQ(statement->Hash(), statement_2->Hash());
@@ -757,7 +757,7 @@ TEST_F(ParserTestBase, OldGroupByTest) {
 TEST_F(ParserTestBase, OldOrderByTest) {
   {
     std::string query = "SELECT * FROM foo ORDER BY id;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
@@ -775,7 +775,7 @@ TEST_F(ParserTestBase, OldOrderByTest) {
 
   {
     std::string query = "SELECT * FROM foo ORDER BY id ASC;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
@@ -792,7 +792,7 @@ TEST_F(ParserTestBase, OldOrderByTest) {
 
   {
     std::string query = "SELECT * FROM foo ORDER BY id DESC;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
@@ -809,7 +809,7 @@ TEST_F(ParserTestBase, OldOrderByTest) {
 
   {
     std::string query = "SELECT * FROM foo ORDER BY id, name;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
@@ -830,7 +830,7 @@ TEST_F(ParserTestBase, OldOrderByTest) {
 
   {
     std::string query = "SELECT * FROM foo ORDER BY id, name DESC;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto sql_stmt = result.GetStatement(0);
     EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
     auto select_stmt = sql_stmt.CastManagedPointerTo<SelectStatement>();
@@ -855,7 +855,7 @@ TEST_F(ParserTestBase, OldConstTest) {
   // Select constants
   std::string query = "SELECT 'str', 1, 3.14 FROM foo;";
 
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto statement = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
   auto select_columns = statement->GetSelectColumns();
   EXPECT_EQ(3, select_columns.size());
@@ -878,7 +878,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo JOIN bar ON foo.id=bar.id JOIN baz ON foo.id2=baz.id2;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     auto join_table = select_stmt->GetSelectTable();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -908,7 +908,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo INNER JOIN bar ON foo.id=bar.id AND foo.val > bar.val;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     auto join_table = select_stmt->GetSelectTable();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -917,7 +917,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo LEFT JOIN bar ON foo.id=bar.id AND foo.val > bar.val;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     auto join_table = select_stmt->GetSelectTable();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -926,7 +926,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo RIGHT JOIN bar ON foo.id=bar.id AND foo.val > bar.val;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     auto join_table = select_stmt->GetSelectTable();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -935,7 +935,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 
   {
     query = "SELECT * FROM foo FULL OUTER JOIN bar ON foo.id=bar.id AND foo.val > bar.val;";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     auto join_table = select_stmt->GetSelectTable();
     EXPECT_EQ(join_table->GetTableReferenceType(), TableReferenceType::JOIN);
@@ -945,7 +945,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
   {
     // test case from SQLite
     query = "SELECT * FROM tab0 AS cor0 CROSS JOIN tab0 AS cor1 WHERE NULL IS NOT NULL;";
-    EXPECT_THROW(pgparser_.BuildParseTree(query), ParserException);
+    EXPECT_THROW(parser::PostgresParser::BuildParseTree(query), ParserException);
   }
 }
 
@@ -953,7 +953,7 @@ TEST_F(ParserTestBase, OldJoinTest) {
 TEST_F(ParserTestBase, OldNestedQueryTest) {
   // Select with nested query
   std::string query = "SELECT * FROM (SELECT * FROM foo) as t;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
 
   EXPECT_EQ(1, result.GetStatements().size());
   auto statement = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
@@ -968,7 +968,7 @@ TEST_F(ParserTestBase, OldNestedQueryTest) {
 TEST_F(ParserTestBase, OldMultiTableTest) {
   // Select from multiple tables
   std::string query = "SELECT foo.name as name_new FROM (SELECT * FROM bar) as b, foo, bar WHERE foo.id = b.id;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   EXPECT_EQ(1, result.GetStatements().size());
   auto statement = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
 
@@ -1008,7 +1008,7 @@ TEST_F(ParserTestBase, OldColumnUpdateTest) {
   queries.emplace_back("UPDATE CUSTOMER SET C_BALANCE = C_BALANCE, C_DELIVERY_CNT = C_DELIVERY_CNT WHERE C_W_ID = 2");
 
   for (const auto &query : queries) {
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
 
     EXPECT_EQ(result.GetStatements().size(), 1);
     auto sql_stmt = result.GetStatement(0);
@@ -1051,7 +1051,7 @@ TEST_F(ParserTestBase, OldColumnUpdateTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldExpressionUpdateTest) {
   std::string query = "UPDATE STOCK SET S_QUANTITY = 48.0 , S_YTD = S_YTD + 1 WHERE S_I_ID = 68999 AND S_W_ID = 4";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto update_stmt = result.GetStatement(0).CastManagedPointerTo<UpdateStatement>();
   EXPECT_EQ(update_stmt->GetUpdateTable()->GetTableName(), "stock");
 
@@ -1100,7 +1100,7 @@ TEST_F(ParserTestBase, OldStringUpdateTest) {
   std::string query =
       "UPDATE ORDER_LINE SET OL_DELIVERY_D = '2016-11-15 15:07:37' WHERE OL_O_ID = 2101 AND OL_D_ID = 2";
 
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto sql_stmt = result.GetStatement(0);
 
   // Check root type
@@ -1158,7 +1158,7 @@ TEST_F(ParserTestBase, OldStringUpdateTest) {
 TEST_F(ParserTestBase, OldDeleteTest) {
   // Simple delete
   std::string query = "DELETE FROM foo;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
 
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::DELETE);
@@ -1171,7 +1171,7 @@ TEST_F(ParserTestBase, OldDeleteTest) {
 TEST_F(ParserTestBase, OldDeleteTestWithPredicate) {
   // Delete with a predicate
   std::string query = "DELETE FROM foo WHERE id=3;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
 
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::DELETE);
@@ -1184,7 +1184,7 @@ TEST_F(ParserTestBase, OldDeleteTestWithPredicate) {
 TEST_F(ParserTestBase, OldInsertTest) {
   // Insert multiple tuples into the table
   std::string query = "INSERT INTO foo VALUES (NULL, 2, 3), (4, 5, 6);";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
 
   EXPECT_EQ(1, result.GetStatements().size());
   EXPECT_TRUE(result.GetStatement(0)->GetType() == StatementType::INSERT);
@@ -1214,7 +1214,7 @@ TEST_F(ParserTestBase, OldCreateTest) {
       "PRIMARY KEY (id),"
       "FOREIGN KEY (c_id) REFERENCES country (cid));";
 
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   // Check column definition
@@ -1246,22 +1246,22 @@ TEST_F(ParserTestBase, OldCreateTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldTransactionTest) {
   std::string query = "BEGIN TRANSACTION;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto transac_stmt = result.GetStatement(0).CastManagedPointerTo<TransactionStatement>();
   EXPECT_EQ(transac_stmt->GetTransactionType(), TransactionStatement::kBegin);
 
   query = "BEGIN;";
-  result = pgparser_.BuildParseTree(query);
+  result = parser::PostgresParser::BuildParseTree(query);
   transac_stmt = result.GetStatement(0).CastManagedPointerTo<TransactionStatement>();
   EXPECT_EQ(transac_stmt->GetTransactionType(), TransactionStatement::kBegin);
 
   query = "COMMIT TRANSACTION;";
-  result = pgparser_.BuildParseTree(query);
+  result = parser::PostgresParser::BuildParseTree(query);
   transac_stmt = result.GetStatement(0).CastManagedPointerTo<TransactionStatement>();
   EXPECT_EQ(transac_stmt->GetTransactionType(), TransactionStatement::kCommit);
 
   query = "ROLLBACK;";
-  result = pgparser_.BuildParseTree(query);
+  result = parser::PostgresParser::BuildParseTree(query);
   transac_stmt = result.GetStatement(0).CastManagedPointerTo<TransactionStatement>();
   EXPECT_EQ(transac_stmt->GetTransactionType(), TransactionStatement::kRollback);
 }
@@ -1269,7 +1269,7 @@ TEST_F(ParserTestBase, OldTransactionTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCreateIndexTest) {
   std::string query = "CREATE UNIQUE INDEX IDX_ORDER ON oorder (O_W_ID, O_D_ID);";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   // Check attributes
@@ -1281,7 +1281,7 @@ TEST_F(ParserTestBase, OldCreateIndexTest) {
   EXPECT_EQ(create_stmt->GetIndexAttributes()[1].GetName(), "o_d_id");
 
   query = "CREATE INDEX ii ON t USING HASH (col);";
-  result = pgparser_.BuildParseTree(query);
+  result = parser::PostgresParser::BuildParseTree(query);
   create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   // Check attributes
@@ -1291,7 +1291,7 @@ TEST_F(ParserTestBase, OldCreateIndexTest) {
   EXPECT_EQ(create_stmt->GetTableName(), "t");
 
   query = "CREATE INDEX ii ON t (col);";
-  result = pgparser_.BuildParseTree(query);
+  result = parser::PostgresParser::BuildParseTree(query);
   create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   // Check attributes
@@ -1301,14 +1301,14 @@ TEST_F(ParserTestBase, OldCreateIndexTest) {
   EXPECT_EQ(create_stmt->GetTableName(), "t");
 
   query = "CREATE INDEX ii ON t USING GIN (col);";
-  EXPECT_THROW(pgparser_.BuildParseTree(query), NotImplementedException);
+  EXPECT_THROW(parser::PostgresParser::BuildParseTree(query), NotImplementedException);
 }
 
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldInsertIntoSelectTest) {
   // insert into a table with select sub-query
   std::string query = "INSERT INTO foo select * from bar where id = 5;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
 
   EXPECT_EQ(result.GetStatements().size(), 1);
   EXPECT_TRUE(result.GetStatement(0)->GetType() == StatementType::INSERT);
@@ -1322,7 +1322,7 @@ TEST_F(ParserTestBase, OldInsertIntoSelectTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCreateDbTest) {
   std::string query = "CREATE DATABASE tt";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
 
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
   EXPECT_EQ(create_stmt->GetCreateType(), CreateStatement::CreateType::kDatabase);
@@ -1332,13 +1332,13 @@ TEST_F(ParserTestBase, OldCreateDbTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCreateSchemaTest) {
   std::string query = "CREATE SCHEMA tt";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
   EXPECT_EQ("tt", create_stmt->GetNamespaceName());
 
   // Test default schema name
   query = "CREATE SCHEMA AUTHORIZATION joe";
-  result = pgparser_.BuildParseTree(query);
+  result = parser::PostgresParser::BuildParseTree(query);
   create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
   EXPECT_EQ("joe", create_stmt->GetNamespaceName());
 }
@@ -1346,7 +1346,7 @@ TEST_F(ParserTestBase, OldCreateSchemaTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCreateViewTest) {
   std::string query = "CREATE VIEW comedies AS SELECT * FROM films WHERE kind = 'Comedy';";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   // Check attributes
@@ -1373,7 +1373,7 @@ TEST_F(ParserTestBase, OldCreateViewTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldDistinctFromTest) {
   std::string query = "SELECT id, value FROM foo WHERE id IS DISTINCT FROM value;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto statement = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
   auto where_expr = statement->GetSelectCondition();
   EXPECT_EQ(ExpressionType::COMPARE_IS_DISTINCT_FROM, where_expr->GetExpressionType());
@@ -1397,7 +1397,7 @@ TEST_F(ParserTestBase, OldConstraintTest) {
       "DEFAULT"
       ");";
 
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   // Check column definition
@@ -1497,7 +1497,7 @@ TEST_F(ParserTestBase, OldDataTypeTest) {
       "b varchar(1024),"
       "c varbinary(32)"
       ");";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto create_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
 
   EXPECT_EQ(create_stmt->GetColumns().size(), 3);
@@ -1530,7 +1530,7 @@ TEST_F(ParserTestBase, OldCreateTriggerTest) {
       "FOR EACH ROW "
       "WHEN (OLD.balance <> NEW.balance) "
       "EXECUTE PROCEDURE check_account_update(update_date);";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
 
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::CREATE);
   auto create_trigger_stmt = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
@@ -1580,7 +1580,7 @@ TEST_F(ParserTestBase, OldCreateTriggerTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldDropTriggerTest) {
   std::string query = "DROP TRIGGER if_dist_exists ON terrier.films;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   EXPECT_EQ(result.GetStatement(0)->GetType(), StatementType::DROP);
   auto drop_trigger_stmt = result.GetStatement(0).CastManagedPointerTo<DropStatement>();
 
@@ -1592,7 +1592,7 @@ TEST_F(ParserTestBase, OldDropTriggerTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldFuncCallTest) {
   std::string query = "SELECT add(1,a), chr(99) FROM TEST WHERE FUN(b) > 2";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
 
   // Check ADD(1,a)
@@ -1638,7 +1638,7 @@ TEST_F(ParserTestBase, OldFuncCallTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldUDFFuncCallTest) {
   std::string query = "SELECT increment(1,b) FROM TEST;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
 
   auto fun_expr = select_stmt->GetSelectColumns()[0].CastManagedPointerTo<FunctionExpression>();
@@ -1659,14 +1659,14 @@ TEST_F(ParserTestBase, OldUDFFuncCallTest) {
 // NOLINTNEXTLINE
 TEST_F(ParserTestBase, OldCaseTest) {
   std::string query = "SELECT id, case when id=100 then 1 else 0 end from tbl;";
-  auto result = pgparser_.BuildParseTree(query);
+  auto result = parser::PostgresParser::BuildParseTree(query);
   auto select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
   auto select_args = select_stmt->GetSelectColumns();
   EXPECT_EQ(select_args.at(0)->GetExpressionType(), ExpressionType::COLUMN_VALUE);
   EXPECT_EQ(select_args.at(1)->GetExpressionType(), ExpressionType::OPERATOR_CASE_EXPR);
 
   query = "SELECT id, case id when 100 then 1 when 200 then 2 end from tbl;";
-  result = pgparser_.BuildParseTree(query);
+  result = parser::PostgresParser::BuildParseTree(query);
   select_stmt = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
   select_args = select_stmt->GetSelectColumns();
   EXPECT_EQ(select_args.at(0)->GetExpressionType(), ExpressionType::COLUMN_VALUE);
@@ -1680,7 +1680,7 @@ TEST_F(ParserTestBase, OldDateTypeTest) {
 
   {
     query = "INSERT INTO test_table VALUES (1, 2, '2017-01-01'::DATE);";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto statement = result.GetStatement(0).CastManagedPointerTo<InsertStatement>();
     auto values = *(statement->GetValues());
     auto cast_expr = values[0][2].CastManagedPointerTo<TypeCastExpression>();
@@ -1694,7 +1694,7 @@ TEST_F(ParserTestBase, OldDateTypeTest) {
 
   {
     query = "CREATE TABLE students (name TEXT, graduation DATE)";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto statement = result.GetStatement(0).CastManagedPointerTo<CreateStatement>();
     auto values = statement->GetColumns();
     auto date_column = values[1];
@@ -1718,7 +1718,7 @@ TEST_F(ParserTestBase, OldTypeCastTest) {
     std::string query = queries[i];
     type::TypeId correct_type = types[i];
 
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto statement = result.GetStatement(0).CastManagedPointerTo<InsertStatement>();
     auto values = *(statement->GetValues());
     auto cast_expr = values[0][2].CastManagedPointerTo<ConstantValueExpression>();
@@ -1731,7 +1731,7 @@ TEST_F(ParserTestBase, OldTypeCastInExpressionTest) {
   std::string query;
   {
     query = "SELECT * FROM a WHERE d <= date '2018-04-04';";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto statement = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     auto where_expr = statement->GetSelectCondition();
     auto cast_expr = where_expr->GetChild(1).CastManagedPointerTo<TypeCastExpression>();
@@ -1745,7 +1745,7 @@ TEST_F(ParserTestBase, OldTypeCastInExpressionTest) {
 
   {
     query = "SELECT '12345'::INTEGER - 12";
-    auto result = pgparser_.BuildParseTree(query);
+    auto result = parser::PostgresParser::BuildParseTree(query);
     auto statement = result.GetStatement(0).CastManagedPointerTo<SelectStatement>();
     auto column = statement->GetSelectColumns()[0];
     EXPECT_EQ(ExpressionType::OPERATOR_MINUS, column->GetExpressionType());

--- a/test/test_util/tpcc/tpcc_plan_test.cpp
+++ b/test/test_util/tpcc/tpcc_plan_test.cpp
@@ -94,8 +94,7 @@ void TpccPlanTest::EndTransaction(bool commit) {
 std::unique_ptr<planner::AbstractPlanNode> TpccPlanTest::Optimize(const std::string &query,
                                                                   catalog::table_oid_t tbl_oid,
                                                                   parser::StatementType stmt_type) {
-  parser::PostgresParser pgparser;
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = parser::PostgresParser::BuildParseTree(query);
 
   // Bind + Transform
   auto accessor = catalog_->GetAccessor(txn_, db_);
@@ -206,8 +205,7 @@ void TpccPlanTest::OptimizeQuery(const std::string &query, catalog::table_oid_t 
                                                catalog::table_oid_t tbl_oid,
                                                std::unique_ptr<planner::AbstractPlanNode> plan)) {
   BeginTransaction();
-  parser::PostgresParser pgparser;
-  auto stmt_list = pgparser.BuildParseTree(query);
+  auto stmt_list = parser::PostgresParser::BuildParseTree(query);
   auto sel_stmt = stmt_list.GetStatement(0).CastManagedPointerTo<parser::SelectStatement>();
   auto plan = Optimize(query, tbl_oid, parser::StatementType::SELECT);
   Check(this, sel_stmt.Get(), tbl_oid, std::move(plan));


### PR DESCRIPTION
All of the internal methods are already `static`, only non-`static` method is the single public API function. There's no state stored, so just made the entire class `static`.

This came up while trying to reason about object ownership of `PostgresParser` when I noticed that there's really no point in instantiating an object to be owned.