### PR TITLE
Fix CodeGen::StringToSql

### DIFF
--- a/src/execution/compiler/codegen.cpp
+++ b/src/execution/compiler/codegen.cpp
@@ -483,7 +483,7 @@ ast::Expr *CodeGen::DateToSql(int16_t year, uint8_t month, uint8_t day) {
 }
 
 ast::Expr *CodeGen::StringToSql(std::string_view str) {
-  ast::Identifier str_ident = Context()->GetIdentifier(str.data());
+  ast::Identifier str_ident = Context()->GetIdentifier({str.data(), str.length()});
   ast::Expr *str_lit = Factory()->NewStringLiteral(DUMMY_POS, str_ident);
   return OneArgCall(ast::Builtin::StringToSql, str_lit);
 }


### PR DESCRIPTION
Pass the `std::string_view`'s length to the constructor of the `LLVM::StringRef` since otherwise LLVM tries to do`strlen` which breaks because they're not null-terminated.

I ran `compiler_test` locally and it looks fine, and will merge after it finishes CI.

Fixes a segfault seen on `INSERT INTO HISTORY VALUES (1,1,1,1,1,1,1.0,'A')` after bootstrapping TPC-C.