### PR TITLE
Analyze

### DIFF
--- a/src/include/optimizer/analyze.h
+++ b/src/include/optimizer/analyze.h
@@ -15,32 +15,32 @@
 namespace terrier {
 
 /**
-* Helper Function for Analyze - calculates the column stats for a particular column
-*
-* @param database oid of the database containing the table containing the column
-* @param table oid of the table containing the column
-* @param column id of the column
-* @param pointer to the sql table containing the column
-* @param pointer to OLAP transaction to scan the column
-* @param The number of most frequent values to be collected in the column stats object
-* @return column stats object containing the column stats
-*/
+ * Helper Function for Analyze - calculates the column stats for a particular column
+ *
+ * @param database oid of the database containing the table containing the column
+ * @param table oid of the table containing the column
+ * @param column id of the column
+ * @param pointer to the sql table containing the column
+ * @param pointer to OLAP transaction to scan the column
+ * @param The number of most frequent values to be collected in the column stats object
+ * @return column stats object containing the column stats
+ */
 template <typename T>
 terrier::optimizer::ColumnStats CalculateColumnStats(catalog::db_oid_t database_id, catalog::table_oid_t table_id,
                                                      catalog::col_oid_t columnID, storage::SqlTable *sql_table,
                                                      terrier::transaction::TransactionContext *scan_txn,
                                                      unsigned mostFrequentNumber);
 /**
-* Analyzes a table and returns a vector of column stats objects for all its columns
-*
-* @param database oid of the database containing the table to analyze
-* @param table oid of the table to analyze
-* @param schema of the table to analuze
-* @param pointer to the sql table
-* @param pointer to OLAP transaction to scan the column
-* @param The number of most frequent values to be collected in the column stats object
-* @return vector of column stats object containing the column stats of all columns of the table
-*/
+ * Analyzes a table and returns a vector of column stats objects for all its columns
+ *
+ * @param database oid of the database containing the table to analyze
+ * @param table oid of the table to analyze
+ * @param schema of the table to analuze
+ * @param pointer to the sql table
+ * @param pointer to OLAP transaction to scan the column
+ * @param The number of most frequent values to be collected in the column stats object
+ * @return vector of column stats object containing the column stats of all columns of the table
+ */
 std::vector<terrier::optimizer::ColumnStats> Analyze(catalog::db_oid_t database_id, catalog::table_oid_t table_id,
                                                      const catalog::Schema &table_schema, storage::SqlTable *sql_table,
                                                      terrier::transaction::TransactionContext *scan_txn,

--- a/src/include/optimizer/analyze.h
+++ b/src/include/optimizer/analyze.h
@@ -14,12 +14,33 @@
 
 namespace terrier {
 
+/**
+* Helper Function for Analyze - calculates the column stats for a particular column
+*
+* @param database oid of the database containing the table containing the column
+* @param table oid of the table containing the column
+* @param column id of the column
+* @param pointer to the sql table containing the column
+* @param pointer to OLAP transaction to scan the column
+* @param The number of most frequent values to be collected in the column stats object
+* @return column stats object containing the column stats
+*/
 template <typename T>
 terrier::optimizer::ColumnStats CalculateColumnStats(catalog::db_oid_t database_id, catalog::table_oid_t table_id,
                                                      catalog::col_oid_t columnID, storage::SqlTable *sql_table,
                                                      terrier::transaction::TransactionContext *scan_txn,
                                                      unsigned mostFrequentNumber);
-
+/**
+* Analyzes a table and returns a vector of column stats objects for all its columns
+*
+* @param database oid of the database containing the table to analyze
+* @param table oid of the table to analyze
+* @param schema of the table to analuze
+* @param pointer to the sql table
+* @param pointer to OLAP transaction to scan the column
+* @param The number of most frequent values to be collected in the column stats object
+* @return vector of column stats object containing the column stats of all columns of the table
+*/
 std::vector<terrier::optimizer::ColumnStats> Analyze(catalog::db_oid_t database_id, catalog::table_oid_t table_id,
                                                      const catalog::Schema &table_schema, storage::SqlTable *sql_table,
                                                      terrier::transaction::TransactionContext *scan_txn,

--- a/src/include/optimizer/analyze.h
+++ b/src/include/optimizer/analyze.h
@@ -1,0 +1,27 @@
+#include <cfloat>
+#include <map>
+#include <vector>
+
+#include "main/db_main.h"
+#include "optimizer/statistics/column_stats.h"
+#include "storage/garbage_collector_thread.h"
+#include "storage/projected_row.h"
+#include "storage/sql_table.h"
+#include "transaction/transaction_context.h"
+#include "transaction/transaction_manager.h"
+#include "type/type_id.h"
+#include "type/type_util.h"
+
+namespace terrier {
+
+template <typename T>
+terrier::optimizer::ColumnStats CalculateColumnStats(catalog::db_oid_t database_id, catalog::table_oid_t table_id,
+                                                     catalog::col_oid_t columnID, storage::SqlTable *sql_table,
+                                                     terrier::transaction::TransactionContext *scan_txn,
+                                                     unsigned mostFrequentNumber);
+
+std::vector<terrier::optimizer::ColumnStats> Analyze(catalog::db_oid_t database_id, catalog::table_oid_t table_id,
+                                                     const catalog::Schema &table_schema, storage::SqlTable *sql_table,
+                                                     terrier::transaction::TransactionContext *scan_txn,
+                                                     unsigned mostFrequentNumber);
+}  // namespace terrier

--- a/src/include/optimizer/statistics/column_stats.h
+++ b/src/include/optimizer/statistics/column_stats.h
@@ -47,10 +47,34 @@ class ColumnStats {
   ColumnStats() = default;
 
   /**
+   * Gets the database ID of the column
+   * @return the database_id_
+   */
+  catalog::db_oid_t GetDatabaseID() const { return database_id_; }
+
+  /**
+   * Gets the table ID of the column
+   * @return the table_id_
+   */
+  catalog::table_oid_t GetTableID() const { return table_id_; }
+
+  /**
    * Gets the column oid of the column
    * @return the column oid
    */
   catalog::col_oid_t GetColumnID() const { return column_id_; }
+
+  /**
+   * Gets the fraction of Null values of the column
+   * @return frac_null_
+   */
+  double GetFracNull() const { return frac_null_; }
+
+  /**
+   * Returns True if the column is part of a base table
+   * @return is_base_table_
+   */
+  bool BaseTable() const { return is_base_table_; }
 
   /**
    * Gets the number of rows in the column

--- a/src/optimizer/analyze.cpp
+++ b/src/optimizer/analyze.cpp
@@ -78,6 +78,7 @@ terrier::optimizer::ColumnStats CalculateColumnStats(catalog::db_oid_t database_
                                             static_cast<double>(num_null_values) / static_cast<double>(num_rows),
                                             most_common_values, most_common_frequencies, histogram_bounds, true);
 
+  delete[] buffer;
   return col_stats;
 }
 

--- a/src/optimizer/analyze.cpp
+++ b/src/optimizer/analyze.cpp
@@ -1,0 +1,143 @@
+#include <algorithm>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <random>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "optimizer/analyze.h"
+
+namespace terrier {
+
+template <typename T>
+terrier::optimizer::ColumnStats CalculateColumnStats(catalog::db_oid_t database_id, catalog::table_oid_t table_id,
+                                                     catalog::col_oid_t columnID, storage::SqlTable *sql_table,
+                                                     terrier::transaction::TransactionContext *scan_txn,
+                                                     unsigned mostFrequentNumber) {
+  // Stats collecting temporary data-structures
+  std::unordered_map<T, unsigned> counting_map;
+  unsigned num_null_values = 0;
+  unsigned num_rows = 0;
+  unsigned top_k = mostFrequentNumber;
+  std::vector<double> histogram_bounds;
+  histogram_bounds.push_back(DBL_MAX);
+  histogram_bounds.push_back(DBL_MIN);
+
+  std::vector<catalog::col_oid_t> current_col_oid_vector{columnID};
+  storage::ProjectionMap projection_list_indices = sql_table->ProjectionMapForOids(current_col_oid_vector);
+  auto initializer =
+      sql_table->InitializerForProjectedColumns(current_col_oid_vector, common::Constants::K_DEFAULT_VECTOR_SIZE);
+  auto *buffer = common::AllocationUtil::AllocateAligned(initializer.ProjectedColumnsSize());
+  storage::ProjectedColumns *projected_column = initializer.Initialize(buffer);
+
+  // scan the results
+  auto iterator_table = sql_table->begin();
+  while (iterator_table != sql_table->end()) {
+    sql_table->Scan(scan_txn, &iterator_table, projected_column);
+    common::RawBitmap *null_bit_map = projected_column->ColumnNullBitmap(projection_list_indices[columnID]);
+    T *col_pointer = reinterpret_cast<T *>(projected_column->ColumnStart(projection_list_indices[columnID]));
+    for (uint32_t i = 0; i < projected_column->NumTuples(); i++) {
+      if (null_bit_map->Test(i)) {
+        if (counting_map.find(col_pointer[i]) != counting_map.end())
+          counting_map[col_pointer[i]]++;
+        else
+          counting_map[col_pointer[i]] = 1;
+
+        histogram_bounds[0] = std::min(static_cast<double>(col_pointer[i]), histogram_bounds[0]);
+        histogram_bounds[1] = std::max(static_cast<double>(col_pointer[i]), histogram_bounds[1]);
+      } else {
+        num_null_values += 1;
+      }
+      num_rows += 1;
+    }
+  }
+
+  std::vector<std::pair<double, double>> intermediate_hist;
+  intermediate_hist.reserve(counting_map.size());
+  for (auto it : counting_map) {
+    intermediate_hist.emplace_back(std::make_pair(static_cast<double>(it.second), static_cast<double>(it.first)));
+  }
+
+  std::sort(intermediate_hist.begin(), intermediate_hist.end());
+  std::reverse(intermediate_hist.begin(), intermediate_hist.end());
+
+  std::vector<double> most_common_values;
+  std::vector<double> most_common_frequencies;
+
+  unsigned index = 0;
+  while (top_k--) {
+    most_common_values.push_back(intermediate_hist[index].second);
+    most_common_frequencies.push_back(intermediate_hist[index].first);
+    index++;
+  }
+
+  terrier::optimizer::ColumnStats col_stats(database_id, table_id, columnID, num_rows, counting_map.size(),
+                                            static_cast<double>(num_null_values) / static_cast<double>(num_rows),
+                                            most_common_values, most_common_frequencies, histogram_bounds, true);
+
+  return col_stats;
+}
+
+std::vector<terrier::optimizer::ColumnStats> Analyze(catalog::db_oid_t database_id, catalog::table_oid_t table_id,
+                                                     const catalog::Schema &table_schema, storage::SqlTable *sql_table,
+                                                     terrier::transaction::TransactionContext *scan_txn,
+                                                     unsigned mostFrequentNumber) {
+  std::vector<catalog::col_oid_t> col_oids;
+  col_oids.reserve(table_schema.GetColumns().size());
+  for (const auto &col : table_schema.GetColumns()) {
+    col_oids.push_back(col.Oid());
+  }
+
+  std::vector<terrier::optimizer::ColumnStats> col_stats_vector;
+
+  for (auto col_id_iterator : col_oids) {
+    switch (table_schema.GetColumn(col_id_iterator).Type()) {
+      case static_cast<terrier::type::TypeId>(0): {
+        break;
+      }
+      case static_cast<terrier::type::TypeId>(1): {
+        col_stats_vector.emplace_back(CalculateColumnStats<bool>(database_id, table_id, col_id_iterator, sql_table,
+                                                                 scan_txn, mostFrequentNumber));
+        break;
+      }
+      case static_cast<terrier::type::TypeId>(2): {
+        col_stats_vector.emplace_back(CalculateColumnStats<int8_t>(database_id, table_id, col_id_iterator, sql_table,
+                                                                   scan_txn, mostFrequentNumber));
+        break;
+      }
+      case static_cast<terrier::type::TypeId>(3): {
+        col_stats_vector.emplace_back(CalculateColumnStats<int16_t>(database_id, table_id, col_id_iterator, sql_table,
+                                                                    scan_txn, mostFrequentNumber));
+        break;
+      }
+      case static_cast<terrier::type::TypeId>(4): {
+        col_stats_vector.emplace_back(CalculateColumnStats<int32_t>(database_id, table_id, col_id_iterator, sql_table,
+                                                                    scan_txn, mostFrequentNumber));
+        break;
+      }
+      case static_cast<terrier::type::TypeId>(5): {
+        col_stats_vector.emplace_back(CalculateColumnStats<int64_t>(database_id, table_id, col_id_iterator, sql_table,
+                                                                    scan_txn, mostFrequentNumber));
+        break;
+      }
+      case static_cast<terrier::type::TypeId>(6): {
+        col_stats_vector.emplace_back(CalculateColumnStats<uint64_t>(database_id, table_id, col_id_iterator, sql_table,
+                                                                     scan_txn, mostFrequentNumber));
+        break;
+      }
+      case static_cast<terrier::type::TypeId>(7): {
+        col_stats_vector.emplace_back(CalculateColumnStats<double>(database_id, table_id, col_id_iterator, sql_table,
+                                                                   scan_txn, mostFrequentNumber));
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return col_stats_vector;
+}
+}  // namespace terrier

--- a/test/optimizer/analyze_test.cpp
+++ b/test/optimizer/analyze_test.cpp
@@ -58,9 +58,8 @@ class AnalyzeTests : public TerrierTest {
 };
 
 /**
- * This test creates multiple worker threads that all try to insert [0,num_inserts) as tuples in the table and into the
- * primary key index. At completion of the workload, only num_inserts_ txns should have committed with visible versions
- * in the index and table.
+ * This test creates fills in the table with i values for all i between 0 to 99. Then it runs the analyze function
+ and confirms the column stats generated.
  */
 // NOLINTNEXTLINE
 TEST_F(AnalyzeTests, SingleColumnTest) {

--- a/test/optimizer/analyze_test.cpp
+++ b/test/optimizer/analyze_test.cpp
@@ -1,0 +1,119 @@
+#include <limits>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "main/db_main.h"
+#include "optimizer/analyze.h"
+#include "optimizer/statistics/column_stats.h"
+#include "storage/garbage_collector_thread.h"
+#include "storage/projected_row.h"
+#include "storage/sql_table.h"
+#include "test_util/catalog_test_util.h"
+#include "test_util/test_harness.h"
+#include "transaction/transaction_context.h"
+#include "transaction/transaction_manager.h"
+#include "type/type_id.h"
+#include "type/type_util.h"
+
+namespace terrier::storage::index {
+
+class AnalyzeTests : public TerrierTest {
+ private:
+  catalog::IndexSchema unique_schema_;
+  catalog::IndexSchema default_schema_;
+
+ public:
+  std::unique_ptr<DBMain> db_main_;
+  common::ManagedPointer<transaction::TransactionManager> txn_manager_;
+
+  // SqlTable
+  catalog::Schema table_schema_;
+  storage::SqlTable *sql_table_;
+  storage::ProjectedRowInitializer tuple_initializer_ =
+      storage::ProjectedRowInitializer::Create(std::vector<uint16_t>{1}, std::vector<uint16_t>{1});
+
+ protected:
+  void SetUp() override {
+    db_main_ = terrier::DBMain::Builder().SetUseGC(true).SetUseGCThread(true).SetRecordBufferSegmentSize(1e6).Build();
+    txn_manager_ = db_main_->GetTransactionLayer()->GetTransactionManager();
+
+    auto col = catalog::Schema::Column(
+        "attribute", type::TypeId::INTEGER, false,
+        parser::ConstantValueExpression(type::TransientValueFactory::GetNull(type::TypeId::INTEGER)));
+    StorageTestUtil::ForceOid(&(col), catalog::col_oid_t(1));
+    table_schema_ = catalog::Schema({col});
+    sql_table_ = new storage::SqlTable(db_main_->GetStorageLayer()->GetBlockStore().Get(), table_schema_);
+    tuple_initializer_ = sql_table_->InitializerForProjectedRow({catalog::col_oid_t(1)});
+
+    std::vector<catalog::IndexSchema::Column> keycols;
+    keycols.emplace_back("", type::TypeId::INTEGER, false,
+                         parser::ColumnValueExpression(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID,
+                                                       catalog::col_oid_t(1)));
+    StorageTestUtil::ForceOid(&(keycols[0]), catalog::indexkeycol_oid_t(1));
+  }
+  void TearDown() override {
+    db_main_->GetTransactionLayer()->GetDeferredActionManager()->RegisterDeferredAction([=]() { delete sql_table_; });
+  }
+};
+
+/**
+ * This test creates multiple worker threads that all try to insert [0,num_inserts) as tuples in the table and into the
+ * primary key index. At completion of the workload, only num_inserts_ txns should have committed with visible versions
+ * in the index and table.
+ */
+// NOLINTNEXTLINE
+TEST_F(AnalyzeTests, SingleColumnTest) {
+  const uint32_t num_inserts = 100;
+
+  std::vector<catalog::col_oid_t> col_oids;
+  col_oids.reserve(table_schema_.GetColumns().size());
+  for (const auto &col : table_schema_.GetColumns()) {
+    col_oids.push_back(col.Oid());
+  }
+  ProjectionMap projection_list_indices = sql_table_->ProjectionMapForOids(col_oids);
+
+  for (uint32_t i = 0; i < num_inserts; i++) {
+    for (uint32_t j = 0; j < i; j++) {
+      auto *const insert_txn = txn_manager_->BeginTransaction();
+      auto *const insert_redo =
+          insert_txn->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
+      auto *const insert_tuple = insert_redo->Delta();
+      *reinterpret_cast<int32_t *>(insert_tuple->AccessForceNotNull(projection_list_indices[catalog::col_oid_t(1)])) =
+          static_cast<int32_t>(i) * 2;
+      sql_table_->Insert(insert_txn, insert_redo);
+      txn_manager_->Commit(insert_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+    }
+  }
+
+  auto *const scan_txn = txn_manager_->BeginTransaction();
+
+  auto result_analyze =
+      Analyze(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, table_schema_, sql_table_, scan_txn, 10);
+
+  txn_manager_->Commit(scan_txn, transaction::TransactionUtil::EmptyCallback, nullptr);
+
+  std::vector<double> result_most_common_values{198, 196, 194, 192, 190, 188, 186, 184, 182, 180};
+  std::vector<double> result_most_common_frequencies{99, 98, 97, 96, 95, 94, 93, 92, 91, 90};
+  std::vector<double> result_histogram_bounds{2, 198};
+
+  EXPECT_EQ(result_analyze[0].GetDatabaseID(), CatalogTestUtil::TEST_DB_OID);
+  EXPECT_EQ(result_analyze[0].GetTableID(), CatalogTestUtil::TEST_TABLE_OID);
+  EXPECT_EQ(result_analyze[0].GetColumnID(), catalog::col_oid_t(1));
+  EXPECT_EQ(result_analyze[0].GetNumRows(), 99 * 50); /* n*(n+1) / 2*/
+  EXPECT_EQ(result_analyze[0].GetCardinality(), 99);
+  EXPECT_EQ(result_analyze[0].GetFracNull(), (double)0);
+  EXPECT_TRUE(result_analyze[0].BaseTable());
+
+  for (unsigned i = 0; i < 10; i++) {
+    EXPECT_EQ(result_analyze[0].GetCommonVals()[i], result_most_common_values[i]);
+  }
+  for (unsigned i = 0; i < 10; i++) {
+    EXPECT_EQ(result_analyze[0].GetCommonFreqs()[i], result_most_common_frequencies[i]);
+  }
+  for (unsigned i = 0; i < 2; i++) {
+    EXPECT_EQ(result_analyze[0].GetHistogramBounds()[i], result_histogram_bounds[i]);
+  }
+}
+
+}  // namespace terrier::storage::index


### PR DESCRIPTION
This is starting of the work to build stats collecting and storing functionality to be merged into terrier so that the cost model can be used more effectively using real stats and the optimizer's effectiveness can be tested on Join Orderings. Also this functionality is required to have the optimizer support parameter value expressions such as while optimizing prepare statements before the first execute is called.
This PR merges analyze function, that given a table scans it and returns a vector of column stats collected for that table. A test case is provided.
Further work includes generating table stats, pg stats and storing the stats somewhere permanent and not in the heap.