### PR TITLE
More ManagedPointers to sort out ownership

### DIFF
--- a/benchmark/benchmark_util/data_table_benchmark_util.cpp
+++ b/benchmark/benchmark_util/data_table_benchmark_util.cpp
@@ -36,7 +36,7 @@ void RandomDataTableTransaction::RandomUpdate(Random *generator) {
 
   auto *const record = txn_->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, initializer);
   record->SetTupleSlot(updated);
-  auto result = test_object_->table_.Update(txn_, updated, *(record->Delta()));
+  auto result = test_object_->table_.Update(common::ManagedPointer(txn_), updated, *(record->Delta()));
   aborted_ = !result;
 }
 
@@ -45,7 +45,7 @@ void RandomDataTableTransaction::RandomInsert(Random *generator) {
   if (aborted_) return;
   auto *const redo =
       txn_->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, test_object_->row_initializer_);
-  const storage::TupleSlot inserted = test_object_->table_.Insert(txn_, *(redo->Delta()));
+  const storage::TupleSlot inserted = test_object_->table_.Insert(common::ManagedPointer(txn_), *(redo->Delta()));
   redo->SetTupleSlot(inserted);
 }
 
@@ -56,7 +56,7 @@ void RandomDataTableTransaction::RandomSelect(Random *generator) {
       *(RandomTestUtil::UniformRandomElement(test_object_->inserted_tuples_, generator));
   auto *select_buffer = buffer_;
   storage::ProjectedRow *select = test_object_->row_initializer_.InitializeRow(select_buffer);
-  test_object_->table_.Select(txn_, selected, select);
+  test_object_->table_.Select(common::ManagedPointer(txn_), selected, select);
 }
 
 void RandomDataTableTransaction::Finish() {
@@ -156,7 +156,7 @@ void LargeDataTableBenchmarkObject::PopulateInitialTable(uint32_t num_tuples, Ra
   for (uint32_t i = 0; i < num_tuples; i++) {
     auto *const redo =
         initial_txn_->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, row_initializer_);
-    const storage::TupleSlot inserted = table_.Insert(initial_txn_, *(redo->Delta()));
+    const storage::TupleSlot inserted = table_.Insert(common::ManagedPointer(initial_txn_), *(redo->Delta()));
     redo->SetTupleSlot(inserted);
     inserted_tuples_.emplace_back(inserted);
   }

--- a/benchmark/catalog/catalog_benchmark.cpp
+++ b/benchmark/catalog/catalog_benchmark.cpp
@@ -28,7 +28,7 @@ class CatalogBenchmark : public benchmark::Fixture {
     catalog_ = db_main_->GetCatalogLayer()->GetCatalog();
     txn_manager_ = db_main_->GetTransactionLayer()->GetTransactionManager();
     auto *txn = txn_manager_->BeginTransaction();
-    db_ = catalog_->GetDatabaseOid(txn, catalog::DEFAULT_DATABASE);
+    db_ = catalog_->GetDatabaseOid(common::ManagedPointer(txn), catalog::DEFAULT_DATABASE);
     txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
   }
 
@@ -43,7 +43,7 @@ class CatalogBenchmark : public benchmark::Fixture {
 
   std::pair<catalog::table_oid_t, catalog::index_oid_t> AddUserTableAndIndex() {
     auto txn = txn_manager_->BeginTransaction();
-    auto accessor = catalog_->GetAccessor(txn, db_);
+    auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
     // Create the column definition (no OIDs)
     std::vector<catalog::Schema::Column> cols;
@@ -69,7 +69,7 @@ class CatalogBenchmark : public benchmark::Fixture {
   std::pair<catalog::table_oid_t, std::vector<catalog::index_oid_t>> AddUserTableAndIndexes(
       const uint16_t num_indexes) {
     auto txn = txn_manager_->BeginTransaction();
-    auto accessor = catalog_->GetAccessor(txn, db_);
+    auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
     // Create the column definition (no OIDs)
     std::vector<catalog::Schema::Column> cols;
@@ -130,7 +130,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetAccessor)(benchmark::State &state) {
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    const auto accessor = catalog_->GetAccessor(txn, db_);
+    const auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
     TERRIER_ASSERT(accessor != nullptr, "getting accessor should not fail");
   }
 
@@ -144,7 +144,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetDatabaseOid)(benchmark::State &state) {
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    const auto test_oid UNUSED_ATTRIBUTE = catalog_->GetDatabaseOid(txn, "terrier");
+    const auto test_oid UNUSED_ATTRIBUTE = catalog_->GetDatabaseOid(common::ManagedPointer(txn), "terrier");
     TERRIER_ASSERT(test_oid == db_, "getting oid should not fail");
   }
 
@@ -158,7 +158,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetDatabaseCatalog)(benchmark::State &state
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
-    const auto dbc UNUSED_ATTRIBUTE = catalog_->GetDatabaseCatalog(txn, db_);
+    const auto dbc UNUSED_ATTRIBUTE = catalog_->GetDatabaseCatalog(common::ManagedPointer(txn), db_);
     TERRIER_ASSERT(dbc != nullptr, "getting accessor should not fail");
   }
 
@@ -171,7 +171,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetIndex)(benchmark::State &state) {
   const auto oids UNUSED_ATTRIBUTE = AddUserTableAndIndex();
 
   auto *txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -189,7 +189,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetIndexOid)(benchmark::State &state) {
   const auto oids UNUSED_ATTRIBUTE = AddUserTableAndIndex();
 
   auto *txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -207,7 +207,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetIndexes)(benchmark::State &state) {
   const auto oids UNUSED_ATTRIBUTE = AddUserTableAndIndex();
 
   auto *txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -225,7 +225,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetIndexSchema)(benchmark::State &state) {
   const auto oids UNUSED_ATTRIBUTE = AddUserTableAndIndex();
 
   auto *txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -240,13 +240,13 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetIndexSchema)(benchmark::State &state) {
 // NOLINTNEXTLINE
 BENCHMARK_DEFINE_F(CatalogBenchmark, GetNamespaceOid)(benchmark::State &state) {
   auto txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
   const auto ns_oid UNUSED_ATTRIBUTE = accessor->CreateNamespace("test_namespace");
   TERRIER_ASSERT(ns_oid != catalog::INVALID_NAMESPACE_OID, "namespace creation should not fail");
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
   txn = txn_manager_->BeginTransaction();
-  accessor = catalog_->GetAccessor(txn, db_);
+  accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -264,7 +264,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetSchema)(benchmark::State &state) {
   const auto oids UNUSED_ATTRIBUTE = AddUserTableAndIndex();
 
   auto *txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -281,7 +281,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetTable)(benchmark::State &state) {
   const auto oids UNUSED_ATTRIBUTE = AddUserTableAndIndex();
 
   auto *txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -299,7 +299,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetTableOid)(benchmark::State &state) {
   const auto oids UNUSED_ATTRIBUTE = AddUserTableAndIndex();
 
   auto *txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {
@@ -318,7 +318,7 @@ BENCHMARK_DEFINE_F(CatalogBenchmark, GetIndexObjects)(benchmark::State &state) {
   const auto oids UNUSED_ATTRIBUTE = AddUserTableAndIndexes(num_indexes);
 
   auto *txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_);
 
   // NOLINTNEXTLINE
   for (auto _ : state) {

--- a/benchmark/storage/index_wrapper_benchmark.cpp
+++ b/benchmark/storage/index_wrapper_benchmark.cpp
@@ -128,11 +128,11 @@ class IndexBenchmark : public benchmark::Fixture {
           insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
       auto *const insert_tuple = insert_redo->Delta();
       *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-      const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+      const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
       *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
 
       // Ensure that insert action appropriately listed
-      EXPECT_TRUE(index_->Insert(insert_txn, *insert_key, tuple_slot));
+      EXPECT_TRUE(index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
     }
     // Store transactions completed
     txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);

--- a/benchmark/storage/recovery_benchmark.cpp
+++ b/benchmark/storage/recovery_benchmark.cpp
@@ -160,8 +160,8 @@ BENCHMARK_DEFINE_F(RecoveryBenchmark, IndexRecovery)(benchmark::State &state) {
 
     // Create database, namespace, and table
     auto *txn = txn_manager->BeginTransaction();
-    auto db_oid = catalog->CreateDatabase(txn, db_name, true);
-    auto catalog_accessor = catalog->GetAccessor(txn, db_oid);
+    auto db_oid = catalog->CreateDatabase(common::ManagedPointer(txn), db_name, true);
+    auto catalog_accessor = catalog->GetAccessor(common::ManagedPointer(txn), db_oid);
     auto namespace_oid = catalog_accessor->CreateNamespace(namespace_name);
 
     // Create random table
@@ -198,7 +198,7 @@ BENCHMARK_DEFINE_F(RecoveryBenchmark, IndexRecovery)(benchmark::State &state) {
         auto *txn = txn_manager->BeginTransaction();
         auto redo_record = txn->StageWrite(db_oid, table_oid, initializer);
         *reinterpret_cast<int32_t *>(redo_record->Delta()->AccessForceNotNull(0)) = key;
-        table->Insert(txn, redo_record);
+        table->Insert(common::ManagedPointer(txn), redo_record);
         txn_manager->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
       }
     };

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -24,7 +24,7 @@
 
 namespace terrier::catalog {
 
-void DatabaseCatalog::Bootstrap(transaction::TransactionContext *const txn) {
+void DatabaseCatalog::Bootstrap(const common::ManagedPointer<transaction::TransactionContext> txn) {
   BootstrapPRIs();
 
   // Declare variable for return values (UNUSED when compiled for release)
@@ -289,7 +289,8 @@ void DatabaseCatalog::BootstrapPRIs() {
   pg_type_all_cols_prm_ = types_->ProjectionMapForOids(pg_type_all_oids);
 }
 
-namespace_oid_t DatabaseCatalog::CreateNamespace(transaction::TransactionContext *const txn, const std::string &name) {
+namespace_oid_t DatabaseCatalog::CreateNamespace(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                                 const std::string &name) {
   if (!TryLock(txn)) return INVALID_NAMESPACE_OID;
   const namespace_oid_t ns_oid{next_oid_++};
   if (!CreateNamespace(txn, name, ns_oid)) {
@@ -298,8 +299,8 @@ namespace_oid_t DatabaseCatalog::CreateNamespace(transaction::TransactionContext
   return ns_oid;
 }
 
-bool DatabaseCatalog::CreateNamespace(transaction::TransactionContext *const txn, const std::string &name,
-                                      const namespace_oid_t ns_oid) {
+bool DatabaseCatalog::CreateNamespace(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                      const std::string &name, const namespace_oid_t ns_oid) {
   // Step 1: Insert into table
   const auto name_varlen = storage::StorageUtil::CreateVarlen(name);
   // Get & Fill Redo Record
@@ -339,7 +340,8 @@ bool DatabaseCatalog::CreateNamespace(transaction::TransactionContext *const txn
   return true;
 }
 
-bool DatabaseCatalog::DeleteNamespace(transaction::TransactionContext *const txn, const namespace_oid_t ns_oid) {
+bool DatabaseCatalog::DeleteNamespace(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                      const namespace_oid_t ns_oid) {
   if (!TryLock(txn)) return false;
   // Step 1: Read the oid index
   // Buffer is large enough for all prs because it's meant to hold 1 VarlenEntry
@@ -424,7 +426,8 @@ bool DatabaseCatalog::DeleteNamespace(transaction::TransactionContext *const txn
   return true;
 }
 
-namespace_oid_t DatabaseCatalog::GetNamespaceOid(transaction::TransactionContext *txn, const std::string &name) {
+namespace_oid_t DatabaseCatalog::GetNamespaceOid(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                                 const std::string &name) {
   // Step 1: Read the name index
   const auto name_pri = namespaces_name_index_->GetProjectedRowInitializer();
   // Buffer is large enough for all prs because it's meant to hold 1 VarlenEntry
@@ -463,8 +466,8 @@ namespace_oid_t DatabaseCatalog::GetNamespaceOid(transaction::TransactionContext
 }
 
 template <typename Column, typename ClassOid, typename ColOid>
-bool DatabaseCatalog::CreateColumn(transaction::TransactionContext *const txn, const ClassOid class_oid,
-                                   const ColOid col_oid, const Column &col) {
+bool DatabaseCatalog::CreateColumn(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                   const ClassOid class_oid, const ColOid col_oid, const Column &col) {
   // Step 1: Insert into the table
   auto *const redo = txn->StageWrite(db_oid_, postgres::COLUMN_TABLE_OID, pg_attribute_all_cols_pri_);
   // Write the attributes in the Redo Record
@@ -537,7 +540,8 @@ bool DatabaseCatalog::CreateColumn(transaction::TransactionContext *const txn, c
 }
 
 template <typename Column, typename ClassOid, typename ColOid>
-std::vector<Column> DatabaseCatalog::GetColumns(transaction::TransactionContext *const txn, ClassOid class_oid) {
+std::vector<Column> DatabaseCatalog::GetColumns(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                                ClassOid class_oid) {
   // Step 1: Read Index
 
   const auto oid_pri = columns_oid_index_->GetProjectedRowInitializer();
@@ -588,7 +592,8 @@ std::vector<Column> DatabaseCatalog::GetColumns(transaction::TransactionContext 
 // TODO(Matt): we need a DeleteColumn()
 
 template <typename Column, typename ClassOid>
-bool DatabaseCatalog::DeleteColumns(transaction::TransactionContext *const txn, const ClassOid class_oid) {
+bool DatabaseCatalog::DeleteColumns(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                    const ClassOid class_oid) {
   // Step 1: Read Index
   const auto oid_pri = columns_oid_index_->GetProjectedRowInitializer();
   auto oid_prm = columns_oid_index_->GetKeyOidToOffsetMap();
@@ -664,15 +669,16 @@ bool DatabaseCatalog::DeleteColumns(transaction::TransactionContext *const txn, 
   return true;
 }
 
-table_oid_t DatabaseCatalog::CreateTable(transaction::TransactionContext *const txn, const namespace_oid_t ns,
-                                         const std::string &name, const Schema &schema) {
+table_oid_t DatabaseCatalog::CreateTable(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                         const namespace_oid_t ns, const std::string &name, const Schema &schema) {
   if (!TryLock(txn)) return INVALID_TABLE_OID;
   const table_oid_t table_oid = static_cast<table_oid_t>(next_oid_++);
 
   return CreateTableEntry(txn, table_oid, ns, name, schema) ? table_oid : INVALID_TABLE_OID;
 }
 
-bool DatabaseCatalog::DeleteIndexes(transaction::TransactionContext *const txn, const table_oid_t table) {
+bool DatabaseCatalog::DeleteIndexes(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                    const table_oid_t table) {
   if (!TryLock(txn)) return false;
   // Get the indexes
   const auto index_oids = GetIndexOids(txn, table);
@@ -687,7 +693,8 @@ bool DatabaseCatalog::DeleteIndexes(transaction::TransactionContext *const txn, 
   return true;
 }
 
-bool DatabaseCatalog::DeleteTable(transaction::TransactionContext *const txn, const table_oid_t table) {
+bool DatabaseCatalog::DeleteTable(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                  const table_oid_t table) {
   if (!TryLock(txn)) return false;
   // We should respect foreign key relations and attempt to delete the table's columns first
   auto result = DeleteColumns<Schema::Column, table_oid_t>(txn, table);
@@ -779,9 +786,9 @@ bool DatabaseCatalog::DeleteTable(transaction::TransactionContext *const txn, co
   return true;
 }
 
-std::pair<uint32_t, postgres::ClassKind> DatabaseCatalog::GetClassOidKind(transaction::TransactionContext *const txn,
-                                                                          const namespace_oid_t ns_oid,
-                                                                          const std::string &name) {
+std::pair<uint32_t, postgres::ClassKind> DatabaseCatalog::GetClassOidKind(
+    const common::ManagedPointer<transaction::TransactionContext> txn, const namespace_oid_t ns_oid,
+    const std::string &name) {
   const auto name_pri = classes_name_index_->GetProjectedRowInitializer();
 
   const auto name_varlen = storage::StorageUtil::CreateVarlen(name);
@@ -824,8 +831,8 @@ std::pair<uint32_t, postgres::ClassKind> DatabaseCatalog::GetClassOidKind(transa
   return std::make_pair(oid, kind);
 }
 
-table_oid_t DatabaseCatalog::GetTableOid(transaction::TransactionContext *const txn, const namespace_oid_t ns,
-                                         const std::string &name) {
+table_oid_t DatabaseCatalog::GetTableOid(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                         const namespace_oid_t ns, const std::string &name) {
   const auto oid_pair = GetClassOidKind(txn, ns, name);
   if (oid_pair.first == catalog::NULL_OID || oid_pair.second != postgres::ClassKind::REGULAR_TABLE) {
     // User called GetTableOid on an object that doesn't have type REGULAR_TABLE
@@ -834,8 +841,8 @@ table_oid_t DatabaseCatalog::GetTableOid(transaction::TransactionContext *const 
   return table_oid_t(oid_pair.first);
 }
 
-bool DatabaseCatalog::SetTablePointer(transaction::TransactionContext *const txn, const table_oid_t table,
-                                      const storage::SqlTable *const table_ptr) {
+bool DatabaseCatalog::SetTablePointer(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                      const table_oid_t table, const storage::SqlTable *const table_ptr) {
   TERRIER_ASSERT(write_lock_.load() == txn->FinishTime(),
                  "Setting the object's pointer should only be done after successful DDL change request. i.e. this txn "
                  "should already have the lock.");
@@ -852,8 +859,8 @@ bool DatabaseCatalog::SetTablePointer(transaction::TransactionContext *const txn
  * @param table to which we want the storage object
  * @return the storage object corresponding to the passed OID
  */
-common::ManagedPointer<storage::SqlTable> DatabaseCatalog::GetTable(transaction::TransactionContext *const txn,
-                                                                    const table_oid_t table) {
+common::ManagedPointer<storage::SqlTable> DatabaseCatalog::GetTable(
+    const common::ManagedPointer<transaction::TransactionContext> txn, const table_oid_t table) {
   const auto ptr_pair = GetClassPtrKind(txn, static_cast<uint32_t>(table));
   if (ptr_pair.second != postgres::ClassKind::REGULAR_TABLE) {
     // User called GetTable with an OID for an object that doesn't have type REGULAR_TABLE
@@ -862,36 +869,39 @@ common::ManagedPointer<storage::SqlTable> DatabaseCatalog::GetTable(transaction:
   return common::ManagedPointer(reinterpret_cast<storage::SqlTable *>(ptr_pair.first));
 }
 
-bool DatabaseCatalog::RenameTable(transaction::TransactionContext *const txn, const table_oid_t table,
-                                  const std::string &name) {
+bool DatabaseCatalog::RenameTable(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                  const table_oid_t table, const std::string &name) {
   if (!TryLock(txn)) return false;
   // TODO(John): Implement
   TERRIER_ASSERT(false, "Not implemented");
   return false;
 }
 
-bool DatabaseCatalog::UpdateSchema(transaction::TransactionContext *const txn, const table_oid_t table,
-                                   Schema *const new_schema) {
+bool DatabaseCatalog::UpdateSchema(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                   const table_oid_t table, Schema *const new_schema) {
   if (!TryLock(txn)) return false;
   // TODO(John): Implement
   TERRIER_ASSERT(false, "Not implemented");
   return false;
 }
 
-const Schema &DatabaseCatalog::GetSchema(transaction::TransactionContext *const txn, const table_oid_t table) {
+const Schema &DatabaseCatalog::GetSchema(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                         const table_oid_t table) {
   const auto ptr_pair = GetClassSchemaPtrKind(txn, static_cast<uint32_t>(table));
   TERRIER_ASSERT(ptr_pair.first != nullptr, "Schema pointer shouldn't ever be NULL under current catalog semantics.");
   TERRIER_ASSERT(ptr_pair.second == postgres::ClassKind::REGULAR_TABLE, "Requested a table schema for a non-table");
   return *reinterpret_cast<Schema *>(ptr_pair.first);
 }
 
-std::vector<constraint_oid_t> DatabaseCatalog::GetConstraints(transaction::TransactionContext *txn, table_oid_t table) {
+std::vector<constraint_oid_t> DatabaseCatalog::GetConstraints(
+    const common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table) {
   // TODO(John): Implement
   TERRIER_ASSERT(false, "Not implemented");
   return {};
 }
 
-std::vector<index_oid_t> DatabaseCatalog::GetIndexOids(transaction::TransactionContext *txn, table_oid_t table) {
+std::vector<index_oid_t> DatabaseCatalog::GetIndexOids(
+    const common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table) {
   // Initialize PR for index scan
   auto oid_pri = indexes_table_index_->GetProjectedRowInitializer();
 
@@ -926,14 +936,16 @@ std::vector<index_oid_t> DatabaseCatalog::GetIndexOids(transaction::TransactionC
   return index_oids;
 }
 
-index_oid_t DatabaseCatalog::CreateIndex(transaction::TransactionContext *txn, namespace_oid_t ns,
-                                         const std::string &name, table_oid_t table, const IndexSchema &schema) {
+index_oid_t DatabaseCatalog::CreateIndex(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                         namespace_oid_t ns, const std::string &name, table_oid_t table,
+                                         const IndexSchema &schema) {
   if (!TryLock(txn)) return INVALID_INDEX_OID;
   const index_oid_t index_oid = static_cast<index_oid_t>(next_oid_++);
   return CreateIndexEntry(txn, ns, table, index_oid, name, schema) ? index_oid : INVALID_INDEX_OID;
 }
 
-bool DatabaseCatalog::DeleteIndex(transaction::TransactionContext *txn, index_oid_t index) {
+bool DatabaseCatalog::DeleteIndex(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                  index_oid_t index) {
   if (!TryLock(txn)) return false;
   // We should respect foreign key relations and attempt to delete the index's columns first
   auto result = DeleteColumns<IndexSchema::Column, index_oid_t>(txn, index);
@@ -1070,19 +1082,19 @@ bool DatabaseCatalog::DeleteIndex(transaction::TransactionContext *txn, index_oi
   return true;
 }
 
-bool DatabaseCatalog::SetTableSchemaPointer(transaction::TransactionContext *const txn, const table_oid_t oid,
-                                            const Schema *const schema) {
+bool DatabaseCatalog::SetTableSchemaPointer(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                            const table_oid_t oid, const Schema *const schema) {
   return SetClassPointer(txn, oid, schema, postgres::REL_SCHEMA_COL_OID);
 }
 
-bool DatabaseCatalog::SetIndexSchemaPointer(transaction::TransactionContext *const txn, const index_oid_t oid,
-                                            const IndexSchema *const schema) {
+bool DatabaseCatalog::SetIndexSchemaPointer(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                            const index_oid_t oid, const IndexSchema *const schema) {
   return SetClassPointer(txn, oid, schema, postgres::REL_SCHEMA_COL_OID);
 }
 
 template <typename ClassOid, typename Ptr>
-bool DatabaseCatalog::SetClassPointer(transaction::TransactionContext *const txn, const ClassOid oid,
-                                      const Ptr *const pointer, const col_oid_t class_col) {
+bool DatabaseCatalog::SetClassPointer(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                      const ClassOid oid, const Ptr *const pointer, const col_oid_t class_col) {
   TERRIER_ASSERT((std::is_same<ClassOid, table_oid_t>::value &&
                   (std::is_same<Ptr, storage::SqlTable>::value || std::is_same<Ptr, catalog::Schema>::value)) ||
                      (std::is_same<ClassOid, index_oid_t>::value && (std::is_same<Ptr, storage::index::Index>::value ||
@@ -1120,8 +1132,8 @@ bool DatabaseCatalog::SetClassPointer(transaction::TransactionContext *const txn
   return classes_->Update(txn, update_redo);
 }
 
-bool DatabaseCatalog::SetIndexPointer(transaction::TransactionContext *const txn, const index_oid_t index,
-                                      const storage::index::Index *const index_ptr) {
+bool DatabaseCatalog::SetIndexPointer(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                      const index_oid_t index, const storage::index::Index *const index_ptr) {
   TERRIER_ASSERT(write_lock_.load() == txn->FinishTime(),
                  "Setting the object's pointer should only be done after successful DDL change request. i.e. this txn "
                  "should already have the lock.");
@@ -1133,8 +1145,8 @@ bool DatabaseCatalog::SetIndexPointer(transaction::TransactionContext *const txn
   return SetClassPointer(txn, index, index_ptr, postgres::REL_PTR_COL_OID);
 }
 
-common::ManagedPointer<storage::index::Index> DatabaseCatalog::GetIndex(transaction::TransactionContext *txn,
-                                                                        index_oid_t index) {
+common::ManagedPointer<storage::index::Index> DatabaseCatalog::GetIndex(
+    const common::ManagedPointer<transaction::TransactionContext> txn, index_oid_t index) {
   const auto ptr_pair = GetClassPtrKind(txn, static_cast<uint32_t>(index));
   if (ptr_pair.second != postgres::ClassKind::INDEX) {
     // User called GetTable with an OID for an object that doesn't have type REGULAR_TABLE
@@ -1143,8 +1155,8 @@ common::ManagedPointer<storage::index::Index> DatabaseCatalog::GetIndex(transact
   return common::ManagedPointer(reinterpret_cast<storage::index::Index *>(ptr_pair.first));
 }
 
-index_oid_t DatabaseCatalog::GetIndexOid(transaction::TransactionContext *txn, namespace_oid_t ns,
-                                         const std::string &name) {
+index_oid_t DatabaseCatalog::GetIndexOid(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                         namespace_oid_t ns, const std::string &name) {
   const auto oid_pair = GetClassOidKind(txn, ns, name);
   if (oid_pair.first == NULL_OID || oid_pair.second != postgres::ClassKind::INDEX) {
     // User called GetIndexOid on an object that doesn't have type INDEX
@@ -1153,7 +1165,8 @@ index_oid_t DatabaseCatalog::GetIndexOid(transaction::TransactionContext *txn, n
   return index_oid_t(oid_pair.first);
 }
 
-const IndexSchema &DatabaseCatalog::GetIndexSchema(transaction::TransactionContext *txn, index_oid_t index) {
+const IndexSchema &DatabaseCatalog::GetIndexSchema(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                                   index_oid_t index) {
   auto ptr_pair = GetClassSchemaPtrKind(txn, static_cast<uint32_t>(index));
   TERRIER_ASSERT(ptr_pair.first != nullptr, "Schema pointer shouldn't ever be NULL under current catalog semantics.");
   TERRIER_ASSERT(ptr_pair.second == postgres::ClassKind::INDEX, "Requested an index schema for a non-index");
@@ -1161,7 +1174,7 @@ const IndexSchema &DatabaseCatalog::GetIndexSchema(transaction::TransactionConte
 }
 
 std::vector<std::pair<common::ManagedPointer<storage::index::Index>, const IndexSchema &>> DatabaseCatalog::GetIndexes(
-    transaction::TransactionContext *txn, table_oid_t table) {
+    const common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table) {
   // Step 1: Get all index oids on table
   // Initialize PR for index scan
   auto indexes_oid_pri = indexes_table_index_->GetProjectedRowInitializer();
@@ -1239,7 +1252,7 @@ std::vector<std::pair<common::ManagedPointer<storage::index::Index>, const Index
   return index_objects;
 }
 
-void DatabaseCatalog::TearDown(transaction::TransactionContext *txn) {
+void DatabaseCatalog::TearDown(const common::ManagedPointer<transaction::TransactionContext> txn) {
   std::vector<parser::AbstractExpression *> expressions;
   std::vector<Schema *> table_schemas;
   std::vector<storage::SqlTable *> tables;
@@ -1321,9 +1334,10 @@ void DatabaseCatalog::TearDown(transaction::TransactionContext *txn) {
   delete[] buffer;
 }
 
-bool DatabaseCatalog::CreateIndexEntry(transaction::TransactionContext *const txn, const namespace_oid_t ns_oid,
-                                       const table_oid_t table_oid, const index_oid_t index_oid,
-                                       const std::string &name, const IndexSchema &schema) {
+bool DatabaseCatalog::CreateIndexEntry(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                       const namespace_oid_t ns_oid, const table_oid_t table_oid,
+                                       const index_oid_t index_oid, const std::string &name,
+                                       const IndexSchema &schema) {
   // First, insert into pg_class
   auto *const class_insert_redo = txn->StageWrite(db_oid_, postgres::CLASS_TABLE_OID, pg_class_all_cols_pri_);
   auto *const class_insert_pr = class_insert_redo->Delta();
@@ -1497,9 +1511,10 @@ bool DatabaseCatalog::CreateIndexEntry(transaction::TransactionContext *const tx
 
 type_oid_t DatabaseCatalog::GetTypeOidForType(type::TypeId type) { return type_oid_t(static_cast<uint8_t>(type)); }
 
-void DatabaseCatalog::InsertType(transaction::TransactionContext *const txn, const type::TypeId internal_type,
-                                 const std::string &name, const namespace_oid_t namespace_oid, const int16_t len,
-                                 bool by_val, const postgres::Type type_category) {
+void DatabaseCatalog::InsertType(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                 const type::TypeId internal_type, const std::string &name,
+                                 const namespace_oid_t namespace_oid, const int16_t len, bool by_val,
+                                 const postgres::Type type_category) {
   // Stage the write into the table
   auto redo_record = txn->StageWrite(db_oid_, postgres::TYPE_TABLE_OID, pg_type_all_cols_pri_);
   auto *delta = redo_record->Delta();
@@ -1575,7 +1590,7 @@ void DatabaseCatalog::InsertType(transaction::TransactionContext *const txn, con
   delete[] buffer;
 }
 
-void DatabaseCatalog::BootstrapTypes(transaction::TransactionContext *const txn) {
+void DatabaseCatalog::BootstrapTypes(const common::ManagedPointer<transaction::TransactionContext> txn) {
   InsertType(txn, type::TypeId::INVALID, "invalid", postgres::NAMESPACE_CATALOG_NAMESPACE_OID, 1, true,
              postgres::Type::BASE);
 
@@ -1610,8 +1625,9 @@ void DatabaseCatalog::BootstrapTypes(transaction::TransactionContext *const txn)
              postgres::Type::BASE);
 }
 
-bool DatabaseCatalog::CreateTableEntry(transaction::TransactionContext *const txn, const table_oid_t table_oid,
-                                       const namespace_oid_t ns_oid, const std::string &name, const Schema &schema) {
+bool DatabaseCatalog::CreateTableEntry(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                       const table_oid_t table_oid, const namespace_oid_t ns_oid,
+                                       const std::string &name, const Schema &schema) {
   auto *const insert_redo = txn->StageWrite(db_oid_, postgres::CLASS_TABLE_OID, pg_class_all_cols_pri_);
   auto *const insert_pr = insert_redo->Delta();
 
@@ -1715,7 +1731,7 @@ bool DatabaseCatalog::CreateTableEntry(transaction::TransactionContext *const tx
 }
 
 std::vector<std::pair<uint32_t, postgres::ClassKind>> DatabaseCatalog::GetNamespaceClassOids(
-    transaction::TransactionContext *const txn, const namespace_oid_t ns_oid) {
+    const common::ManagedPointer<transaction::TransactionContext> txn, const namespace_oid_t ns_oid) {
   std::vector<storage::TupleSlot> index_scan_results;
 
   // Initialize both PR initializers, allocate buffer using size of largest one so we can reuse buffer
@@ -1749,8 +1765,8 @@ std::vector<std::pair<uint32_t, postgres::ClassKind>> DatabaseCatalog::GetNamesp
   return ns_objects;
 }
 
-std::pair<void *, postgres::ClassKind> DatabaseCatalog::GetClassPtrKind(transaction::TransactionContext *txn,
-                                                                        uint32_t oid) {
+std::pair<void *, postgres::ClassKind> DatabaseCatalog::GetClassPtrKind(
+    const common::ManagedPointer<transaction::TransactionContext> txn, uint32_t oid) {
   std::vector<storage::TupleSlot> index_results;
 
   // Initialize both PR initializers, allocate buffer using size of largest one so we can reuse buffer
@@ -1788,8 +1804,8 @@ std::pair<void *, postgres::ClassKind> DatabaseCatalog::GetClassPtrKind(transact
   return {ptr, kind};
 }
 
-std::pair<void *, postgres::ClassKind> DatabaseCatalog::GetClassSchemaPtrKind(transaction::TransactionContext *txn,
-                                                                              uint32_t oid) {
+std::pair<void *, postgres::ClassKind> DatabaseCatalog::GetClassSchemaPtrKind(
+    const common::ManagedPointer<transaction::TransactionContext> txn, uint32_t oid) {
   std::vector<storage::TupleSlot> index_results;
 
   // Initialize both PR initializers, allocate buffer using size of largest one so we can reuse buffer
@@ -1849,7 +1865,7 @@ Column DatabaseCatalog::MakeColumn(storage::ProjectedRow *const pr, const storag
   return col;
 }
 
-bool DatabaseCatalog::TryLock(transaction::TransactionContext *const txn) {
+bool DatabaseCatalog::TryLock(const common::ManagedPointer<transaction::TransactionContext> txn) {
   auto current_val = write_lock_.load();
 
   const transaction::timestamp_t txn_id = txn->FinishTime();     // this is the uncommitted txn id
@@ -1880,26 +1896,25 @@ bool DatabaseCatalog::TryLock(transaction::TransactionContext *const txn) {
   return false;
 }
 
-template bool DatabaseCatalog::CreateColumn<Schema::Column, table_oid_t>(transaction::TransactionContext *const txn,
-                                                                         const table_oid_t class_oid,
-                                                                         const col_oid_t col_oid,
-                                                                         const Schema::Column &col);
+template bool DatabaseCatalog::CreateColumn<Schema::Column, table_oid_t>(
+    const common::ManagedPointer<transaction::TransactionContext> txn, const table_oid_t class_oid,
+    const col_oid_t col_oid, const Schema::Column &col);
 template bool DatabaseCatalog::CreateColumn<IndexSchema::Column, index_oid_t>(
-    transaction::TransactionContext *const txn, const index_oid_t class_oid, const indexkeycol_oid_t col_oid,
-    const IndexSchema::Column &col);
+    const common::ManagedPointer<transaction::TransactionContext> txn, const index_oid_t class_oid,
+    const indexkeycol_oid_t col_oid, const IndexSchema::Column &col);
 
 template std::vector<Schema::Column> DatabaseCatalog::GetColumns<Schema::Column, table_oid_t, col_oid_t>(
-    transaction::TransactionContext *const txn, const table_oid_t class_oid);
+    const common::ManagedPointer<transaction::TransactionContext> txn, const table_oid_t class_oid);
 
 template std::vector<IndexSchema::Column>
 DatabaseCatalog::GetColumns<IndexSchema::Column, index_oid_t, indexkeycol_oid_t>(
-    transaction::TransactionContext *const txn, const index_oid_t class_oid);
+    const common::ManagedPointer<transaction::TransactionContext> txn, const index_oid_t class_oid);
 
-template bool DatabaseCatalog::DeleteColumns<Schema::Column, table_oid_t>(transaction::TransactionContext *const txn,
-                                                                          const table_oid_t class_oid);
+template bool DatabaseCatalog::DeleteColumns<Schema::Column, table_oid_t>(
+    const common::ManagedPointer<transaction::TransactionContext> txn, const table_oid_t class_oid);
 
 template bool DatabaseCatalog::DeleteColumns<IndexSchema::Column, index_oid_t>(
-    transaction::TransactionContext *const txn, const index_oid_t class_oid);
+    const common::ManagedPointer<transaction::TransactionContext> txn, const index_oid_t class_oid);
 
 template Schema::Column DatabaseCatalog::MakeColumn<Schema::Column, col_oid_t>(storage::ProjectedRow *const pr,
                                                                                const storage::ProjectionMap &pr_map);

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -8,6 +8,7 @@
 #include "catalog/catalog_accessor.h"
 #include "catalog/catalog_defs.h"
 #include "catalog/database_catalog.h"
+#include "common/managed_pointer.h"
 #include "transaction/transaction_context.h"
 #include "transaction/transaction_defs.h"
 
@@ -63,7 +64,8 @@ class Catalog {
    * @return OID of the database or INVALID_DATABASE_OID if the operation failed
    *   (which should only occur if there is already a database with that name)
    */
-  db_oid_t CreateDatabase(transaction::TransactionContext *txn, const std::string &name, bool bootstrap);
+  db_oid_t CreateDatabase(common::ManagedPointer<transaction::TransactionContext> txn, const std::string &name,
+                          bool bootstrap);
 
   /**
    * Deletes the given database.  This operation will fail if there is any DDL
@@ -73,7 +75,7 @@ class Catalog {
    * @param database OID to be deleted
    * @return true if the deletion succeeds, false otherwise
    */
-  bool DeleteDatabase(transaction::TransactionContext *txn, db_oid_t database);
+  bool DeleteDatabase(common::ManagedPointer<transaction::TransactionContext> txn, db_oid_t database);
 
   /**
    * Renames the given database.
@@ -82,7 +84,8 @@ class Catalog {
    * @param name which the database will now have
    * @return true if the operation succeeds, false otherwise
    */
-  bool RenameDatabase(transaction::TransactionContext *txn, db_oid_t database, const std::string &name);
+  bool RenameDatabase(common::ManagedPointer<transaction::TransactionContext> txn, db_oid_t database,
+                      const std::string &name);
 
   /**
    * Resolve a database name to its OID.
@@ -90,7 +93,7 @@ class Catalog {
    * @param name of the database to resolve
    * @return OID of the database or INVALID_DATABASE_OID if it does not exist
    */
-  db_oid_t GetDatabaseOid(transaction::TransactionContext *txn, const std::string &name);
+  db_oid_t GetDatabaseOid(common::ManagedPointer<transaction::TransactionContext> txn, const std::string &name);
 
   /**
    * Gets the database-specific catalog object.
@@ -99,7 +102,8 @@ class Catalog {
    * @return DatabaseCatalog object which has catalog information for the
    *   specific database
    */
-  common::ManagedPointer<DatabaseCatalog> GetDatabaseCatalog(transaction::TransactionContext *txn, db_oid_t database);
+  common::ManagedPointer<DatabaseCatalog> GetDatabaseCatalog(
+      common::ManagedPointer<transaction::TransactionContext> txn, db_oid_t database);
 
   /**
    * Creates a new accessor into the catalog which will handle transactionality and sequencing of catalog operations.
@@ -107,7 +111,8 @@ class Catalog {
    * @param database in which this transaction is scoped
    * @return a CatalogAccessor object for use with this transaction
    */
-  std::unique_ptr<CatalogAccessor> GetAccessor(transaction::TransactionContext *txn, db_oid_t database);
+  std::unique_ptr<CatalogAccessor> GetAccessor(common::ManagedPointer<transaction::TransactionContext> txn,
+                                               db_oid_t database);
 
  private:
   DISALLOW_COPY_AND_MOVE(Catalog);
@@ -146,8 +151,8 @@ class Catalog {
    * @param db_oid oid for new database
    * @return true if creation succeeded, false otherwise
    */
-  bool CreateDatabase(transaction::TransactionContext *txn, const std::string &name, bool bootstrap,
-                      catalog::db_oid_t db_oid);
+  bool CreateDatabase(common::ManagedPointer<transaction::TransactionContext> txn, const std::string &name,
+                      bool bootstrap, catalog::db_oid_t db_oid);
 
   /**
    * Creates a new database entry.
@@ -157,8 +162,8 @@ class Catalog {
    * @param dbc database catalog object for the new database
    * @return true if successful, otherwise false
    */
-  bool CreateDatabaseEntry(transaction::TransactionContext *txn, db_oid_t db, const std::string &name,
-                           DatabaseCatalog *dbc);
+  bool CreateDatabaseEntry(common::ManagedPointer<transaction::TransactionContext> txn, db_oid_t db,
+                           const std::string &name, DatabaseCatalog *dbc);
 
   /**
    * Deletes a database entry without scheduling the catalog object for destruction
@@ -166,7 +171,7 @@ class Catalog {
    * @param db OID of the database
    * @return pointer to the database object if successful, otherwise nullptr
    */
-  DatabaseCatalog *DeleteDatabaseEntry(transaction::TransactionContext *txn, db_oid_t db);
+  DatabaseCatalog *DeleteDatabaseEntry(common::ManagedPointer<transaction::TransactionContext> txn, db_oid_t db);
 
   /**
    * Creates a lambda that captures the necessary values by value and handles

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -271,8 +271,8 @@ class CatalogAccessor {
    * @param txn the transaction context for this accessor
    * @warning This constructor should never be called directly.  Instead you should get accessors from the catalog.
    */
-  CatalogAccessor(common::ManagedPointer<Catalog> catalog, common::ManagedPointer<DatabaseCatalog> dbc,
-                  transaction::TransactionContext *txn)
+  CatalogAccessor(const common::ManagedPointer<Catalog> catalog, const common::ManagedPointer<DatabaseCatalog> dbc,
+                  const common::ManagedPointer<transaction::TransactionContext> txn)
       : catalog_(catalog),
         dbc_(dbc),
         txn_(txn),
@@ -282,7 +282,7 @@ class CatalogAccessor {
  private:
   const common::ManagedPointer<Catalog> catalog_;
   const common::ManagedPointer<DatabaseCatalog> dbc_;
-  transaction::TransactionContext *const txn_;
+  const common::ManagedPointer<transaction::TransactionContext> txn_;
   std::vector<namespace_oid_t> search_path_;
   namespace_oid_t default_namespace_;
 

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -35,7 +35,7 @@ class DatabaseCatalog {
    * Adds the default/mandatory entries into the catalog that describe itself
    * @param txn for the operation
    */
-  void Bootstrap(transaction::TransactionContext *txn);
+  void Bootstrap(common::ManagedPointer<transaction::TransactionContext> txn);
 
   /**
    * Creates a new namespace within the database
@@ -43,7 +43,7 @@ class DatabaseCatalog {
    * @param name of the new namespace
    * @return OID of the new namespace or INVALID_NAMESPACE_OID if the operation failed
    */
-  namespace_oid_t CreateNamespace(transaction::TransactionContext *txn, const std::string &name);
+  namespace_oid_t CreateNamespace(common::ManagedPointer<transaction::TransactionContext> txn, const std::string &name);
 
   /**
    * Deletes the namespace and any objects assigned to the namespace.  The
@@ -54,7 +54,7 @@ class DatabaseCatalog {
    * @param ns_oid OID to be deleted
    * @return true if the deletion succeeded, otherwise false
    */
-  bool DeleteNamespace(transaction::TransactionContext *txn, namespace_oid_t ns_oid);
+  bool DeleteNamespace(common::ManagedPointer<transaction::TransactionContext> txn, namespace_oid_t ns_oid);
 
   /**
    * Resolve a namespace name to its OID.
@@ -62,7 +62,7 @@ class DatabaseCatalog {
    * @param name of the namespace
    * @return OID of the namespace or INVALID_NAMESPACE_OID if it does not exist
    */
-  namespace_oid_t GetNamespaceOid(transaction::TransactionContext *txn, const std::string &name);
+  namespace_oid_t GetNamespaceOid(common::ManagedPointer<transaction::TransactionContext> txn, const std::string &name);
 
   /**
    * Create a new user table in the catalog.
@@ -76,8 +76,8 @@ class DatabaseCatalog {
    * function call prior to committing.
    * @see src/include/catalog/table_details.h
    */
-  table_oid_t CreateTable(transaction::TransactionContext *txn, namespace_oid_t ns, const std::string &name,
-                          const Schema &schema);
+  table_oid_t CreateTable(common::ManagedPointer<transaction::TransactionContext> txn, namespace_oid_t ns,
+                          const std::string &name, const Schema &schema);
 
   /**
    * Deletes a table and all child objects (i.e columns, indexes, etc.) from
@@ -86,7 +86,7 @@ class DatabaseCatalog {
    * @param table to be deleted
    * @return true if the deletion succeeded, otherwise false
    */
-  bool DeleteTable(transaction::TransactionContext *txn, table_oid_t table);
+  bool DeleteTable(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table);
 
   /**
    * Resolve a table name to its OID
@@ -95,7 +95,8 @@ class DatabaseCatalog {
    * @param name of the table
    * @return OID of the table or INVALID_TABLE_OID if the table does not exist
    */
-  table_oid_t GetTableOid(transaction::TransactionContext *txn, namespace_oid_t ns, const std::string &name);
+  table_oid_t GetTableOid(common::ManagedPointer<transaction::TransactionContext> txn, namespace_oid_t ns,
+                          const std::string &name);
 
   /**
    * Rename a table.
@@ -104,7 +105,8 @@ class DatabaseCatalog {
    * @param name which the table will now have
    * @return true if the operation succeeded, otherwise false
    */
-  bool RenameTable(transaction::TransactionContext *txn, table_oid_t table, const std::string &name);
+  bool RenameTable(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table,
+                   const std::string &name);
 
   /**
    * Inform the catalog of where the underlying storage for a table is
@@ -118,7 +120,8 @@ class DatabaseCatalog {
    * @warning It is unsafe to call delete on the SqlTable pointer after calling
    * this function regardless of the return status.
    */
-  bool SetTablePointer(transaction::TransactionContext *txn, table_oid_t table, const storage::SqlTable *table_ptr);
+  bool SetTablePointer(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table,
+                       const storage::SqlTable *table_ptr);
 
   /**
    * Obtain the storage pointer for a SQL table
@@ -126,7 +129,8 @@ class DatabaseCatalog {
    * @param table to which we want the storage object
    * @return the storage object corresponding to the passed OID
    */
-  common::ManagedPointer<storage::SqlTable> GetTable(transaction::TransactionContext *txn, table_oid_t table);
+  common::ManagedPointer<storage::SqlTable> GetTable(common::ManagedPointer<transaction::TransactionContext> txn,
+                                                     table_oid_t table);
 
   /**
    * Apply a new schema to the given table.  The changes should modify the latest
@@ -142,7 +146,7 @@ class DatabaseCatalog {
    * schema object after this call, they should use the GetSchema function to
    * obtain the authoritative schema for this table.
    */
-  bool UpdateSchema(transaction::TransactionContext *txn, table_oid_t table, Schema *new_schema);
+  bool UpdateSchema(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table, Schema *new_schema);
 
   /**
    * Get the visible schema describing the table.
@@ -150,7 +154,7 @@ class DatabaseCatalog {
    * @param table corresponding to the requested schema
    * @return the visible schema object for the identified table
    */
-  const Schema &GetSchema(transaction::TransactionContext *txn, table_oid_t table);
+  const Schema &GetSchema(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table);
 
   /**
    * A list of all constraints on this table
@@ -158,7 +162,8 @@ class DatabaseCatalog {
    * @param table being queried
    * @return vector of OIDs for all of the constraints that apply to this table
    */
-  std::vector<constraint_oid_t> GetConstraints(transaction::TransactionContext *txn, table_oid_t table);
+  std::vector<constraint_oid_t> GetConstraints(common::ManagedPointer<transaction::TransactionContext> txn,
+                                               table_oid_t table);
 
   /**
    * A list of all indexes on the given table
@@ -166,7 +171,7 @@ class DatabaseCatalog {
    * @param table being queried
    * @return vector of OIDs for all of the indexes on this table
    */
-  std::vector<index_oid_t> GetIndexOids(transaction::TransactionContext *txn, table_oid_t table);
+  std::vector<index_oid_t> GetIndexOids(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table);
 
   /**
    * Create the catalog entries for a new index.
@@ -177,8 +182,8 @@ class DatabaseCatalog {
    * @param schema describing the new index
    * @return OID of the new index or INVALID_INDEX_OID if creation failed
    */
-  index_oid_t CreateIndex(transaction::TransactionContext *txn, namespace_oid_t ns, const std::string &name,
-                          table_oid_t table, const IndexSchema &schema);
+  index_oid_t CreateIndex(common::ManagedPointer<transaction::TransactionContext> txn, namespace_oid_t ns,
+                          const std::string &name, table_oid_t table, const IndexSchema &schema);
 
   /**
    * Delete an index.  Any constraints that utilize this index must be deleted
@@ -187,7 +192,7 @@ class DatabaseCatalog {
    * @param index to be deleted
    * @return true if the deletion succeeded, otherwise false.
    */
-  bool DeleteIndex(transaction::TransactionContext *txn, index_oid_t index);
+  bool DeleteIndex(common::ManagedPointer<transaction::TransactionContext> txn, index_oid_t index);
 
   /**
    * Resolve an index name to its OID
@@ -196,7 +201,8 @@ class DatabaseCatalog {
    * @param name of the index
    * @return OID of the index or INVALID_INDEX_OID if it does not exist
    */
-  index_oid_t GetIndexOid(transaction::TransactionContext *txn, namespace_oid_t ns, const std::string &name);
+  index_oid_t GetIndexOid(common::ManagedPointer<transaction::TransactionContext> txn, namespace_oid_t ns,
+                          const std::string &name);
 
   /**
    * Gets the schema used to define the index
@@ -204,7 +210,7 @@ class DatabaseCatalog {
    * @param index being queried
    * @return the index schema
    */
-  const IndexSchema &GetIndexSchema(transaction::TransactionContext *txn, index_oid_t index);
+  const IndexSchema &GetIndexSchema(common::ManagedPointer<transaction::TransactionContext> txn, index_oid_t index);
 
   /**
    * Inform the catalog of where the underlying implementation of the index is
@@ -218,7 +224,8 @@ class DatabaseCatalog {
    * @warning It is unsafe to call delete on the Index pointer after calling
    * this function regardless of the return status.
    */
-  bool SetIndexPointer(transaction::TransactionContext *txn, index_oid_t index, const storage::index::Index *index_ptr);
+  bool SetIndexPointer(common::ManagedPointer<transaction::TransactionContext> txn, index_oid_t index,
+                       const storage::index::Index *index_ptr);
 
   /**
    * Obtain the pointer to the index
@@ -226,7 +233,8 @@ class DatabaseCatalog {
    * @param index to which we want a pointer
    * @return the pointer to the index
    */
-  common::ManagedPointer<storage::index::Index> GetIndex(transaction::TransactionContext *txn, index_oid_t index);
+  common::ManagedPointer<storage::index::Index> GetIndex(common::ManagedPointer<transaction::TransactionContext> txn,
+                                                         index_oid_t index);
 
   /**
    * Returns index pointers and schemas for every index on a table. Provides much better performance than individual
@@ -236,7 +244,7 @@ class DatabaseCatalog {
    * @return vector of pairs of index pointers and their corresponding schemas
    */
   std::vector<std::pair<common::ManagedPointer<storage::index::Index>, const IndexSchema &>> GetIndexes(
-      transaction::TransactionContext *txn, table_oid_t table);
+      common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table);
 
  private:
   /**
@@ -246,7 +254,8 @@ class DatabaseCatalog {
    * @param ns_oid oid of the namespace
    * @return true if creation is successful
    */
-  bool CreateNamespace(transaction::TransactionContext *txn, const std::string &name, namespace_oid_t ns_oid);
+  bool CreateNamespace(common::ManagedPointer<transaction::TransactionContext> txn, const std::string &name,
+                       namespace_oid_t ns_oid);
 
   /**
    * Add entry to pg_attribute
@@ -258,7 +267,8 @@ class DatabaseCatalog {
    * @return whether insertion is successful
    */
   template <typename Column, typename ClassOid, typename ColOid>
-  bool CreateColumn(transaction::TransactionContext *txn, ClassOid class_oid, ColOid col_oid, const Column &col);
+  bool CreateColumn(common::ManagedPointer<transaction::TransactionContext> txn, ClassOid class_oid, ColOid col_oid,
+                    const Column &col);
   /**
    * Get entries from pg_attribute
    * @tparam Column type of columns
@@ -267,7 +277,7 @@ class DatabaseCatalog {
    * @return the column from pg_attribute
    */
   template <typename Column, typename ClassOid, typename ColOid>
-  std::vector<Column> GetColumns(transaction::TransactionContext *txn, ClassOid class_oid);
+  std::vector<Column> GetColumns(common::ManagedPointer<transaction::TransactionContext> txn, ClassOid class_oid);
 
   /**
    * A list of all oids and their postgres::ClassKind from pg_class on the given namespace. This is currently designed
@@ -276,8 +286,8 @@ class DatabaseCatalog {
    * @param ns being queried
    * @return vector of OIDs for all of the objects on this namespace
    */
-  std::vector<std::pair<uint32_t, postgres::ClassKind>> GetNamespaceClassOids(transaction::TransactionContext *txn,
-                                                                              namespace_oid_t ns_oid);
+  std::vector<std::pair<uint32_t, postgres::ClassKind>> GetNamespaceClassOids(
+      common::ManagedPointer<transaction::TransactionContext> txn, namespace_oid_t ns_oid);
 
   /**
    * Delete entries from pg_attribute
@@ -286,7 +296,7 @@ class DatabaseCatalog {
    * @return the column from pg_attribute
    */
   template <typename Column, typename ClassOid>
-  bool DeleteColumns(transaction::TransactionContext *txn, ClassOid class_oid);
+  bool DeleteColumns(common::ManagedPointer<transaction::TransactionContext> txn, ClassOid class_oid);
 
   storage::SqlTable *namespaces_;
   storage::index::Index *namespaces_oid_index_;
@@ -351,9 +361,9 @@ class DatabaseCatalog {
 
   explicit DatabaseCatalog(db_oid_t oid) : write_lock_(transaction::INITIAL_TXN_TIMESTAMP), db_oid_(oid) {}
 
-  void TearDown(transaction::TransactionContext *txn);
-  bool CreateTableEntry(transaction::TransactionContext *txn, table_oid_t table_oid, namespace_oid_t ns_oid,
-                        const std::string &name, const Schema &schema);
+  void TearDown(common::ManagedPointer<transaction::TransactionContext> txn);
+  bool CreateTableEntry(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table_oid,
+                        namespace_oid_t ns_oid, const std::string &name, const Schema &schema);
 
   friend class Catalog;
   friend class postgres::Builder;
@@ -369,7 +379,7 @@ class DatabaseCatalog {
    * @warning this requires that commit actions be performed after the commit time is stored in the
    * TransactionContext's FinishTime.
    */
-  bool TryLock(transaction::TransactionContext *txn);
+  bool TryLock(common::ManagedPointer<transaction::TransactionContext> txn);
 
   /**
    * Atomically updates the next oid counter to the max of the current count and the provided next oid
@@ -393,8 +403,9 @@ class DatabaseCatalog {
    * @param schema describing the new index
    * @return true if creation succeeded, false otherwise
    */
-  bool CreateIndexEntry(transaction::TransactionContext *txn, namespace_oid_t ns_oid, table_oid_t table_oid,
-                        index_oid_t index_oid, const std::string &name, const IndexSchema &schema);
+  bool CreateIndexEntry(common::ManagedPointer<transaction::TransactionContext> txn, namespace_oid_t ns_oid,
+                        table_oid_t table_oid, index_oid_t index_oid, const std::string &name,
+                        const IndexSchema &schema);
 
   /**
    * Delete all of the indexes for a given table. This is currently designed as an internal function, though could be
@@ -403,13 +414,13 @@ class DatabaseCatalog {
    * @param table to remove all indexes for
    * @return true if the deletion succeeded, otherwise false.
    */
-  bool DeleteIndexes(transaction::TransactionContext *txn, table_oid_t table);
+  bool DeleteIndexes(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t table);
 
   /**
    * Bootstraps the built-in types found in type::Type
    * @param txn transaction to insert into catalog with
    */
-  void BootstrapTypes(transaction::TransactionContext *txn);
+  void BootstrapTypes(common::ManagedPointer<transaction::TransactionContext> txn);
 
   /**
    * Creates all of the ProjectedRowInitializers and ProjectionMaps for the catalog. These can be stashed because the
@@ -427,8 +438,9 @@ class DatabaseCatalog {
    * @param by_val true if type should be passed by value. false if passed by reference
    * @param type_category category of type
    */
-  void InsertType(transaction::TransactionContext *txn, type::TypeId internal_type, const std::string &name,
-                  namespace_oid_t namespace_oid, int16_t len, bool by_val, postgres::Type type_category);
+  void InsertType(common::ManagedPointer<transaction::TransactionContext> txn, type::TypeId internal_type,
+                  const std::string &name, namespace_oid_t namespace_oid, int16_t len, bool by_val,
+                  postgres::Type type_category);
 
   /**
    * Returns oid for built in type. Currently, we simply use the underlying int for the enum as the oid
@@ -445,8 +457,8 @@ class DatabaseCatalog {
    * @param name name of the table, index, view, etc.
    * @return a pair of oid and ClassKind
    */
-  std::pair<uint32_t, postgres::ClassKind> GetClassOidKind(transaction::TransactionContext *txn, namespace_oid_t ns_oid,
-                                                           const std::string &name);
+  std::pair<uint32_t, postgres::ClassKind> GetClassOidKind(common::ManagedPointer<transaction::TransactionContext> txn,
+                                                           namespace_oid_t ns_oid, const std::string &name);
 
   /**
    * Helper function to query an object pointer form pg_class
@@ -455,7 +467,8 @@ class DatabaseCatalog {
    * @return pair of ptr to and ClassKind of object requested. ptr will be nullptr if no entry was found for the given
    * oid
    */
-  std::pair<void *, postgres::ClassKind> GetClassPtrKind(transaction::TransactionContext *txn, uint32_t oid);
+  std::pair<void *, postgres::ClassKind> GetClassPtrKind(common::ManagedPointer<transaction::TransactionContext> txn,
+                                                         uint32_t oid);
 
   /**
    * Helper function to query a schema pointer form pg_class
@@ -464,7 +477,8 @@ class DatabaseCatalog {
    * @return pair of ptr to schema and ClassKind of object requested. ptr will be nullptr if no entry was found for the
    * given oid
    */
-  std::pair<void *, postgres::ClassKind> GetClassSchemaPtrKind(transaction::TransactionContext *txn, uint32_t oid);
+  std::pair<void *, postgres::ClassKind> GetClassSchemaPtrKind(
+      common::ManagedPointer<transaction::TransactionContext> txn, uint32_t oid);
 
   /**
    * Sets a table's schema in pg_class
@@ -474,7 +488,8 @@ class DatabaseCatalog {
    * @param schema object schema to insert
    * @return true if succesfull
    */
-  bool SetTableSchemaPointer(transaction::TransactionContext *txn, table_oid_t oid, const Schema *schema);
+  bool SetTableSchemaPointer(common::ManagedPointer<transaction::TransactionContext> txn, table_oid_t oid,
+                             const Schema *schema);
 
   /**
    * Sets an index's schema in pg_class
@@ -484,7 +499,8 @@ class DatabaseCatalog {
    * @param schema object schema to insert
    * @return true if succesfull
    */
-  bool SetIndexSchemaPointer(transaction::TransactionContext *txn, index_oid_t oid, const IndexSchema *schema);
+  bool SetIndexSchemaPointer(common::ManagedPointer<transaction::TransactionContext> txn, index_oid_t oid,
+                             const IndexSchema *schema);
 
   /**
    * Inserts a provided pointer into a given pg_class column. Can be used for class object and schema pointers
@@ -499,7 +515,8 @@ class DatabaseCatalog {
    * @return true if successful
    */
   template <typename ClassOid, typename Ptr>
-  bool SetClassPointer(transaction::TransactionContext *txn, ClassOid oid, const Ptr *pointer, col_oid_t class_col);
+  bool SetClassPointer(common::ManagedPointer<transaction::TransactionContext> txn, ClassOid oid, const Ptr *pointer,
+                       col_oid_t class_col);
 
   /**
    * @tparam Column column type (either index or table)

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -189,7 +189,7 @@ class DBMain {
       // Bootstrap the default database in the catalog.
       if (create_default_database) {
         auto *bootstrap_txn = txn_layer->GetTransactionManager()->BeginTransaction();
-        catalog_->CreateDatabase(bootstrap_txn, catalog::DEFAULT_DATABASE, true);
+        catalog_->CreateDatabase(common::ManagedPointer(bootstrap_txn), catalog::DEFAULT_DATABASE, true);
         txn_layer->GetTransactionManager()->Commit(bootstrap_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
       }
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -2,6 +2,7 @@
 #include <list>
 #include <unordered_map>
 #include <vector>
+
 #include "common/performance_counter.h"
 #include "storage/projected_columns.h"
 #include "storage/storage_defs.h"
@@ -130,7 +131,8 @@ class DataTable {
    * reference col_id 0
    * @return true if tuple is visible to this txn and ProjectedRow has been populated, false otherwise
    */
-  bool Select(transaction::TransactionContext *txn, TupleSlot slot, ProjectedRow *out_buffer) const;
+  bool Select(common::ManagedPointer<transaction::TransactionContext> txn, TupleSlot slot,
+              ProjectedRow *out_buffer) const;
 
   // TODO(Tianyu): Should this be updated in place or return a new iterator? Does the caller ever want to
   // save a point of scan and come back to it later?
@@ -148,7 +150,8 @@ class DataTable {
    * @param out_buffer output buffer. The object should already contain projection list information. This buffer is
    *                   always cleared of old values.
    */
-  void Scan(transaction::TransactionContext *txn, SlotIterator *start_pos, ProjectedColumns *out_buffer) const;
+  void Scan(common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *start_pos,
+            ProjectedColumns *out_buffer) const;
 
   /**
    * @return the first tuple slot contained in the data table
@@ -180,7 +183,7 @@ class DataTable {
    * not reference col_id 0
    * @return true if successful, false otherwise
    */
-  bool Update(transaction::TransactionContext *txn, TupleSlot slot, const ProjectedRow &redo);
+  bool Update(common::ManagedPointer<transaction::TransactionContext> txn, TupleSlot slot, const ProjectedRow &redo);
 
   /**
    * Inserts a tuple, as given in the redo, and update the version chain the link to the given
@@ -191,7 +194,7 @@ class DataTable {
    * @return the TupleSlot allocated for this insert, used to identify this tuple's physical location for indexes and
    * such.
    */
-  TupleSlot Insert(transaction::TransactionContext *txn, const ProjectedRow &redo);
+  TupleSlot Insert(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo);
 
   /**
    * Deletes the given TupleSlot, this will call StageDelete on the provided txn to generate the RedoRecord for delete.
@@ -200,7 +203,7 @@ class DataTable {
    * @param slot the slot of the tuple to delete
    * @return true if successful, false otherwise
    */
-  bool Delete(transaction::TransactionContext *txn, TupleSlot slot);
+  bool Delete(common::ManagedPointer<transaction::TransactionContext> txn, TupleSlot slot);
 
   /**
    * Return a pointer to the performance counter for the data table.
@@ -254,9 +257,11 @@ class DataTable {
   // A templatized version for select, so that we can use the same code for both row and column access.
   // the method is explicitly instantiated for ProjectedRow and ProjectedColumns::RowView
   template <class RowType>
-  bool SelectIntoBuffer(transaction::TransactionContext *txn, TupleSlot slot, RowType *out_buffer) const;
+  bool SelectIntoBuffer(common::ManagedPointer<transaction::TransactionContext> txn, TupleSlot slot,
+                        RowType *out_buffer) const;
 
-  void InsertInto(transaction::TransactionContext *txn, const ProjectedRow &redo, TupleSlot dest);
+  void InsertInto(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo,
+                  TupleSlot dest);
   // Atomically read out the version pointer value.
   UndoRecord *AtomicallyReadVersionPtr(TupleSlot slot, const TupleAccessStrategy &accessor) const;
 

--- a/src/include/storage/index/bwtree_index.h
+++ b/src/include/storage/index/bwtree_index.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+
 #include "bwtree/bwtree.h"
 #include "storage/index/index.h"
 #include "storage/index/index_defs.h"
@@ -36,7 +37,8 @@ class BwTreeIndex final : public Index {
 
   void PerformGarbageCollection() final { bwtree_->PerformGarbageCollection(); };
 
-  bool Insert(transaction::TransactionContext *const txn, const ProjectedRow &tuple, const TupleSlot location) final {
+  bool Insert(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+              const TupleSlot location) final {
     TERRIER_ASSERT(!(metadata_.GetSchema().Unique()),
                    "This Insert is designed for secondary indexes with no uniqueness constraints.");
     KeyType index_key;
@@ -54,7 +56,7 @@ class BwTreeIndex final : public Index {
     return result;
   }
 
-  bool InsertUnique(transaction::TransactionContext *const txn, const ProjectedRow &tuple,
+  bool InsertUnique(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
                     const TupleSlot location) final {
     TERRIER_ASSERT(metadata_.GetSchema().Unique(), "This Insert is designed for indexes with uniqueness constraints.");
     KeyType index_key;
@@ -89,7 +91,8 @@ class BwTreeIndex final : public Index {
     return result;
   }
 
-  void Delete(transaction::TransactionContext *const txn, const ProjectedRow &tuple, const TupleSlot location) final {
+  void Delete(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+              const TupleSlot location) final {
     KeyType index_key;
     index_key.SetFromProjectedRow(tuple, metadata_);
 

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <variant>  // NOLINT (Matt): lint thinks this C++17 header is a C header because it only knows C++11
 #include <vector>
+
 #include "libcuckoo/cuckoohash_map.hh"
 #include "storage/index/index.h"
 #include "storage/index/index_defs.h"
@@ -88,7 +89,8 @@ class HashIndex final : public Index {
  public:
   IndexType Type() const final { return IndexType::HASHMAP; }
 
-  bool Insert(transaction::TransactionContext *const txn, const ProjectedRow &tuple, const TupleSlot location) final {
+  bool Insert(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+              const TupleSlot location) final {
     TERRIER_ASSERT(!(metadata_.GetSchema().Unique()),
                    "This Insert is designed for secondary indexes with no uniqueness constraints.");
     KeyType index_key;
@@ -135,7 +137,7 @@ class HashIndex final : public Index {
     return true;
   }
 
-  bool InsertUnique(transaction::TransactionContext *const txn, const ProjectedRow &tuple,
+  bool InsertUnique(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
                     const TupleSlot location) final {
     TERRIER_ASSERT(metadata_.GetSchema().Unique(), "This Insert is designed for indexes with uniqueness constraints.");
     KeyType index_key;
@@ -214,7 +216,8 @@ class HashIndex final : public Index {
     return overall_result;
   }
 
-  void Delete(transaction::TransactionContext *const txn, const ProjectedRow &tuple, const TupleSlot location) final {
+  void Delete(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+              const TupleSlot location) final {
     KeyType index_key;
     index_key.SetFromProjectedRow(tuple, metadata_);
 

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -3,6 +3,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "common/performance_counter.h"
 #include "storage/data_table.h"
@@ -71,7 +72,8 @@ class Index {
    * @param location value
    * @return false if the value already exists, true otherwise
    */
-  virtual bool Insert(transaction::TransactionContext *txn, const ProjectedRow &tuple, TupleSlot location) = 0;
+  virtual bool Insert(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+                      TupleSlot location) = 0;
 
   /**
    * Inserts a key-value pair only if any matching keys have TupleSlots that don't conflict with the calling txn
@@ -81,7 +83,8 @@ class Index {
    * @return true if the value was inserted, false otherwise
    *         (either because value exists, or predicate returns true for one of the existing values)
    */
-  virtual bool InsertUnique(transaction::TransactionContext *txn, const ProjectedRow &tuple, TupleSlot location) = 0;
+  virtual bool InsertUnique(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+                            TupleSlot location) = 0;
 
   /**
    * Doesn't immediately call delete on the index. Registers a commit action in the txn that will eventually register a
@@ -90,7 +93,8 @@ class Index {
    * @param tuple key
    * @param location value
    */
-  virtual void Delete(transaction::TransactionContext *txn, const ProjectedRow &tuple, TupleSlot location) = 0;
+  virtual void Delete(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+                      TupleSlot location) = 0;
 
   /**
    * Finds all the values associated with the given key in our index.

--- a/src/include/storage/recovery/recovery_manager.h
+++ b/src/include/storage/recovery/recovery_manager.h
@@ -206,9 +206,9 @@ class RecoveryManager : public common::DedicatedThreadOwner {
    */
   common::ManagedPointer<catalog::DatabaseCatalog> GetDatabaseCatalog(transaction::TransactionContext *txn,
                                                                       catalog::db_oid_t db_oid) {
-    auto db_catalog_ptr = catalog_->GetDatabaseCatalog(txn, db_oid);
+    auto db_catalog_ptr = catalog_->GetDatabaseCatalog(common::ManagedPointer(txn), db_oid);
     TERRIER_ASSERT(db_catalog_ptr != nullptr, "No catalog for given database oid");
-    auto result UNUSED_ATTRIBUTE = db_catalog_ptr->TryLock(txn);
+    auto result UNUSED_ATTRIBUTE = db_catalog_ptr->TryLock(common::ManagedPointer(txn));
     TERRIER_ASSERT(result, "There should not be concurrent DDL changes during recovery.");
     return db_catalog_ptr;
   }

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -3,6 +3,7 @@
 #include <set>
 #include <utility>
 #include <vector>
+
 #include "catalog/schema.h"
 #include "storage/data_table.h"
 #include "storage/projected_columns.h"
@@ -60,7 +61,8 @@ class SqlTable {
    * @param out_buffer output buffer. The object should already contain projection list information. @see ProjectedRow.
    * @return true if tuple is visible to this txn and ProjectedRow has been populated, false otherwise
    */
-  bool Select(transaction::TransactionContext *const txn, const TupleSlot slot, ProjectedRow *const out_buffer) const {
+  bool Select(const common::ManagedPointer<transaction::TransactionContext> txn, const TupleSlot slot,
+              ProjectedRow *const out_buffer) const {
     return table_.data_table_->Select(txn, slot, out_buffer);
   }
 
@@ -73,7 +75,7 @@ class SqlTable {
    * TupleSlot in this RedoRecord must be set to the intended tuple.
    * @return true if successful, false otherwise
    */
-  bool Update(transaction::TransactionContext *const txn, RedoRecord *const redo) const {
+  bool Update(const common::ManagedPointer<transaction::TransactionContext> txn, RedoRecord *const redo) const {
     TERRIER_ASSERT(redo->GetTupleSlot() != TupleSlot(nullptr, 0), "TupleSlot was never set in this RedoRecord.");
     TERRIER_ASSERT(redo == reinterpret_cast<LogRecord *>(txn->redo_buffer_.LastRecord())
                                ->LogRecord::GetUnderlyingRecordBodyAs<RedoRecord>(),
@@ -96,7 +98,7 @@ class SqlTable {
    * @param redo after-image of the inserted tuple.
    * @return TupleSlot for the inserted tuple
    */
-  TupleSlot Insert(transaction::TransactionContext *const txn, RedoRecord *const redo) const {
+  TupleSlot Insert(const common::ManagedPointer<transaction::TransactionContext> txn, RedoRecord *const redo) const {
     TERRIER_ASSERT(redo->GetTupleSlot() == TupleSlot(nullptr, 0), "TupleSlot was set in this RedoRecord.");
     TERRIER_ASSERT(redo == reinterpret_cast<LogRecord *>(txn->redo_buffer_.LastRecord())
                                ->LogRecord::GetUnderlyingRecordBodyAs<RedoRecord>(),
@@ -113,7 +115,7 @@ class SqlTable {
    * @param slot the slot of the tuple to delete
    * @return true if successful, false otherwise
    */
-  bool Delete(transaction::TransactionContext *const txn, const TupleSlot slot) {
+  bool Delete(const common::ManagedPointer<transaction::TransactionContext> txn, const TupleSlot slot) {
     TERRIER_ASSERT(txn->redo_buffer_.LastRecord() != nullptr,
                    "The RedoBuffer is empty even though StageDelete should have been called.");
     TERRIER_ASSERT(
@@ -143,7 +145,7 @@ class SqlTable {
    * @param out_buffer output buffer. The object should already contain projection list information. This buffer is
    *                   always cleared of old values.
    */
-  void Scan(transaction::TransactionContext *const txn, DataTable::SlotIterator *const start_pos,
+  void Scan(const common::ManagedPointer<transaction::TransactionContext> txn, DataTable::SlotIterator *const start_pos,
             ProjectedColumns *const out_buffer) const {
     return table_.data_table_->Scan(txn, start_pos, out_buffer);
   }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1,5 +1,7 @@
 #include "storage/data_table.h"
+
 #include <list>
+
 #include "common/allocator.h"
 #include "storage/block_access_controller.h"
 #include "storage/storage_util.h"
@@ -31,13 +33,13 @@ DataTable::~DataTable() {
   }
 }
 
-bool DataTable::Select(terrier::transaction::TransactionContext *txn, terrier::storage::TupleSlot slot,
-                       terrier::storage::ProjectedRow *out_buffer) const {
+bool DataTable::Select(const common::ManagedPointer<transaction::TransactionContext> txn, TupleSlot slot,
+                       ProjectedRow *out_buffer) const {
   data_table_counter_.IncrementNumSelect(1);
   return SelectIntoBuffer(txn, slot, out_buffer);
 }
 
-void DataTable::Scan(transaction::TransactionContext *const txn, SlotIterator *const start_pos,
+void DataTable::Scan(const common::ManagedPointer<transaction::TransactionContext> txn, SlotIterator *const start_pos,
                      ProjectedColumns *const out_buffer) const {
   // TODO(Tianyu): So far this is not that much better than tuple-at-a-time access,
   // but can be improved if block is read-only, or if we implement version synopsis, to just use std::memcpy when it's
@@ -85,7 +87,8 @@ DataTable::SlotIterator DataTable::end() const {  // NOLINT for STL name compabi
   return {this, last_block, insert_head};
 }
 
-bool DataTable::Update(transaction::TransactionContext *const txn, const TupleSlot slot, const ProjectedRow &redo) {
+bool DataTable::Update(const common::ManagedPointer<transaction::TransactionContext> txn, const TupleSlot slot,
+                       const ProjectedRow &redo) {
   TERRIER_ASSERT(redo.NumColumns() <= accessor_.GetBlockLayout().NumColumns() - NUM_RESERVED_COLUMNS,
                  "The input buffer cannot change the reserved columns, so it should have fewer attributes.");
   TERRIER_ASSERT(redo.NumColumns() > 0, "The input buffer should modify at least one attribute.");
@@ -146,7 +149,8 @@ void DataTable::CheckMoveHead(std::list<RawBlock *>::iterator block) {
   }
 }
 
-TupleSlot DataTable::Insert(transaction::TransactionContext *const txn, const ProjectedRow &redo) {
+TupleSlot DataTable::Insert(const common::ManagedPointer<transaction::TransactionContext> txn,
+                            const ProjectedRow &redo) {
   TERRIER_ASSERT(redo.NumColumns() == accessor_.GetBlockLayout().NumColumns() - NUM_RESERVED_COLUMNS,
                  "The input buffer never changes the version pointer column, so it should have  exactly 1 fewer "
                  "attribute than the DataTable's layout.");
@@ -201,7 +205,8 @@ TupleSlot DataTable::Insert(transaction::TransactionContext *const txn, const Pr
   return result;
 }
 
-void DataTable::InsertInto(transaction::TransactionContext *txn, const ProjectedRow &redo, TupleSlot dest) {
+void DataTable::InsertInto(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo,
+                           TupleSlot dest) {
   TERRIER_ASSERT(accessor_.Allocated(dest), "destination slot must already be allocated");
   TERRIER_ASSERT(accessor_.IsNull(dest, VERSION_POINTER_COLUMN_ID),
                  "The slot needs to be logically deleted to every running transaction");
@@ -221,7 +226,7 @@ void DataTable::InsertInto(transaction::TransactionContext *txn, const Projected
   }
 }
 
-bool DataTable::Delete(transaction::TransactionContext *const txn, const TupleSlot slot) {
+bool DataTable::Delete(const common::ManagedPointer<transaction::TransactionContext> txn, const TupleSlot slot) {
   data_table_counter_.IncrementNumDelete(1);
   UndoRecord *const undo = txn->UndoRecordForDelete(this, slot);
   slot.GetBlock()->controller_.WaitUntilHot();
@@ -247,8 +252,8 @@ bool DataTable::Delete(transaction::TransactionContext *const txn, const TupleSl
 }
 
 template <class RowType>
-bool DataTable::SelectIntoBuffer(transaction::TransactionContext *const txn, const TupleSlot slot,
-                                 RowType *const out_buffer) const {
+bool DataTable::SelectIntoBuffer(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                 const TupleSlot slot, RowType *const out_buffer) const {
   TERRIER_ASSERT(out_buffer->NumColumns() <= accessor_.GetBlockLayout().NumColumns() - NUM_RESERVED_COLUMNS,
                  "The output buffer never returns the version pointer columns, so it should have "
                  "fewer attributes.");
@@ -328,11 +333,12 @@ bool DataTable::SelectIntoBuffer(transaction::TransactionContext *const txn, con
   return visible;
 }
 
-template bool DataTable::SelectIntoBuffer<ProjectedRow>(transaction::TransactionContext *txn, const TupleSlot slot,
-                                                        ProjectedRow *const out_buffer) const;
-template bool DataTable::SelectIntoBuffer<ProjectedColumns::RowView>(transaction::TransactionContext *txn,
-                                                                     const TupleSlot slot,
-                                                                     ProjectedColumns::RowView *const out_buffer) const;
+template bool DataTable::SelectIntoBuffer<ProjectedRow>(
+    const common::ManagedPointer<transaction::TransactionContext> txn, const TupleSlot slot,
+    ProjectedRow *const out_buffer) const;
+template bool DataTable::SelectIntoBuffer<ProjectedColumns::RowView>(
+    const common::ManagedPointer<transaction::TransactionContext> txn, const TupleSlot slot,
+    ProjectedColumns::RowView *const out_buffer) const;
 
 UndoRecord *DataTable::AtomicallyReadVersionPtr(const TupleSlot slot, const TupleAccessStrategy &accessor) const {
   // Okay to ignore presence bit, because we use that for logical delete, not for validity of the version pointer value

--- a/src/storage/recovery/recovery_manager.cpp
+++ b/src/storage/recovery/recovery_manager.cpp
@@ -148,7 +148,7 @@ void RecoveryManager::ReplayRedoRecord(transaction::TransactionContext *txn, Log
     TERRIER_ASSERT(memcmp(redo_record->Delta(), staged_record->Delta(), redo_record->Delta()->Size()) == 0,
                    "ProjectedRow of original and staged records must be identical");
     // Insert will always succeed
-    auto new_tuple_slot = sql_table_ptr->Insert(txn, staged_record);
+    auto new_tuple_slot = sql_table_ptr->Insert(common::ManagedPointer(txn), staged_record);
     UpdateIndexesOnTable(txn, staged_record->GetDatabaseOid(), staged_record->GetTableOid(), sql_table_ptr,
                          new_tuple_slot, staged_record->Delta(), true /* insert */);
     TERRIER_ASSERT(staged_record->GetTupleSlot() == new_tuple_slot,
@@ -161,7 +161,7 @@ void RecoveryManager::ReplayRedoRecord(transaction::TransactionContext *txn, Log
     // Stage the write. This way the recovery operation is logged if logging is enabled
     auto staged_record = txn->StageRecoveryWrite(record);
     TERRIER_ASSERT(staged_record->GetTupleSlot() == new_tuple_slot, "Staged record must have the mapped tuple slot");
-    bool result UNUSED_ATTRIBUTE = sql_table_ptr->Update(txn, staged_record);
+    bool result UNUSED_ATTRIBUTE = sql_table_ptr->Update(common::ManagedPointer(txn), staged_record);
     TERRIER_ASSERT(result, "Buffered changes should always succeed during commit");
   }
 }
@@ -171,7 +171,7 @@ void RecoveryManager::ReplayDeleteRecord(transaction::TransactionContext *txn, L
   // Get tuple slot
   auto new_tuple_slot = GetTupleSlotMapping(delete_record->GetTupleSlot());
   auto db_catalog_ptr = GetDatabaseCatalog(txn, delete_record->GetDatabaseOid());
-  auto sql_table_ptr = db_catalog_ptr->GetTable(txn, delete_record->GetTableOid());
+  auto sql_table_ptr = db_catalog_ptr->GetTable(common::ManagedPointer(txn), delete_record->GetTableOid());
   const auto &schema = GetTableSchema(txn, db_catalog_ptr, delete_record->GetTableOid());
 
   // Stage the delete. This way the recovery operation is logged if logging is enabled
@@ -185,10 +185,10 @@ void RecoveryManager::ReplayDeleteRecord(transaction::TransactionContext *txn, L
   auto initializer = sql_table_ptr->InitializerForProjectedRow(all_table_oids);
   auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedRowSize());
   auto pr = initializer.InitializeRow(buffer);
-  sql_table_ptr->Select(txn, new_tuple_slot, pr);
+  sql_table_ptr->Select(common::ManagedPointer(txn), new_tuple_slot, pr);
 
   // Delete from the table
-  bool result UNUSED_ATTRIBUTE = sql_table_ptr->Delete(txn, new_tuple_slot);
+  bool result UNUSED_ATTRIBUTE = sql_table_ptr->Delete(common::ManagedPointer(txn), new_tuple_slot);
   TERRIER_ASSERT(result, "Buffered changes should always succeed during commit");
 
   // Delete from the indexes
@@ -277,7 +277,7 @@ void RecoveryManager::UpdateIndexesOnTable(transaction::TransactionContext *txn,
     }
 
     default:  // Non-catalog table
-      index_objects = db_catalog_ptr->GetIndexes(txn, table_oid);
+      index_objects = db_catalog_ptr->GetIndexes(common::ManagedPointer(txn), table_oid);
   }
 
   // If there's no indexes on the table, we can return
@@ -328,11 +328,11 @@ void RecoveryManager::UpdateIndexesOnTable(transaction::TransactionContext *txn,
 
     if (insert) {
       bool result UNUSED_ATTRIBUTE = (index->metadata_.GetSchema().Unique())
-                                         ? index->InsertUnique(txn, *index_pr, tuple_slot)
-                                         : index->Insert(txn, *index_pr, tuple_slot);
+                                         ? index->InsertUnique(common::ManagedPointer(txn), *index_pr, tuple_slot)
+                                         : index->Insert(common::ManagedPointer(txn), *index_pr, tuple_slot);
       TERRIER_ASSERT(result, "Insert into index should always succeed for a committed transaction");
     } else {
-      index->Delete(txn, *index_pr, tuple_slot);
+      index->Delete(common::ManagedPointer(txn), *index_pr, tuple_slot);
     }
   }
 
@@ -415,11 +415,11 @@ uint32_t RecoveryManager::ProcessSpecialCasePGDatabaseRecord(
     std::string name_string(name_varlen.StringView());
 
     // Step 2: Recreate the database
-    auto result UNUSED_ATTRIBUTE = catalog_->CreateDatabase(txn, name_string, false, db_oid);
+    auto result UNUSED_ATTRIBUTE = catalog_->CreateDatabase(common::ManagedPointer(txn), name_string, false, db_oid);
     TERRIER_ASSERT(result, "Database recreation should succeed");
     catalog_->UpdateNextOid(db_oid);
     // Manually bootstrap the PRIs
-    catalog_->GetDatabaseCatalog(txn, db_oid)->BootstrapPRIs();
+    catalog_->GetDatabaseCatalog(common::ManagedPointer(txn), db_oid)->BootstrapPRIs();
 
     // Step 3: Update metadata. We need to use the indexes on pg_database to find what tuple slot we just inserted into.
     // We get the new tuple slot using the oid index.
@@ -449,7 +449,7 @@ uint32_t RecoveryManager::ProcessSpecialCasePGDatabaseRecord(
   auto pr_map = pg_database->ProjectionMapForOids({catalog::postgres::DATOID_COL_OID});
   auto *buffer = common::AllocationUtil::AllocateAligned(pr_init.ProjectedRowSize());
   auto *pr = pr_init.InitializeRow(buffer);
-  pg_database->Select(txn, GetTupleSlotMapping(delete_record->GetTupleSlot()), pr);
+  pg_database->Select(common::ManagedPointer(txn), GetTupleSlotMapping(delete_record->GetTupleSlot()), pr);
   auto db_oid =
       *(reinterpret_cast<catalog::db_oid_t *>(pr->AccessWithNullCheck(pr_map[catalog::postgres::DATOID_COL_OID])));
   delete[] buffer;
@@ -480,7 +480,8 @@ uint32_t RecoveryManager::ProcessSpecialCasePGDatabaseRecord(
           std::string name_string(name_varlen.StringView());
 
           // Step 5: Rename the database
-          auto result UNUSED_ATTRIBUTE = catalog_->RenameDatabase(txn, next_db_oid, name_string);
+          auto result UNUSED_ATTRIBUTE =
+              catalog_->RenameDatabase(common::ManagedPointer(txn), next_db_oid, name_string);
           TERRIER_ASSERT(result, "Renaming of database should always succeed during replaying");
 
           // Step 6: Update metadata and clean up additional record processed. We need to use the indexes on
@@ -506,7 +507,7 @@ uint32_t RecoveryManager::ProcessSpecialCasePGDatabaseRecord(
   }
 
   // Step 3: If it wasn't a renaming, we simply need to drop the database
-  auto result UNUSED_ATTRIBUTE = catalog_->DeleteDatabase(txn, db_oid);
+  auto result UNUSED_ATTRIBUTE = catalog_->DeleteDatabase(common::ManagedPointer(txn), db_oid);
   TERRIER_ASSERT(result, "Database deletion should succeed");
 
   // Step 4: Clean up any metadata
@@ -559,7 +560,7 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
         auto pr_map = pg_class_ptr->ProjectionMapForOids(col_oids);
         auto *buffer = common::AllocationUtil::AllocateAligned(pr_init.ProjectedRowSize());
         auto *pr = pr_init.InitializeRow(buffer);
-        pg_class_ptr->Select(txn, GetTupleSlotMapping(redo_record->GetTupleSlot()), pr);
+        pg_class_ptr->Select(common::ManagedPointer(txn), GetTupleSlotMapping(redo_record->GetTupleSlot()), pr);
         auto class_oid =
             *(reinterpret_cast<uint32_t *>(pr->AccessWithNullCheck(pr_map[catalog::postgres::RELOID_COL_OID])));
         auto class_kind = *(reinterpret_cast<catalog::postgres::ClassKind *>(
@@ -570,12 +571,12 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
             // Step 2: Query pg_attribute for the columns of the table
             auto schema_cols =
                 db_catalog->GetColumns<catalog::Schema::Column, catalog::table_oid_t, catalog::col_oid_t>(
-                    txn, catalog::table_oid_t(class_oid));
+                    common::ManagedPointer(txn), catalog::table_oid_t(class_oid));
 
             // Step 3: Create and set schema in catalog
             auto *schema = new catalog::Schema(std::move(schema_cols));
             bool result UNUSED_ATTRIBUTE =
-                db_catalog->SetTableSchemaPointer(txn, catalog::table_oid_t(class_oid), schema);
+                db_catalog->SetTableSchemaPointer(common::ManagedPointer(txn), catalog::table_oid_t(class_oid), schema);
             TERRIER_ASSERT(result, "Setting table schema pointer should succeed, entry should be in pg_class already");
 
             // Step 4: Create and set table pointers in catalog
@@ -586,7 +587,8 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
             } else {
               sql_table = new SqlTable(block_store_.Get(), *schema);
             }
-            result = db_catalog->SetTablePointer(txn, catalog::table_oid_t(class_oid), sql_table);
+            result =
+                db_catalog->SetTablePointer(common::ManagedPointer(txn), catalog::table_oid_t(class_oid), sql_table);
             TERRIER_ASSERT(result, "Setting table pointer should succeed, entry should be in pg_class already");
 
             // Step 5: Update catalog oid
@@ -600,7 +602,7 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
             // Step 2: Query pg_attribute for the columns of the index
             auto index_cols =
                 db_catalog->GetColumns<catalog::IndexSchema::Column, catalog::index_oid_t, catalog::indexkeycol_oid_t>(
-                    txn, catalog::index_oid_t(class_oid));
+                    common::ManagedPointer(txn), catalog::index_oid_t(class_oid));
 
             // Step 3: Query pg_index for the metadata we need for the index schema
             auto pg_indexes_index = db_catalog->indexes_oid_index_;
@@ -620,7 +622,8 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
             delete[] buffer;  // Delete old buffer, it won't be large enough for this PR
             buffer = common::AllocationUtil::AllocateAligned(pg_index_pr_init.ProjectedRowSize());
             pr = pg_index_pr_init.InitializeRow(buffer);
-            bool result UNUSED_ATTRIBUTE = db_catalog->indexes_->Select(txn, tuple_slot_result[0], pr);
+            bool result UNUSED_ATTRIBUTE =
+                db_catalog->indexes_->Select(common::ManagedPointer(txn), tuple_slot_result[0], pr);
             TERRIER_ASSERT(result, "Select into pg_index should succeed during recovery");
             bool is_unique = *(reinterpret_cast<bool *>(
                 pr->AccessWithNullCheck(pg_index_pr_map[catalog::postgres::INDISUNIQUE_COL_OID])));
@@ -636,7 +639,8 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
             // Step 4: Create and set IndexSchema in catalog
             auto *index_schema =
                 new catalog::IndexSchema(index_cols, index_type, is_unique, is_primary, is_exclusion, is_immediate);
-            result = db_catalog->SetIndexSchemaPointer(txn, catalog::index_oid_t(class_oid), index_schema);
+            result = db_catalog->SetIndexSchemaPointer(common::ManagedPointer(txn), catalog::index_oid_t(class_oid),
+                                                       index_schema);
             TERRIER_ASSERT(result, "Setting index schema pointer should succeed, entry should be in pg_class already");
 
             // Step 5: Create and set index pointer in catalog
@@ -646,7 +650,7 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
             } else {
               index = index::IndexBuilder().SetKeySchema(*index_schema).Build();
             }
-            result = db_catalog->SetIndexPointer(txn, catalog::index_oid_t(class_oid), index);
+            result = db_catalog->SetIndexPointer(common::ManagedPointer(txn), catalog::index_oid_t(class_oid), index);
             TERRIER_ASSERT(result, "Setting index pointer should succeed, entry should be in pg_class already");
 
             // Step 6: Update catalog oid
@@ -686,7 +690,7 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
   auto pr_map = pg_class->ProjectionMapForOids(col_oids);
   auto *buffer = common::AllocationUtil::AllocateAligned(pr_init.ProjectedRowSize());
   auto *pr = pr_init.InitializeRow(buffer);
-  pg_class->Select(txn, GetTupleSlotMapping(delete_record->GetTupleSlot()), pr);
+  pg_class->Select(common::ManagedPointer(txn), GetTupleSlotMapping(delete_record->GetTupleSlot()), pr);
   auto class_oid = *(reinterpret_cast<uint32_t *>(pr->AccessWithNullCheck(pr_map[catalog::postgres::RELOID_COL_OID])));
   auto class_kind = *(reinterpret_cast<catalog::postgres::ClassKind *>(
       pr->AccessWithNullCheck(pr_map[catalog::postgres::RELKIND_COL_OID])));
@@ -722,8 +726,9 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
           std::string name_string(name_varlen.StringView());
 
           // Step 5: Rename the table
-          auto result UNUSED_ATTRIBUTE = GetDatabaseCatalog(txn, next_redo_record->GetDatabaseOid())
-                                             ->RenameTable(txn, catalog::table_oid_t(next_class_oid), name_string);
+          auto result UNUSED_ATTRIBUTE =
+              GetDatabaseCatalog(txn, next_redo_record->GetDatabaseOid())
+                  ->RenameTable(common::ManagedPointer(txn), catalog::table_oid_t(next_class_oid), name_string);
           TERRIER_ASSERT(result, "Renaming should always succeed during replaying");
 
           // Step 6: Update metadata and clean up additional record processed. We need to use the indexes on
@@ -751,11 +756,11 @@ uint32_t RecoveryManager::ProcessSpecialCasePGClassRecord(
   bool result UNUSED_ATTRIBUTE;
   switch (class_kind) {
     case (catalog::postgres::ClassKind::REGULAR_TABLE): {
-      result = db_catalog_ptr->DeleteTable(txn, catalog::table_oid_t(class_oid));
+      result = db_catalog_ptr->DeleteTable(common::ManagedPointer(txn), catalog::table_oid_t(class_oid));
       break;
     }
     case (catalog::postgres::ClassKind::INDEX): {
-      result = db_catalog_ptr->DeleteIndex(txn, catalog::index_oid_t(class_oid));
+      result = db_catalog_ptr->DeleteIndex(common::ManagedPointer(txn), catalog::index_oid_t(class_oid));
       break;
     }
 
@@ -808,7 +813,7 @@ common::ManagedPointer<storage::SqlTable> RecoveryManager::GetSqlTable(transacti
       break;
     }
     default:
-      table_ptr = db_catalog_ptr->GetTable(txn, table_oid);
+      table_ptr = db_catalog_ptr->GetTable(common::ManagedPointer(txn), table_oid);
   }
 
   TERRIER_ASSERT(table_ptr != nullptr, "Table is not in the catalog for the given oid");
@@ -914,7 +919,8 @@ const catalog::Schema &RecoveryManager::GetTableSchema(
     transaction::TransactionContext *txn, const common::ManagedPointer<catalog::DatabaseCatalog> &db_catalog,
     const catalog::table_oid_t table_oid) const {
   auto search = catalog_table_schemas_.find(table_oid);
-  return (search != catalog_table_schemas_.end()) ? search->second : db_catalog->GetSchema(txn, table_oid);
+  return (search != catalog_table_schemas_.end()) ? search->second
+                                                  : db_catalog->GetSchema(common::ManagedPointer(txn), table_oid);
 }
 
 }  // namespace terrier::storage

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -15,15 +15,15 @@ void TrafficCop::HandBufferToReplication(std::unique_ptr<network::ReadBuffer> bu
 std::pair<catalog::db_oid_t, catalog::namespace_oid_t> TrafficCop::CreateTempNamespace(
     int sockfd, const std::string &database_name) {
   auto txn = txn_manager_->BeginTransaction();
-  auto db_oid = catalog_->GetDatabaseOid(txn, database_name);
+  auto db_oid = catalog_->GetDatabaseOid(common::ManagedPointer(txn), database_name);
 
   if (db_oid == catalog::INVALID_DATABASE_OID) {
     txn_manager_->Abort(txn);
     return {catalog::INVALID_DATABASE_OID, catalog::INVALID_NAMESPACE_OID};
   }
 
-  auto ns_oid =
-      catalog_->GetAccessor(txn, db_oid)->CreateNamespace(std::string(TEMP_NAMESPACE_PREFIX) + std::to_string(sockfd));
+  auto ns_oid = catalog_->GetAccessor(common::ManagedPointer(txn), db_oid)
+                    ->CreateNamespace(std::string(TEMP_NAMESPACE_PREFIX) + std::to_string(sockfd));
   if (ns_oid == catalog::INVALID_NAMESPACE_OID) {
     txn_manager_->Abort(txn);
     return {db_oid, catalog::INVALID_NAMESPACE_OID};
@@ -35,7 +35,7 @@ std::pair<catalog::db_oid_t, catalog::namespace_oid_t> TrafficCop::CreateTempNam
 
 bool TrafficCop::DropTempNamespace(catalog::namespace_oid_t ns_oid, catalog::db_oid_t db_oid) {
   auto txn = txn_manager_->BeginTransaction();
-  auto db_accessor = catalog_->GetAccessor(txn, db_oid);
+  auto db_accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_oid);
   if (!db_accessor) {
     txn_manager_->Abort(txn);
     return false;

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -46,7 +46,7 @@ class BinderCorrectnessTest : public TerrierTest {
     // create database
     txn_ = txn_manager_->BeginTransaction();
     BINDER_LOG_DEBUG("Creating database %s", default_database_name_.c_str());
-    db_oid_ = catalog_->CreateDatabase(txn_, default_database_name_, true);
+    db_oid_ = catalog_->CreateDatabase(common::ManagedPointer(txn_), default_database_name_, true);
     // commit the transactions
     txn_manager_->Commit(txn_, TestCallbacks::EmptyCallback, nullptr);
     BINDER_LOG_DEBUG("database %s created!", default_database_name_.c_str());
@@ -59,7 +59,7 @@ class BinderCorrectnessTest : public TerrierTest {
     //  for testcases to see if the binder does not differentiate between upper and lower cases
     // create table A
     txn_ = txn_manager_->BeginTransaction();
-    accessor_ = catalog_->GetAccessor(txn_, db_oid_);
+    accessor_ = catalog_->GetAccessor(common::ManagedPointer(txn_), db_oid_);
     // Create the column definition (no OIDs) for CREATE TABLE A(A1 int, a2 varchar)
     std::vector<catalog::Schema::Column> cols_a;
     cols_a.emplace_back("a1", type::TypeId::INTEGER, true, int_default);
@@ -75,7 +75,7 @@ class BinderCorrectnessTest : public TerrierTest {
 
     // create Table B
     txn_ = txn_manager_->BeginTransaction();
-    accessor_ = catalog_->GetAccessor(txn_, db_oid_);
+    accessor_ = catalog_->GetAccessor(common::ManagedPointer(txn_), db_oid_);
 
     // Create the column definition (no OIDs) for CREATE TABLE b(b1 int, B2 varchar)
     std::vector<catalog::Schema::Column> cols_b;
@@ -98,7 +98,7 @@ class BinderCorrectnessTest : public TerrierTest {
     SetUpTables();
     // prepare for testing
     txn_ = txn_manager_->BeginTransaction();
-    accessor_ = catalog_->GetAccessor(txn_, db_oid_);
+    accessor_ = catalog_->GetAccessor(common::ManagedPointer(txn_), db_oid_);
     binder_ = new binder::BindNodeVisitor(common::ManagedPointer(accessor_), default_database_name_);
   }
 

--- a/test/common/stat_registry_test.cpp
+++ b/test/common/stat_registry_test.cpp
@@ -176,7 +176,7 @@ TEST(StatRegistryTest, GTEST_DEBUG_ONLY(DataTableStatTest)) {
   auto *redo_buffer = terrier::common::AllocationUtil::AllocateAligned(init.ProjectedRowSize());
   auto *redo = init.InitializeRow(redo_buffer);
 
-  data_table.Insert(txn, *redo);
+  data_table.Insert(common::ManagedPointer(txn), *redo);
 
   // initialize stat registry
   auto test_stat_reg = std::make_shared<terrier::common::StatisticsRegistry>();

--- a/test/include/test_util/storage_test_util.h
+++ b/test/include/test_util/storage_test_util.h
@@ -389,8 +389,8 @@ class StorageTestUtil {
     bool result = true;
     for (auto &tuple : table_one_tuples) {
       TERRIER_ASSERT(tuple_slot_map.find(tuple) != tuple_slot_map.end(), "No mapping for this tuple slot");
-      table_one->Select(txn_one, tuple, row_one);
-      table_two->Select(txn_two, tuple_slot_map.at(tuple), row_two);
+      table_one->Select(common::ManagedPointer(txn_one), tuple, row_one);
+      table_two->Select(common::ManagedPointer(txn_two), tuple_slot_map.at(tuple), row_two);
       if (!ProjectionListEqualDeep(layout, row_one, row_two)) {
         result = false;
         break;

--- a/test/metrics/metrics_test.cpp
+++ b/test/metrics/metrics_test.cpp
@@ -62,7 +62,7 @@ class MetricsTests : public TerrierTest {
         insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-    sql_table_->Insert(insert_txn, insert_redo);
+    sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
     txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
   }
 

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -64,7 +64,7 @@ class NetworkTests : public TerrierTest {
     tcop_ = new trafficcop::TrafficCop(common::ManagedPointer(txn_manager_), common::ManagedPointer(catalog_));
 
     auto txn = txn_manager_->BeginTransaction();
-    catalog_->CreateDatabase(txn, catalog::DEFAULT_DATABASE, true);
+    catalog_->CreateDatabase(common::ManagedPointer(txn), catalog::DEFAULT_DATABASE, true);
     txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
     network_logger->set_level(spdlog::level::trace);

--- a/test/optimizer/operator_transformer_test.cpp
+++ b/test/optimizer/operator_transformer_test.cpp
@@ -53,7 +53,7 @@ class OperatorTransformerTest : public TerrierTest {
     // create database
     txn_ = txn_manager_->BeginTransaction();
     OPTIMIZER_LOG_DEBUG("Creating database %s", default_database_name_.c_str());
-    db_oid_ = catalog_->CreateDatabase(txn_, default_database_name_, true);
+    db_oid_ = catalog_->CreateDatabase(common::ManagedPointer(txn_), default_database_name_, true);
     // commit the transactions
     txn_manager_->Commit(txn_, TestCallbacks::EmptyCallback, nullptr);
     OPTIMIZER_LOG_DEBUG("database %s created!", default_database_name_.c_str());
@@ -64,7 +64,7 @@ class OperatorTransformerTest : public TerrierTest {
 
     // create table A
     txn_ = txn_manager_->BeginTransaction();
-    accessor_ = catalog_->GetAccessor(txn_, db_oid_);
+    accessor_ = catalog_->GetAccessor(common::ManagedPointer(txn_), db_oid_);
     // Create the column definition (no OIDs) for CREATE TABLE A(A1 int, a2 varchar)
     std::vector<catalog::Schema::Column> cols_a;
     cols_a.emplace_back("a1", type::TypeId::INTEGER, true, int_default);
@@ -80,7 +80,7 @@ class OperatorTransformerTest : public TerrierTest {
 
     // create Table B
     txn_ = txn_manager_->BeginTransaction();
-    accessor_ = catalog_->GetAccessor(txn_, db_oid_);
+    accessor_ = catalog_->GetAccessor(common::ManagedPointer(txn_), db_oid_);
 
     // Create the column definition (no OIDs) for CREATE TABLE b(b1 int, B2 varchar)
     std::vector<catalog::Schema::Column> cols_b;
@@ -95,7 +95,7 @@ class OperatorTransformerTest : public TerrierTest {
 
     // create index on a1
     txn_ = txn_manager_->BeginTransaction();
-    accessor_ = catalog_->GetAccessor(txn_, db_oid_);
+    accessor_ = catalog_->GetAccessor(common::ManagedPointer(txn_), db_oid_);
 
     auto col = catalog::IndexSchema::Column(
         "a1", type::TypeId::INTEGER, true,
@@ -119,7 +119,7 @@ class OperatorTransformerTest : public TerrierTest {
     SetUpTables();
     // prepare for testing
     txn_ = txn_manager_->BeginTransaction();
-    accessor_ = catalog_->GetAccessor(txn_, db_oid_);
+    accessor_ = catalog_->GetAccessor(common::ManagedPointer(txn_), db_oid_);
     binder_ = new binder::BindNodeVisitor(common::ManagedPointer(accessor_), default_database_name_);
   }
 

--- a/test/storage/block_compactor_test.cpp
+++ b/test/storage/block_compactor_test.cpp
@@ -124,7 +124,7 @@ TEST_F(BlockCompactorTest, CompactionTest) {
 
     for (uint32_t i = 0; i < layout.NumSlots(); i++) {
       storage::TupleSlot slot(block, i);
-      bool visible = table.Select(txn, slot, read_row);
+      bool visible = table.Select(common::ManagedPointer(txn), slot, read_row);
       if (i >= num_tuples) {
         EXPECT_FALSE(visible);  // Should be deleted after compaction
       } else {
@@ -211,7 +211,7 @@ TEST_F(BlockCompactorTest, GatherTest) {
     transaction::TransactionContext *txn = txn_manager.BeginTransaction();
     for (uint32_t i = 0; i < num_tuples; i++) {
       storage::TupleSlot slot(block, i);
-      bool visible = table.Select(txn, slot, read_row);
+      bool visible = table.Select(common::ManagedPointer(txn), slot, read_row);
       EXPECT_TRUE(visible);  // Should be filled after compaction
       auto entry = tuple_set.find(read_row);
       EXPECT_NE(entry, tuple_set.end());  // Should be present in the original
@@ -331,7 +331,7 @@ TEST_F(BlockCompactorTest, DictionaryCompressionTest) {
     transaction::TransactionContext *txn = txn_manager.BeginTransaction();
     for (uint32_t i = 0; i < num_tuples; i++) {
       storage::TupleSlot slot(block, i);
-      bool visible = table.Select(txn, slot, read_row);
+      bool visible = table.Select(common::ManagedPointer(txn), slot, read_row);
       EXPECT_TRUE(visible);  // Should be filled after compaction
       auto entry = tuple_set.find(read_row);
       EXPECT_NE(entry, tuple_set.end());  // Should be present in the original

--- a/test/storage/bwtree_index_test.cpp
+++ b/test/storage/bwtree_index_test.cpp
@@ -124,10 +124,10 @@ TEST_F(BwTreeIndexTests, UniqueInsert) {
             insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-        const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+        const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
         *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-        if (unique_index_->InsertUnique(insert_txn, *insert_key, tuple_slot)) {
+        if (unique_index_->InsertUnique(common::ManagedPointer(insert_txn), *insert_key, tuple_slot)) {
           txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
         } else {
           txn_manager_->Abort(insert_txn);
@@ -141,10 +141,10 @@ TEST_F(BwTreeIndexTests, UniqueInsert) {
             insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-        const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+        const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
         *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-        if (unique_index_->InsertUnique(insert_txn, *insert_key, tuple_slot)) {
+        if (unique_index_->InsertUnique(common::ManagedPointer(insert_txn), *insert_key, tuple_slot)) {
           txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
         } else {
           txn_manager_->Abort(insert_txn);
@@ -198,10 +198,10 @@ TEST_F(BwTreeIndexTests, DefaultInsert) {
             insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-        const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+        const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
         *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-        EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+        EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
         txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
       }
     } else {
@@ -211,10 +211,10 @@ TEST_F(BwTreeIndexTests, DefaultInsert) {
             insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-        const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+        const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
         *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-        EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+        EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
         txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
       }
     }
@@ -259,12 +259,12 @@ TEST_F(BwTreeIndexTests, ScanAscending) {
         insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-    const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+    const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
     auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
     *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
 
-    EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+    EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
     reference[i] = tuple_slot;
   }
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
@@ -333,11 +333,11 @@ TEST_F(BwTreeIndexTests, ScanDescending) {
         insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-    const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+    const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
     auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
     *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-    EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+    EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
     reference[i] = tuple_slot;
   }
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
@@ -406,11 +406,11 @@ TEST_F(BwTreeIndexTests, ScanLimitAscending) {
         insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-    const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+    const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
     auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
     *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-    EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+    EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
     reference[i] = tuple_slot;
   }
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
@@ -475,11 +475,11 @@ TEST_F(BwTreeIndexTests, ScanLimitDescending) {
         insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
     auto *const insert_tuple = insert_redo->Delta();
     *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-    const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+    const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
     auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
     *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-    EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+    EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
     reference[i] = tuple_slot;
   }
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
@@ -540,12 +540,12 @@ TEST_F(BwTreeIndexTests, UniqueKey1) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(unique_index_->InsertUnique(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -569,12 +569,12 @@ TEST_F(BwTreeIndexTests, UniqueKey1) {
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index and fails due to write-write conflict with txn 0
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_FALSE(unique_index_->InsertUnique(txn1, *insert_key, new_tuple_slot));
+  EXPECT_FALSE(unique_index_->InsertUnique(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   txn_manager_->Abort(txn1);
 
@@ -601,12 +601,12 @@ TEST_F(BwTreeIndexTests, UniqueKey2) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(unique_index_->InsertUnique(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -627,12 +627,12 @@ TEST_F(BwTreeIndexTests, UniqueKey2) {
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index and fails due to visible key conflict with txn 0
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_FALSE(unique_index_->InsertUnique(txn1, *insert_key, new_tuple_slot));
+  EXPECT_FALSE(unique_index_->InsertUnique(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   txn_manager_->Abort(txn1);
 
@@ -657,12 +657,12 @@ TEST_F(BwTreeIndexTests, UniqueKey3) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(unique_index_->InsertUnique(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -679,12 +679,12 @@ TEST_F(BwTreeIndexTests, UniqueKey3) {
   insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto new_tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index and fails due to visible key conflict with txn 0
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_FALSE(unique_index_->InsertUnique(txn0, *insert_key, new_tuple_slot));
+  EXPECT_FALSE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, new_tuple_slot));
 
   txn_manager_->Abort(txn0);
 
@@ -708,12 +708,12 @@ TEST_F(BwTreeIndexTests, UniqueKey4) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(unique_index_->InsertUnique(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -728,12 +728,12 @@ TEST_F(BwTreeIndexTests, UniqueKey4) {
 
   // txn 0 deletes from table
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_slot);
-  EXPECT_TRUE(sql_table_->Delete(txn0, tuple_slot));
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), tuple_slot));
 
   // txn 0 deletes from index
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  unique_index_->Delete(txn0, *insert_key, tuple_slot);
+  unique_index_->Delete(common::ManagedPointer(txn0), *insert_key, tuple_slot);
 
   auto *txn1 = txn_manager_->BeginTransaction();
 
@@ -741,12 +741,12 @@ TEST_F(BwTreeIndexTests, UniqueKey4) {
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index and fails due to write-write conflict with txn 0
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_FALSE(unique_index_->InsertUnique(txn1, *insert_key, new_tuple_slot));
+  EXPECT_FALSE(unique_index_->InsertUnique(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   txn_manager_->Commit(txn0, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -790,12 +790,12 @@ TEST_F(BwTreeIndexTests, CommitInsert1) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -864,12 +864,12 @@ TEST_F(BwTreeIndexTests, CommitInsert2) {
       txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index
   auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(txn1, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn1), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -935,12 +935,12 @@ TEST_F(BwTreeIndexTests, AbortInsert1) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -1008,12 +1008,12 @@ TEST_F(BwTreeIndexTests, AbortInsert2) {
       txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index
   auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(txn1, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn1), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -1078,12 +1078,12 @@ TEST_F(BwTreeIndexTests, CommitUpdate1) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1102,17 +1102,17 @@ TEST_F(BwTreeIndexTests, CommitUpdate1) {
 
   // txn 0 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
-  default_index_->Delete(txn0, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
 
   insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
-  const auto new_tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15445;
-  EXPECT_TRUE(default_index_->Insert(txn0, *insert_key, new_tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn0), *insert_key, new_tuple_slot));
 
   // txn 1 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -1205,12 +1205,12 @@ TEST_F(BwTreeIndexTests, CommitUpdate2) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1229,17 +1229,17 @@ TEST_F(BwTreeIndexTests, CommitUpdate2) {
 
   // txn 1 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
-  default_index_->Delete(txn1, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn1), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn1), *insert_key, results[0]);
 
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15445;
-  EXPECT_TRUE(default_index_->Insert(txn1, *insert_key, new_tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   results.clear();
 
@@ -1332,12 +1332,12 @@ TEST_F(BwTreeIndexTests, AbortUpdate1) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1356,17 +1356,17 @@ TEST_F(BwTreeIndexTests, AbortUpdate1) {
 
   // txn 0 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
-  default_index_->Delete(txn0, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
 
   insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
-  const auto new_tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15445;
-  EXPECT_TRUE(default_index_->Insert(txn0, *insert_key, new_tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn0), *insert_key, new_tuple_slot));
 
   // txn 1 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -1459,12 +1459,12 @@ TEST_F(BwTreeIndexTests, AbortUpdate2) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1483,17 +1483,17 @@ TEST_F(BwTreeIndexTests, AbortUpdate2) {
 
   // txn 1 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
-  default_index_->Delete(txn1, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn1), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn1), *insert_key, results[0]);
 
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15445;
-  EXPECT_TRUE(default_index_->Insert(txn1, *insert_key, new_tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   results.clear();
 
@@ -1586,12 +1586,12 @@ TEST_F(BwTreeIndexTests, CommitDelete1) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1610,8 +1610,8 @@ TEST_F(BwTreeIndexTests, CommitDelete1) {
 
   // txn 0 deletes in the table and index
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
-  default_index_->Delete(txn0, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
 
   // txn 0 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -1678,12 +1678,12 @@ TEST_F(BwTreeIndexTests, CommitDelete2) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1702,8 +1702,8 @@ TEST_F(BwTreeIndexTests, CommitDelete2) {
 
   // txn 1 deletes in the table and index
   txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
-  default_index_->Delete(txn1, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn1), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn1), *insert_key, results[0]);
 
   results.clear();
 
@@ -1770,12 +1770,12 @@ TEST_F(BwTreeIndexTests, AbortDelete1) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1794,8 +1794,8 @@ TEST_F(BwTreeIndexTests, AbortDelete1) {
 
   // txn 0 deletes in the table and index
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
-  default_index_->Delete(txn0, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
 
   // txn 0 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -1863,12 +1863,12 @@ TEST_F(BwTreeIndexTests, AbortDelete2) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1887,8 +1887,8 @@ TEST_F(BwTreeIndexTests, AbortDelete2) {
 
   // txn 1 deletes in the table and index
   txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
-  default_index_->Delete(txn1, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn1), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn1), *insert_key, results[0]);
 
   results.clear();
 

--- a/test/storage/data_table_concurrent_test.cpp
+++ b/test/storage/data_table_concurrent_test.cpp
@@ -31,7 +31,7 @@ class FakeTransaction {
     storage::ProjectedRow *redo = redo_initializer_.InitializeRow(redo_buffer);
     StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
 
-    storage::TupleSlot slot = table_->Insert(&txn_, *redo);
+    storage::TupleSlot slot = table_->Insert(common::ManagedPointer(&txn_), *redo);
     inserted_slots_.push_back(slot);
     reference_tuples_.emplace(slot, redo);
     return slot;
@@ -47,7 +47,7 @@ class FakeTransaction {
     storage::ProjectedRow *update = update_initializer.InitializeRow(update_buffer);
     StorageTestUtil::PopulateRandomRow(update, layout_, null_bias_, generator);
 
-    bool result = table_->Update(&txn_, slot, *update);
+    bool result = table_->Update(common::ManagedPointer(&txn_), slot, *update);
     // the update buffer does not need to live past this scope
     delete[] update_buffer;
     return result;
@@ -113,7 +113,7 @@ TEST_F(DataTableConcurrentTests, ConcurrentInsert) {
     for (auto &fake_txn : fake_txns) {
       for (auto slot : fake_txn->InsertedTuples()) {
         storage::ProjectedRow *select_row = select_initializer.InitializeRow(select_buffer);
-        tested.Select(fake_txn->GetTxn(), slot, select_row);
+        tested.Select(common::ManagedPointer(fake_txn->GetTxn()), slot, select_row);
         EXPECT_TRUE(StorageTestUtil::ProjectionListEqualShallow(layout, fake_txn->GetReferenceTuple(slot), select_row));
       }
     }

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -43,7 +43,7 @@ class RandomDataTableTestObject {
         new transaction::TransactionContext(timestamp, timestamp, common::ManagedPointer(buffer_pool), DISABLED);
     loose_txns_.push_back(txn);
 
-    storage::TupleSlot slot = table_.Insert(txn, *redo);
+    storage::TupleSlot slot = table_.Insert(common::ManagedPointer(txn), *redo);
     inserted_slots_.push_back(slot);
     tuple_versions_[slot].emplace_back(timestamp, redo);
 
@@ -61,7 +61,7 @@ class RandomDataTableTestObject {
     storage::ProjectedRow *redo = redo_initializer_.InitializeRow(redo_buffer);
     StorageTestUtil::PopulateRandomRow(redo, layout_, null_bias_, generator);
 
-    storage::TupleSlot slot = table_.Insert(txn, *redo);
+    storage::TupleSlot slot = table_.Insert(common::ManagedPointer(txn), *redo);
     inserted_slots_.push_back(slot);
     tuple_versions_[slot].emplace_back(txn->StartTime(), redo);
 
@@ -88,7 +88,7 @@ class RandomDataTableTestObject {
         new transaction::TransactionContext(timestamp, timestamp, common::ManagedPointer(buffer_pool), DISABLED);
     loose_txns_.push_back(txn);
 
-    bool result = table_.Update(txn, slot, *update);
+    bool result = table_.Update(common::ManagedPointer(txn), slot, *update);
 
     if (result) {
       // manually apply the delta in an append-only fashion
@@ -132,7 +132,7 @@ class RandomDataTableTestObject {
 
     // generate a redo ProjectedRow for Select
     storage::ProjectedRow *select_row = redo_initializer_.InitializeRow(select_buffer_);
-    table_.Select(txn, slot, select_row);
+    table_.Select(common::ManagedPointer(txn), slot, select_row);
     return select_row;
   }
 
@@ -141,7 +141,7 @@ class RandomDataTableTestObject {
     auto *txn =
         new transaction::TransactionContext(timestamp, timestamp, common::ManagedPointer(buffer_pool), DISABLED);
     loose_txns_.push_back(txn);
-    table_.Scan(txn, begin, buffer);
+    table_.Scan(common::ManagedPointer(txn), begin, buffer);
   }
 
   storage::DataTable &GetTable() { return table_; }

--- a/test/storage/hash_index_test.cpp
+++ b/test/storage/hash_index_test.cpp
@@ -110,10 +110,10 @@ TEST_F(HashIndexTests, UniqueInsert) {
             insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-        const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+        const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
         *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-        if (unique_index_->InsertUnique(insert_txn, *insert_key, tuple_slot)) {
+        if (unique_index_->InsertUnique(common::ManagedPointer(insert_txn), *insert_key, tuple_slot)) {
           txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
         } else {
           txn_manager_->Abort(insert_txn);
@@ -127,10 +127,10 @@ TEST_F(HashIndexTests, UniqueInsert) {
             insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-        const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+        const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
         *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-        if (unique_index_->InsertUnique(insert_txn, *insert_key, tuple_slot)) {
+        if (unique_index_->InsertUnique(common::ManagedPointer(insert_txn), *insert_key, tuple_slot)) {
           txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
         } else {
           txn_manager_->Abort(insert_txn);
@@ -185,10 +185,10 @@ TEST_F(HashIndexTests, DefaultInsert) {
             insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-        const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+        const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
         *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-        EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+        EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
         txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
       }
     } else {
@@ -198,10 +198,10 @@ TEST_F(HashIndexTests, DefaultInsert) {
             insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
         auto *const insert_tuple = insert_redo->Delta();
         *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = i;
-        const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+        const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
         *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = i;
-        EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+        EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
         txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
       }
     }
@@ -243,12 +243,12 @@ TEST_F(HashIndexTests, UniqueKey1) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(unique_index_->InsertUnique(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -272,12 +272,12 @@ TEST_F(HashIndexTests, UniqueKey1) {
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index and fails due to write-write conflict with txn 0
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_FALSE(unique_index_->InsertUnique(txn1, *insert_key, new_tuple_slot));
+  EXPECT_FALSE(unique_index_->InsertUnique(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   txn_manager_->Abort(txn1);
 
@@ -304,12 +304,12 @@ TEST_F(HashIndexTests, UniqueKey2) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(unique_index_->InsertUnique(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -330,12 +330,12 @@ TEST_F(HashIndexTests, UniqueKey2) {
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index and fails due to visible key conflict with txn 0
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_FALSE(unique_index_->InsertUnique(txn1, *insert_key, new_tuple_slot));
+  EXPECT_FALSE(unique_index_->InsertUnique(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   txn_manager_->Abort(txn1);
 
@@ -360,12 +360,12 @@ TEST_F(HashIndexTests, UniqueKey3) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(unique_index_->InsertUnique(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -382,12 +382,12 @@ TEST_F(HashIndexTests, UniqueKey3) {
   insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto new_tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index and fails due to visible key conflict with txn 0
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_FALSE(unique_index_->InsertUnique(txn0, *insert_key, new_tuple_slot));
+  EXPECT_FALSE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, new_tuple_slot));
 
   txn_manager_->Abort(txn0);
 
@@ -411,12 +411,12 @@ TEST_F(HashIndexTests, UniqueKey4) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(unique_index_->InsertUnique(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(unique_index_->InsertUnique(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -431,12 +431,12 @@ TEST_F(HashIndexTests, UniqueKey4) {
 
   // txn 0 deletes from table
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_slot);
-  EXPECT_TRUE(sql_table_->Delete(txn0, tuple_slot));
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), tuple_slot));
 
   // txn 0 deletes from index
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  unique_index_->Delete(txn0, *insert_key, tuple_slot);
+  unique_index_->Delete(common::ManagedPointer(txn0), *insert_key, tuple_slot);
 
   auto *txn1 = txn_manager_->BeginTransaction();
 
@@ -444,12 +444,12 @@ TEST_F(HashIndexTests, UniqueKey4) {
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index and fails due to write-write conflict with txn 0
   insert_key = unique_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_FALSE(unique_index_->InsertUnique(txn1, *insert_key, new_tuple_slot));
+  EXPECT_FALSE(unique_index_->InsertUnique(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   txn_manager_->Commit(txn0, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -493,12 +493,12 @@ TEST_F(HashIndexTests, CommitInsert1) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -567,12 +567,12 @@ TEST_F(HashIndexTests, CommitInsert2) {
       txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index
   auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(txn1, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn1), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -638,12 +638,12 @@ TEST_F(HashIndexTests, AbortInsert1) {
       txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   // txn 0 inserts into index
   auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(txn0, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn0), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -711,12 +711,12 @@ TEST_F(HashIndexTests, AbortInsert2) {
       txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   // txn 1 inserts into index
   auto *const insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(txn1, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn1), *insert_key, tuple_slot));
 
   std::vector<storage::TupleSlot> results;
 
@@ -781,12 +781,12 @@ TEST_F(HashIndexTests, CommitUpdate1) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -805,17 +805,17 @@ TEST_F(HashIndexTests, CommitUpdate1) {
 
   // txn 0 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
-  default_index_->Delete(txn0, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
 
   insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
-  const auto new_tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15445;
-  EXPECT_TRUE(default_index_->Insert(txn0, *insert_key, new_tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn0), *insert_key, new_tuple_slot));
 
   // txn 1 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -908,12 +908,12 @@ TEST_F(HashIndexTests, CommitUpdate2) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -932,17 +932,17 @@ TEST_F(HashIndexTests, CommitUpdate2) {
 
   // txn 1 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
-  default_index_->Delete(txn1, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn1), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn1), *insert_key, results[0]);
 
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15445;
-  EXPECT_TRUE(default_index_->Insert(txn1, *insert_key, new_tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   results.clear();
 
@@ -1035,12 +1035,12 @@ TEST_F(HashIndexTests, AbortUpdate1) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1059,17 +1059,17 @@ TEST_F(HashIndexTests, AbortUpdate1) {
 
   // txn 0 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
-  default_index_->Delete(txn0, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
 
   insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
-  const auto new_tuple_slot = sql_table_->Insert(txn0, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn0), insert_redo);
 
   insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15445;
-  EXPECT_TRUE(default_index_->Insert(txn0, *insert_key, new_tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn0), *insert_key, new_tuple_slot));
 
   // txn 1 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -1162,12 +1162,12 @@ TEST_F(HashIndexTests, AbortUpdate2) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1186,17 +1186,17 @@ TEST_F(HashIndexTests, AbortUpdate2) {
 
   // txn 1 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
-  default_index_->Delete(txn1, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn1), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn1), *insert_key, results[0]);
 
   insert_redo = txn1->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15445;
-  const auto new_tuple_slot = sql_table_->Insert(txn1, insert_redo);
+  const auto new_tuple_slot = sql_table_->Insert(common::ManagedPointer(txn1), insert_redo);
 
   insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15445;
-  EXPECT_TRUE(default_index_->Insert(txn1, *insert_key, new_tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(txn1), *insert_key, new_tuple_slot));
 
   results.clear();
 
@@ -1289,12 +1289,12 @@ TEST_F(HashIndexTests, CommitDelete1) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1313,8 +1313,8 @@ TEST_F(HashIndexTests, CommitDelete1) {
 
   // txn 0 deletes in the table and index
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
-  default_index_->Delete(txn0, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
 
   // txn 0 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -1381,12 +1381,12 @@ TEST_F(HashIndexTests, CommitDelete2) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1405,8 +1405,8 @@ TEST_F(HashIndexTests, CommitDelete2) {
 
   // txn 1 deletes in the table and index
   txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
-  default_index_->Delete(txn1, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn1), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn1), *insert_key, results[0]);
 
   results.clear();
 
@@ -1473,12 +1473,12 @@ TEST_F(HashIndexTests, AbortDelete1) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1497,8 +1497,8 @@ TEST_F(HashIndexTests, AbortDelete1) {
 
   // txn 0 deletes in the table and index
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn0, results[0]));
-  default_index_->Delete(txn0, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
 
   // txn 0 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -1566,12 +1566,12 @@ TEST_F(HashIndexTests, AbortDelete2) {
       insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   auto *insert_tuple = insert_redo->Delta();
   *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(0)) = 15721;
-  const auto tuple_slot = sql_table_->Insert(insert_txn, insert_redo);
+  const auto tuple_slot = sql_table_->Insert(common::ManagedPointer(insert_txn), insert_redo);
 
   // insert_txn inserts into index
   auto *insert_key = default_index_->GetProjectedRowInitializer().InitializeRow(key_buffer_1_);
   *reinterpret_cast<int32_t *>(insert_key->AccessForceNotNull(0)) = 15721;
-  EXPECT_TRUE(default_index_->Insert(insert_txn, *insert_key, tuple_slot));
+  EXPECT_TRUE(default_index_->Insert(common::ManagedPointer(insert_txn), *insert_key, tuple_slot));
 
   txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
@@ -1590,8 +1590,8 @@ TEST_F(HashIndexTests, AbortDelete2) {
 
   // txn 1 deletes in the table and index
   txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
-  EXPECT_TRUE(sql_table_->Delete(txn1, results[0]));
-  default_index_->Delete(txn1, *insert_key, results[0]);
+  EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn1), results[0]));
+  default_index_->Delete(common::ManagedPointer(txn1), *insert_key, results[0]);
 
   results.clear();
 

--- a/test/storage/index_key_test.cpp
+++ b/test/storage/index_key_test.cpp
@@ -249,17 +249,17 @@ class IndexKeyTests : public TerrierTest {
     index->ScanKey(*txn, *key, &results);
     EXPECT_TRUE(results.empty());
 
-    const auto tuple_slot = sql_table->Insert(txn, insert_redo);
+    const auto tuple_slot = sql_table->Insert(common::ManagedPointer(txn), insert_redo);
 
-    EXPECT_TRUE(index->Insert(txn, *key, tuple_slot));
+    EXPECT_TRUE(index->Insert(common::ManagedPointer(txn), *key, tuple_slot));
 
     index->ScanKey(*txn, *key, &results);
     EXPECT_EQ(results.size(), 1);
     EXPECT_EQ(results[0], tuple_slot);
 
     txn->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_slot);
-    sql_table->Delete(txn, tuple_slot);
-    index->Delete(txn, *key, tuple_slot);
+    sql_table->Delete(common::ManagedPointer(txn), tuple_slot);
+    index->Delete(common::ManagedPointer(txn), *key, tuple_slot);
 
     results.clear();
     index->ScanKey(*txn, *key, &results);

--- a/test/test_util/tpcc/builder.cpp
+++ b/test/test_util/tpcc/builder.cpp
@@ -5,7 +5,7 @@ namespace terrier::tpcc {
 Database *Builder::Build(const storage::index::IndexType index_type) {
   // create the database in the catalog
   auto *txn = txn_manager_->BeginTransaction();
-  const catalog::db_oid_t db_oid = catalog_->CreateDatabase(txn, "tpcc", true);
+  const catalog::db_oid_t db_oid = catalog_->CreateDatabase(common::ManagedPointer(txn), "tpcc", true);
   txn_manager_->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
 
   // generate all of the table schemas
@@ -21,7 +21,7 @@ Database *Builder::Build(const storage::index::IndexType index_type) {
 
   // create the tables in the catalog
   txn = txn_manager_->BeginTransaction();
-  auto accessor = catalog_->GetAccessor(txn, db_oid);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_oid);
 
   const catalog::table_oid_t item_table_oid =
       accessor->CreateTable(accessor->GetDefaultNamespace(), "ITEM", item_schema);
@@ -89,7 +89,7 @@ Database *Builder::Build(const storage::index::IndexType index_type) {
 
   // get the table pointers back from the catalog
   txn = txn_manager_->BeginTransaction();
-  accessor = catalog_->GetAccessor(txn, db_oid);
+  accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_oid);
 
   const auto item_table = accessor->GetTable(item_table_oid);
   const auto warehouse_table = accessor->GetTable(warehouse_table_oid);
@@ -177,7 +177,7 @@ Database *Builder::Build(const storage::index::IndexType index_type) {
 
   // create the indexes in the catalog
   txn = txn_manager_->BeginTransaction();
-  accessor = catalog_->GetAccessor(txn, db_oid);
+  accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_oid);
 
   const catalog::index_oid_t warehouse_primary_index_oid = accessor->CreateIndex(
       accessor->GetDefaultNamespace(), warehouse_table_oid, "WAREHOUSE PRIMARY", warehouse_primary_index_schema);
@@ -250,7 +250,7 @@ Database *Builder::Build(const storage::index::IndexType index_type) {
 
   // get the table pointers back from the catalog
   txn = txn_manager_->BeginTransaction();
-  accessor = catalog_->GetAccessor(txn, db_oid);
+  accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_oid);
 
   const auto warehouse_index = accessor->GetIndex(warehouse_primary_index_oid);
   const auto district_index = accessor->GetIndex(district_primary_index_oid);

--- a/test/test_util/tpcc/stock_level.cpp
+++ b/test/test_util/tpcc/stock_level.cpp
@@ -1,4 +1,5 @@
 #include "test_util/tpcc/stock_level.h"
+
 #include <unordered_map>
 #include <vector>
 
@@ -25,7 +26,8 @@ bool StockLevel::Execute(transaction::TransactionManager *const txn_manager, Dat
   TERRIER_ASSERT(index_scan_results.size() == 1, "District index lookup failed.");
 
   auto *district_select_tuple = district_select_pr_initializer_.InitializeRow(worker->district_tuple_buffer_);
-  bool select_result UNUSED_ATTRIBUTE = db->district_table_->Select(txn, index_scan_results[0], district_select_tuple);
+  bool select_result UNUSED_ATTRIBUTE =
+      db->district_table_->Select(common::ManagedPointer(txn), index_scan_results[0], district_select_tuple);
   TERRIER_ASSERT(select_result, "District should be present.");
 
   const auto d_next_o_id = *reinterpret_cast<int32_t *>(district_select_tuple->AccessWithNullCheck(0));
@@ -58,7 +60,8 @@ bool StockLevel::Execute(transaction::TransactionManager *const txn_manager, Dat
   for (const auto &order_line_tuple_slot : index_scan_results) {
     storage::ProjectedRow *order_line_select_tuple =
         order_line_select_pr_initializer_.InitializeRow(worker->order_line_tuple_buffer_);
-    select_result = db->order_line_table_->Select(txn, order_line_tuple_slot, order_line_select_tuple);
+    select_result =
+        db->order_line_table_->Select(common::ManagedPointer(txn), order_line_tuple_slot, order_line_select_tuple);
     TERRIER_ASSERT(select_result, "Order line index contained this.");
     const auto ol_i_id = *reinterpret_cast<int32_t *>(order_line_select_tuple->AccessForceNotNull(0));
     TERRIER_ASSERT(ol_i_id >= 1 && ol_i_id <= 100000, "Invalid ol_i_id read from the Order Line table.");
@@ -76,7 +79,8 @@ bool StockLevel::Execute(transaction::TransactionManager *const txn_manager, Dat
     TERRIER_ASSERT(stock_index_scan_results.size() == 1, "Couldn't find a matching stock item.");
 
     auto *const stock_select_tuple = stock_select_pr_initializer_.InitializeRow(worker->stock_tuple_buffer_);
-    select_result = db->stock_table_->Select(txn, stock_index_scan_results[0], stock_select_tuple);
+    select_result =
+        db->stock_table_->Select(common::ManagedPointer(txn), stock_index_scan_results[0], stock_select_tuple);
     TERRIER_ASSERT(select_result, "Stock index contained this.");
     const auto s_quantity = *reinterpret_cast<int16_t *>(stock_select_tuple->AccessForceNotNull(0));
     TERRIER_ASSERT(s_quantity >= 10 && s_quantity <= 100, "Invalid s_quantity read from the Stock table.");

--- a/test/test_util/tpcc/tpcc_plan_test.cpp
+++ b/test/test_util/tpcc/tpcc_plan_test.cpp
@@ -80,7 +80,7 @@ void TpccPlanTest::TearDown() { delete tpcc_db_; }
 
 void TpccPlanTest::BeginTransaction() {
   txn_ = txn_manager_->BeginTransaction();
-  accessor_ = catalog_->GetAccessor(txn_, db_).release();
+  accessor_ = catalog_->GetAccessor(common::ManagedPointer(txn_), db_).release();
 }
 
 void TpccPlanTest::EndTransaction(bool commit) {
@@ -98,7 +98,7 @@ std::unique_ptr<planner::AbstractPlanNode> TpccPlanTest::Optimize(const std::str
   auto stmt_list = pgparser.BuildParseTree(query);
 
   // Bind + Transform
-  auto accessor = catalog_->GetAccessor(txn_, db_);
+  auto accessor = catalog_->GetAccessor(common::ManagedPointer(txn_), db_);
   auto *binder = new binder::BindNodeVisitor(common::ManagedPointer(accessor), "tpcc");
   binder->BindNameToNode(stmt_list.GetStatement(0), &stmt_list);
   auto *transformer = new optimizer::QueryToOperatorTransformer(common::ManagedPointer(accessor));

--- a/test/traffic_cop/traffic_cop_test.cpp
+++ b/test/traffic_cop/traffic_cop_test.cpp
@@ -86,9 +86,9 @@ TEST_F(TrafficCopTests, TemporaryNamespaceTest) {
     catalog::namespace_oid_t new_namespace_oid = catalog::INVALID_NAMESPACE_OID;
     do {
       auto txn = txn_manager_->BeginTransaction();
-      auto db_oid = catalog_->GetDatabaseOid(txn, catalog::DEFAULT_DATABASE);
+      auto db_oid = catalog_->GetDatabaseOid(common::ManagedPointer(txn), catalog::DEFAULT_DATABASE);
       EXPECT_NE(db_oid, catalog::INVALID_DATABASE_OID);
-      auto db_accessor = catalog_->GetAccessor(txn, db_oid);
+      auto db_accessor = catalog_->GetAccessor(common::ManagedPointer(txn), db_oid);
       EXPECT_NE(db_accessor, nullptr);
       new_namespace_oid = db_accessor->CreateNamespace(std::string(trafficcop::TEMP_NAMESPACE_PREFIX));
       txn_manager_->Abort(txn);

--- a/util/execution/tpl.cpp
+++ b/util/execution/tpl.cpp
@@ -83,13 +83,14 @@ static void CompileAndRun(const std::string &source, const std::string &name = "
 
   auto *txn = txn_manager->BeginTransaction();
 
-  auto db_oid = catalog->CreateDatabase(txn, "test_db", true);
-  auto accessor = std::unique_ptr<catalog::CatalogAccessor>(catalog->GetAccessor(txn, db_oid));
+  auto db_oid = catalog->CreateDatabase(common::ManagedPointer(txn), "test_db", true);
+  auto accessor = catalog->GetAccessor(common::ManagedPointer(txn), db_oid);
   auto ns_oid = accessor->GetDefaultNamespace();
 
   // Make the execution context
   exec::OutputPrinter printer(output_schema);
-  exec::ExecutionContext exec_ctx{db_oid, txn, printer, output_schema, std::move(accessor)};
+  exec::ExecutionContext exec_ctx{db_oid, common::ManagedPointer(txn), printer, output_schema,
+                                  common::ManagedPointer(accessor)};
   // Add dummy parameters for tests
   sql::Date date(1937, 3, 7);
   std::vector<type::TransientValue> params;


### PR DESCRIPTION
Making more object life cycle and ownership explicit as we stitch stuff together. `ExecutionContext` no longer owns the `CatalogAccessor`. The entire `Catalog` and storage APIs (`SQLTable`, indexes) now take `ManaagedPointer` for `TransactionContext` where appropriate. This results in a huge diff for a simple refactor.