### PR TITLE
pg_catalog not ending up in the default namespace search path

### DIFF
--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -30,14 +30,22 @@ void BinderContext::AddRegularTable(const common::ManagedPointer<catalog::Catalo
     throw BINDER_EXCEPTION(("Unknown database name " + db_name).c_str());
   }
 
-  auto namespace_id = accessor->GetNamespaceOid(namespace_name);
-  if (namespace_id == catalog::INVALID_NAMESPACE_OID) {
-    throw BINDER_EXCEPTION(("Unknown namespace name " + namespace_name).c_str());
-  }
+  catalog::table_oid_t table_id;
+  if (!namespace_name.empty()) {
+    auto namespace_id = accessor->GetNamespaceOid(namespace_name);
+    if (namespace_id == catalog::INVALID_NAMESPACE_OID) {
+      throw BINDER_EXCEPTION(("Unknown namespace name " + namespace_name).c_str());
+    }
 
-  auto table_id = accessor->GetTableOid(namespace_id, table_name);
-  if (table_id == catalog::INVALID_TABLE_OID) {
-    throw BINDER_EXCEPTION(("Unknown table name " + table_name).c_str());
+    table_id = accessor->GetTableOid(namespace_id, table_name);
+    if (table_id == catalog::INVALID_TABLE_OID) {
+      throw BINDER_EXCEPTION(("Unknown table name " + table_name).c_str());
+    }
+  } else {
+    table_id = accessor->GetTableOid(table_name);
+    if (table_id == catalog::INVALID_TABLE_OID) {
+      throw BINDER_EXCEPTION(("Unknown table name " + table_name).c_str());
+    }
   }
 
   auto schema = accessor->GetSchema(table_id);


### PR DESCRIPTION
Fix #707.

pg_catalog not ending up in the default namespace search path

The issue was when running the query
terrier=# select * from pg_index;
ERROR:  binding failed

We shouldn't have to qualify pg_catalog.pg_index. It was in the binder context's AddRegularTable method when passing the empty string for the namespace. It set it to default, public. Then uses this public namespace and the table name (even though the table is not in public) to fetch the tableoid, where it was getting the binding issue.

Tested it out locally on
select * from pg_index;
select * from pg_class;