### PR TITLE
Add GetBlockStore() to Catalog and CatalogAccessor.

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -314,4 +314,12 @@ std::function<void()> Catalog::DeallocateDatabaseCatalog(DatabaseCatalog *const 
     delete dbc;
   };
 }
+
+common::ManagedPointer<storage::BlockStore> Catalog::GetBlockStore() const {
+  // TODO(Matt): at some point we may decide the Catalog owns this, but right now it doesn't. Taking ownership may
+  // introduce life cycle issues (i.e. guaranteeing that all tables are freed and Blocks returned before this object
+  // gets deleted)
+  return common::ManagedPointer(catalog_block_store_);
+}
+
 }  // namespace terrier::catalog

--- a/src/catalog/catalog_accessor.cpp
+++ b/src/catalog/catalog_accessor.cpp
@@ -1,7 +1,9 @@
 #include "catalog/catalog_accessor.h"
+
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog.h"
 
 namespace terrier::catalog {
@@ -128,6 +130,13 @@ bool CatalogAccessor::SetIndexPointer(index_oid_t index, storage::index::Index *
 
 common::ManagedPointer<storage::index::Index> CatalogAccessor::GetIndex(index_oid_t index) const {
   return dbc_->GetIndex(txn_, index);
+}
+
+common::ManagedPointer<storage::BlockStore> CatalogAccessor::GetBlockStore() const {
+  // TODO(Matt): at some point we may decide to adjust the source  (i.e. each DatabaseCatalog has one), stick it in a
+  // pg_tablespace table, or we may eliminate the concept entirely. This works for now to allow CREATE nodes to bind a
+  // BlockStore
+  return catalog_->GetBlockStore();
 }
 
 }  // namespace terrier::catalog

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -114,6 +114,11 @@ class Catalog {
   std::unique_ptr<CatalogAccessor> GetAccessor(common::ManagedPointer<transaction::TransactionContext> txn,
                                                db_oid_t database);
 
+  /**
+   * @return Catalog's BlockStore
+   */
+  common::ManagedPointer<storage::BlockStore> GetBlockStore() const;
+
  private:
   DISALLOW_COPY_AND_MOVE(Catalog);
   friend class storage::RecoveryManager;

--- a/src/include/catalog/catalog_accessor.h
+++ b/src/include/catalog/catalog_accessor.h
@@ -265,6 +265,11 @@ class CatalogAccessor {
   common::ManagedPointer<storage::index::Index> GetIndex(index_oid_t index) const;
 
   /**
+   * @return BlockStore to be used for CREATE operations
+   */
+  common::ManagedPointer<storage::BlockStore> GetBlockStore() const;
+
+  /**
    * Instantiates a new accessor into the catalog for the given database.
    * @param catalog pointer to the catalog being accessed
    * @param dbc pointer to the database catalog being accessed


### PR DESCRIPTION
The plan node for `CREATE TABLE` needs a pointer to a `BlockStore` in order to be executed. We decided that this should come from the `CatalogAccessor`. In order to facilitate as quickly as possible, this just returns the `BlockStore` that was passed to the `Catalog` as a dependency to be used for its tables. Open questions remain, and will not be addressed in this PR:
1. What is the scope of a `BlockStore`. System-wide? Per-database?
2. Does it belong in a proper table a la `pg_tablespace`?
3. Does `BlockStore` usage even make sense, or should we just be relying on jemalloc to allocate new `RawBlock`s for us? I am not convinced of `BlockStore`'s benefits right now.