### PR TITLE
Add Index::InsertUnique logic to CodeGen

### DIFF
--- a/src/execution/compiler/operator/insert_translator.cpp
+++ b/src/execution/compiler/operator/insert_translator.cpp
@@ -1,6 +1,8 @@
 #include "execution/compiler/operator/insert_translator.h"
+
 #include <utility>
 #include <vector>
+
 #include "execution/compiler/function_builder.h"
 #include "execution/compiler/translator_factory.h"
 
@@ -153,7 +155,8 @@ void InsertTranslator::GenIndexInsert(FunctionBuilder *builder, const catalog::i
 
   // Insert into index
   // if (insert not successfull) { Abort(); }
-  auto index_insert_call = codegen_->OneArgCall(ast::Builtin::IndexInsert, inserter_, true);
+  auto index_insert_call = codegen_->OneArgCall(
+      index_schema.Unique() ? ast::Builtin::IndexInsertUnique : ast::Builtin::IndexInsert, inserter_, true);
   auto cond = codegen_->UnaryOp(parsing::Token::Type::BANG, index_insert_call);
   builder->StartIfStmt(cond);
   Abort(builder);

--- a/src/execution/compiler/operator/update_translator.cpp
+++ b/src/execution/compiler/operator/update_translator.cpp
@@ -1,6 +1,8 @@
 #include "execution/compiler/operator/update_translator.h"
+
 #include <utility>
 #include <vector>
+
 #include "execution/compiler/function_builder.h"
 #include "execution/compiler/translator_factory.h"
 
@@ -142,11 +144,13 @@ void UpdateTranslator::GenIndexInsert(FunctionBuilder *builder, const catalog::i
   auto index = codegen_->Accessor()->GetIndex(index_oid);
   const auto &index_pm = index->GetKeyOidToOffsetMap();
   const auto &index_schema = codegen_->Accessor()->GetIndexSchema(index_oid);
+
   pr_filler_.GenFiller(index_pm, index_schema, codegen_->MakeExpr(insert_index_pr), builder);
 
   // Insert into index
   // if (insert not successfull) { Abort(); }
-  auto index_insert_call = codegen_->OneArgCall(ast::Builtin::IndexInsert, updater_, true);
+  auto index_insert_call = codegen_->OneArgCall(
+      index_schema.Unique() ? ast::Builtin::IndexInsertUnique : ast::Builtin::IndexInsert, updater_, true);
   auto cond = codegen_->UnaryOp(parsing::Token::Type::BANG, index_insert_call);
   builder->StartIfStmt(cond);
   Abort(builder);

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -1,8 +1,7 @@
-#include "execution/sema/sema.h"
-
 #include "execution/ast/ast_node_factory.h"
 #include "execution/ast/context.h"
 #include "execution/ast/type.h"
+#include "execution/sema/sema.h"
 
 namespace terrier::execution::sema {
 
@@ -1868,6 +1867,13 @@ void Sema::CheckBuiltinStorageInterfaceCall(ast::CallExpr *call, ast::Builtin bu
       call->SetType(GetBuiltinType(ast::BuiltinType::Bool));
       break;
     }
+    case ast::Builtin::IndexInsertUnique: {
+      if (!CheckArgCount(call, 1)) {
+        return;
+      }
+      call->SetType(GetBuiltinType(ast::BuiltinType::Bool));
+      break;
+    }
     case ast::Builtin::IndexDelete: {
       if (!CheckArgCount(call, 2)) {
         return;
@@ -2236,6 +2242,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::GetIndexPR:
     case ast::Builtin::GetIndexPRBind:
     case ast::Builtin::IndexInsert:
+    case ast::Builtin::IndexInsertUnique:
     case ast::Builtin::IndexDelete:
     case ast::Builtin::StorageInterfaceFree: {
       CheckBuiltinStorageInterfaceCall(call, builtin);

--- a/src/execution/sql/storage_interface.cpp
+++ b/src/execution/sql/storage_interface.cpp
@@ -65,6 +65,11 @@ bool StorageInterface::IndexInsert() {
   return curr_index_->Insert(exec_ctx_->GetTxn(), *index_pr_, table_redo_->GetTupleSlot());
 }
 
+bool StorageInterface::IndexInsertUnique() {
+  TERRIER_ASSERT(need_indexes_, "Index PR not allocated!");
+  return curr_index_->InsertUnique(exec_ctx_->GetTxn(), *index_pr_, table_redo_->GetTupleSlot());
+}
+
 void StorageInterface::IndexDelete(storage::TupleSlot table_tuple_slot) {
   TERRIER_ASSERT(need_indexes_, "Index PR not allocated!");
   curr_index_->Delete(exec_ctx_->GetTxn(), *index_pr_, table_tuple_slot);

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1785,6 +1785,12 @@ void BytecodeGenerator::VisitBuiltinStorageInterfaceCall(ast::CallExpr *call, as
       ExecutionResult()->SetDestination(cond.ValueOf());
       break;
     }
+    case ast::Builtin::IndexInsertUnique: {
+      LocalVar cond = ExecutionResult()->GetOrCreateDestination(ast::BuiltinType::Get(ctx, ast::BuiltinType::Bool));
+      Emitter()->Emit(Bytecode::StorageInterfaceIndexInsertUnique, cond, storage_interface);
+      ExecutionResult()->SetDestination(cond.ValueOf());
+      break;
+    }
     case ast::Builtin::IndexDelete: {
       LocalVar tuple_slot = VisitExpressionForRValue(call->Arguments()[1]);
       Emitter()->Emit(Bytecode::StorageInterfaceIndexDelete, storage_interface, tuple_slot);
@@ -2069,6 +2075,7 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     case ast::Builtin::GetIndexPR:
     case ast::Builtin::GetIndexPRBind:
     case ast::Builtin::IndexInsert:
+    case ast::Builtin::IndexInsertUnique:
     case ast::Builtin::IndexDelete:
     case ast::Builtin::StorageInterfaceFree: {
       VisitBuiltinStorageInterfaceCall(call, builtin);

--- a/src/execution/vm/bytecode_handlers.cpp
+++ b/src/execution/vm/bytecode_handlers.cpp
@@ -223,6 +223,10 @@ void OpStorageInterfaceIndexInsert(bool *result, terrier::execution::sql::Storag
   *result = storage_interface->IndexInsert();
 }
 
+void OpStorageInterfaceIndexInsertUnique(bool *result, terrier::execution::sql::StorageInterface *storage_interface) {
+  *result = storage_interface->IndexInsertUnique();
+}
+
 void OpStorageInterfaceIndexDelete(terrier::execution::sql::StorageInterface *storage_interface,
                                    terrier::storage::TupleSlot *tuple_slot) {
   storage_interface->IndexDelete(*tuple_slot);

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1595,6 +1595,13 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     DISPATCH_NEXT();
   }
 
+  OP(StorageInterfaceIndexInsertUnique) : {
+    auto *result = frame->LocalAt<bool *>(READ_LOCAL_ID());
+    auto *storage_interface = frame->LocalAt<sql::StorageInterface *>(READ_LOCAL_ID());
+    OpStorageInterfaceIndexInsertUnique(result, storage_interface);
+    DISPATCH_NEXT();
+  }
+
   OP(StorageInterfaceIndexDelete) : {
     auto *storage_interface = frame->LocalAt<sql::StorageInterface *>(READ_LOCAL_ID());
     auto *tuple_slot = frame->LocalAt<storage::TupleSlot *>(READ_LOCAL_ID());

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -202,6 +202,7 @@ namespace terrier::execution::ast {
   F(GetIndexPR, getIndexPR)                                             \
   F(GetIndexPRBind, getIndexPRBind)                                     \
   F(IndexInsert, indexInsert)                                           \
+  F(IndexInsertUnique, indexInsertUnique)                               \
   F(IndexDelete, indexDelete)                                           \
   F(StorageInterfaceFree, storageInterfaceFree)                         \
                                                                         \

--- a/src/include/execution/sql/storage_interface.h
+++ b/src/include/execution/sql/storage_interface.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+
 #include "execution/exec/execution_context.h"
 #include "execution/util/execution_common.h"
 
@@ -69,6 +70,12 @@ class EXPORT StorageInterface {
    * @return Whether insertion was successful.
    */
   bool IndexInsert();
+
+  /**
+   * InsertUnique into the current index
+   * @return Whether insertion was successful.
+   */
+  bool IndexInsertUnique();
 
  protected:
   /**

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1503,6 +1503,9 @@ VM_OP void OpStorageInterfaceGetIndexPR(terrier::storage::ProjectedRow **pr_resu
 
 VM_OP void OpStorageInterfaceIndexInsert(bool *result, terrier::execution::sql::StorageInterface *storage_interface);
 
+VM_OP void OpStorageInterfaceIndexInsertUnique(bool *result,
+                                               terrier::execution::sql::StorageInterface *storage_interface);
+
 VM_OP void OpStorageInterfaceIndexDelete(terrier::execution::sql::StorageInterface *storage_interface,
                                          terrier::storage::TupleSlot *tuple_slot);
 

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -382,6 +382,7 @@ namespace terrier::execution::vm {
   F(StorageInterfaceTableDelete, OperandType::Local, OperandType::Local, OperandType::Local)                          \
   F(StorageInterfaceGetIndexPR, OperandType::Local, OperandType::Local, OperandType::UImm4)                           \
   F(StorageInterfaceIndexInsert, OperandType::Local, OperandType::Local)                                              \
+  F(StorageInterfaceIndexInsertUnique, OperandType::Local, OperandType::Local)                                        \
   F(StorageInterfaceIndexDelete, OperandType::Local, OperandType::Local)                                              \
   F(StorageInterfaceFree, OperandType::Local)                                                                         \
                                                                                                                       \


### PR DESCRIPTION
`InsertTranslator` and `UpdateTranslator` only generate the non-unique insert method for the index wrapper, resulting in a failed assertion with a unique index. Hooray for the storage layer keeping us honest.

Fixes a failure seen on `INSERT INTO \"NEW ORDER\" VALUES (1,2,3)` after bootstrapping TPC-C.