### PR TITLE
Fix read-only txns commit callback not invoked with logging enabled

### DIFF
--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -289,7 +289,7 @@ class DBMain {
       std::unique_ptr<storage::LogManager> log_manager = DISABLED;
       if (use_logging_) {
         log_manager = std::make_unique<storage::LogManager>(
-            log_file_path_, num_log_manager_buffers_, std::chrono::milliseconds{log_serialization_interval_},
+            log_file_path_, num_log_manager_buffers_, std::chrono::microseconds{log_serialization_interval_},
             std::chrono::milliseconds{log_persist_interval_}, log_persist_threshold_,
             common::ManagedPointer(buffer_segment_pool), common::ManagedPointer(thread_registry));
         log_manager->Start();

--- a/src/storage/write_ahead_log/log_serializer_task.cpp
+++ b/src/storage/write_ahead_log/log_serializer_task.cpp
@@ -73,7 +73,7 @@ bool LogSerializerTask::Process() {
     }
 
     // Mark the last buffer that was written to as full
-    if (filled_buffer_ != nullptr) HandFilledBufferToWriter();
+    if (buffers_processed) HandFilledBufferToWriter();
 
     // Bulk remove all the transactions we serialized. This prevents having to take the TimestampManager's latch once
     // for each timestamp we remove.


### PR DESCRIPTION
Issue: Nothing gets serialized into a buffer for read-only txns, but the condition for handing stuff to the disk consumer task (responsible for invoking commit callbacks) is if anything was serialized. 

How to reproduce: send `BEGIN; COMMIT;` over psql and seeing `COMMIT;` block forever.

Changes:

- `LogSerializerTask` will hand off what it has to `DiskLogConsumerTask` if it processed any log records, regardless of whether it serialized anything from those records

- `DiskLogConsumerTask` checks in case it's processing an empty buffer (all read-only txns) rather than blindly dereferencing it (which was safe and protected by an assertion before).

- Added a test with a real callback to verify correctness.

- Fixed an unrelated bug in `DBMain` for one of the args to the `LogManager`.