### PR TITLE
CREATE TABLE with a qualified namespace work as expected

### DIFF
--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -295,7 +295,7 @@ void QueryToOperatorTransformer::Visit(parser::CreateStatement *op, parser::Pars
       break;
     case parser::CreateStatement::CreateType::kTable:
       create_expr = std::make_unique<OperatorExpression>(
-          LogicalCreateTable::Make(accessor_->GetDefaultNamespace(), op->GetTableName(), op->GetColumns(),
+          LogicalCreateTable::Make(accessor_->GetNamespaceOid(op->GetNamespaceName()), op->GetTableName(), op->GetColumns(),
                                    op->GetForeignKeys()),
           std::vector<std::unique_ptr<OperatorExpression>>{});
       // TODO(Ling): for other procedures to generate create table plan, refer to create_table_plan_node builder.

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -295,8 +295,8 @@ void QueryToOperatorTransformer::Visit(parser::CreateStatement *op, parser::Pars
       break;
     case parser::CreateStatement::CreateType::kTable:
       create_expr = std::make_unique<OperatorExpression>(
-          LogicalCreateTable::Make(accessor_->GetNamespaceOid(op->GetNamespaceName()), op->GetTableName(), op->GetColumns(),
-                                   op->GetForeignKeys()),
+          LogicalCreateTable::Make(accessor_->GetNamespaceOid(op->GetNamespaceName()), op->GetTableName(),
+                                   op->GetColumns(), op->GetForeignKeys()),
           std::vector<std::unique_ptr<OperatorExpression>>{});
       // TODO(Ling): for other procedures to generate create table plan, refer to create_table_plan_node builder.
       //  Following part might be more adequate to be handled by optimizer when it it actually constructing the plan


### PR DESCRIPTION
Fix #706.
```
terrier=# create schema foo;
CREATE SCHEMA
terrier=# create table foo.bar (id integer);
CREATE TABLE
terrier=# SELECT * from pg_catalog.pg_class;
```

The results show that the table ends up in the public namespace rather than foo, so there's a bug somewhere. 

This PR: default namespace was being used and thats why the table was always created under the public namespace.