### PR TITLE
OutputSchema and assorted PlanGenerator fixes

### DIFF
--- a/src/execution/compiler/operator/index_scan_translator.cpp
+++ b/src/execution/compiler/operator/index_scan_translator.cpp
@@ -11,7 +11,7 @@ namespace terrier::execution::compiler {
 IndexScanTranslator::IndexScanTranslator(const planner::IndexScanPlanNode *op, CodeGen *codegen)
     : OperatorTranslator(codegen),
       op_(op),
-      input_oids_(op_->CollectInputOids()),
+      input_oids_(op_->GetColumnOids()),
       table_schema_(codegen_->Accessor()->GetSchema(op_->GetTableOid())),
       table_pm_(codegen_->Accessor()->GetTable(op_->GetTableOid())->ProjectionMapForOids(input_oids_)),
       index_schema_(codegen_->Accessor()->GetIndexSchema(op_->GetIndexOid())),

--- a/src/execution/compiler/operator/seq_scan_translator.cpp
+++ b/src/execution/compiler/operator/seq_scan_translator.cpp
@@ -15,7 +15,7 @@ SeqScanTranslator::SeqScanTranslator(const terrier::planner::SeqScanPlanNode *op
     : OperatorTranslator(codegen),
       op_(op),
       schema_(codegen->Accessor()->GetSchema(op_->GetTableOid())),
-      input_oids_(op_->CollectInputOids()),
+      input_oids_(op_->GetColumnIds()),
       pm_(codegen->Accessor()->GetTable(op_->GetTableOid())->ProjectionMapForOids(input_oids_)),
       has_predicate_(op_->GetScanPredicate() != nullptr),
       is_vectorizable_{IsVectorizable(op_->GetScanPredicate().Get())},

--- a/src/execution/compiler/operator/seq_scan_translator.cpp
+++ b/src/execution/compiler/operator/seq_scan_translator.cpp
@@ -15,7 +15,7 @@ SeqScanTranslator::SeqScanTranslator(const terrier::planner::SeqScanPlanNode *op
     : OperatorTranslator(codegen),
       op_(op),
       schema_(codegen->Accessor()->GetSchema(op_->GetTableOid())),
-      input_oids_(op_->GetColumnIds()),
+      input_oids_(op_->GetColumnOids()),
       pm_(codegen->Accessor()->GetTable(op_->GetTableOid())->ProjectionMapForOids(input_oids_)),
       has_predicate_(op_->GetScanPredicate() != nullptr),
       is_vectorizable_{IsVectorizable(op_->GetScanPredicate().Get())},

--- a/src/include/optimizer/plan_generator.h
+++ b/src/include/optimizer/plan_generator.h
@@ -235,21 +235,6 @@ class PlanGenerator : public OperatorVisitor {
   std::unique_ptr<planner::OutputSchema> GenerateScanOutputSchema(catalog::table_oid_t tbl_oid);
 
   /**
-   * Generate a predicate expression for scan plans
-   *
-   * @param predicate_expr the original expression
-   * @param alias the table alias
-   * @param db_oid Database OID
-   * @param tbl_oid Table OID for catalog lookup
-   *
-   * @return a predicate that is already evaluated, which could be used to
-   * generate a scan plan i.e. all tuple idx are set
-   */
-  std::unique_ptr<parser::AbstractExpression> GeneratePredicateForScan(
-      common::ManagedPointer<parser::AbstractExpression> predicate_expr, const std::string &alias,
-      catalog::db_oid_t db_oid, catalog::table_oid_t tbl_oid);
-
-  /**
    * Generate projection info and projection schema for join
    * @returns output schema of projection
    */

--- a/src/include/planner/plannodes/index_scan_plan_node.h
+++ b/src/include/planner/plannodes/index_scan_plan_node.h
@@ -367,7 +367,7 @@ class IndexScanPlanNode : public AbstractScanPlanNode {
   std::vector<std::unique_ptr<parser::AbstractExpression>> FromJson(const nlohmann::json &j) override;
 
  private:
-  :ndexScanType scan_type_;
+  IndexScanType scan_type_;
   catalog::index_oid_t index_oid_;
   catalog::table_oid_t table_oid_;
   std::vector<catalog::col_oid_t> column_oids_;

--- a/src/include/planner/plannodes/index_scan_plan_node.h
+++ b/src/include/planner/plannodes/index_scan_plan_node.h
@@ -314,7 +314,7 @@ class IndexScanPlanNode : public AbstractScanPlanNode {
   /**
    * @return OIDs of columns to scan
    */
-  const std::vector<catalog::col_oid_t> &GetColumnIds() const { return column_oids_; }
+  const std::vector<catalog::col_oid_t> &GetColumnOids() const { return column_oids_; }
 
   /**
    * @returns Index Scan Description
@@ -366,37 +366,8 @@ class IndexScanPlanNode : public AbstractScanPlanNode {
   nlohmann::json ToJson() const override;
   std::vector<std::unique_ptr<parser::AbstractExpression>> FromJson(const nlohmann::json &j) override;
 
-  /**
-   * Collect all column oids in this expression
-   * @warning slow!
-   * @return the vector of unique columns oids
-   */
-  std::vector<catalog::col_oid_t> CollectInputOids() const {
-    std::vector<catalog::col_oid_t> result;
-    // Output expressions
-    for (const auto &col : GetOutputSchema()->GetColumns()) {
-      CollectOids(&result, col.GetExpr());
-    }
-    // Remove duplicates
-    std::unordered_set<catalog::col_oid_t> s(result.begin(), result.end());
-    result.assign(s.begin(), s.end());
-    return result;
-  }
-
  private:
-  void CollectOids(std::vector<catalog::col_oid_t> *result,
-                   common::ManagedPointer<parser::AbstractExpression> expr) const {
-    if (expr->GetExpressionType() == parser::ExpressionType::COLUMN_VALUE) {
-      auto column_val = expr.CastManagedPointerTo<parser::ColumnValueExpression>();
-      result->emplace_back(column_val->GetColumnOid());
-    } else {
-      for (const auto &child : expr->GetChildren()) {
-        CollectOids(result, child);
-      }
-    }
-  }
-
-  IndexScanType scan_type_;
+  :ndexScanType scan_type_;
   catalog::index_oid_t index_oid_;
   catalog::table_oid_t table_oid_;
   std::vector<catalog::col_oid_t> column_oids_;

--- a/src/include/planner/plannodes/seq_scan_plan_node.h
+++ b/src/include/planner/plannodes/seq_scan_plan_node.h
@@ -124,36 +124,7 @@ class SeqScanPlanNode : public AbstractScanPlanNode {
   nlohmann::json ToJson() const override;
   std::vector<std::unique_ptr<parser::AbstractExpression>> FromJson(const nlohmann::json &j) override;
 
-  /**
-   * Collect all column oids in this expression
-   * @return the vector of unique columns oids
-   */
-  std::vector<catalog::col_oid_t> CollectInputOids() const {
-    std::vector<catalog::col_oid_t> result;
-    // Scan predicate
-    if (GetScanPredicate() != nullptr) CollectOids(&result, GetScanPredicate().Get());
-    // Output expressions
-    for (const auto &col : GetOutputSchema()->GetColumns()) {
-      CollectOids(&result, col.GetExpr().Get());
-    }
-    // Remove duplicates
-    std::unordered_set<catalog::col_oid_t> s(result.begin(), result.end());
-    result.assign(s.begin(), s.end());
-    return result;
-  }
-
  private:
-  void CollectOids(std::vector<catalog::col_oid_t> *result, const parser::AbstractExpression *expr) const {
-    if (expr->GetExpressionType() == parser::ExpressionType::COLUMN_VALUE) {
-      auto column_val = static_cast<const parser::ColumnValueExpression *>(expr);
-      result->emplace_back(column_val->GetColumnOid());
-    } else {
-      for (const auto &child : expr->GetChildren()) {
-        CollectOids(result, child.Get());
-      }
-    }
-  }
-
   /**
    * OIDs of columns to scan
    */

--- a/src/include/planner/plannodes/seq_scan_plan_node.h
+++ b/src/include/planner/plannodes/seq_scan_plan_node.h
@@ -107,7 +107,7 @@ class SeqScanPlanNode : public AbstractScanPlanNode {
   /**
    * @return OIDs of columns to scan
    */
-  const std::vector<catalog::col_oid_t> &GetColumnIds() const { return column_oids_; }
+  const std::vector<catalog::col_oid_t> &GetColumnOids() const { return column_oids_; }
 
   /**
    * @return the OID for the table being scanned

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -132,49 +132,19 @@ std::vector<catalog::col_oid_t> PlanGenerator::GenerateColumnsForScan() {
 
 std::unique_ptr<planner::OutputSchema> PlanGenerator::GenerateScanOutputSchema(catalog::table_oid_t tbl_oid) {
   // Underlying tuple provided by the table's schema.
-  const auto &schema = accessor_->GetSchema(tbl_oid);
-  std::unordered_map<catalog::col_oid_t, unsigned> coloid_to_offset;
-  for (size_t idx = 0; idx < schema.GetColumns().size(); idx++) {
-    coloid_to_offset[schema.GetColumns()[idx].Oid()] = static_cast<unsigned>(idx);
-  }
-
   std::vector<planner::OutputSchema::Column> columns;
   for (auto &output_expr : output_cols_) {
     TERRIER_ASSERT(output_expr->GetExpressionType() == parser::ExpressionType::COLUMN_VALUE,
                    "Scan columns should all be base table columns");
 
     auto tve = output_expr.CastManagedPointerTo<parser::ColumnValueExpression>();
-    auto col_id = tve->GetColumnOid();
-    auto old_idx = coloid_to_offset.at(col_id);
 
     // output schema of a plan node is literally the columns of the table.
     // there is no such thing as an intermediate column here!
-    auto dve = std::make_unique<parser::DerivedValueExpression>(tve->GetReturnValueType(), 0, old_idx);
-    columns.emplace_back(tve->GetColumnName(), tve->GetReturnValueType(), std::move(dve));
+    columns.emplace_back(tve->GetColumnName(), tve->GetReturnValueType(), tve->Copy());
   }
 
   return std::make_unique<planner::OutputSchema>(std::move(columns));
-}
-
-std::unique_ptr<parser::AbstractExpression> PlanGenerator::GeneratePredicateForScan(
-    common::ManagedPointer<parser::AbstractExpression> predicate_expr, const std::string &alias,
-    catalog::db_oid_t db_oid, catalog::table_oid_t tbl_oid) {
-  if (predicate_expr.Get() == nullptr) {
-    return nullptr;
-  }
-
-  ExprMap table_expr_map;
-  auto exprs = OptimizerUtil::GenerateTableColumnValueExprs(accessor_, alias, db_oid, tbl_oid);
-  for (size_t idx = 0; idx < exprs.size(); idx++) {
-    table_expr_map[common::ManagedPointer(exprs[idx])] = static_cast<int>(idx);
-  }
-
-  // Makes a copy
-  auto pred = parser::ExpressionUtil::EvaluateExpression({table_expr_map}, predicate_expr);
-  for (auto *expr : exprs) {
-    delete expr;
-  }
-  return pred;
 }
 
 void PlanGenerator::Visit(const SeqScan *op) {
@@ -182,10 +152,7 @@ void PlanGenerator::Visit(const SeqScan *op) {
   std::vector<catalog::col_oid_t> column_ids = GenerateColumnsForScan();
 
   // Generate the predicate in the scan
-  auto conj_expr = parser::ExpressionUtil::JoinAnnotatedExprs(op->GetPredicates());
-  auto predicate = GeneratePredicateForScan(common::ManagedPointer(conj_expr), op->GetTableAlias(),
-                                            op->GetDatabaseOID(), op->GetTableOID())
-                       .release();
+  auto predicate = parser::ExpressionUtil::JoinAnnotatedExprs(op->GetPredicates()).release();
   RegisterPointerCleanup<parser::AbstractExpression>(predicate, true, true);
 
   // OutputSchema
@@ -212,10 +179,7 @@ void PlanGenerator::Visit(const IndexScan *op) {
   auto output_schema = GenerateScanOutputSchema(tbl_oid);
 
   // Generate the predicate in the scan
-  auto conj_expr = parser::ExpressionUtil::JoinAnnotatedExprs(op->GetPredicates());
-  auto predicate =
-      GeneratePredicateForScan(common::ManagedPointer(conj_expr), op->GetTableAlias(), op->GetDatabaseOID(), tbl_oid)
-          .release();
+  auto predicate = parser::ExpressionUtil::JoinAnnotatedExprs(op->GetPredicates()).release();
   RegisterPointerCleanup<parser::AbstractExpression>(predicate, true, true);
 
   // Create index scan desc
@@ -239,6 +203,7 @@ void PlanGenerator::Visit(const IndexScan *op) {
                      .SetDatabaseOid(op->GetDatabaseOID())
                      .SetNamespaceOid(op->GetNamespaceOID())
                      .SetIndexOid(op->GetIndexOID())
+                     .SetTableOid(tbl_oid)
                      .SetColumnOids(std::move(column_ids))
                      .SetIndexScanDescription(std::move(index_desc))
                      .Build();

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -673,7 +673,6 @@ void PlanGenerator::Visit(const Update *op) {
   auto builder = planner::UpdatePlanNode::Builder();
   std::unordered_set<catalog::col_oid_t> update_col_offsets;
 
-  const auto &alias = op->GetTableAlias();
   auto tbl_oid = op->GetTableOid();
   auto tbl_schema = accessor_->GetSchema(tbl_oid);
 
@@ -686,7 +685,7 @@ void PlanGenerator::Visit(const Update *op) {
       throw SYNTAX_EXCEPTION("Multiple assignments to same column");
 
     update_col_offsets.insert(col_id);
-    builder.AddSetClause(std::make_pair(col_id, value->GetUpdateValue()));
+    builder.AddSetClause(std::make_pair(col_id, update->GetUpdateValue()));
   }
 
   // Empty OutputSchema for update

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -685,7 +685,9 @@ void PlanGenerator::Visit(const Update *op) {
       throw SYNTAX_EXCEPTION("Multiple assignments to same column");
 
     update_col_offsets.insert(col_id);
-    builder.AddSetClause(std::make_pair(col_id, update->GetUpdateValue()));
+    auto upd_value = update->GetUpdateValue()->Copy().release();
+    builder.AddSetClause(std::make_pair(col_id, common::ManagedPointer(upd_value)));
+    RegisterPointerCleanup<parser::AbstractExpression>(upd_value, true, true);
   }
 
   // Empty OutputSchema for update

--- a/test/execution/compiler_test.cpp
+++ b/test/execution/compiler_test.cpp
@@ -1733,12 +1733,8 @@ TEST_F(CompilerTest, InsertIntoSelectWithParamTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan1 = builder.SetOutputSchema(std::move(schema))
-                    .SetColumnOids({
-                        table_schema1.GetColumn("colA").Oid(),
-                        table_schema1.GetColumn("colB").Oid(),
-                        table_schema1.GetColumn("colC").Oid(),
-                        table_schema1.GetColumn("colD").Oid()
-                    })
+                    .SetColumnOids({table_schema1.GetColumn("colA").Oid(), table_schema1.GetColumn("colB").Oid(),
+                                    table_schema1.GetColumn("colC").Oid(), table_schema1.GetColumn("colD").Oid()})
                     .SetScanPredicate(predicate)
                     .SetIsForUpdateFlag(false)
                     .SetNamespaceOid(NSOid())

--- a/test/execution/compiler_test.cpp
+++ b/test/execution/compiler_test.cpp
@@ -100,9 +100,12 @@ TEST_F(CompilerTest, SimpleSeqScanTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     // Make New Column
     auto col3 = expr_maker.OpMul(col1, col2);
     auto col4 = expr_maker.ComparisonGe(col1, expr_maker.OpMul(expr_maker.Constant(100), col2));
@@ -118,6 +121,7 @@ TEST_F(CompilerTest, SimpleSeqScanTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -153,9 +157,12 @@ TEST_F(CompilerTest, SimpleSeqScanWithParamsTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     // Make New Column
     auto col3 = expr_maker.OpMul(col1, col2);
     auto param1 = expr_maker.PVE(type::TypeId::INTEGER, 0);
@@ -174,6 +181,7 @@ TEST_F(CompilerTest, SimpleSeqScanWithParamsTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -214,9 +222,12 @@ TEST_F(CompilerTest, SimpleIndexScanTest) {
   std::unique_ptr<planner::AbstractPlanNode> index_scan;
   OutputSchemaHelper index_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     auto const_500 = expr_maker.Constant(500);
     index_scan_out.AddOutput("col1", col1);
     index_scan_out.AddOutput("col2", col2);
@@ -257,9 +268,12 @@ TEST_F(CompilerTest, SimpleIndexScanAsendingTest) {
   std::unique_ptr<planner::AbstractPlanNode> index_scan;
   OutputSchemaHelper index_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     index_scan_out.AddOutput("col1", col1);
     index_scan_out.AddOutput("col2", col2);
     auto schema = index_scan_out.MakeSchema();
@@ -518,9 +532,12 @@ TEST_F(CompilerTest, SimpleAggregateTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     seq_scan_out.AddOutput("col2", col2);
     auto schema = seq_scan_out.MakeSchema();
@@ -529,6 +546,7 @@ TEST_F(CompilerTest, SimpleAggregateTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -588,9 +606,12 @@ TEST_F(CompilerTest, SimpleAggregateHavingTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     seq_scan_out.AddOutput("col2", col2);
     auto schema = seq_scan_out.MakeSchema();
@@ -599,6 +620,7 @@ TEST_F(CompilerTest, SimpleAggregateHavingTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -791,9 +813,12 @@ TEST_F(CompilerTest, SimpleSortTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     seq_scan_out.AddOutput("col2", col2);
     auto schema = seq_scan_out.MakeSchema();
@@ -802,6 +827,7 @@ TEST_F(CompilerTest, SimpleSortTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -1006,9 +1032,12 @@ TEST_F(CompilerTest, SimpleIndexNestedLoopJoinTest) {
   {
     auto table_oid2 = accessor->GetTableOid(NSOid(), "test_2");
     auto table_schema2 = accessor->GetSchema(table_oid2);
+    // OIDs
+    auto cola_oid = table_schema2.GetColumn("colA").Oid();
+    auto colb_oid = table_schema2.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema2.GetColumn("col1").Oid(), type::TypeId::SMALLINT);
-    auto col2 = expr_maker.CVE(table_schema2.GetColumn("col2").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     seq_scan_out.AddOutput("col2", col2);
     auto schema = seq_scan_out.MakeSchema();
@@ -1017,6 +1046,7 @@ TEST_F(CompilerTest, SimpleIndexNestedLoopJoinTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -1107,15 +1137,19 @@ TEST_F(CompilerTest, SimpleIndexNestedLoopJoinMultiColumnTest) {
   {
     auto table_oid1 = accessor->GetTableOid(NSOid(), "test_1");
     auto table_schema1 = accessor->GetSchema(table_oid1);
+    // OIDs
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
+    auto colb_oid = table_schema1.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     seq_scan_out.AddOutput("col2", col2);
     auto schema = seq_scan_out.MakeSchema();
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
                    .SetScanPredicate(nullptr)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -1240,8 +1274,10 @@ TEST_F(CompilerTest, SimpleDeleteTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     // Make predicate
     auto pred1 = expr_maker.ComparisonGe(col1, expr_maker.Constant(495));
@@ -1251,6 +1287,7 @@ TEST_F(CompilerTest, SimpleDeleteTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -1374,9 +1411,12 @@ TEST_F(CompilerTest, SimpleUpdateTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
+    auto colb_oid = table_schema1.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     seq_scan_out.AddOutput("col2", col2);
     // Make predicate
@@ -1387,6 +1427,7 @@ TEST_F(CompilerTest, SimpleUpdateTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -1512,11 +1553,16 @@ TEST_F(CompilerTest, SimpleInsertTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
+    auto colc_oid = table_schema.GetColumn("colC").Oid();
+    auto cold_oid = table_schema.GetColumn("colD").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("colB").Oid(), type::TypeId::INTEGER);
-    auto col3 = expr_maker.CVE(table_schema1.GetColumn("colC").Oid(), type::TypeId::INTEGER);
-    auto col4 = expr_maker.CVE(table_schema1.GetColumn("colD").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
+    auto col3 = expr_maker.CVE(colc_oid, type::TypeId::INTEGER);
+    auto col4 = expr_maker.CVE(cold_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     seq_scan_out.AddOutput("col2", col2);
     seq_scan_out.AddOutput("col3", col3);
@@ -1527,6 +1573,7 @@ TEST_F(CompilerTest, SimpleInsertTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid, colc_oid, cold_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -1680,11 +1727,16 @@ TEST_F(CompilerTest, InsertIntoSelectWithParamTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
+    auto colc_oid = table_schema.GetColumn("colC").Oid();
+    auto cold_oid = table_schema.GetColumn("colD").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("colB").Oid(), type::TypeId::INTEGER);
-    auto col3 = expr_maker.CVE(table_schema1.GetColumn("colC").Oid(), type::TypeId::INTEGER);
-    auto col4 = expr_maker.CVE(table_schema1.GetColumn("colD").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
+    auto col3 = expr_maker.CVE(colc_oid, type::TypeId::INTEGER);
+    auto col4 = expr_maker.CVE(cold_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     seq_scan_out.AddOutput("col2", col2);
     seq_scan_out.AddOutput("col3", col3);
@@ -1695,6 +1747,7 @@ TEST_F(CompilerTest, InsertIntoSelectWithParamTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid, colc_oid, cold_oid})
                    .SetScanPredicate(predicate)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -1856,6 +1909,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
                    .SetScanPredicate(nullptr)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())

--- a/test/execution/compiler_test.cpp
+++ b/test/execution/compiler_test.cpp
@@ -234,6 +234,7 @@ TEST_F(CompilerTest, SimpleIndexScanTest) {
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid)
+                     .SetColumnOids({cola_oid, colb_oid})
                      .SetIndexOid(index_oid)
                      .AddIndexColumn(catalog::indexkeycol_oid_t(1), const_500)
                      .SetNamespaceOid(NSOid())
@@ -279,6 +280,7 @@ TEST_F(CompilerTest, SimpleIndexScanAsendingTest) {
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid)
+                     .SetColumnOids({cola_oid, colb_oid})
                      .SetIndexOid(index_oid)
                      .AddLoIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(495))
                      .AddHiIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(505))
@@ -337,14 +339,18 @@ TEST_F(CompilerTest, SimpleIndexScanLimitAsendingTest) {
   std::unique_ptr<planner::AbstractPlanNode> index_scan;
   OutputSchemaHelper index_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     index_scan_out.AddOutput("col1", col1);
     index_scan_out.AddOutput("col2", col2);
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid)
+                     .SetColumnOids({cola_oid, colb_oid})
                      .SetIndexOid(index_oid)
                      .AddLoIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(495))
                      .AddHiIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(505))
@@ -402,14 +408,18 @@ TEST_F(CompilerTest, SimpleIndexScanDesendingTest) {
   std::unique_ptr<planner::AbstractPlanNode> index_scan;
   OutputSchemaHelper index_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     index_scan_out.AddOutput("col1", col1);
     index_scan_out.AddOutput("col2", col2);
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid)
+                     .SetColumnOids({cola_oid, colb_oid})
                      .SetIndexOid(index_oid)
                      .AddLoIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(495))
                      .AddHiIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(505))
@@ -467,14 +477,18 @@ TEST_F(CompilerTest, SimpleIndexScanLimitDesendingTest) {
   std::unique_ptr<planner::AbstractPlanNode> index_scan;
   OutputSchemaHelper index_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     index_scan_out.AddOutput("col1", col1);
     index_scan_out.AddOutput("col2", col2);
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid)
+                     .SetColumnOids({cola_oid, colb_oid})
                      .SetIndexOid(index_oid)
                      .AddLoIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(495))
                      .AddHiIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(505))
@@ -698,9 +712,12 @@ TEST_F(CompilerTest, SimpleHashJoinTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan1;
   OutputSchemaHelper seq_scan_out1{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
+    auto colb_oid = table_schema1.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out1.AddOutput("col1", col1);
     seq_scan_out1.AddOutput("col2", col2);
     auto schema = seq_scan_out1.MakeSchema();
@@ -709,6 +726,7 @@ TEST_F(CompilerTest, SimpleHashJoinTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan1 = builder.SetOutputSchema(std::move(schema))
+                    .SetColumnOids({cola_oid, colb_oid})
                     .SetScanPredicate(predicate)
                     .SetIsForUpdateFlag(false)
                     .SetNamespaceOid(NSOid())
@@ -719,9 +737,12 @@ TEST_F(CompilerTest, SimpleHashJoinTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan2;
   OutputSchemaHelper seq_scan_out2{1, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema2.GetColumn("col1").Oid();
+    auto colb_oid = table_schema2.GetColumn("col2").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema2.GetColumn("col1").Oid(), type::TypeId::SMALLINT);
-    auto col2 = expr_maker.CVE(table_schema2.GetColumn("col2").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::SMALLINT);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out2.AddOutput("col1", col1);
     seq_scan_out2.AddOutput("col2", col2);
     auto schema = seq_scan_out2.MakeSchema();
@@ -729,6 +750,7 @@ TEST_F(CompilerTest, SimpleHashJoinTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan2 = builder.SetOutputSchema(std::move(schema))
+                    .SetColumnOids({cola_oid, colb_oid})
                     .SetScanPredicate(predicate)
                     .SetIsForUpdateFlag(false)
                     .SetNamespaceOid(NSOid())
@@ -915,9 +937,12 @@ TEST_F(CompilerTest, SimpleNestedLoopJoinTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan1;
   OutputSchemaHelper seq_scan_out1{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
+    auto colb_oid = table_schema1.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out1.AddOutput("col1", col1);
     seq_scan_out1.AddOutput("col2", col2);
     auto schema = seq_scan_out1.MakeSchema();
@@ -926,6 +951,7 @@ TEST_F(CompilerTest, SimpleNestedLoopJoinTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan1 = builder.SetOutputSchema(std::move(schema))
+                    .SetColumnOids({cola_oid, colb_oid})
                     .SetScanPredicate(predicate)
                     .SetIsForUpdateFlag(false)
                     .SetNamespaceOid(NSOid())
@@ -936,9 +962,12 @@ TEST_F(CompilerTest, SimpleNestedLoopJoinTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan2;
   OutputSchemaHelper seq_scan_out2{1, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema2.GetColumn("col1").Oid();
+    auto colb_oid = table_schema2.GetColumn("col2").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema2.GetColumn("col1").Oid(), type::TypeId::SMALLINT);
-    auto col2 = expr_maker.CVE(table_schema2.GetColumn("col2").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::SMALLINT);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
     seq_scan_out2.AddOutput("col1", col1);
     seq_scan_out2.AddOutput("col2", col2);
     auto schema = seq_scan_out2.MakeSchema();
@@ -946,6 +975,7 @@ TEST_F(CompilerTest, SimpleNestedLoopJoinTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan2 = builder.SetOutputSchema(std::move(schema))
+                    .SetColumnOids({cola_oid, colb_oid})
                     .SetScanPredicate(predicate)
                     .SetIsForUpdateFlag(false)
                     .SetNamespaceOid(NSOid())
@@ -1033,8 +1063,8 @@ TEST_F(CompilerTest, SimpleIndexNestedLoopJoinTest) {
     auto table_oid2 = accessor->GetTableOid(NSOid(), "test_2");
     auto table_schema2 = accessor->GetSchema(table_oid2);
     // OIDs
-    auto cola_oid = table_schema2.GetColumn("colA").Oid();
-    auto colb_oid = table_schema2.GetColumn("colB").Oid();
+    auto cola_oid = table_schema2.GetColumn("col1").Oid();
+    auto colb_oid = table_schema2.GetColumn("col2").Oid();
     // Get Table columns
     auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
     auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
@@ -1249,6 +1279,7 @@ TEST_F(CompilerTest, SimpleDeleteTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan1 = builder.SetOutputSchema(std::move(schema))
+                    .SetColumnOids({table_schema1.GetColumn("colA").Oid()})
                     .SetScanPredicate(predicate)
                     .SetIsForUpdateFlag(false)
                     .SetNamespaceOid(NSOid())
@@ -1316,6 +1347,7 @@ TEST_F(CompilerTest, SimpleDeleteTest) {
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid1)
+                     .SetColumnOids({table_schema1.GetColumn("colA").Oid()})
                      .SetIndexOid(index_oid1)
                      .AddLoIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(495))
                      .AddHiIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(505))
@@ -1369,6 +1401,8 @@ TEST_F(CompilerTest, SimpleUpdateTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan1 = builder.SetOutputSchema(std::move(schema))
+                    .SetColumnOids({table_schema1.GetColumn("colA").Oid(), table_schema1.GetColumn("colB").Oid(),
+                                    table_schema1.GetColumn("colC").Oid(), table_schema1.GetColumn("colD").Oid()})
                     .SetScanPredicate(predicate)
                     .SetIsForUpdateFlag(false)
                     .SetNamespaceOid(NSOid())
@@ -1471,15 +1505,19 @@ TEST_F(CompilerTest, SimpleUpdateTest) {
   std::unique_ptr<planner::AbstractPlanNode> index_scan;
   OutputSchemaHelper index_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
+    auto colb_oid = table_schema1.GetColumn("colB").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("colB").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
 
     index_scan_out.AddOutput("col1", col1);
     index_scan_out.AddOutput("col2", col2);
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid1)
+                     .SetColumnOids({cola_oid, colb_oid})
                      .SetIndexOid(index_oid1)
                      .AddLoIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(-505))
                      .AddHiIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(-495))
@@ -1554,10 +1592,10 @@ TEST_F(CompilerTest, SimpleInsertTest) {
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
     // OIDs
-    auto cola_oid = table_schema.GetColumn("colA").Oid();
-    auto colb_oid = table_schema.GetColumn("colB").Oid();
-    auto colc_oid = table_schema.GetColumn("colC").Oid();
-    auto cold_oid = table_schema.GetColumn("colD").Oid();
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
+    auto colb_oid = table_schema1.GetColumn("colB").Oid();
+    auto colc_oid = table_schema1.GetColumn("colC").Oid();
+    auto cold_oid = table_schema1.GetColumn("colD").Oid();
     // Get Table columns
     auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
     auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
@@ -1618,11 +1656,16 @@ TEST_F(CompilerTest, SimpleInsertTest) {
   std::unique_ptr<planner::AbstractPlanNode> index_scan;
   OutputSchemaHelper index_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
+    auto colb_oid = table_schema1.GetColumn("colB").Oid();
+    auto colc_oid = table_schema1.GetColumn("colC").Oid();
+    auto cold_oid = table_schema1.GetColumn("colD").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("colB").Oid(), type::TypeId::INTEGER);
-    auto col3 = expr_maker.CVE(table_schema1.GetColumn("colC").Oid(), type::TypeId::INTEGER);
-    auto col4 = expr_maker.CVE(table_schema1.GetColumn("colD").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
+    auto col3 = expr_maker.CVE(colc_oid, type::TypeId::INTEGER);
+    auto col4 = expr_maker.CVE(cold_oid, type::TypeId::INTEGER);
 
     index_scan_out.AddOutput("col1", col1);
     index_scan_out.AddOutput("col2", col2);
@@ -1631,6 +1674,7 @@ TEST_F(CompilerTest, SimpleInsertTest) {
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid1)
+                     .SetColumnOids({cola_oid, colb_oid, colc_oid, cold_oid})
                      .SetIndexOid(index_oid1)
                      .AddLoIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(-10000))
                      .AddHiIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(-1))
@@ -1689,6 +1733,12 @@ TEST_F(CompilerTest, InsertIntoSelectWithParamTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan1 = builder.SetOutputSchema(std::move(schema))
+                    .SetColumnOids({
+                        table_schema1.GetColumn("colA").Oid(),
+                        table_schema1.GetColumn("colB").Oid(),
+                        table_schema1.GetColumn("colC").Oid(),
+                        table_schema1.GetColumn("colD").Oid()
+                    })
                     .SetScanPredicate(predicate)
                     .SetIsForUpdateFlag(false)
                     .SetNamespaceOid(NSOid())
@@ -1728,10 +1778,10 @@ TEST_F(CompilerTest, InsertIntoSelectWithParamTest) {
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
     // OIDs
-    auto cola_oid = table_schema.GetColumn("colA").Oid();
-    auto colb_oid = table_schema.GetColumn("colB").Oid();
-    auto colc_oid = table_schema.GetColumn("colC").Oid();
-    auto cold_oid = table_schema.GetColumn("colD").Oid();
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
+    auto colb_oid = table_schema1.GetColumn("colB").Oid();
+    auto colc_oid = table_schema1.GetColumn("colC").Oid();
+    auto cold_oid = table_schema1.GetColumn("colD").Oid();
     // Get Table columns
     auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
     auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
@@ -1790,11 +1840,16 @@ TEST_F(CompilerTest, InsertIntoSelectWithParamTest) {
   std::unique_ptr<planner::AbstractPlanNode> index_scan;
   OutputSchemaHelper index_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema1.GetColumn("colA").Oid();
+    auto colb_oid = table_schema1.GetColumn("colB").Oid();
+    auto colc_oid = table_schema1.GetColumn("colC").Oid();
+    auto cold_oid = table_schema1.GetColumn("colD").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("colA").Oid(), type::TypeId::INTEGER);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("colB").Oid(), type::TypeId::INTEGER);
-    auto col3 = expr_maker.CVE(table_schema1.GetColumn("colC").Oid(), type::TypeId::INTEGER);
-    auto col4 = expr_maker.CVE(table_schema1.GetColumn("colD").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
+    auto col3 = expr_maker.CVE(colc_oid, type::TypeId::INTEGER);
+    auto col4 = expr_maker.CVE(cold_oid, type::TypeId::INTEGER);
 
     index_scan_out.AddOutput("col1", col1);
     index_scan_out.AddOutput("col2", col2);
@@ -1803,6 +1858,7 @@ TEST_F(CompilerTest, InsertIntoSelectWithParamTest) {
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid1)
+                     .SetColumnOids({cola_oid, colb_oid, colc_oid, cold_oid})
                      .SetIndexOid(index_oid1)
                      .AddLoIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(-1000))
                      .AddHiIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.Constant(-1))
@@ -1895,11 +1951,15 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
   std::unique_ptr<planner::AbstractPlanNode> seq_scan;
   OutputSchemaHelper seq_scan_out{0, &expr_maker};
   {
+    auto col1_oid = table_schema1.GetColumn("varchar_col").Oid();
+    auto col2_oid = table_schema1.GetColumn("date_col").Oid();
+    auto col3_oid = table_schema1.GetColumn("real_col").Oid();
+    auto col4_oid = table_schema1.GetColumn("int_col").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("varchar_col").Oid(), type::TypeId::VARCHAR);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("date_col").Oid(), type::TypeId::DATE);
-    auto col3 = expr_maker.CVE(table_schema1.GetColumn("real_col").Oid(), type::TypeId::DECIMAL);
-    auto col4 = expr_maker.CVE(table_schema1.GetColumn("int_col").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(col1_oid, type::TypeId::VARCHAR);
+    auto col2 = expr_maker.CVE(col2_oid, type::TypeId::DATE);
+    auto col3 = expr_maker.CVE(col3_oid, type::TypeId::DECIMAL);
+    auto col4 = expr_maker.CVE(col4_oid, type::TypeId::INTEGER);
     seq_scan_out.AddOutput("col1", col1);
     seq_scan_out.AddOutput("col2", col2);
     seq_scan_out.AddOutput("col3", col3);
@@ -1909,7 +1969,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     // Build
     planner::SeqScanPlanNode::Builder builder;
     seq_scan = builder.SetOutputSchema(std::move(schema))
-                   .SetColumnOids({cola_oid, colb_oid})
+                   .SetColumnOids({col1_oid, col2_oid, col3_oid, col4_oid})
                    .SetScanPredicate(nullptr)
                    .SetIsForUpdateFlag(false)
                    .SetNamespaceOid(NSOid())
@@ -1961,11 +2021,16 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
   std::unique_ptr<planner::AbstractPlanNode> index_scan;
   OutputSchemaHelper index_scan_out{0, &expr_maker};
   {
+    // OIDs
+    auto cola_oid = table_schema1.GetColumn("varchar_col").Oid();
+    auto colb_oid = table_schema1.GetColumn("date_col").Oid();
+    auto colc_oid = table_schema1.GetColumn("real_col").Oid();
+    auto cold_oid = table_schema1.GetColumn("int_col").Oid();
     // Get Table columns
-    auto col1 = expr_maker.CVE(table_schema1.GetColumn("varchar_col").Oid(), type::TypeId::VARCHAR);
-    auto col2 = expr_maker.CVE(table_schema1.GetColumn("date_col").Oid(), type::TypeId::DATE);
-    auto col3 = expr_maker.CVE(table_schema1.GetColumn("real_col").Oid(), type::TypeId::DECIMAL);
-    auto col4 = expr_maker.CVE(table_schema1.GetColumn("int_col").Oid(), type::TypeId::INTEGER);
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::VARCHAR);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::DATE);
+    auto col3 = expr_maker.CVE(colc_oid, type::TypeId::DECIMAL);
+    auto col4 = expr_maker.CVE(cold_oid, type::TypeId::INTEGER);
 
     index_scan_out.AddOutput("col1", col1);
     index_scan_out.AddOutput("col2", col2);
@@ -1974,6 +2039,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     auto schema = index_scan_out.MakeSchema();
     planner::IndexScanPlanNode::Builder builder;
     index_scan = builder.SetTableOid(table_oid1)
+                     .SetColumnOids({cola_oid, colb_oid, colc_oid, cold_oid})
                      .SetIndexOid(index_oid1)
                      .AddLoIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.PVE(type::TypeId::VARCHAR, 0))
                      .AddHiIndexColumn(catalog::indexkeycol_oid_t(1), expr_maker.PVE(type::TypeId::VARCHAR, 1))

--- a/test/optimizer/tpcc_plan_delivery_test.cpp
+++ b/test/optimizer/tpcc_plan_delivery_test.cpp
@@ -111,7 +111,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryDeleteNewOrder) {
     // IdxScan OutputSchema/ColumnIds
     auto idx_scan_schema = idx_scan->GetOutputSchema();
     EXPECT_EQ(idx_scan_schema->GetColumns().size(), schema.GetColumns().size());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), schema.GetColumns().size());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), schema.GetColumns().size());
 
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
@@ -121,7 +121,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryDeleteNewOrder) {
       EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
       EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
 
-      EXPECT_EQ(idx_scan->GetColumnIds()[idx], col.Oid());
+      EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
   };
@@ -183,7 +183,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryUpdateCarrierId) {
     // IdxScan OutputSchema/ColumnIds
     auto idx_scan_schema = idx_scan->GetOutputSchema();
     EXPECT_EQ(idx_scan_schema->GetColumns().size(), schema.GetColumns().size());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), schema.GetColumns().size());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), schema.GetColumns().size());
 
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
@@ -193,7 +193,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryUpdateCarrierId) {
       EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
       EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
 
-      EXPECT_EQ(idx_scan->GetColumnIds()[idx], col.Oid());
+      EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
   };
@@ -250,7 +250,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryUpdateDeliveryDate) {
     // IdxScan OutputSchema/ColumnIds
     auto idx_scan_schema = idx_scan->GetOutputSchema();
     EXPECT_EQ(idx_scan_schema->GetColumns().size(), schema.GetColumns().size());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), schema.GetColumns().size());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), schema.GetColumns().size());
 
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
@@ -260,7 +260,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryUpdateDeliveryDate) {
       EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
       EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
 
-      EXPECT_EQ(idx_scan->GetColumnIds()[idx], col.Oid());
+      EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
   };
@@ -321,8 +321,8 @@ TEST_F(TpccPlanDeliveryTests, DeliverySumOrderAmount) {
     EXPECT_EQ(idx_scan->IsForUpdate(), false);
     EXPECT_EQ(idx_scan->GetDatabaseOid(), test->db_);
     EXPECT_EQ(idx_scan->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), 1);
-    EXPECT_EQ(idx_scan->GetColumnIds()[0], schema.GetColumn("ol_amount").Oid());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), 1);
+    EXPECT_EQ(idx_scan->GetColumnOids()[0], schema.GetColumn("ol_amount").Oid());
 
     auto &idx_desc = idx_scan->GetIndexScanDescription();
     EXPECT_EQ(idx_desc.GetExpressionTypeList().size(), 3);
@@ -451,7 +451,7 @@ TEST_F(TpccPlanDeliveryTests, UpdateCustomBalanceDeliveryCount) {
     // IdxScan OutputSchema/ColumnIds -> match schema
     auto idx_scan_schema = idx_scan->GetOutputSchema();
     EXPECT_EQ(idx_scan_schema->GetColumns().size(), schema.GetColumns().size());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), schema.GetColumns().size());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), schema.GetColumns().size());
 
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
@@ -461,7 +461,7 @@ TEST_F(TpccPlanDeliveryTests, UpdateCustomBalanceDeliveryCount) {
       EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
       EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
 
-      EXPECT_EQ(idx_scan->GetColumnIds()[idx], col.Oid());
+      EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
   };

--- a/test/optimizer/tpcc_plan_index_scan.cpp
+++ b/test/optimizer/tpcc_plan_index_scan.cpp
@@ -32,8 +32,8 @@ TEST_F(TpccPlanIndexScanTests, SimplePredicateIndexScan) {
     EXPECT_EQ(plan->GetChildrenSize(), 0);
     auto index_plan = reinterpret_cast<planner::IndexScanPlanNode *>(plan.get());
     EXPECT_EQ(index_plan->GetIndexOid(), test->pk_new_order_);
-    EXPECT_EQ(index_plan->GetColumnIds().size(), 1);
-    EXPECT_EQ(index_plan->GetColumnIds()[0], schema.GetColumn("no_o_id").Oid());
+    EXPECT_EQ(index_plan->GetColumnOids().size(), 1);
+    EXPECT_EQ(index_plan->GetColumnOids()[0], schema.GetColumn("no_o_id").Oid());
     EXPECT_EQ(index_plan->IsForUpdate(), false);
     EXPECT_EQ(index_plan->GetDatabaseOid(), test->db_);
     EXPECT_EQ(index_plan->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());
@@ -76,8 +76,8 @@ TEST_F(TpccPlanIndexScanTests, SimplePredicateFlippedIndexScan) {
     EXPECT_EQ(plan->GetChildrenSize(), 0);
     auto index_plan = reinterpret_cast<planner::IndexScanPlanNode *>(plan.get());
     EXPECT_EQ(index_plan->GetIndexOid(), test->pk_new_order_);
-    EXPECT_EQ(index_plan->GetColumnIds().size(), 1);
-    EXPECT_EQ(index_plan->GetColumnIds()[0], schema.GetColumn("no_o_id").Oid());
+    EXPECT_EQ(index_plan->GetColumnOids().size(), 1);
+    EXPECT_EQ(index_plan->GetColumnOids()[0], schema.GetColumn("no_o_id").Oid());
     EXPECT_EQ(index_plan->IsForUpdate(), false);
     EXPECT_EQ(index_plan->GetDatabaseOid(), test->db_);
     EXPECT_EQ(index_plan->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());
@@ -121,8 +121,8 @@ TEST_F(TpccPlanIndexScanTests, IndexFulfillSort) {
     EXPECT_EQ(plan->GetChildrenSize(), 0);
     auto index_plan = reinterpret_cast<planner::IndexScanPlanNode *>(plan.get());
     EXPECT_EQ(index_plan->GetIndexOid(), test->pk_new_order_);
-    EXPECT_EQ(index_plan->GetColumnIds().size(), 1);
-    EXPECT_EQ(index_plan->GetColumnIds()[0], schema.GetColumn("no_o_id").Oid());
+    EXPECT_EQ(index_plan->GetColumnOids().size(), 1);
+    EXPECT_EQ(index_plan->GetColumnOids()[0], schema.GetColumn("no_o_id").Oid());
     EXPECT_EQ(index_plan->IsForUpdate(), false);
     EXPECT_EQ(index_plan->GetDatabaseOid(), test->db_);
     EXPECT_EQ(index_plan->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());
@@ -164,8 +164,8 @@ TEST_F(TpccPlanIndexScanTests, IndexFulfillSortAndPredicate) {
     EXPECT_EQ(plan->GetChildrenSize(), 0);
     auto index_plan = reinterpret_cast<planner::IndexScanPlanNode *>(plan.get());
     EXPECT_EQ(index_plan->GetIndexOid(), test->pk_new_order_);
-    EXPECT_EQ(index_plan->GetColumnIds().size(), 1);
-    EXPECT_EQ(index_plan->GetColumnIds()[0], schema.GetColumn("no_o_id").Oid());
+    EXPECT_EQ(index_plan->GetColumnOids().size(), 1);
+    EXPECT_EQ(index_plan->GetColumnOids()[0], schema.GetColumn("no_o_id").Oid());
     EXPECT_EQ(index_plan->IsForUpdate(), false);
     EXPECT_EQ(index_plan->GetDatabaseOid(), test->db_);
     EXPECT_EQ(index_plan->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());
@@ -237,9 +237,9 @@ TEST_F(TpccPlanIndexScanTests, IndexFulfillSortAndPredicateWithLimitOffset) {
     EXPECT_EQ(plani->GetChildrenSize(), 0);
     auto index_plan = reinterpret_cast<const planner::IndexScanPlanNode *>(plani);
     EXPECT_EQ(index_plan->GetIndexOid(), test->pk_new_order_);
-    EXPECT_EQ(index_plan->GetColumnIds().size(), 2);
-    EXPECT_EQ(index_plan->GetColumnIds()[0], schema.GetColumn("no_w_id").Oid());
-    EXPECT_EQ(index_plan->GetColumnIds()[1], schema.GetColumn("no_o_id").Oid());
+    EXPECT_EQ(index_plan->GetColumnOids().size(), 2);
+    EXPECT_EQ(index_plan->GetColumnOids()[0], schema.GetColumn("no_w_id").Oid());
+    EXPECT_EQ(index_plan->GetColumnOids()[1], schema.GetColumn("no_o_id").Oid());
     EXPECT_EQ(index_plan->IsForUpdate(), false);
     EXPECT_EQ(index_plan->GetDatabaseOid(), test->db_);
     EXPECT_EQ(index_plan->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());

--- a/test/optimizer/tpcc_plan_index_scan.cpp
+++ b/test/optimizer/tpcc_plan_index_scan.cpp
@@ -26,11 +26,6 @@ TEST_F(TpccPlanIndexScanTests, SimplePredicateIndexScan) {
                   std::unique_ptr<planner::AbstractPlanNode> plan) {
     // Get Schema
     auto &schema = test->accessor_->GetSchema(test->tbl_new_order_);
-    unsigned no_d_id_offset = 0;
-    for (size_t idx = 0; idx < schema.GetColumns().size(); idx++) {
-      auto idx_u = static_cast<unsigned>(idx);
-      if (schema.GetColumn(idx_u).Name() == "no_d_id") no_d_id_offset = static_cast<unsigned>(idx_u);
-    }
 
     // Should use New Order Primary Key (NO_W_ID, NO_D_ID, NO_O_ID)
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::INDEXSCAN);
@@ -56,12 +51,12 @@ TEST_F(TpccPlanIndexScanTests, SimplePredicateIndexScan) {
     EXPECT_TRUE(scan_pred != nullptr);
     EXPECT_EQ(scan_pred->GetExpressionType(), parser::ExpressionType::COMPARE_EQUAL);
     EXPECT_EQ(scan_pred->GetChildrenSize(), 2);
-    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
+    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
     EXPECT_EQ(scan_pred->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
-    auto dve = scan_pred->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
+    auto tve = scan_pred->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), no_d_id_offset);  // ValueIdx() should be offset into underlying tuple
+    EXPECT_EQ(tve->GetColumnName(), "no_d_id");
+    EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("no_d_id").Oid());
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);
   };
 
@@ -75,11 +70,6 @@ TEST_F(TpccPlanIndexScanTests, SimplePredicateFlippedIndexScan) {
                   std::unique_ptr<planner::AbstractPlanNode> plan) {
     // Get Schema
     auto &schema = test->accessor_->GetSchema(test->tbl_new_order_);
-    unsigned no_d_id_offset = 0;
-    for (size_t idx = 0; idx < schema.GetColumns().size(); idx++) {
-      auto idx_u = static_cast<unsigned>(idx);
-      if (schema.GetColumn(idx_u).Name() == "no_d_id") no_d_id_offset = static_cast<unsigned>(idx_u);
-    }
 
     // Should use New Order Primary Key (NO_W_ID, NO_D_ID, NO_O_ID)
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::INDEXSCAN);
@@ -106,12 +96,12 @@ TEST_F(TpccPlanIndexScanTests, SimplePredicateFlippedIndexScan) {
     EXPECT_TRUE(scan_pred != nullptr);
     EXPECT_EQ(scan_pred->GetExpressionType(), parser::ExpressionType::COMPARE_LESS_THAN);
     EXPECT_EQ(scan_pred->GetChildrenSize(), 2);
-    EXPECT_EQ(scan_pred->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
+    EXPECT_EQ(scan_pred->GetChild(1)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
     EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
-    auto dve = scan_pred->GetChild(1).CastManagedPointerTo<parser::DerivedValueExpression>();
+    auto tve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto cve = scan_pred->GetChild(0).CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), no_d_id_offset);  // ValueIdx() should be offset into underlying tuple
+    EXPECT_EQ(tve->GetColumnName(), "no_d_id");
+    EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("no_d_id").Oid());
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);
   };
 
@@ -168,13 +158,6 @@ TEST_F(TpccPlanIndexScanTests, IndexFulfillSortAndPredicate) {
                   std::unique_ptr<planner::AbstractPlanNode> plan) {
     // Get Schema
     auto &schema = test->accessor_->GetSchema(test->tbl_new_order_);
-    unsigned no_w_id_offset = 0;
-    for (size_t idx = 0; idx < schema.GetColumns().size(); idx++) {
-      auto idx_u = static_cast<unsigned>(idx);
-      if (schema.GetColumn(idx_u).Name() == "no_w_id") {
-        no_w_id_offset = idx_u;
-      }
-    }
 
     // Should use New Order Primary Key (NO_W_ID, NO_D_ID, NO_O_ID)
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::INDEXSCAN);
@@ -202,12 +185,12 @@ TEST_F(TpccPlanIndexScanTests, IndexFulfillSortAndPredicate) {
     EXPECT_TRUE(scan_pred != nullptr);
     EXPECT_EQ(scan_pred->GetExpressionType(), parser::ExpressionType::COMPARE_EQUAL);
     EXPECT_EQ(scan_pred->GetChildrenSize(), 2);
-    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
+    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
     EXPECT_EQ(scan_pred->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
-    auto dve = scan_pred->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
+    auto tve = scan_pred->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), no_w_id_offset);  // ValueIdx() should be offset into underlying tuple
+    EXPECT_EQ(tve->GetColumnName(), "no_w_id");
+    EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("no_w_id").Oid());
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);
   };
 
@@ -221,13 +204,6 @@ TEST_F(TpccPlanIndexScanTests, IndexFulfillSortAndPredicateWithLimitOffset) {
                   std::unique_ptr<planner::AbstractPlanNode> plan) {
     // Get Schema
     auto &schema = test->accessor_->GetSchema(test->tbl_new_order_);
-    unsigned no_w_id_offset = 0;
-    for (size_t idx = 0; idx < schema.GetColumns().size(); idx++) {
-      auto idx_u = static_cast<unsigned>(idx);
-      if (schema.GetColumn(idx_u).Name() == "no_w_id") {
-        no_w_id_offset = idx_u;
-      }
-    }
     EXPECT_EQ(plan->GetChildrenSize(), 1);
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::PROJECTION);
 
@@ -283,12 +259,12 @@ TEST_F(TpccPlanIndexScanTests, IndexFulfillSortAndPredicateWithLimitOffset) {
     EXPECT_TRUE(scan_pred != nullptr);
     EXPECT_EQ(scan_pred->GetExpressionType(), parser::ExpressionType::COMPARE_EQUAL);
     EXPECT_EQ(scan_pred->GetChildrenSize(), 2);
-    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
+    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
     EXPECT_EQ(scan_pred->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
-    auto dve = scan_pred->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
+    auto tve = scan_pred->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), no_w_id_offset);  // ValueIdx() should be offset into underlying tuple
+    EXPECT_EQ(tve->GetColumnName(), "no_w_id");
+    EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("no_w_id").Oid());
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);
   };
 

--- a/test/optimizer/tpcc_plan_neworder_test.cpp
+++ b/test/optimizer/tpcc_plan_neworder_test.cpp
@@ -54,9 +54,8 @@ TEST_F(TpccPlanNewOrderTests, UpdateDistrict) {
     EXPECT_EQ(update->GetSetClauses()[0].first, schema.GetColumn("d_next_o_id").Oid());
     auto expr = update->GetSetClauses()[0].second.CastManagedPointerTo<parser::OperatorExpression>();
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-    auto dve = expr->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), d_next_o_id_idx);
+    auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
+    EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("d_next_o_id").Oid());
     EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
     auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);
@@ -132,18 +131,6 @@ TEST_F(TpccPlanNewOrderTests, GetStock) {
 TEST_F(TpccPlanNewOrderTests, UpdateStock) {
   auto check = [](TpccPlanTest *test, catalog::table_oid_t tbl_oid, std::unique_ptr<planner::AbstractPlanNode> plan) {
     auto &schema = test->accessor_->GetSchema(tbl_oid);
-    auto s_ytd_idx = -1;
-    auto s_order_cnt_idx = -1;
-    auto s_remote_cnt_idx = -1;
-    for (size_t i = 0; i < schema.GetColumns().size(); i++) {
-      if (schema.GetColumns()[i].Name() == "s_ytd") {
-        s_ytd_idx = static_cast<int>(i);
-      } else if (schema.GetColumns()[i].Name() == "s_order_cnt") {
-        s_order_cnt_idx = static_cast<int>(i);
-      } else if (schema.GetColumns()[i].Name() == "s_remote_cnt") {
-        s_remote_cnt_idx = static_cast<int>(i);
-      }
-    }
 
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::UPDATE);
     auto update = reinterpret_cast<planner::UpdatePlanNode *>(plan.get());
@@ -169,9 +156,8 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
     {
       auto expr = update->GetSetClauses()[1].second.CastManagedPointerTo<parser::OperatorExpression>();
       EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
-      EXPECT_EQ(dve->GetTupleIdx(), 0);
-      EXPECT_EQ(dve->GetValueIdx(), s_ytd_idx);
+      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
+      EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("s_ytd").Oid());
       EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
       EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);
@@ -180,9 +166,8 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
     {
       auto expr = update->GetSetClauses()[2].second.CastManagedPointerTo<parser::OperatorExpression>();
       EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
-      EXPECT_EQ(dve->GetTupleIdx(), 0);
-      EXPECT_EQ(dve->GetValueIdx(), s_order_cnt_idx);
+      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
+      EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("s_order_cnt").Oid());
       EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
       EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);
@@ -191,9 +176,8 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
     {
       auto expr = update->GetSetClauses()[3].second.CastManagedPointerTo<parser::OperatorExpression>();
       EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
-      EXPECT_EQ(dve->GetTupleIdx(), 0);
-      EXPECT_EQ(dve->GetValueIdx(), s_remote_cnt_idx);
+      auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
+      EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("s_remote_cnt").Oid());
       EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
       EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);

--- a/test/optimizer/tpcc_plan_neworder_test.cpp
+++ b/test/optimizer/tpcc_plan_neworder_test.cpp
@@ -94,7 +94,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateDistrict) {
     // IdxScan OutputSchema/ColumnIds
     auto idx_scan_schema = idx_scan->GetOutputSchema();
     EXPECT_EQ(idx_scan_schema->GetColumns().size(), schema.GetColumns().size());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), schema.GetColumns().size());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), schema.GetColumns().size());
 
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
@@ -104,7 +104,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateDistrict) {
       EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
       EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
 
-      EXPECT_EQ(idx_scan->GetColumnIds()[idx], col.Oid());
+      EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
   };
@@ -234,7 +234,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
     // IdxScan OutputSchema/ColumnIds
     auto idx_scan_schema = idx_scan->GetOutputSchema();
     EXPECT_EQ(idx_scan_schema->GetColumns().size(), schema.GetColumns().size());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), schema.GetColumns().size());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), schema.GetColumns().size());
 
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
@@ -244,7 +244,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
       EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
       EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
 
-      EXPECT_EQ(idx_scan->GetColumnIds()[idx], col.Oid());
+      EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
   };

--- a/test/optimizer/tpcc_plan_neworder_test.cpp
+++ b/test/optimizer/tpcc_plan_neworder_test.cpp
@@ -41,12 +41,6 @@ TEST_F(TpccPlanNewOrderTests, InsertNewOrder) {
 TEST_F(TpccPlanNewOrderTests, UpdateDistrict) {
   auto check = [](TpccPlanTest *test, catalog::table_oid_t tbl_oid, std::unique_ptr<planner::AbstractPlanNode> plan) {
     auto &schema = test->accessor_->GetSchema(tbl_oid);
-    auto d_next_o_id_idx = -1;
-    for (size_t i = 0; i < schema.GetColumns().size(); i++) {
-      if (schema.GetColumns()[i].Name() == "d_next_o_id") {
-        d_next_o_id_idx = static_cast<int>(i);
-      }
-    }
 
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::UPDATE);
     auto update = reinterpret_cast<planner::UpdatePlanNode *>(plan.get());
@@ -99,11 +93,9 @@ TEST_F(TpccPlanNewOrderTests, UpdateDistrict) {
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
       auto idx_scan_expr = idx_scan_schema->GetColumn(idx).GetExpr();
-      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
-      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::DerivedValueExpression>();
-      EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
-      EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
-
+      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
+      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::ColumnValueExpression>();
+      EXPECT_EQ(idx_scan_expr_dve->GetColumnOid(), col.Oid());
       EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
@@ -239,11 +231,9 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
       auto idx_scan_expr = idx_scan_schema->GetColumn(idx).GetExpr();
-      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
-      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::DerivedValueExpression>();
-      EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
-      EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
-
+      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
+      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::ColumnValueExpression>();
+      EXPECT_EQ(idx_scan_expr_dve->GetColumnOid(), col.Oid());
       EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }

--- a/test/optimizer/tpcc_plan_payment_test.cpp
+++ b/test/optimizer/tpcc_plan_payment_test.cpp
@@ -64,7 +64,7 @@ TEST_F(TpccPlanPaymentTests, UpdateWarehouse) {
     // IdxScan OutputSchema/ColumnIds -> match schema
     auto idx_scan_schema = idx_scan->GetOutputSchema();
     EXPECT_EQ(idx_scan_schema->GetColumns().size(), schema.GetColumns().size());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), schema.GetColumns().size());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), schema.GetColumns().size());
 
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
@@ -74,7 +74,7 @@ TEST_F(TpccPlanPaymentTests, UpdateWarehouse) {
       EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
       EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
 
-      EXPECT_EQ(idx_scan->GetColumnIds()[idx], col.Oid());
+      EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
   };
@@ -143,7 +143,7 @@ TEST_F(TpccPlanPaymentTests, UpdateDistrict) {
     // IdxScan OutputSchema/ColumnIds -> match schema
     auto idx_scan_schema = idx_scan->GetOutputSchema();
     EXPECT_EQ(idx_scan_schema->GetColumns().size(), schema.GetColumns().size());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), schema.GetColumns().size());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), schema.GetColumns().size());
 
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
@@ -153,7 +153,7 @@ TEST_F(TpccPlanPaymentTests, UpdateDistrict) {
       EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
       EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
 
-      EXPECT_EQ(idx_scan->GetColumnIds()[idx], col.Oid());
+      EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
   };
@@ -242,7 +242,7 @@ TEST_F(TpccPlanPaymentTests, UpdateCustomerBalance) {
     // IdxScan OutputSchema/ColumnIds -> match schema
     auto idx_scan_schema = idx_scan->GetOutputSchema();
     EXPECT_EQ(idx_scan_schema->GetColumns().size(), schema.GetColumns().size());
-    EXPECT_EQ(idx_scan->GetColumnIds().size(), schema.GetColumns().size());
+    EXPECT_EQ(idx_scan->GetColumnOids().size(), schema.GetColumns().size());
 
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
@@ -252,7 +252,7 @@ TEST_F(TpccPlanPaymentTests, UpdateCustomerBalance) {
       EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
       EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
 
-      EXPECT_EQ(idx_scan->GetColumnIds()[idx], col.Oid());
+      EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
   };

--- a/test/optimizer/tpcc_plan_payment_test.cpp
+++ b/test/optimizer/tpcc_plan_payment_test.cpp
@@ -17,12 +17,6 @@ struct TpccPlanPaymentTests : public TpccPlanTest {};
 TEST_F(TpccPlanPaymentTests, UpdateWarehouse) {
   auto check = [](TpccPlanTest *test, catalog::table_oid_t tbl_oid, std::unique_ptr<planner::AbstractPlanNode> plan) {
     auto &schema = test->accessor_->GetSchema(tbl_oid);
-    auto w_ytd_idx = -1;
-    for (size_t i = 0; i < schema.GetColumns().size(); i++) {
-      if (schema.GetColumns()[i].Name() == "w_ytd") {
-        w_ytd_idx = static_cast<int>(i);
-      }
-    }
 
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::UPDATE);
     auto update = reinterpret_cast<planner::UpdatePlanNode *>(plan.get());
@@ -36,9 +30,8 @@ TEST_F(TpccPlanPaymentTests, UpdateWarehouse) {
     EXPECT_EQ(update->GetSetClauses()[0].first, schema.GetColumn("w_ytd").Oid());
     auto expr = update->GetSetClauses()[0].second;
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-    auto dve = expr->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), w_ytd_idx);
+    auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
+    EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("w_ytd").Oid());
 
     // Idx Scan, full output schema
     EXPECT_EQ(update->GetChildren().size(), 1);
@@ -91,12 +84,6 @@ TEST_F(TpccPlanPaymentTests, GetWarehouse) {
 TEST_F(TpccPlanPaymentTests, UpdateDistrict) {
   auto check = [](TpccPlanTest *test, catalog::table_oid_t tbl_oid, std::unique_ptr<planner::AbstractPlanNode> plan) {
     auto &schema = test->accessor_->GetSchema(tbl_oid);
-    auto d_ytd_idx = -1;
-    for (size_t i = 0; i < schema.GetColumns().size(); i++) {
-      if (schema.GetColumns()[i].Name() == "d_ytd") {
-        d_ytd_idx = static_cast<int>(i);
-      }
-    }
 
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::UPDATE);
     auto update = reinterpret_cast<planner::UpdatePlanNode *>(plan.get());
@@ -110,9 +97,8 @@ TEST_F(TpccPlanPaymentTests, UpdateDistrict) {
     EXPECT_EQ(update->GetSetClauses()[0].first, schema.GetColumn("d_ytd").Oid());
     auto expr = update->GetSetClauses()[0].second;
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::OPERATOR_PLUS);
-    auto dve = expr->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), d_ytd_idx);
+    auto dve = expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
+    EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("d_ytd").Oid());
 
     // Idx Scan, full output schema
     EXPECT_EQ(update->GetChildren().size(), 1);

--- a/test/optimizer/tpcc_plan_payment_test.cpp
+++ b/test/optimizer/tpcc_plan_payment_test.cpp
@@ -69,11 +69,9 @@ TEST_F(TpccPlanPaymentTests, UpdateWarehouse) {
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
       auto idx_scan_expr = idx_scan_schema->GetColumn(idx).GetExpr();
-      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
-      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::DerivedValueExpression>();
-      EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
-      EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
-
+      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
+      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::ColumnValueExpression>();
+      EXPECT_EQ(idx_scan_expr_dve->GetColumnOid(), col.Oid());
       EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
@@ -148,11 +146,9 @@ TEST_F(TpccPlanPaymentTests, UpdateDistrict) {
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
       auto idx_scan_expr = idx_scan_schema->GetColumn(idx).GetExpr();
-      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
-      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::DerivedValueExpression>();
-      EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
-      EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
-
+      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
+      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::ColumnValueExpression>();
+      EXPECT_EQ(idx_scan_expr_dve->GetColumnOid(), col.Oid());
       EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }
@@ -247,11 +243,9 @@ TEST_F(TpccPlanPaymentTests, UpdateCustomerBalance) {
     size_t idx = 0;
     for (auto &col : schema.GetColumns()) {
       auto idx_scan_expr = idx_scan_schema->GetColumn(idx).GetExpr();
-      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
-      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::DerivedValueExpression>();
-      EXPECT_EQ(idx_scan_expr_dve->GetTupleIdx(), 0);
-      EXPECT_EQ(idx_scan_expr_dve->GetValueIdx(), idx);
-
+      EXPECT_EQ(idx_scan_expr->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
+      auto idx_scan_expr_dve = idx_scan_expr.CastManagedPointerTo<parser::ColumnValueExpression>();
+      EXPECT_EQ(idx_scan_expr_dve->GetColumnOid(), col.Oid());
       EXPECT_EQ(idx_scan->GetColumnOids()[idx], col.Oid());
       idx++;
     }

--- a/test/optimizer/tpcc_plan_seq_scan.cpp
+++ b/test/optimizer/tpcc_plan_seq_scan.cpp
@@ -48,13 +48,6 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicate) {
   auto check = [](TpccPlanTest *test, parser::SelectStatement *sel_stmt, catalog::table_oid_t tbl_oid,
                   std::unique_ptr<planner::AbstractPlanNode> plan) {
     auto &schema = test->accessor_->GetSchema(test->tbl_order_);
-    auto offset = 0;
-    for (size_t idx = 0; idx < schema.GetColumns().size(); idx++) {
-      auto idx_u = static_cast<unsigned>(idx);
-      if (schema.GetColumn(idx_u).Name() == "o_carrier_id") {
-        offset = static_cast<unsigned>(idx_u);
-      }
-    }
 
     EXPECT_EQ(plan->GetChildrenSize(), 0);
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::SEQSCAN);
@@ -72,12 +65,12 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicate) {
     EXPECT_TRUE(scan_pred != nullptr);
     EXPECT_EQ(scan_pred->GetExpressionType(), parser::ExpressionType::COMPARE_EQUAL);
     EXPECT_EQ(scan_pred->GetChildrenSize(), 2);
-    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
+    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
     EXPECT_EQ(scan_pred->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
-    auto dve = scan_pred->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
+    auto tve = scan_pred->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), offset);  // ValueIdx() should be offset into underlying tuple
+    EXPECT_EQ(tve->GetColumnName(), "o_carrier_id");
+    EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("o_carrier_id").Oid());
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 5);
   };
 
@@ -91,11 +84,6 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateOrderBy) {
                   std::unique_ptr<planner::AbstractPlanNode> plan) {
     // Find column offset that matches with o_carrier_id
     auto &schema = test->accessor_->GetSchema(test->tbl_order_);
-    unsigned carrier_offset = 0;
-    for (size_t idx = 0; idx < schema.GetColumns().size(); idx++) {
-      if (schema.GetColumns()[idx].Name() == "o_carrier_id") carrier_offset = static_cast<unsigned>(idx);
-    }
-
     EXPECT_EQ(plan->GetChildrenSize(), 1);
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::PROJECTION);
 
@@ -133,12 +121,12 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateOrderBy) {
     EXPECT_TRUE(scan_pred != nullptr);
     EXPECT_EQ(scan_pred->GetExpressionType(), parser::ExpressionType::COMPARE_EQUAL);
     EXPECT_EQ(scan_pred->GetChildrenSize(), 2);
-    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
+    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
     EXPECT_EQ(scan_pred->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
-    auto *dve = reinterpret_cast<const parser::DerivedValueExpression *>(scan_pred->GetChild(0).Get());
-    auto *cve = reinterpret_cast<const parser::ConstantValueExpression *>(scan_pred->GetChild(1).Get());
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), carrier_offset);  // ValueIdx() should be offset into underlying tuple (all cols)
+    auto tve = scan_pred->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
+    auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
+    EXPECT_EQ(tve->GetColumnName(), "o_carrier_id");
+    EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("o_carrier_id").Oid());
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 5);
   };
 
@@ -152,10 +140,6 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateLimit) {
                   std::unique_ptr<planner::AbstractPlanNode> plan) {
     // Find column offset that matches with o_carrier_id
     auto &schema = test->accessor_->GetSchema(test->tbl_order_);
-    unsigned carrier_offset = 0;
-    for (size_t idx = 0; idx < schema.GetColumns().size(); idx++) {
-      if (schema.GetColumns()[idx].Name() == "o_carrier_id") carrier_offset = static_cast<unsigned>(idx);
-    }
 
     EXPECT_EQ(plan->GetChildrenSize(), 1);
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::LIMIT);
@@ -180,12 +164,12 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateLimit) {
     EXPECT_TRUE(scan_pred != nullptr);
     EXPECT_EQ(scan_pred->GetExpressionType(), parser::ExpressionType::COMPARE_EQUAL);
     EXPECT_EQ(scan_pred->GetChildrenSize(), 2);
-    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
+    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
     EXPECT_EQ(scan_pred->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
-    auto *dve = reinterpret_cast<const parser::DerivedValueExpression *>(scan_pred->GetChild(0).Get());
-    auto *cve = reinterpret_cast<const parser::ConstantValueExpression *>(scan_pred->GetChild(1).Get());
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), carrier_offset);  // ValueIdx() should be offset into underlying tuple (all cols)
+    auto tve = scan_pred->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
+    auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
+    EXPECT_EQ(tve->GetColumnName(), "o_carrier_id");
+    EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("o_carrier_id").Oid());
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 5);
   };
 
@@ -199,11 +183,6 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateOrderByLimit) {
                   std::unique_ptr<planner::AbstractPlanNode> plan) {
     // Find column offset that matches with o_carrier_id
     auto &schema = test->accessor_->GetSchema(test->tbl_order_);
-    unsigned carrier_offset = 0;
-    for (size_t idx = 0; idx < schema.GetColumns().size(); idx++) {
-      if (schema.GetColumns()[idx].Name() == "o_carrier_id") carrier_offset = static_cast<unsigned>(idx);
-    }
-
     EXPECT_EQ(plan->GetChildrenSize(), 1);
     EXPECT_EQ(plan->GetPlanNodeType(), planner::PlanNodeType::PROJECTION);
 
@@ -249,12 +228,12 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateOrderByLimit) {
     EXPECT_TRUE(scan_pred != nullptr);
     EXPECT_EQ(scan_pred->GetExpressionType(), parser::ExpressionType::COMPARE_EQUAL);
     EXPECT_EQ(scan_pred->GetChildrenSize(), 2);
-    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::VALUE_TUPLE);
+    EXPECT_EQ(scan_pred->GetChild(0)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
     EXPECT_EQ(scan_pred->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
-    auto dve = scan_pred->GetChild(0).CastManagedPointerTo<parser::DerivedValueExpression>();
+    auto tve = scan_pred->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(dve->GetTupleIdx(), 0);
-    EXPECT_EQ(dve->GetValueIdx(), carrier_offset);  // ValueIdx() should be offset into underlying tuple (all cols)
+    EXPECT_EQ(tve->GetColumnName(), "o_carrier_id");
+    EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("o_carrier_id").Oid());
     EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 5);
   };
 

--- a/test/optimizer/tpcc_plan_seq_scan.cpp
+++ b/test/optimizer/tpcc_plan_seq_scan.cpp
@@ -35,8 +35,8 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelect) {
     auto &schema = test->accessor_->GetSchema(tbl_oid);
     EXPECT_EQ(seq->GetTableOid(), test->tbl_new_order_);
 
-    EXPECT_EQ(seq->GetColumnIds().size(), 1);
-    EXPECT_EQ(seq->GetColumnIds()[0], schema.GetColumn("no_o_id").Oid());
+    EXPECT_EQ(seq->GetColumnOids().size(), 1);
+    EXPECT_EQ(seq->GetColumnOids()[0], schema.GetColumn("no_o_id").Oid());
   };
 
   std::string query = "SELECT NO_O_ID FROM \"NEW ORDER\"";
@@ -57,8 +57,8 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicate) {
     EXPECT_EQ(seq->GetDatabaseOid(), test->db_);
     EXPECT_EQ(seq->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());
     EXPECT_EQ(seq->GetTableOid(), test->tbl_order_);
-    EXPECT_EQ(seq->GetColumnIds().size(), 1);
-    EXPECT_EQ(seq->GetColumnIds()[0], schema.GetColumn("o_id").Oid());
+    EXPECT_EQ(seq->GetColumnOids().size(), 1);
+    EXPECT_EQ(seq->GetColumnOids()[0], schema.GetColumn("o_id").Oid());
 
     // Check Scan Predicate
     auto scan_pred = seq->GetScanPredicate();
@@ -112,9 +112,9 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateOrderBy) {
     EXPECT_EQ(seq->GetDatabaseOid(), test->db_);
     EXPECT_EQ(seq->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());
     EXPECT_EQ(seq->GetTableOid(), test->tbl_order_);
-    EXPECT_EQ(seq->GetColumnIds().size(), 2);
-    EXPECT_EQ(seq->GetColumnIds()[0], schema.GetColumn("o_ol_cnt").Oid());
-    EXPECT_EQ(seq->GetColumnIds()[1], schema.GetColumn("o_id").Oid());
+    EXPECT_EQ(seq->GetColumnOids().size(), 2);
+    EXPECT_EQ(seq->GetColumnOids()[0], schema.GetColumn("o_ol_cnt").Oid());
+    EXPECT_EQ(seq->GetColumnOids()[1], schema.GetColumn("o_id").Oid());
 
     // Check scan predicate
     auto scan_pred = seq->GetScanPredicate();
@@ -156,8 +156,8 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateLimit) {
     EXPECT_EQ(seq->GetDatabaseOid(), test->db_);
     EXPECT_EQ(seq->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());
     EXPECT_EQ(seq->GetTableOid(), test->tbl_order_);
-    EXPECT_EQ(seq->GetColumnIds().size(), 1);
-    EXPECT_EQ(seq->GetColumnIds()[0], schema.GetColumn("o_id").Oid());
+    EXPECT_EQ(seq->GetColumnOids().size(), 1);
+    EXPECT_EQ(seq->GetColumnOids()[0], schema.GetColumn("o_id").Oid());
 
     // Check scan predicate
     auto scan_pred = seq->GetScanPredicate();
@@ -219,9 +219,9 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateOrderByLimit) {
     EXPECT_EQ(seq->GetDatabaseOid(), test->db_);
     EXPECT_EQ(seq->GetNamespaceOid(), test->accessor_->GetDefaultNamespace());
     EXPECT_EQ(seq->GetTableOid(), test->tbl_order_);
-    EXPECT_EQ(seq->GetColumnIds().size(), 2);
-    EXPECT_EQ(seq->GetColumnIds()[0], schema.GetColumn("o_ol_cnt").Oid());
-    EXPECT_EQ(seq->GetColumnIds()[1], schema.GetColumn("o_id").Oid());
+    EXPECT_EQ(seq->GetColumnOids().size(), 2);
+    EXPECT_EQ(seq->GetColumnOids()[0], schema.GetColumn("o_ol_cnt").Oid());
+    EXPECT_EQ(seq->GetColumnOids()[1], schema.GetColumn("o_id").Oid());
 
     // Check scan predicate
     auto scan_pred = seq->GetScanPredicate();


### PR DESCRIPTION
PR fixes the following set of bugs between the optimizer and execution engine:
- [x] OutputSchema of Seq/Index scans are now ColumnValueExpressions
- [x] IndexScanPlanNode's TableOid was not being set
- [x] Seq/Index scans predicate use ColumnValueExpressions

(actual index scans will be fixed in a separate PR)