### PR TITLE
Travis: Unlink Homebrew's python@2 formula before running packages.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       env:
         - NAME="macos-10.14/AppleClang-1001.0.46.4 (Debug/packages.sh)" CMAKE_BUILD_TYPE=debug
       install:
+        - brew unlink python@2
         - echo 'y' | ./script/installation/packages.sh
         - export LLVM_DIR=/usr/local/Cellar/llvm@8/8.0.1_1
     - os: linux


### PR DESCRIPTION
Trying to fix what I believe to be a recent change to the Travis macOS image which manifests as:

```
==> Installing tbb dependency: python
896==> Downloading https://homebrew.bintray.com/bottles/python-3.7.6_1.mojave.bottl
897==> Downloading from https://akamai.bintray.com/64/643d627c2b4fc03a3286c397d2992
898######################################################################## 100.0%
899==> Pouring python-3.7.6_1.mojave.bottle.tar.gz
900Error: The `brew link` step did not complete successfully
901The formula built, but is not symlinked into /usr/local
902Could not symlink Frameworks/Python.framework/Headers
903Target /usr/local/Frameworks/Python.framework/Headers
904is a symlink belonging to python@2. You can unlink it:
905  brew unlink python@2
906
907To force the link and overwrite all conflicting files:
908  brew link --overwrite python
909
910To list all files that would be deleted:
911  brew link --overwrite --dry-run python
912
913Possible conflicting files are:
914/usr/local/Frameworks/Python.framework/Headers -> /usr/local/Cellar/python@2/2.7.17/Frameworks/Python.framework/Headers
915/usr/local/Frameworks/Python.framework/Python -> /usr/local/Cellar/python@2/2.7.17/Frameworks/Python.framework/Python
916/usr/local/Frameworks/Python.framework/Resources -> /usr/local/Cellar/python@2/2.7.17/Frameworks/Python.framework/Resources
917/usr/local/Frameworks/Python.framework/Versions/Current -> /usr/local/Cellar/python@2/2.7.17/Frameworks/Python.framework/Versions/Current
918==> /usr/local/Cellar/python/3.7.6_1/bin/python3 -s setup.py --no-user-cfg insta
919==> /usr/local/Cellar/python/3.7.6_1/bin/python3 -s setup.py --no-user-cfg insta
920==> /usr/local/Cellar/python/3.7.6_1/bin/python3 -s setup.py --no-user-cfg insta
921==> Caveats
922Python has been installed as
923  /usr/local/bin/python3
924
925Unversioned symlinks `python`, `python-config`, `pip` etc. pointing to
926`python3`, `python3-config`, `pip3` etc., respectively, have been installed into
927  /usr/local/opt/python/libexec/bin
928
929If you need Homebrew's Python 2.7 run
930  brew install python@2
931
932You can install Python packages with
933  pip3 install <package>
934They will install into the site-package directory
935  /usr/local/lib/python3.7/site-packages
936
937See: https://docs.brew.sh/Homebrew-and-Python
```