### PR TITLE
Implement Date and Timestamp support

### DIFF
--- a/sample_tpl/tpl_tests.txt
+++ b/sample_tpl/tpl_tests.txt
@@ -39,6 +39,7 @@ types/int_aggregators.tpl,false,0
 types/real_aggregators.tpl,false,0
 types/dates.tpl,false,0
 types/strings.tpl,false,0
+types/timestamps.tpl,false,0
 #scope.tpl,false,3 <Add after merging Wan's scoping PR>
 #scope-2.tpl,false,42 <Add after merging Wan's scoping PR>
 

--- a/sample_tpl/types/timestamps.tpl
+++ b/sample_tpl/types/timestamps.tpl
@@ -1,0 +1,20 @@
+fun main() -> int64 {
+  var present1 = @timestampToSqlHMSu(2019, 1, 2, 11, 22, 33, 120)
+  var present2 = @timestampToSqlHMSu(2019, 1, 2, 11, 22, 33, 120)
+  var future = @timestampToSqlHMSu(2019, 1, 2, 11, 22, 33, 121)
+  var past = @timestampToSqlHMSu(2019, 1, 2, 11, 22, 33, 119)
+
+  if (present1 != present2 or !(@sqlToBool(present1 == present2))) {
+    return 1
+  }
+
+  if (present1 >= future or !(@sqlToBool(future > present1))) {
+    return 1
+  }
+
+  if (present1 <= past or !(@sqlToBool(past < present1))) {
+    return 1
+  }
+
+  return 0
+}

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "binder/binder_util.h"
 #include "catalog/catalog_accessor.h"
 #include "catalog/catalog_defs.h"
 #include "common/exception.h"
@@ -16,12 +17,17 @@
 #include "parser/expression/aggregate_expression.h"
 #include "parser/expression/case_expression.h"
 #include "parser/expression/column_value_expression.h"
+#include "parser/expression/constant_value_expression.h"
 #include "parser/expression/function_expression.h"
 #include "parser/expression/operator_expression.h"
 #include "parser/expression/star_expression.h"
 #include "parser/expression/subquery_expression.h"
+#include "parser/expression/type_cast_expression.h"
 #include "parser/sql_statement.h"
+#include "type/transient_value_factory.h"
+#include "type/transient_value_peeker.h"
 #include "type/type_id.h"
+#include "util/time_util.h"
 
 namespace terrier::binder {
 
@@ -35,7 +41,7 @@ void BindNodeVisitor::BindNameToNode(common::ManagedPointer<parser::SQLStatement
 }
 
 void BindNodeVisitor::Visit(parser::SelectStatement *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting SelectStatement ...");
+  BINDER_LOG_TRACE("Visiting SelectStatement ...");
   context_ = new BinderContext(context_);
 
   if (node->GetSelectTable() != nullptr) node->GetSelectTable()->Accept(this, parse_result);
@@ -52,7 +58,7 @@ void BindNodeVisitor::Visit(parser::SelectStatement *node, parser::ParseResult *
   if (node->GetSelectGroupBy() != nullptr) node->GetSelectGroupBy()->Accept(this, parse_result);
 
   std::vector<common::ManagedPointer<parser::AbstractExpression>> new_select_list;
-  BINDER_LOG_DEBUG("Gathering select columns...");
+  BINDER_LOG_TRACE("Gathering select columns...");
   for (auto &select_element : node->GetSelectColumns()) {
     if (select_element->GetExpressionType() == parser::ExpressionType::STAR) {
       context_->GenerateAllColumnExpressions(parse_result, &new_select_list);
@@ -82,7 +88,7 @@ void BindNodeVisitor::Visit(parser::SelectStatement *node, parser::ParseResult *
 
 // Some sub query nodes inside SelectStatement
 void BindNodeVisitor::Visit(parser::JoinDefinition *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting JoinDefinition ...");
+  BINDER_LOG_TRACE("Visiting JoinDefinition ...");
   // The columns in join condition can only bind to the join tables
   node->GetLeftTable()->Accept(this, parse_result);
   node->GetRightTable()->Accept(this, parse_result);
@@ -90,7 +96,7 @@ void BindNodeVisitor::Visit(parser::JoinDefinition *node, parser::ParseResult *p
 }
 
 void BindNodeVisitor::Visit(parser::TableRef *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting TableRef ...");
+  BINDER_LOG_TRACE("Visiting TableRef ...");
   node->TryBindDatabaseName(default_database_name_);
   if (node->GetSelect() != nullptr) {
     if (node->GetAlias().empty()) throw BINDER_EXCEPTION("Alias not found for query derived table");
@@ -118,19 +124,19 @@ void BindNodeVisitor::Visit(parser::TableRef *node, parser::ParseResult *parse_r
 }
 
 void BindNodeVisitor::Visit(parser::GroupByDescription *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting GroupByDescription ...");
+  BINDER_LOG_TRACE("Visiting GroupByDescription ...");
   for (auto &col : node->GetColumns()) col->Accept(this, parse_result);
   if (node->GetHaving() != nullptr) node->GetHaving()->Accept(this, parse_result);
 }
 
 void BindNodeVisitor::Visit(parser::OrderByDescription *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting OrderByDescription ...");
+  BINDER_LOG_TRACE("Visiting OrderByDescription ...");
   for (auto &expr : node->GetOrderByExpressions())
     if (expr != nullptr) expr->Accept(this, parse_result);
 }
 
 void BindNodeVisitor::Visit(parser::UpdateStatement *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting UpdateStatement ...");
+  BINDER_LOG_TRACE("Visiting UpdateStatement ...");
   context_ = new BinderContext(nullptr);
 
   node->GetUpdateTable()->Accept(this, parse_result);
@@ -144,7 +150,7 @@ void BindNodeVisitor::Visit(parser::UpdateStatement *node, parser::ParseResult *
 }
 
 void BindNodeVisitor::Visit(parser::DeleteStatement *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting DeleteStatement ...");
+  BINDER_LOG_TRACE("Visiting DeleteStatement ...");
   context_ = new BinderContext(nullptr);
   node->GetDeletionTable()->TryBindDatabaseName(default_database_name_);
   auto table = node->GetDeletionTable();
@@ -161,11 +167,11 @@ void BindNodeVisitor::Visit(parser::DeleteStatement *node, parser::ParseResult *
 
 void BindNodeVisitor::Visit(UNUSED_ATTRIBUTE parser::LimitDescription *node,
                             UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting LimitDescription ...");
+  BINDER_LOG_TRACE("Visiting LimitDescription ...");
 }
 
 void BindNodeVisitor::Visit(parser::CopyStatement *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting CopyStatement ...");
+  BINDER_LOG_TRACE("Visiting CopyStatement ...");
   context_ = new BinderContext(nullptr);
   if (node->GetCopyTable() != nullptr) {
     node->GetCopyTable()->Accept(this, parse_result);
@@ -185,11 +191,11 @@ void BindNodeVisitor::Visit(parser::CopyStatement *node, parser::ParseResult *pa
 
 void BindNodeVisitor::Visit(UNUSED_ATTRIBUTE parser::CreateFunctionStatement *node,
                             UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting CreateFunctionStatement ...");
+  BINDER_LOG_TRACE("Visiting CreateFunctionStatement ...");
 }
 
 void BindNodeVisitor::Visit(parser::CreateStatement *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting CreateStatement ...");
+  BINDER_LOG_TRACE("Visiting CreateStatement ...");
   context_ = new BinderContext(context_);
 
   auto create_type = node->GetCreateType();
@@ -297,21 +303,88 @@ void BindNodeVisitor::Visit(parser::CreateStatement *node, parser::ParseResult *
 }
 
 void BindNodeVisitor::Visit(parser::InsertStatement *node, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting InsertStatement ...");
+  BINDER_LOG_TRACE("Visiting InsertStatement ...");
   context_ = new BinderContext(nullptr);
   node->GetInsertionTable()->TryBindDatabaseName(default_database_name_);
+
+  // TODO(WAN): It is unclear what this visitor pattern really buys us. Because of the
+  //  Visit -> Accept [ -> AcceptChildren] -> Visit loop, we lose the context of what we're currently
+  //  binding. Consider binding "INSERT INTO foo VALUES (1, 'a', '2020-01-01'::date);" for input values validation.
+  //  The BinderContext can be extended to maintain the table name that we are currently binding, but by the time
+  //  the visitor pattern sends you to the actual values, we will have lost track of whether we are currently binding
+  //  the first, second, or third column of foo. More generally, the structure of the binder and the expressions it
+  //  uses does not seem to allow for easy non-global reasoning. I could also just be missing something?
+  //  In any case, this is currently how transforming strings to dates is done.
 
   auto table = node->GetInsertionTable();
   context_->AddRegularTable(catalog_accessor_, table->GetDatabaseName(), table->GetNamespaceName(),
                             table->GetTableName(), table->GetTableName());
-  if (node->GetSelect() != nullptr) node->GetSelect()->Accept(this, parse_result);
+
+  if (node->GetSelect() != nullptr) {  // INSERT FROM SELECT
+    node->GetSelect()->Accept(this, parse_result);
+  } else {  // RAW INSERT
+    // Perform input validation and parsing of strings into dates.
+    auto binder_table_data = context_->GetTableMapping(table->GetTableName());
+    const auto &table_schema = std::get<2>(*binder_table_data);
+
+    auto insert_columns = node->GetInsertColumns();
+    // Validate input columns.
+    {
+      // Test that all the insert columns exist.
+      for (const auto &col : *insert_columns) {
+        if (!BinderContext::ColumnInSchema(table_schema, col)) {
+          throw BINDER_EXCEPTION("Insert column does not exist");
+        }
+      }
+    }
+
+    auto num_schema_columns = table_schema.GetColumns().size();
+    auto num_insert_columns = insert_columns->size();  // potentially 0 if unspecified by query
+    auto insert_values = node->GetValues();
+    // Validate input values.
+    {
+      for (auto &values : *insert_values) {
+        size_t num_values = values.size();
+        // Test that they have the same number of columns.
+        {
+          bool is_insert_cols_specified = num_insert_columns != 0;
+          bool insert_cols_ok = is_insert_cols_specified && num_values == num_insert_columns;
+          bool insert_schema_ok = !is_insert_cols_specified && num_values == num_schema_columns;
+          if (!(insert_cols_ok || insert_schema_ok)) {
+            throw BINDER_EXCEPTION("Mismatch in number of insert columns and number of insert values.");
+          }
+        }
+        // Test that the column values are of the right type.
+        for (size_t i = 0; i < num_values; ++i) {
+          // TODO(WAN): handle additional cases, possibly think about calling DeriveReturnValueType
+          //  so that we handle (1+2) type of expressions
+          //  ADDENDUM. So I thought DeriveReturnValueType would actually derive the return value type.
+          //  This appears to be a bad assumption. We should rename it to DeriveReturnValueTypeForAggregates()
+          //  or else fix up any other codepaths. I've currently fixed it for ConstantValueExpression.
+          auto expr = values[i];
+          auto ret_type = expr->GetReturnValueType();
+          auto expected_ret_type = table_schema.GetColumn(i).Type();
+
+          auto is_cast_expression = expr->GetExpressionType() == parser::ExpressionType::OPERATOR_CAST;
+          auto mismatched_type = ret_type != expected_ret_type;
+
+          if (is_cast_expression || mismatched_type) {
+            auto converted = BinderUtil::Convert(values[i], expected_ret_type);
+            TERRIER_ASSERT(converted != nullptr, "Conversion cannot be null!");
+            values[i] = common::ManagedPointer(converted);
+            parse_result->AddExpression(std::move(converted));
+          }
+        }
+      }
+    }
+  }
 
   delete context_;
   context_ = nullptr;
 }
 
 void BindNodeVisitor::Visit(parser::DropStatement *node, UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting DropStatement ...");
+  BINDER_LOG_TRACE("Visiting DropStatement ...");
   context_ = new BinderContext(context_);
 
   auto drop_type = node->GetDropType();
@@ -347,28 +420,35 @@ void BindNodeVisitor::Visit(parser::DropStatement *node, UNUSED_ATTRIBUTE parser
 }
 void BindNodeVisitor::Visit(UNUSED_ATTRIBUTE parser::PrepareStatement *node,
                             UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting PrepareStatement ...");
+  BINDER_LOG_TRACE("Visiting PrepareStatement ...");
 }
 void BindNodeVisitor::Visit(UNUSED_ATTRIBUTE parser::ExecuteStatement *node,
                             UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting ExecuteStatement ...");
+  BINDER_LOG_TRACE("Visiting ExecuteStatement ...");
 }
 void BindNodeVisitor::Visit(UNUSED_ATTRIBUTE parser::TransactionStatement *node,
                             UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting TransactionStatement ...");
+  BINDER_LOG_TRACE("Visiting TransactionStatement ...");
 }
 void BindNodeVisitor::Visit(parser::AnalyzeStatement *node, UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting AnalyzeStatement ...");
+  BINDER_LOG_TRACE("Visiting AnalyzeStatement ...");
   node->GetAnalyzeTable()->TryBindDatabaseName(default_database_name_);
 }
 
 void BindNodeVisitor::Visit(UNUSED_ATTRIBUTE parser::ConstantValueExpression *expr,
                             UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting ConstantValueExpression ...");
+  BINDER_LOG_TRACE("Visiting ConstantValueExpression ...");
+  // TODO(WAN): see comment in Visit(InsertStatement *, ParseResult*)
+}
+
+void BindNodeVisitor::Visit(UNUSED_ATTRIBUTE parser::TypeCastExpression *expr,
+                            UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
+  BINDER_LOG_TRACE("Visiting TypeCastExpression...");
+  // TODO(WAN): see comment in Visit(InsertStatement *, ParseResult*)
 }
 
 void BindNodeVisitor::Visit(parser::ColumnValueExpression *expr, UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting ColumnValueExpression ...");
+  BINDER_LOG_TRACE("Visiting ColumnValueExpression ...");
   // TODO(Ling): consider remove precondition check if the *_oid_ will never be initialized till binder
   //  That is, the object would not be initialized using ColumnValueExpression(database_oid, table_oid, column_oid)
   //  at this point
@@ -401,20 +481,20 @@ void BindNodeVisitor::Visit(parser::ColumnValueExpression *expr, UNUSED_ATTRIBUT
 }
 
 void BindNodeVisitor::Visit(parser::CaseExpression *expr, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting CaseExpression ...");
+  BINDER_LOG_TRACE("Visiting CaseExpression ...");
   for (size_t i = 0; i < expr->GetWhenClauseSize(); ++i) {
     expr->GetWhenClauseCondition(i)->Accept(this, parse_result);
   }
 }
 
 void BindNodeVisitor::Visit(parser::SubqueryExpression *expr, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting SubqueryExpression ...");
+  BINDER_LOG_TRACE("Visiting SubqueryExpression ...");
   expr->GetSubselect()->Accept(this, parse_result);
 }
 
 void BindNodeVisitor::Visit(UNUSED_ATTRIBUTE parser::StarExpression *expr,
                             UNUSED_ATTRIBUTE parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting StarExpression ...");
+  BINDER_LOG_TRACE("Visiting StarExpression ...");
   if (context_ == nullptr || !context_->HasTables()) {
     throw BINDER_EXCEPTION("Invalid [Expression :: STAR].");
   }
@@ -422,12 +502,12 @@ void BindNodeVisitor::Visit(UNUSED_ATTRIBUTE parser::StarExpression *expr,
 
 // Derive value type for these expressions
 void BindNodeVisitor::Visit(parser::OperatorExpression *expr, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting OperatorExpression ...");
+  BINDER_LOG_TRACE("Visiting OperatorExpression ...");
   SqlNodeVisitor::Visit(expr, parse_result);
   expr->DeriveReturnValueType();
 }
 void BindNodeVisitor::Visit(parser::AggregateExpression *expr, parser::ParseResult *parse_result) {
-  BINDER_LOG_DEBUG("Visiting AggregateExpression ...");
+  BINDER_LOG_TRACE("Visiting AggregateExpression ...");
   SqlNodeVisitor::Visit(expr, parse_result);
   expr->DeriveReturnValueType();
 }

--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -235,4 +235,11 @@ void BinderContext::GenerateAllColumnExpressions(
   }
 }
 
+common::ManagedPointer<BinderContext::TableMetadata> BinderContext::GetTableMapping(const std::string &table_name) {
+  if (regular_table_alias_map_.find(table_name) == regular_table_alias_map_.end()) {
+    return nullptr;
+  }
+  return common::ManagedPointer(&regular_table_alias_map_[table_name]);
+}
+
 }  // namespace terrier::binder

--- a/src/execution/ast/ast_dump.cpp
+++ b/src/execution/ast/ast_dump.cpp
@@ -334,6 +334,14 @@ void AstDumperImpl::VisitImplicitCastExpr(ImplicitCastExpr *node) {
         DumpPrimitive("FloatToSqlReal");
         break;
       }
+      case CastKind::SqlTimestampToTimestamp: {
+        DumpPrimitive("SqlTimestampToTimestamp");
+        break;
+      }
+      case CastKind::TimestampToSqlTimestamp: {
+        DumpPrimitive("TimestampToSqlTimestamp");
+        break;
+      }
     }
   }
   DumpPrimitive(">");

--- a/src/execution/compiler/expression/param_value_translator.cpp
+++ b/src/execution/compiler/expression/param_value_translator.cpp
@@ -34,6 +34,9 @@ ast::Expr *ParamValueTranslator::DeriveExpr(ExpressionEvaluator *evaluator) {
     case type::TypeId::DATE:
       builtin = ast::Builtin::GetParamDate;
       break;
+    case type::TypeId::TIMESTAMP:
+      builtin = ast::Builtin::GetParamTimestamp;
+      break;
     case type::TypeId::VARCHAR:
       builtin = ast::Builtin::GetParamString;
       break;

--- a/src/execution/exec/output.cpp
+++ b/src/execution/exec/output.cpp
@@ -57,11 +57,11 @@ void OutputPrinter::operator()(byte *tuples, uint32_t num_tuples, uint32_t tuple
           break;
         }
         case type::TypeId::DATE: {
-          auto *val = reinterpret_cast<sql::Date *>(tuples + row * tuple_size + curr_offset);
+          auto *val = reinterpret_cast<sql::DateVal *>(tuples + row * tuple_size + curr_offset);
           if (val->is_null_) {
             ss << "NULL";
           } else {
-            ss << sql::ValUtil::DateToString(*val);
+            ss << val->val_.ToString();
           }
           break;
         }

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -38,29 +38,95 @@ bool AreAllFunctions(const ArgTypes... type) {
 void Sema::CheckBuiltinMapCall(UNUSED_ATTRIBUTE ast::CallExpr *call) {}
 
 void Sema::CheckBuiltinSqlConversionCall(ast::CallExpr *call, ast::Builtin builtin) {
+  // SQL Date.
   if (builtin == ast::Builtin::DateToSql) {
     if (!CheckArgCountAtLeast(call, 3)) return;
-    auto uint16_t_kind = ast::BuiltinType::Uint16;
-    auto uint8_t_kind = ast::BuiltinType::Uint8;
-    // First argument (year) is a uint16_t
+    auto int32_t_kind = ast::BuiltinType::Int32;
+    auto uint32_t_kind = ast::BuiltinType::Uint32;
+    // First argument (year) is a int32_t
     if (!call->Arguments()[0]->GetType()->IsIntegerType()) {
-      ReportIncorrectCallArg(call, 0, GetBuiltinType(uint16_t_kind));
+      ReportIncorrectCallArg(call, 0, GetBuiltinType(int32_t_kind));
       return;
     }
-    // First argument (month) is a uint8_t
+    // Second argument (month) is a uint32_t
     if (!call->Arguments()[1]->GetType()->IsIntegerType()) {
-      ReportIncorrectCallArg(call, 1, GetBuiltinType(uint8_t_kind));
+      ReportIncorrectCallArg(call, 1, GetBuiltinType(uint32_t_kind));
       return;
     }
-    // First argument (day) is a uint8_t
+    // Third argument (day) is a uint32_t
     if (!call->Arguments()[2]->GetType()->IsIntegerType()) {
-      ReportIncorrectCallArg(call, 2, GetBuiltinType(uint8_t_kind));
+      ReportIncorrectCallArg(call, 2, GetBuiltinType(uint32_t_kind));
       return;
     }
     // Return a date type
     call->SetType(GetBuiltinType(ast::BuiltinType::Date));
     return;
   }
+
+  // SQL Timestamp.
+  if (builtin == ast::Builtin::TimestampToSql) {
+    if (!CheckArgCountAtLeast(call, 1)) {
+      return;
+    }
+    auto uint64_t_kind = ast::BuiltinType::Uint64;
+    // First argument (julian_usec) is a uint64_t
+    if (!call->Arguments()[0]->GetType()->IsIntegerType()) {
+      ReportIncorrectCallArg(call, 0, GetBuiltinType(uint64_t_kind));
+      return;
+    }
+    call->SetType(GetBuiltinType(ast::BuiltinType::Timestamp));
+    return;
+  }
+
+  // SQL Timestamp, HMSu.
+  if (builtin == ast::Builtin::TimestampToSqlHMSu) {
+    if (!CheckArgCountAtLeast(call, 7)) {
+      return;
+    }
+    auto int32_t_kind = ast::BuiltinType::Int32;
+    auto uint8_t_kind = ast::BuiltinType::Uint8;
+    auto uint32_t_kind = ast::BuiltinType::Uint32;
+    auto uint64_t_kind = ast::BuiltinType::Uint64;
+    // First argument (year) is a int32_t
+    if (!call->Arguments()[0]->GetType()->IsIntegerType()) {
+      ReportIncorrectCallArg(call, 0, GetBuiltinType(int32_t_kind));
+      return;
+    }
+    // Second argument (month) is a uint32_t
+    if (!call->Arguments()[1]->GetType()->IsIntegerType()) {
+      ReportIncorrectCallArg(call, 1, GetBuiltinType(uint32_t_kind));
+      return;
+    }
+    // Third argument (day) is a uint32_t
+    if (!call->Arguments()[2]->GetType()->IsIntegerType()) {
+      ReportIncorrectCallArg(call, 2, GetBuiltinType(uint32_t_kind));
+      return;
+    }
+    // Fourth argument (hour) is a uint8_t
+    if (!call->Arguments()[3]->GetType()->IsIntegerType()) {
+      ReportIncorrectCallArg(call, 3, GetBuiltinType(uint8_t_kind));
+      return;
+    }
+    // Fifth argument (minute) is a uint8_t
+    if (!call->Arguments()[4]->GetType()->IsIntegerType()) {
+      ReportIncorrectCallArg(call, 4, GetBuiltinType(uint8_t_kind));
+      return;
+    }
+    // Sixth argument (second) is a uint8_t
+    if (!call->Arguments()[5]->GetType()->IsIntegerType()) {
+      ReportIncorrectCallArg(call, 5, GetBuiltinType(uint8_t_kind));
+      return;
+    }
+    // Seventh argument (microsecond) is a uint64_t
+    if (!call->Arguments()[6]->GetType()->IsIntegerType()) {
+      ReportIncorrectCallArg(call, 6, GetBuiltinType(uint64_t_kind));
+      return;
+    }
+    call->SetType(GetBuiltinType(ast::BuiltinType::Timestamp));
+    return;
+  }
+
+  // One arg functions below.
   if (!CheckArgCount(call, 1)) {
     return;
   }
@@ -1973,6 +2039,10 @@ void Sema::CheckBuiltinParamCall(ast::CallExpr *call, ast::Builtin builtin) {
       sql_type = ast::BuiltinType::Date;
       break;
     }
+    case ast::Builtin::GetParamTimestamp: {
+      sql_type = ast::BuiltinType::Timestamp;
+      break;
+    }
     case ast::Builtin::GetParamString: {
       sql_type = ast::BuiltinType::StringVal;
       break;
@@ -2013,6 +2083,8 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::StringToSql:
     case ast::Builtin::VarlenToSql:
     case ast::Builtin::DateToSql:
+    case ast::Builtin::TimestampToSql:
+    case ast::Builtin::TimestampToSqlHMSu:
     case ast::Builtin::SqlToBool: {
       CheckBuiltinSqlConversionCall(call, builtin);
       break;

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -1041,6 +1041,11 @@ void Sema::CheckBuiltinPCICall(ast::CallExpr *call, ast::Builtin builtin) {
       call->SetType(GetBuiltinType(ast::BuiltinType::Date));
       break;
     }
+    case ast::Builtin::PCIGetTimestamp:
+    case ast::Builtin::PCIGetTimestampNull: {
+      call->SetType(GetBuiltinType(ast::BuiltinType::Timestamp));
+      break;
+    }
     case ast::Builtin::PCIGetVarlen:
     case ast::Builtin::PCIGetVarlenNull: {
       call->SetType(GetBuiltinType(ast::BuiltinType::StringVal));
@@ -1639,6 +1644,12 @@ void Sema::CheckBuiltinPRCall(ast::CallExpr *call, ast::Builtin builtin) {
       sql_type = ast::BuiltinType::Date;
       break;
     }
+    case ast::Builtin::PRSetTimestamp:
+    case ast::Builtin::PRSetTimestampNull: {
+      is_set_call = true;
+      sql_type = ast::BuiltinType::Timestamp;
+      break;
+    }
     case ast::Builtin::PRSetVarlen:
     case ast::Builtin::PRSetVarlenNull: {
       is_set_call = true;
@@ -1671,6 +1682,11 @@ void Sema::CheckBuiltinPRCall(ast::CallExpr *call, ast::Builtin builtin) {
     case ast::Builtin::PRGetDate:
     case ast::Builtin::PRGetDateNull: {
       sql_type = ast::BuiltinType::Date;
+      break;
+    }
+    case ast::Builtin::PRGetTimestamp:
+    case ast::Builtin::PRGetTimestampNull: {
+      sql_type = ast::BuiltinType::Timestamp;
       break;
     }
     case ast::Builtin::PRGetVarlen:
@@ -2059,6 +2075,8 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::PCIGetDoubleNull:
     case ast::Builtin::PCIGetDate:
     case ast::Builtin::PCIGetDateNull:
+    case ast::Builtin::PCIGetTimestamp:
+    case ast::Builtin::PCIGetTimestampNull:
     case ast::Builtin::PCIGetVarlen:
     case ast::Builtin::PCIGetVarlenNull: {
       CheckBuiltinPCICall(call, builtin);
@@ -2228,6 +2246,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::PRSetReal:
     case ast::Builtin::PRSetDouble:
     case ast::Builtin::PRSetDate:
+    case ast::Builtin::PRSetTimestamp:
     case ast::Builtin::PRSetVarlen:
     case ast::Builtin::PRSetBoolNull:
     case ast::Builtin::PRSetTinyIntNull:
@@ -2237,6 +2256,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::PRSetRealNull:
     case ast::Builtin::PRSetDoubleNull:
     case ast::Builtin::PRSetDateNull:
+    case ast::Builtin::PRSetTimestampNull:
     case ast::Builtin::PRSetVarlenNull:
     case ast::Builtin::PRGetBool:
     case ast::Builtin::PRGetTinyInt:
@@ -2246,6 +2266,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::PRGetReal:
     case ast::Builtin::PRGetDouble:
     case ast::Builtin::PRGetDate:
+    case ast::Builtin::PRGetTimestamp:
     case ast::Builtin::PRGetVarlen:
     case ast::Builtin::PRGetBoolNull:
     case ast::Builtin::PRGetTinyIntNull:
@@ -2255,6 +2276,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::PRGetRealNull:
     case ast::Builtin::PRGetDoubleNull:
     case ast::Builtin::PRGetDateNull:
+    case ast::Builtin::PRGetTimestampNull:
     case ast::Builtin::PRGetVarlenNull: {
       CheckBuiltinPRCall(call, builtin);
       break;
@@ -2282,6 +2304,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::GetParamReal:
     case ast::Builtin::GetParamDouble:
     case ast::Builtin::GetParamDate:
+    case ast::Builtin::GetParamTimestamp:
     case ast::Builtin::GetParamString: {
       CheckBuiltinParamCall(call, builtin);
       break;

--- a/src/execution/sema/sema_checking.cpp
+++ b/src/execution/sema/sema_checking.cpp
@@ -174,17 +174,6 @@ Sema::CheckResult Sema::CheckComparisonOperands(parsing::Token::Type op, const S
     return {built_ret_type(left->GetType()), left, new_right};
   }
 
-  // Primitive timestamp -> Sql Timestamp
-  if (left->GetType()->IsBoolType() && right->GetType()->IsSpecificBuiltin(ast::BuiltinType::Boolean)) {
-    auto new_left = ImplCastExprToType(left, right->GetType(), ast::CastKind::BoolToSqlBool);
-    return {built_ret_type(right->GetType()), new_left, right};
-  }
-  // Sql Boolean <- Primitive bool
-  if (left->GetType()->IsSpecificBuiltin(ast::BuiltinType::Boolean) && right->GetType()->IsBoolType()) {
-    auto new_right = ImplCastExprToType(right, left->GetType(), ast::CastKind::BoolToSqlBool);
-    return {built_ret_type(left->GetType()), left, new_right};
-  }
-
   // If neither input expression is arithmetic, it's an ill-formed operation
   if (!left->GetType()->IsArithmetic() || !right->GetType()->IsArithmetic()) {
     GetErrorReporter()->Report(pos, ErrorMessages::kIllegalTypesForBinary, op, left->GetType(), right->GetType());

--- a/src/execution/sema/sema_checking.cpp
+++ b/src/execution/sema/sema_checking.cpp
@@ -174,6 +174,17 @@ Sema::CheckResult Sema::CheckComparisonOperands(parsing::Token::Type op, const S
     return {built_ret_type(left->GetType()), left, new_right};
   }
 
+  // Primitive timestamp -> Sql Timestamp
+  if (left->GetType()->IsBoolType() && right->GetType()->IsSpecificBuiltin(ast::BuiltinType::Boolean)) {
+    auto new_left = ImplCastExprToType(left, right->GetType(), ast::CastKind::BoolToSqlBool);
+    return {built_ret_type(right->GetType()), new_left, right};
+  }
+  // Sql Boolean <- Primitive bool
+  if (left->GetType()->IsSpecificBuiltin(ast::BuiltinType::Boolean) && right->GetType()->IsBoolType()) {
+    auto new_right = ImplCastExprToType(right, left->GetType(), ast::CastKind::BoolToSqlBool);
+    return {built_ret_type(left->GetType()), left, new_right};
+  }
+
   // If neither input expression is arithmetic, it's an ill-formed operation
   if (!left->GetType()->IsArithmetic() || !right->GetType()->IsArithmetic()) {
     GetErrorReporter()->Report(pos, ErrorMessages::kIllegalTypesForBinary, op, left->GetType(), right->GetType());

--- a/src/execution/sql/runtime_types.cpp
+++ b/src/execution/sql/runtime_types.cpp
@@ -1,0 +1,118 @@
+#include "execution/sql/runtime_types.h"
+#include <date/date.h>
+
+#include <string>
+
+#include "common/exception.h"
+#include "util/time_util.h"
+
+namespace terrier::execution::sql {
+
+namespace {
+
+// The below Julian date conversions are taken from Postgres.
+
+bool IsValidJulianDate(int32_t year, uint32_t month, uint32_t day) {
+  return year <= 9999 && month >= 1 && month <= 12 && day >= 1 && day <= 31;
+}
+
+uint32_t BuildJulianDate(int32_t year, uint32_t month, uint32_t day) {
+  return terrier::util::TimeConvertor::PostgresDate2J(year, month, day);
+}
+
+uint32_t BuildJulianDate(date::year_month_day ymd) {
+  auto year = static_cast<int32_t>(ymd.year());
+  auto month = static_cast<uint32_t>(ymd.month());
+  auto day = static_cast<uint32_t>(ymd.day());
+  return BuildJulianDate(year, month, day);
+}
+
+void SplitJulianDate(uint32_t julian_date, int32_t *year, uint32_t *month, uint32_t *day) {
+  auto ymd = terrier::util::TimeConvertor::PostgresJ2Date(julian_date);
+
+  *year = static_cast<int32_t>(ymd.year());
+  *month = static_cast<uint32_t>(ymd.month());
+  *day = static_cast<uint32_t>(ymd.day());
+}
+
+}  // namespace
+
+bool Date::IsValid() const noexcept {
+  int32_t year;
+  uint32_t month, day;
+  SplitJulianDate(value_, &year, &month, &day);
+  return IsValidJulianDate(year, month, day);
+}
+
+std::string Date::ToString() const { return terrier::util::TimeConvertor::FormatDate(type::date_t{value_}); }
+
+int32_t Date::ExtractYear() const noexcept {
+  int32_t year;
+  uint32_t month, day;
+  SplitJulianDate(value_, &year, &month, &day);
+  return year;
+}
+
+uint32_t Date::ExtractMonth() const noexcept {
+  int32_t year;
+  uint32_t month, day;
+  SplitJulianDate(value_, &year, &month, &day);
+  return month;
+}
+
+uint32_t Date::ExtractDay() const noexcept {
+  int32_t year;
+  uint32_t month, day;
+  SplitJulianDate(value_, &year, &month, &day);
+  return day;
+}
+
+void Date::ExtractComponents(int32_t *year, uint32_t *month, uint32_t *day) {
+  SplitJulianDate(value_, year, month, day);
+}
+
+uint32_t Date::ToNative() const noexcept { return value_; }
+
+Date Date::FromNative(Date::NativeType val) {
+  Date d{};
+  d.value_ = val;
+  return d;
+}
+
+Date Date::FromString(const std::string &str) {
+  auto result = terrier::util::TimeConvertor::ParseDate(str);
+  if (!result.first) {
+    throw CONVERSION_EXCEPTION("Invalid date.");
+  }
+  return Date(BuildJulianDate(terrier::util::TimeConvertor::YMDFromDate(result.second)));
+}
+
+Date Date::FromYMD(int32_t year, uint32_t month, uint32_t day) {
+  if (!IsValidJulianDate(year, month, day)) {
+    throw CONVERSION_EXCEPTION("Invalid date.");
+  }
+  return Date(BuildJulianDate(year, month, day));
+}
+
+bool Date::IsValidDate(int32_t year, uint32_t month, uint32_t day) { return IsValidJulianDate(year, month, day); }
+
+std::string Timestamp::ToString() const {
+  return terrier::util::TimeConvertor::FormatTimestamp(type::timestamp_t{value_});
+}
+
+uint64_t Timestamp::ToNative() const noexcept { return value_; }
+
+Timestamp Timestamp::FromNative(Timestamp::NativeType val) {
+  Timestamp ts;
+  ts.value_ = val;
+  return ts;
+}
+
+Timestamp Timestamp::FromHMSu(int32_t year, uint32_t month, uint32_t day, uint8_t hour, uint8_t minute, uint8_t sec,
+                              uint64_t usec) {
+  Timestamp ts;
+  ts.value_ = !terrier::util::TimeConvertor::TimestampFromHMSu(year, month, day, hour, minute, sec, usec);
+  return ts;
+}
+
+}  // namespace terrier::execution::sql

--- a/src/execution/vm/llvm_engine.cpp
+++ b/src/execution/vm/llvm_engine.cpp
@@ -74,6 +74,8 @@ class LLVMEngine::TPLMemoryManager : public llvm::SectionMemoryManager {
     EXECUTION_LOG_DEBUG("Symbol '{}' not found in cache, checking process ...", name);
 
     llvm::JITSymbol symbol = llvm::SectionMemoryManager::findSymbol(name);
+    // If you're here because you tripped the assertion, check that you have EXPORT'd symbol definitions.
+    // Symptoms may include your code working in interpreted, adaptive, and codegen, but not in JIT.
     TERRIER_ASSERT(symbol.getAddress().get() != 0, "Resolved symbol has no address!");
     symbols_[name] = {symbol.getAddress().get(), symbol.getFlags()};
     return symbol;

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1583,7 +1583,6 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   GEN_PR_SET(Double, sql::Real)
   GEN_PR_SET(DateVal, sql::DateVal)
   GEN_PR_SET(TimestampVal, sql::TimestampVal)
-  GEN_PR_SET(Varlen, sql::StringVal)
 #undef GEN_PR_SET
 
   OP(PRSetVarlen) : {

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -655,7 +655,8 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   GEN_PCI_ACCESS(Real, sql::Real)
   GEN_PCI_ACCESS(Double, sql::Real)
   GEN_PCI_ACCESS(Decimal, sql::Decimal)
-  GEN_PCI_ACCESS(Date, sql::Date)
+  GEN_PCI_ACCESS(DateVal, sql::DateVal)
+  GEN_PCI_ACCESS(TimestampVal, sql::TimestampVal)
   GEN_PCI_ACCESS(Varlen, sql::StringVal)
 #undef GEN_PCI_ACCESS
 
@@ -785,11 +786,31 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   }
 
   OP(InitDate) : {
-    auto *sql_date = frame->LocalAt<sql::Date *>(READ_LOCAL_ID());
-    auto year = frame->LocalAt<uint16_t>(READ_LOCAL_ID());
-    auto month = frame->LocalAt<uint8_t>(READ_LOCAL_ID());
-    auto day = frame->LocalAt<uint8_t>(READ_LOCAL_ID());
+    auto *sql_date = frame->LocalAt<sql::DateVal *>(READ_LOCAL_ID());
+    auto year = frame->LocalAt<int32_t>(READ_LOCAL_ID());
+    auto month = frame->LocalAt<uint32_t>(READ_LOCAL_ID());
+    auto day = frame->LocalAt<uint32_t>(READ_LOCAL_ID());
     OpInitDate(sql_date, year, month, day);
+    DISPATCH_NEXT();
+  }
+
+  OP(InitTimestamp) : {
+    auto *sql_timestamp = frame->LocalAt<sql::TimestampVal *>(READ_LOCAL_ID());
+    auto usec = frame->LocalAt<uint64_t>(READ_LOCAL_ID());
+    OpInitTimestamp(sql_timestamp, usec);
+    DISPATCH_NEXT();
+  }
+
+  OP(InitTimestampHMSu) : {
+    auto *sql_timestamp = frame->LocalAt<sql::TimestampVal *>(READ_LOCAL_ID());
+    auto year = frame->LocalAt<int32_t>(READ_LOCAL_ID());
+    auto month = frame->LocalAt<uint32_t>(READ_LOCAL_ID());
+    auto day = frame->LocalAt<uint32_t>(READ_LOCAL_ID());
+    auto h = frame->LocalAt<uint8_t>(READ_LOCAL_ID());
+    auto m = frame->LocalAt<uint8_t>(READ_LOCAL_ID());
+    auto s = frame->LocalAt<uint8_t>(READ_LOCAL_ID());
+    auto us = frame->LocalAt<uint64_t>(READ_LOCAL_ID());
+    OpInitTimestampHMSu(sql_timestamp, year, month, day, h, m, s, us);
     DISPATCH_NEXT();
   }
 
@@ -808,41 +829,48 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     DISPATCH_NEXT();
   }
 
-#define GEN_CMP(op)                                                  \
-  OP(op##BoolVal) : {                                                \
-    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());  \
-    auto *left = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());    \
-    auto *right = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());   \
-    Op##op##BoolVal(result, left, right);                            \
-    DISPATCH_NEXT();                                                 \
-  }                                                                  \
-  OP(op##Integer) : {                                                \
-    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());  \
-    auto *left = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());    \
-    auto *right = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());   \
-    Op##op##Integer(result, left, right);                            \
-    DISPATCH_NEXT();                                                 \
-  }                                                                  \
-  OP(op##Real) : {                                                   \
-    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());  \
-    auto *left = frame->LocalAt<sql::Real *>(READ_LOCAL_ID());       \
-    auto *right = frame->LocalAt<sql::Real *>(READ_LOCAL_ID());      \
-    Op##op##Real(result, left, right);                               \
-    DISPATCH_NEXT();                                                 \
-  }                                                                  \
-  OP(op##StringVal) : {                                              \
-    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());  \
-    auto *left = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());  \
-    auto *right = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID()); \
-    Op##op##StringVal(result, left, right);                          \
-    DISPATCH_NEXT();                                                 \
-  }                                                                  \
-  OP(op##Date) : {                                                   \
-    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());  \
-    auto *left = frame->LocalAt<sql::Date *>(READ_LOCAL_ID());       \
-    auto *right = frame->LocalAt<sql::Date *>(READ_LOCAL_ID());      \
-    Op##op##Date(result, left, right);                               \
-    DISPATCH_NEXT();                                                 \
+#define GEN_CMP(op)                                                     \
+  OP(op##BoolVal) : {                                                   \
+    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());     \
+    auto *left = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());       \
+    auto *right = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());      \
+    Op##op##BoolVal(result, left, right);                               \
+    DISPATCH_NEXT();                                                    \
+  }                                                                     \
+  OP(op##Integer) : {                                                   \
+    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());     \
+    auto *left = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());       \
+    auto *right = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());      \
+    Op##op##Integer(result, left, right);                               \
+    DISPATCH_NEXT();                                                    \
+  }                                                                     \
+  OP(op##Real) : {                                                      \
+    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());     \
+    auto *left = frame->LocalAt<sql::Real *>(READ_LOCAL_ID());          \
+    auto *right = frame->LocalAt<sql::Real *>(READ_LOCAL_ID());         \
+    Op##op##Real(result, left, right);                                  \
+    DISPATCH_NEXT();                                                    \
+  }                                                                     \
+  OP(op##StringVal) : {                                                 \
+    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());     \
+    auto *left = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());     \
+    auto *right = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());    \
+    Op##op##StringVal(result, left, right);                             \
+    DISPATCH_NEXT();                                                    \
+  }                                                                     \
+  OP(op##DateVal) : {                                                   \
+    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());     \
+    auto *left = frame->LocalAt<sql::DateVal *>(READ_LOCAL_ID());       \
+    auto *right = frame->LocalAt<sql::DateVal *>(READ_LOCAL_ID());      \
+    Op##op##DateVal(result, left, right);                               \
+    DISPATCH_NEXT();                                                    \
+  }                                                                     \
+  OP(op##TimestampVal) : {                                              \
+    auto *result = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());     \
+    auto *left = frame->LocalAt<sql::TimestampVal *>(READ_LOCAL_ID());  \
+    auto *right = frame->LocalAt<sql::TimestampVal *>(READ_LOCAL_ID()); \
+    Op##op##TimestampVal(result, left, right);                          \
+    DISPATCH_NEXT();                                                    \
   }
   GEN_CMP(GreaterThan);
   GEN_CMP(GreaterThanEqual);
@@ -1530,7 +1558,8 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   GEN_PR_ACCESS(BigInt, sql::Integer)
   GEN_PR_ACCESS(Real, sql::Real)
   GEN_PR_ACCESS(Double, sql::Real)
-  GEN_PR_ACCESS(Date, sql::Date)
+  GEN_PR_ACCESS(DateVal, sql::DateVal)
+  GEN_PR_ACCESS(TimestampVal, sql::TimestampVal)
   GEN_PR_ACCESS(Varlen, sql::StringVal)
 #undef GEN_PR_ACCESS
 
@@ -1556,7 +1585,8 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   GEN_PR_SET(BigInt, sql::Integer)
   GEN_PR_SET(Real, sql::Real)
   GEN_PR_SET(Double, sql::Real)
-  GEN_PR_SET(Date, sql::Date)
+  GEN_PR_SET(DateVal, sql::DateVal)
+  GEN_PR_SET(TimestampVal, sql::TimestampVal)
   GEN_PR_SET(Varlen, sql::StringVal)
 #undef GEN_PR_SET
 
@@ -1665,7 +1695,8 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
   GEN_PARAM_GET(BigInt, Integer)
   GEN_PARAM_GET(Real, Real)
   GEN_PARAM_GET(Double, Real)
-  GEN_PARAM_GET(Date, Date)
+  GEN_PARAM_GET(DateVal, DateVal)
+  GEN_PARAM_GET(TimestampVal, TimestampVal)
   GEN_PARAM_GET(String, StringVal)
 #undef GEN_PARAM_GET
 

--- a/src/include/binder/bind_node_visitor.h
+++ b/src/include/binder/bind_node_visitor.h
@@ -76,6 +76,7 @@ class BindNodeVisitor : public SqlNodeVisitor {
   // void Visit(parser::FunctionExpression *expr, parser::ParseResult *parse_result) override;
   void Visit(parser::OperatorExpression *expr, parser::ParseResult *parse_result) override;
   void Visit(parser::AggregateExpression *expr, parser::ParseResult *parse_result) override;
+  void Visit(parser::TypeCastExpression *expr, parser::ParseResult *parse_result) override;
 
  private:
   /** Current context of the query or subquery */

--- a/src/include/binder/binder_context.h
+++ b/src/include/binder/binder_context.h
@@ -35,6 +35,9 @@ namespace binder {
  */
 class BinderContext {
  public:
+  /** TableMetadata is currently a tuple of database oid, table oid, and schema of the table. */
+  using TableMetadata = std::tuple<catalog::db_oid_t, catalog::table_oid_t, catalog::Schema>;
+
   /**
    * Initializes the BinderContext object which has an empty regular table map and an empty nested table map.
    * It also takes in a pointer to the binder context's upper context, and the constructor determines the depth of the
@@ -169,12 +172,18 @@ class BinderContext {
   void GenerateAllColumnExpressions(parser::ParseResult *parse_result,
                                     std::vector<common::ManagedPointer<parser::AbstractExpression>> *exprs);
 
+  /**
+   * Return the binder context's metadata for the provided @p table_name.
+   * @param table_name the name of the table to look up
+   * @return pointer to the {database oid, table oid, schema} corresponding to @p table_name, nullptr if not found
+   */
+  common::ManagedPointer<TableMetadata> GetTableMapping(const std::string &table_name);
+
  private:
   /**
-   * Map table alias to a tuple of database oid, table oid, and schema of the table
+   * Map table alias to its metadata
    */
-  std::unordered_map<std::string, std::tuple<catalog::db_oid_t, catalog::table_oid_t, catalog::Schema>>
-      regular_table_alias_map_;
+  std::unordered_map<std::string, TableMetadata> regular_table_alias_map_;
 
   /**
    * Map the table alias to maps which is from table alias to the value type

--- a/src/include/binder/binder_util.h
+++ b/src/include/binder/binder_util.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "parser/expression/abstract_expression.h"
+#include "parser/expression/constant_value_expression.h"
+#include "parser/expression/type_cast_expression.h"
+#include "parser/expression_defs.h"
+#include "type/transient_value_factory.h"
+#include "type/transient_value_peeker.h"
+#include "util/time_util.h"
+
+namespace terrier::binder {
+/** Utility functions for the binder's role in semantically validating and transforming input. */
+class BinderUtil {
+ public:
+  /**
+   * Create the real expression represented by @p expr. Does not modify the existing expression.
+   *
+   * This currently handles the following conversions:
+   *   - Dates/timestamps come in as strings. This parses the strings into a Date/Timestamp TransientValue.
+   *   - Type-cast expressions are unwrapped and follow the above rules for conversion.
+   *
+   * @param expr The expression to convert, this is not modified.
+   * @param expected_ret_type The expected return type of this expression.
+   * @return A pointer to the new converted expression.
+   */
+  static std::unique_ptr<parser::AbstractExpression> Convert(common::ManagedPointer<parser::AbstractExpression> expr,
+                                                             type::TypeId expected_ret_type) {
+    auto expr_type = expr->GetExpressionType();
+    auto expr_ret_type = expr->GetReturnValueType();
+
+    TERRIER_ASSERT(expr_type == parser::ExpressionType::OPERATOR_CAST || expr_ret_type != expected_ret_type,
+                   "Types already compatible!");
+
+    switch (expr_type) {
+      case parser::ExpressionType::VALUE_CONSTANT: {
+        auto cexpr = expr.CastManagedPointerTo<parser::ConstantValueExpression>();
+        std::string str{type::TransientValuePeeker::PeekVarChar(cexpr->GetValue())};
+
+        if (expected_ret_type == type::TypeId::DATE) {
+          auto parsed = util::TimeConvertor::ParseDate(str);
+          if (!parsed.first) {
+            throw BINDER_EXCEPTION("Unable to parse the date.");
+          }
+          return std::make_unique<parser::ConstantValueExpression>(type::TransientValueFactory::GetDate(parsed.second));
+        }
+
+        if (expected_ret_type == type::TypeId::TIMESTAMP) {
+          auto parsed = util::TimeConvertor::ParseTimestamp(str);
+          if (!parsed.first) {
+            throw BINDER_EXCEPTION("Unable to parse the timestamp.");
+          }
+          return std::make_unique<parser::ConstantValueExpression>(
+              type::TransientValueFactory::GetTimestamp(parsed.second));
+        }
+      }
+      case parser::ExpressionType::OPERATOR_CAST: {
+        auto cast_expr = expr.CastManagedPointerTo<parser::TypeCastExpression>();
+        TERRIER_ASSERT(cast_expr->GetChildrenSize() == 1, "Cannot type-cast multiple children.");
+        auto child = cast_expr->GetChild(0);
+        return Convert(child, expected_ret_type);
+      }
+      default:
+        throw BINDER_EXCEPTION("Mismatch in expected return type and expression return type.");
+    }
+  }
+};
+
+}  // namespace terrier::binder

--- a/src/include/binder/binder_util.h
+++ b/src/include/binder/binder_util.h
@@ -44,7 +44,7 @@ class BinderUtil {
         // TODO(WAN): There is code repetition here, but given that we intend to nuke the TransientValue
         //  in favor of Prashanth's Value system, this is probably fine and is easier to read.
         switch (expected_ret_type) {
-            // We expect to turn integers into TINYINT.
+          // We expect to turn integers into TINYINT.
           case type::TypeId::TINYINT: {
             if (expr_ret_type != type::TypeId::INTEGER) {
               throw BINDER_EXCEPTION("Can't convert to TINYINT.");

--- a/src/include/binder/binder_util.h
+++ b/src/include/binder/binder_util.h
@@ -41,8 +41,34 @@ class BinderUtil {
       case parser::ExpressionType::VALUE_CONSTANT: {
         auto cexpr = expr.CastManagedPointerTo<parser::ConstantValueExpression>();
 
+        // TODO(WAN): There is code repetition here, but given that we intend to nuke the TransientValue
+        //  in favor of Prashanth's Value system, this is probably fine and is easier to read.
         switch (expected_ret_type) {
-          // We expect to turn integers into decimals.
+            // We expect to turn integers into TINYINT.
+          case type::TypeId::TINYINT: {
+            if (expr_ret_type != type::TypeId::INTEGER) {
+              throw BINDER_EXCEPTION("Can't convert to TINYINT.");
+            }
+            int32_t val{type::TransientValuePeeker::PeekInteger(cexpr->GetValue())};
+            return std::make_unique<parser::ConstantValueExpression>(type::TransientValueFactory::GetTinyInt(val));
+          }
+          // We expect to turn integers into SMALLINT.
+          case type::TypeId::SMALLINT: {
+            if (expr_ret_type != type::TypeId::INTEGER) {
+              throw BINDER_EXCEPTION("Can't convert to SMALLINT.");
+            }
+            int32_t val{type::TransientValuePeeker::PeekInteger(cexpr->GetValue())};
+            return std::make_unique<parser::ConstantValueExpression>(type::TransientValueFactory::GetSmallInt(val));
+          }
+          // We expect to turn integers into BIGINT.
+          case type::TypeId::BIGINT: {
+            if (expr_ret_type != type::TypeId::INTEGER) {
+              throw BINDER_EXCEPTION("Can't convert to BIGINT.");
+            }
+            int32_t val{type::TransientValuePeeker::PeekInteger(cexpr->GetValue())};
+            return std::make_unique<parser::ConstantValueExpression>(type::TransientValueFactory::GetBigInt(val));
+          }
+          // We expect to turn integers into DECIMAL.
           case type::TypeId::DECIMAL: {
             if (expr_ret_type != type::TypeId::INTEGER) {
               throw BINDER_EXCEPTION("Can't convert to DECIMAL.");
@@ -50,7 +76,7 @@ class BinderUtil {
             int32_t val{type::TransientValuePeeker::PeekInteger(cexpr->GetValue())};
             return std::make_unique<parser::ConstantValueExpression>(type::TransientValueFactory::GetDecimal(val));
           }
-          // We expect to turn strings into dates.
+          // We expect to turn strings into DATE.
           case type::TypeId::DATE: {
             if (expr_ret_type != type::TypeId::VARCHAR) {
               throw BINDER_EXCEPTION("Can't convert to DATE.");
@@ -63,7 +89,7 @@ class BinderUtil {
             return std::make_unique<parser::ConstantValueExpression>(
                 type::TransientValueFactory::GetDate(parsed.second));
           }
-          // We expect to turn strings into timestamps.
+          // We expect to turn strings into TIMESTAMP.
           case type::TypeId::TIMESTAMP: {
             if (expr_ret_type != type::TypeId::VARCHAR) {
               throw BINDER_EXCEPTION("Can't convert to TIMESTAMP.");

--- a/src/include/binder/binder_util.h
+++ b/src/include/binder/binder_util.h
@@ -48,8 +48,7 @@ class BinderUtil {
               throw BINDER_EXCEPTION("Can't convert to DECIMAL.");
             }
             int32_t val{type::TransientValuePeeker::PeekInteger(cexpr->GetValue())};
-            return std::make_unique<parser::ConstantValueExpression>(
-                type::TransientValueFactory::GetDecimal(val));
+            return std::make_unique<parser::ConstantValueExpression>(type::TransientValueFactory::GetDecimal(val));
           }
           // We expect to turn strings into dates.
           case type::TypeId::DATE: {
@@ -58,7 +57,9 @@ class BinderUtil {
             }
             std::string str{type::TransientValuePeeker::PeekVarChar(cexpr->GetValue())};
             auto parsed = util::TimeConvertor::ParseDate(str);
-            if (!parsed.first) { throw BINDER_EXCEPTION("Unable to parse the date."); }
+            if (!parsed.first) {
+              throw BINDER_EXCEPTION("Unable to parse the date.");
+            }
             return std::make_unique<parser::ConstantValueExpression>(
                 type::TransientValueFactory::GetDate(parsed.second));
           }
@@ -69,7 +70,9 @@ class BinderUtil {
             }
             std::string str{type::TransientValuePeeker::PeekVarChar(cexpr->GetValue())};
             auto parsed = util::TimeConvertor::ParseTimestamp(str);
-            if (!parsed.first) { throw BINDER_EXCEPTION("Unable to parse the timestamp."); }
+            if (!parsed.first) {
+              throw BINDER_EXCEPTION("Unable to parse the timestamp.");
+            }
             return std::make_unique<parser::ConstantValueExpression>(
                 type::TransientValueFactory::GetTimestamp(parsed.second));
           }

--- a/src/include/execution/ast/ast.h
+++ b/src/include/execution/ast/ast.h
@@ -1271,7 +1271,14 @@ enum class CastKind : uint8_t {
   BitCast,
 
   // 64 bit float To Sql Real
-  FloatToSqlReal
+  FloatToSqlReal,
+
+  // Conversion of a SQL timestamp value (potentially nullable) into a primitive
+  // timestamp value
+  SqlTimestampToTimestamp,
+
+  // Conversion of a primitive boolean into a SQL boolean
+  TimestampToSqlTimestamp,
 };
 
 /**

--- a/src/include/execution/ast/ast.h
+++ b/src/include/execution/ast/ast.h
@@ -1273,11 +1273,10 @@ enum class CastKind : uint8_t {
   // 64 bit float To Sql Real
   FloatToSqlReal,
 
-  // Conversion of a SQL timestamp value (potentially nullable) into a primitive
-  // timestamp value
+  // Conversion of a SQL timestamp value (potentially nullable) into a primitive timestamp value
   SqlTimestampToTimestamp,
 
-  // Conversion of a primitive boolean into a SQL boolean
+  // Conversion of a primitive timestamp valueinto a SQL timestamp
   TimestampToSqlTimestamp,
 };
 

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -15,6 +15,7 @@ namespace terrier::execution::ast {
   F(StringToSql, stringToSql)                                           \
   F(VarlenToSql, varlenToSql)                                           \
   F(DateToSql, dateToSql)                                               \
+  F(TimestampToSql, timestampToSql)                                               \
                                                                         \
   /* Vectorized Filters */                                              \
   F(FilterEq, filterEq)                                                 \
@@ -58,6 +59,7 @@ namespace terrier::execution::ast {
   F(PCIGetReal, pciGetReal)                                             \
   F(PCIGetDouble, pciGetDouble)                                         \
   F(PCIGetDate, pciGetDate)                                             \
+  F(PCIGetTimestamp, pciGetTimestamp)                                             \
   F(PCIGetVarlen, pciGetVarlen)                                         \
   F(PCIGetBoolNull, pciGetBoolNull)                                     \
   F(PCIGetTinyIntNull, pciGetTinyIntNull)                               \
@@ -67,6 +69,7 @@ namespace terrier::execution::ast {
   F(PCIGetRealNull, pciGetRealNull)                                     \
   F(PCIGetDoubleNull, pciGetDoubleNull)                                 \
   F(PCIGetDateNull, pciGetDateNull)                                     \
+  F(PCIGetTimestampNull, pciGetTimestampNull)                                     \
   F(PCIGetVarlenNull, pciGetVarlenNull)                                 \
                                                                         \
   /* Hashing */                                                         \
@@ -169,6 +172,7 @@ namespace terrier::execution::ast {
   F(PRSetReal, prSetReal)                                               \
   F(PRSetDouble, prSetDouble)                                           \
   F(PRSetDate, prSetDate)                                               \
+  F(PRSetTimestamp, prSetTimestamp)                                               \
   F(PRSetVarlen, prSetVarlen)                                           \
   F(PRSetBoolNull, prSetBoolNull)                                       \
   F(PRSetTinyIntNull, prSetTinyIntNull)                                 \
@@ -178,6 +182,7 @@ namespace terrier::execution::ast {
   F(PRSetRealNull, prSetRealNull)                                       \
   F(PRSetDoubleNull, prSetDoubleNull)                                   \
   F(PRSetDateNull, prSetDateNull)                                       \
+  F(PRSetTimestampNull, prSetTimestampNull)                                       \
   F(PRSetVarlenNull, prSetVarlenNull)                                   \
   F(PRGetBool, prGetBool)                                               \
   F(PRGetTinyInt, prGetTinyInt)                                         \
@@ -187,6 +192,7 @@ namespace terrier::execution::ast {
   F(PRGetReal, prGetReal)                                               \
   F(PRGetDouble, prGetDouble)                                           \
   F(PRGetDate, prGetDate)                                               \
+  F(PRGetTimestamp, prGetTimestamp)                                               \
   F(PRGetVarlen, prGetVarlen)                                           \
   F(PRGetBoolNull, prGetBoolNull)                                       \
   F(PRGetTinyIntNull, prGetTinyIntNull)                                 \
@@ -196,6 +202,7 @@ namespace terrier::execution::ast {
   F(PRGetRealNull, prGetRealNull)                                       \
   F(PRGetDoubleNull, prGetDoubleNull)                                   \
   F(PRGetDateNull, prGetDateNull)                                       \
+  F(PRGetTimestampNull, prGetTimestampNull)                                       \
   F(PRGetVarlenNull, prGetVarlenNull)                                   \
                                                                         \
   /* SQL Table Calls */                                                 \
@@ -221,6 +228,7 @@ namespace terrier::execution::ast {
   F(GetParamReal, getParamReal)                                         \
   F(GetParamDouble, getParamDouble)                                     \
   F(GetParamDate, getParamDate)                                         \
+  F(GetParamTimestamp, getParamTimestamp)                                         \
   F(GetParamString, getParamString)
 
 /**

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -15,7 +15,8 @@ namespace terrier::execution::ast {
   F(StringToSql, stringToSql)                                           \
   F(VarlenToSql, varlenToSql)                                           \
   F(DateToSql, dateToSql)                                               \
-  F(TimestampToSql, timestampToSql)                                               \
+  F(TimestampToSql, timestampToSql)                                     \
+  F(TimestampToSqlHMSu, timestampToSqlHMSu)                             \
                                                                         \
   /* Vectorized Filters */                                              \
   F(FilterEq, filterEq)                                                 \
@@ -59,7 +60,7 @@ namespace terrier::execution::ast {
   F(PCIGetReal, pciGetReal)                                             \
   F(PCIGetDouble, pciGetDouble)                                         \
   F(PCIGetDate, pciGetDate)                                             \
-  F(PCIGetTimestamp, pciGetTimestamp)                                             \
+  F(PCIGetTimestamp, pciGetTimestamp)                                   \
   F(PCIGetVarlen, pciGetVarlen)                                         \
   F(PCIGetBoolNull, pciGetBoolNull)                                     \
   F(PCIGetTinyIntNull, pciGetTinyIntNull)                               \
@@ -69,7 +70,7 @@ namespace terrier::execution::ast {
   F(PCIGetRealNull, pciGetRealNull)                                     \
   F(PCIGetDoubleNull, pciGetDoubleNull)                                 \
   F(PCIGetDateNull, pciGetDateNull)                                     \
-  F(PCIGetTimestampNull, pciGetTimestampNull)                                     \
+  F(PCIGetTimestampNull, pciGetTimestampNull)                           \
   F(PCIGetVarlenNull, pciGetVarlenNull)                                 \
                                                                         \
   /* Hashing */                                                         \
@@ -172,7 +173,7 @@ namespace terrier::execution::ast {
   F(PRSetReal, prSetReal)                                               \
   F(PRSetDouble, prSetDouble)                                           \
   F(PRSetDate, prSetDate)                                               \
-  F(PRSetTimestamp, prSetTimestamp)                                               \
+  F(PRSetTimestamp, prSetTimestamp)                                     \
   F(PRSetVarlen, prSetVarlen)                                           \
   F(PRSetBoolNull, prSetBoolNull)                                       \
   F(PRSetTinyIntNull, prSetTinyIntNull)                                 \
@@ -182,7 +183,7 @@ namespace terrier::execution::ast {
   F(PRSetRealNull, prSetRealNull)                                       \
   F(PRSetDoubleNull, prSetDoubleNull)                                   \
   F(PRSetDateNull, prSetDateNull)                                       \
-  F(PRSetTimestampNull, prSetTimestampNull)                                       \
+  F(PRSetTimestampNull, prSetTimestampNull)                             \
   F(PRSetVarlenNull, prSetVarlenNull)                                   \
   F(PRGetBool, prGetBool)                                               \
   F(PRGetTinyInt, prGetTinyInt)                                         \
@@ -192,7 +193,7 @@ namespace terrier::execution::ast {
   F(PRGetReal, prGetReal)                                               \
   F(PRGetDouble, prGetDouble)                                           \
   F(PRGetDate, prGetDate)                                               \
-  F(PRGetTimestamp, prGetTimestamp)                                               \
+  F(PRGetTimestamp, prGetTimestamp)                                     \
   F(PRGetVarlen, prGetVarlen)                                           \
   F(PRGetBoolNull, prGetBoolNull)                                       \
   F(PRGetTinyIntNull, prGetTinyIntNull)                                 \
@@ -202,7 +203,7 @@ namespace terrier::execution::ast {
   F(PRGetRealNull, prGetRealNull)                                       \
   F(PRGetDoubleNull, prGetDoubleNull)                                   \
   F(PRGetDateNull, prGetDateNull)                                       \
-  F(PRGetTimestampNull, prGetTimestampNull)                                       \
+  F(PRGetTimestampNull, prGetTimestampNull)                             \
   F(PRGetVarlenNull, prGetVarlenNull)                                   \
                                                                         \
   /* SQL Table Calls */                                                 \
@@ -228,7 +229,7 @@ namespace terrier::execution::ast {
   F(GetParamReal, getParamReal)                                         \
   F(GetParamDouble, getParamDouble)                                     \
   F(GetParamDate, getParamDate)                                         \
-  F(GetParamTimestamp, getParamTimestamp)                                         \
+  F(GetParamTimestamp, getParamTimestamp)                               \
   F(GetParamString, getParamString)
 
 /**

--- a/src/include/execution/ast/type.h
+++ b/src/include/execution/ast/type.h
@@ -95,8 +95,8 @@ class Context;
   SQL(Real, terrier::execution::sql::Real)                                                      \
   SQL(Decimal, terrier::execution::sql::Decimal)                                                \
   SQL(StringVal, terrier::execution::sql::StringVal)                                            \
-  SQL(Date, terrier::execution::sql::Date)                                                      \
-  SQL(Timestamp, terrier::execution::sql::Timestamp)
+  SQL(Date, terrier::execution::sql::DateVal)                                                   \
+  SQL(Timestamp, terrier::execution::sql::TimestampVal)
 
 // Ignore a builtin
 #define IGNORE_BUILTIN_TYPE (...)

--- a/src/include/execution/compiler/codegen.h
+++ b/src/include/execution/compiler/codegen.h
@@ -294,6 +294,12 @@ class CodeGen {
   ast::Expr *DateToSql(int16_t year, uint8_t month, uint8_t day);
 
   /**
+   * @param unix_timestamp The number to convert to a sql Timestamp.
+   * @return The generated sql Timestamp
+   */
+  ast::Expr *TimestampToSql(int64_t unix_timestamp);
+
+  /**
    * Convert a raw string to a sql StringVal.
    * @param str The string to convert to a sql StringVal.
    * @return The generate sql StringVal

--- a/src/include/execution/compiler/codegen.h
+++ b/src/include/execution/compiler/codegen.h
@@ -285,19 +285,20 @@ class CodeGen {
   ast::Expr *FloatToSql(double num);
 
   /**
-   * Create a date value
+   * Create a date value.
    * @param year The year of the date.
    * @param month The month of the date.
    * @param day The day of the date
-   * @return The generate sql Date
+   * @return The generated sql Date.
    */
-  ast::Expr *DateToSql(int16_t year, uint8_t month, uint8_t day);
+  ast::Expr *DateToSql(int32_t year, uint32_t month, uint32_t day);
 
   /**
-   * @param unix_timestamp The number to convert to a sql Timestamp.
-   * @return The generated sql Timestamp
+   * Create a timestamp value.
+   * @param julian_usec The number of microseconds in Julian time.
+   * @return The generated sql Timestamp.
    */
-  ast::Expr *TimestampToSql(int64_t unix_timestamp);
+  ast::Expr *TimestampToSql(uint64_t julian_usec);
 
   /**
    * Convert a raw string to a sql StringVal.

--- a/src/include/execution/compiler/translator_factory.h
+++ b/src/include/execution/compiler/translator_factory.h
@@ -5,6 +5,7 @@
 #include "execution/compiler/operator/operator_translator.h"
 #include "execution/util/region.h"
 #include "parser/expression/abstract_expression.h"
+#include "parser/expression_defs.h"
 #include "planner/plannodes/abstract_plan_node.h"
 namespace terrier::execution::compiler {
 
@@ -112,6 +113,11 @@ class TranslatorFactory {
   static bool IsNullOp(parser::ExpressionType type) {
     return (type == parser::ExpressionType::OPERATOR_IS_NULL || type == parser::ExpressionType::OPERATOR_IS_NOT_NULL);
   }
+
+  /**
+   * Whether this is a cast operation
+   */
+  static bool IsCastOp(parser::ExpressionType type) { return type == parser::ExpressionType::OPERATOR_CAST; }
 };
 
 }  // namespace terrier::execution::compiler

--- a/src/include/execution/sql/functions/comparison_functions.h
+++ b/src/include/execution/sql/functions/comparison_functions.h
@@ -137,32 +137,62 @@ class EXPORT ComparisonFunctions {
   /**
    * Sets result = (v1 == v2)
    */
-  static void EqDate(BoolVal *result, const Date &v1, const Date &v2);
+  static void EqDateVal(BoolVal *result, const DateVal &v1, const DateVal &v2);
 
   /**
    * Sets result = (v1 >= v2)
    */
-  static void GeDate(BoolVal *result, const Date &v1, const Date &v2);
+  static void GeDateVal(BoolVal *result, const DateVal &v1, const DateVal &v2);
 
   /**
    * Sets result = (v1 > v2)
    */
-  static void GtDate(BoolVal *result, const Date &v1, const Date &v2);
+  static void GtDateVal(BoolVal *result, const DateVal &v1, const DateVal &v2);
 
   /**
    * Sets result = (v1 <= v2)
    */
-  static void LeDate(BoolVal *result, const Date &v1, const Date &v2);
+  static void LeDateVal(BoolVal *result, const DateVal &v1, const DateVal &v2);
 
   /**
    * Sets result = (v1 < v2)
    */
-  static void LtDate(BoolVal *result, const Date &v1, const Date &v2);
+  static void LtDateVal(BoolVal *result, const DateVal &v1, const DateVal &v2);
 
   /**
    * Sets result = (v1 != v2)
    */
-  static void NeDate(BoolVal *result, const Date &v1, const Date &v2);
+  static void NeDateVal(BoolVal *result, const DateVal &v1, const DateVal &v2);
+
+  /**
+   * Sets result = (v1 == v2)
+   */
+  static void EqTimestampVal(BoolVal *result, const TimestampVal &v1, const TimestampVal &v2);
+
+  /**
+   * Sets result = (v1 >= v2)
+   */
+  static void GeTimestampVal(BoolVal *result, const TimestampVal &v1, const TimestampVal &v2);
+
+  /**
+   * Sets result = (v1 > v2)
+   */
+  static void GtTimestampVal(BoolVal *result, const TimestampVal &v1, const TimestampVal &v2);
+
+  /**
+   * Sets result = (v1 <= v2)
+   */
+  static void LeTimestampVal(BoolVal *result, const TimestampVal &v1, const TimestampVal &v2);
+
+  /**
+   * Sets result = (v1 < v2)
+   */
+  static void LtTimestampVal(BoolVal *result, const TimestampVal &v1, const TimestampVal &v2);
+
+  /**
+   * Sets result = (v1 != v2)
+   */
+  static void NeTimestampVal(BoolVal *result, const TimestampVal &v1, const TimestampVal &v2);
 
   /**
    * Compare two raw strings. Returns:
@@ -235,22 +265,13 @@ class EXPORT ComparisonFunctions {
     *result = BoolVal(Compare(v1, v2) OP 0);                                                     \
   }
 
-#define BINARY_COMPARISON_DATE_FN_HIDE_NULL(NAME, TYPE, OP)                                      \
-  inline void ComparisonFunctions::NAME##TYPE(BoolVal *result, const TYPE &v1, const TYPE &v2) { \
-    if (v1.is_null_ || v2.is_null_) {                                                            \
-      *result = BoolVal::Null();                                                                 \
-      return;                                                                                    \
-    }                                                                                            \
-    result->is_null_ = false;                                                                    \
-    result->val_ = v1.ymd_ OP v2.ymd_;                                                           \
-  }
-
 #define BINARY_COMPARISON_ALL_TYPES(NAME, OP)                \
   BINARY_COMPARISON_NUMERIC_FN_HIDE_NULL(NAME, BoolVal, OP)  \
   BINARY_COMPARISON_NUMERIC_FN_HIDE_NULL(NAME, Integer, OP)  \
   BINARY_COMPARISON_NUMERIC_FN_HIDE_NULL(NAME, Real, OP)     \
   BINARY_COMPARISON_STRING_FN_HIDE_NULL(NAME, StringVal, OP) \
-  BINARY_COMPARISON_DATE_FN_HIDE_NULL(NAME, Date, OP)
+  BINARY_COMPARISON_NUMERIC_FN_HIDE_NULL(NAME, DateVal, OP)  \
+  BINARY_COMPARISON_NUMERIC_FN_HIDE_NULL(NAME, TimestampVal, OP)
 
 BINARY_COMPARISON_ALL_TYPES(Eq, ==);
 BINARY_COMPARISON_ALL_TYPES(Ge, >=);
@@ -263,5 +284,4 @@ BINARY_COMPARISON_ALL_TYPES(Ne, !=);
 #undef BINARY_COMPARISON_STRING_FN_HIDE_NULL
 #undef BINARY_COMPARISON_NUMERIC_FN_HIDE_NULL
 #undef BINARY_COMPARISON_DATE_FN_HIDE_NULL
-
 }  // namespace terrier::execution::sql

--- a/src/include/execution/sql/runtime_types.h
+++ b/src/include/execution/sql/runtime_types.h
@@ -1,0 +1,257 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+
+#include "execution/util/hash.h"
+
+namespace terrier::execution::sql {
+
+class Timestamp;
+
+/** Number of milliseconds in a day. */
+static constexpr uint64_t K_MS_PER_DAY = 24 * 60 * 60 * 1000;
+/** Number of microseconds in a day. */
+static constexpr uint64_t K_US_PER_DAY = static_cast<uint64_t>(24) * 60 * 60 * 1000 * 1000;
+
+/** A SQL date. */
+class EXPORT Date {
+ public:
+  /** The internal representation of a SQL date. */
+  using NativeType = uint32_t;
+
+  /** Empty constructor. */
+  Date() = default;
+
+  /** @return True if this is a valid date instance; false otherwise. */
+  bool IsValid() const noexcept;
+
+  /** @return A string representation of this date in the form "YYYY-MM-MM". */
+  std::string ToString() const;
+
+  /** @return The year of this date. */
+  int32_t ExtractYear() const noexcept;
+
+  /** @return The month of this date. */
+  uint32_t ExtractMonth() const noexcept;
+
+  /** @return The day of this date. */
+  uint32_t ExtractDay() const noexcept;
+
+  /**
+   * Convert this date object into its year, month, and day parts.
+   * @param[out] year The year corresponding to this date.
+   * @param[out] month The month corresponding to this date.
+   * @param[out] day The day corresponding to this date.
+   */
+  void ExtractComponents(int32_t *year, uint32_t *month, uint32_t *day);
+
+  /**
+   * Convert this date instance into a timestamp instance.
+   * @return The timestamp instance representing this date.
+   */
+  Timestamp ConvertToTimestamp() const noexcept;
+
+  /**
+   * Compute the hash value of this date instance.
+   * @param seed The value to seed the hash with.
+   * @return The hash value for this date instance.
+   */
+  hash_t Hash(const hash_t seed) const { return util::Hasher::Hash(value_, seed); }
+
+  /**
+   * @return The hash value of this date instance.
+   */
+  hash_t Hash() const { return Hash(0); }
+
+  /**
+   * @return True if this date equals @em that date; false otherwise.
+   */
+  bool operator==(const Date &that) const noexcept { return value_ == that.value_; }
+
+  /**
+   * @return True if this date is not equal to @em that date; false otherwise.
+   */
+  bool operator!=(const Date &that) const noexcept { return value_ != that.value_; }
+
+  /**
+   * @return True if this data occurs before @em that date; false otherwise.
+   */
+  bool operator<(const Date &that) const noexcept { return value_ < that.value_; }
+
+  /**
+   * @return True if this data occurs before or is the same as @em that date; false otherwise.
+   */
+  bool operator<=(const Date &that) const noexcept { return value_ <= that.value_; }
+
+  /**
+   * @return True if this date occurs after @em that date; false otherwise.
+   */
+  bool operator>(const Date &that) const noexcept { return value_ > that.value_; }
+
+  /**
+   * @return True if this date occurs after or is equal to @em that date; false otherwise.
+   */
+  bool operator>=(const Date &that) const noexcept { return value_ >= that.value_; }
+
+  /** @return The native representation of the date. */
+  Date::NativeType ToNative() const noexcept;
+
+  /**
+   * Construct a Date with the specified native representation.
+   * @param val The native representation of a date.
+   * @return The constructed Date.
+   */
+  static Date FromNative(Date::NativeType val);
+
+  /**
+   * Convert a string of the form "YYYY-MM-DD" into a date instance.
+   * @param str The string to convert.
+   * @return The constructed Date. May be invalid.
+   */
+  static Date FromString(const std::string &str);
+
+  /**
+   * Create a Date instance from a specified year, month, and day.
+   * @param year The year of the date.
+   * @param month The month of the date.
+   * @param day The day of the date.
+   * @return The constructed date. May be invalid.
+   */
+  static Date FromYMD(int32_t year, uint32_t month, uint32_t day);
+
+  /**
+   * Is the date corresponding to the given year, month, and day a valid date?
+   * @param year The year of the date.
+   * @param month The month of the date.
+   * @param day The day of the date.
+   * @return True if valid date.
+   */
+  static bool IsValidDate(int32_t year, uint32_t month, uint32_t day);
+
+ private:
+  friend class Timestamp;
+  friend struct DateVal;
+  friend class PostgresPacketWriter;
+
+  // Private constructor to force static factories.
+  explicit Date(NativeType value) : value_(value) {}
+
+ private:
+  // Date value
+  NativeType value_;
+};
+
+/**
+ * A SQL timestamp.
+ */
+class EXPORT Timestamp {
+ public:
+  /** The internal representation of a SQL timestamp. */
+  using NativeType = uint64_t;
+
+  /**
+   * Empty constructor.
+   */
+  Timestamp() = default;
+
+  /**
+   * Compute the hash value of this timestamp instance.
+   * @param seed The value to seed the hash with.
+   * @return The hash value for this timestamp instance.
+   */
+  hash_t Hash(const hash_t seed) const { return util::Hasher::Hash(value_, seed); }
+
+  /**
+   * @return The hash value of this timestamp instance.
+   */
+  hash_t Hash() const { return Hash(0); }
+
+  /**
+   * @return A string representation of timestamp in the form "YYYY-MM-DD HH:MM:SS.ZZZ"
+   */
+  std::string ToString() const;
+
+  /**
+   * @return True if this timestamp equals @em that timestamp; false otherwise.
+   */
+  bool operator==(const Timestamp &that) const noexcept { return value_ == that.value_; }
+
+  /**
+   * @return True if this timestamp is not equal to @em that timestamp; false otherwise.
+   */
+  bool operator!=(const Timestamp &that) const noexcept { return value_ != that.value_; }
+
+  /**
+   * @return True if this data occurs before @em that timestamp; false otherwise.
+   */
+  bool operator<(const Timestamp &that) const noexcept { return value_ < that.value_; }
+
+  /**
+   * @return True if this data occurs before or is the same as @em that timestamp; false otherwise.
+   */
+  bool operator<=(const Timestamp &that) const noexcept { return value_ <= that.value_; }
+
+  /**
+   * @return True if this timestamp occurs after @em that timestamp; false otherwise.
+   */
+  bool operator>(const Timestamp &that) const noexcept { return value_ > that.value_; }
+
+  /**
+   * @return True if this timestamp occurs after or is equal to @em that timestamp; false otherwise.
+   */
+  bool operator>=(const Timestamp &that) const noexcept { return value_ >= that.value_; }
+
+  /** @return The native representation of the timestamp. */
+  Timestamp::NativeType ToNative() const noexcept;
+
+  /**
+   * Construct a Timestamp with the specified native representation.
+   * @param val The native representation of a timestamp.
+   * @return The constructed timestamp.
+   */
+  static Timestamp FromNative(Timestamp::NativeType val);
+
+  /**
+   * Convert a C-style string of the form "YYYY-MM-DD HH::MM::SS" into a timestamp. Will attempt to
+   * convert the first timestamp-like object it sees, skipping any leading whitespace.
+   * @param str The string to convert.
+   * @param len The length of the string.
+   * @return The constructed Timestamp. May be invalid.
+   */
+  static Timestamp FromString(const char *str, std::size_t len);
+
+  /**
+   * Instantiate a timestamp with the specified number of microseconds in Julian time.
+   * @param usec The number of microseconds in Julian time.
+   * @return The constructed timestamp.
+   */
+  static Timestamp FromMicroseconds(uint64_t usec) { return Timestamp(usec); }
+
+  /** Instantiate a timestamp from calendar time. */
+  static Timestamp FromHMSu(int32_t year, uint32_t month, uint32_t day, uint8_t hour, uint8_t minute, uint8_t sec,
+                            uint64_t usec);
+
+  /**
+   * Convert a string of the form "YYYY-MM-DD HH::MM::SS" into a timestamp. Will attempt to convert
+   * the first timestamp-like object it sees, skipping any leading whitespace.
+   * @param str The string to convert.
+   * @return The constructed Timestamp. May be invalid.
+   */
+  static Timestamp FromString(const std::string &str) { return FromString(str.c_str(), str.size()); }
+
+ private:
+  friend class Date;
+  friend struct TimestampVal;
+
+  explicit Timestamp(NativeType value) : value_(value) {}
+
+ private:
+  // Timestamp value
+  NativeType value_;
+};
+
+/** Converts the provided date into a timestamp. */
+inline Timestamp Date::ConvertToTimestamp() const noexcept { return Timestamp(value_ * K_US_PER_DAY); }
+
+}  // namespace terrier::execution::sql

--- a/src/include/execution/sql/value.h
+++ b/src/include/execution/sql/value.h
@@ -8,8 +8,10 @@
 #include "common/math_util.h"
 #include "date/date.h"
 #include "execution/exec/execution_context.h"
+#include "execution/sql/runtime_types.h"
 #include "execution/util/execution_common.h"
 #include "type/type_id.h"
+#include "util/time_util.h"
 
 namespace terrier::execution::sql {
 
@@ -333,77 +335,58 @@ struct StringVal : public Val {
 };
 
 /**
- * Date
+ * A NULL-able SQL date value.
  */
-struct Date : public Val {
-  /**
-   * Date value
-   * Can be represented by an int32 (for the storage layer), or by a year-month-day struct.
-   */
-  union {
-    date::year_month_day ymd_;
-    uint32_t int_val_;
-  };
+struct DateVal : public Val {
+  /** The date value. */
+  Date val_;
 
   /**
-   * Constructor
-   * @param date date value
+   * Construct a non-NULL date with the given date value.
+   * @param val The date value.
    */
-  explicit Date(uint32_t date) noexcept : Val(false), int_val_{date} {}
+  explicit DateVal(Date val) noexcept : Val(false), val_(val) {}
 
   /**
-   * Constructor
-   * @param date date value from a TransientValue
+   * Construct a non-NULL date with the given date value.
+   * @param val The raw date value.
    */
-  explicit Date(type::date_t date) noexcept : Val(false), int_val_{!date} {}
+  explicit DateVal(Date::NativeType val) noexcept : DateVal(Date{val}) {}
 
   /**
-   * Constructor
-   * @param year year value
-   * @param month month value
-   * @param day day value
+   * @return A NULL date.
    */
-  Date(date::year year, date::month month, date::day day) noexcept : Val(false), ymd_{year, month, day} {}
-
-  /**
-   * Constructor
-   * @param year year value
-   * @param month month value
-   * @param day day value
-   */
-  Date(int16_t year, uint8_t month, uint8_t day) noexcept
-      : Val(false), ymd_{date::year(year) / date::month(month) / date::day(day)} {}
-
-  /**
-   * @return a NULL Date.
-   */
-  static Date Null() {
-    Date date(0);
+  static DateVal Null() {
+    DateVal date(Date{});
     date.is_null_ = true;
     return date;
   }
 };
 
 /**
- * Timestamp
+ * A NULL-able SQL timestamp value.
  */
-struct Timestamp : public Val {
-  /**
-   * Time value
-   */
-  timespec time_;
+struct TimestampVal : public Val {
+  /** The timestamp value. */
+  Timestamp val_;
 
   /**
-   * Constructor
-   * @param time time value
+   * Construct a non-NULL timestamp with the given value.
+   * @param val The timestamp value.
    */
-  explicit Timestamp(timespec time) noexcept : Val(false), time_(time) {}
+  explicit TimestampVal(Timestamp val) noexcept : Val(false), val_(val) {}
 
   /**
-   * @return a NULL Timestamp
+   * Construct a non-NULL timestamp with the given raw timestamp value.
+   * @param val The raw timestamp value.
    */
-  static Timestamp Null() {
-    Timestamp timestamp({0, 0});
+  explicit TimestampVal(Timestamp::NativeType val) noexcept : TimestampVal(Timestamp{val}) {}
+
+  /**
+   * @return A NULL timestamp.
+   */
+  static TimestampVal Null() {
+    TimestampVal timestamp(Timestamp{0});
     timestamp.is_null_ = true;
     return timestamp;
   }
@@ -427,10 +410,11 @@ struct ValUtil {
       case type::TypeId::BOOLEAN:
         return static_cast<uint32_t>(common::MathUtil::AlignTo(sizeof(BoolVal), 8));
       case type::TypeId::DATE:
+        return static_cast<uint32_t>(common::MathUtil::AlignTo(sizeof(DateVal), 8));
       case type::TypeId::TIMESTAMP:
-        return static_cast<uint32_t>(common::MathUtil::AlignTo(sizeof(Date), 8));
+        return static_cast<uint32_t>(common::MathUtil::AlignTo(sizeof(TimestampVal), 8));
       case type::TypeId::DECIMAL:
-        // TODO(Amadou): We only support reals for now. Switch to Decima once it's implemented
+        // TODO(Amadou): We only support reals for now. Switch to Decimal once it's implemented
         return static_cast<uint32_t>(common::MathUtil::AlignTo(sizeof(Real), 8));
       case type::TypeId::VARCHAR:
       case type::TypeId::VARBINARY:
@@ -438,49 +422,6 @@ struct ValUtil {
       default:
         return 0;
     }
-  }
-
-  /**
-   * Convert a date to a string
-   * @param date date to convert
-   * @return the date in the yyyy-mm-dd format
-   */
-  static std::string DateToString(const Date &date) {
-    std::stringstream ss;
-    ss << date.ymd_;
-    return ss.str();
-  }
-
-  /**
-   * Return the year part of the date
-   */
-  static int16_t ExtractYear(const Date &date) { return int16_t(static_cast<int>(date.ymd_.year())); }
-
-  /**
-   * Return the month part of the date
-   */
-  static uint8_t ExtractMonth(const Date &date) { return uint8_t(static_cast<unsigned>(date.ymd_.month())); }
-
-  /**
-   * Return the day part of the date
-   */
-  static uint8_t ExtractDay(const Date &date) { return uint8_t(static_cast<unsigned>(date.ymd_.day())); }
-
-  /**
-   * Construct a date object from a string
-   * @param str string representation of the date
-   * @return the constructed date object
-   */
-  static Date StringToDate(const std::string &str) {
-    std::stringstream ss(str);
-    int16_t year, month, day;
-    // Token to dismiss the '-' character
-    // Am using the int16_t type to prevent the string stream from returning ascii codes.
-    char tok;
-    ss >> year >> tok;
-    ss >> month >> tok;
-    ss >> day;
-    return Date(int16_t(year), uint8_t(month), uint8_t(day));
   }
 };
 

--- a/src/include/execution/util/hash.h
+++ b/src/include/execution/util/hash.h
@@ -27,11 +27,11 @@ class EXPORT Hasher {
  public:
   /**
    * Compute the hash value of an arithmetic input. The input is allowed to be
-   * either an integral numbers (8- to 64-bits) or floating pointer numbers.
+   * either an integral numbers (8- to 64-bits) or floating point numbers.
    * @tparam METHOD The hash method to use.
    * @tparam T The input arithmetic type.
    * @param val The input value to hash.
-   * @return The compute hash.
+   * @return The computed hash.
    */
   template <HashMethod METHOD = HashMethod::Crc, typename T>
   static auto Hash(const T val) -> std::enable_if_t<std::is_arithmetic_v<T>, hash_t> {
@@ -44,6 +44,25 @@ class EXPORT Hasher {
         return HashMurmur2(val);
       case HashMethod::xxHash3:
         return HashXX3(val);
+    }
+  }
+
+  /**
+   * Compute the hash value of an arithmetic input. The input is allowed to be
+   * either an integral numbers (8- to 64-bits) or floating pointer numbers.
+   * @tparam METHOD The hash method to use.
+   * @tparam T The input arithmetic type.
+   * @param val The input value to hash.
+   * @param seed The hash seed.
+   * @return The computed hash.
+   */
+  template <HashMethod METHOD = HashMethod::Crc, typename T>
+  static auto Hash(const T val, const hash_t seed) -> std::enable_if_t<std::is_arithmetic_v<T>, hash_t> {
+    switch (METHOD) {
+      case HashMethod::Crc:
+        return HashCrc(val, seed);
+      case HashMethod::Murmur2:
+        return HashMurmur2(val, seed);
     }
   }
 

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -15,12 +15,14 @@
 #include "execution/sql/index_iterator.h"
 #include "execution/sql/join_hash_table.h"
 #include "execution/sql/projected_columns_iterator.h"
+#include "execution/sql/runtime_types.h"
 #include "execution/sql/sorter.h"
 #include "execution/sql/storage_interface.h"
 #include "execution/sql/table_vector_iterator.h"
 #include "execution/sql/thread_state_container.h"
 #include "execution/util/execution_common.h"
 #include "execution/util/hash.h"
+#include "util/time_util.h"
 
 // All VM terrier::bytecode op handlers must use this macro
 #define VM_OP EXPORT
@@ -358,15 +360,26 @@ VM_OP_HOT void OpPCIGetDecimal(terrier::execution::sql::Decimal *out,
   out->val_ = 0;
 }
 
-VM_OP_HOT void OpPCIGetDate(terrier::execution::sql::Date *out, terrier::execution::sql::ProjectedColumnsIterator *iter,
-                            uint16_t col_idx) {
+VM_OP_HOT void OpPCIGetDateVal(terrier::execution::sql::DateVal *out,
+                               terrier::execution::sql::ProjectedColumnsIterator *iter, uint16_t col_idx) {
   // Read
   auto *ptr = iter->Get<uint32_t, false>(col_idx, nullptr);
   TERRIER_ASSERT(ptr != nullptr, "Null pointer when trying to read date");
 
   // Set
   out->is_null_ = false;
-  out->int_val_ = *ptr;
+  out->val_ = terrier::execution::sql::Date::FromNative(*ptr);
+}
+
+VM_OP_HOT void OpPCIGetTimestampVal(terrier::execution::sql::TimestampVal *out,
+                                    terrier::execution::sql::ProjectedColumnsIterator *iter, uint16_t col_idx) {
+  // Read
+  auto *ptr = iter->Get<uint64_t, false>(col_idx, nullptr);
+  TERRIER_ASSERT(ptr != nullptr, "Null pointer when trying to read date");
+
+  // Set
+  out->is_null_ = false;
+  out->val_ = terrier::execution::sql::Timestamp::FromNative(*ptr);
 }
 
 VM_OP_HOT void OpPCIGetVarlen(terrier::execution::sql::StringVal *out,
@@ -469,8 +482,8 @@ VM_OP_HOT void OpPCIGetDecimalNull(terrier::execution::sql::Decimal *out,
   out->is_null_ = false;
 }
 
-VM_OP_HOT void OpPCIGetDateNull(terrier::execution::sql::Date *out,
-                                terrier::execution::sql::ProjectedColumnsIterator *iter, uint16_t col_idx) {
+VM_OP_HOT void OpPCIGetDateValNull(terrier::execution::sql::DateVal *out,
+                                   terrier::execution::sql::ProjectedColumnsIterator *iter, uint16_t col_idx) {
   // Read
   bool null = false;
   auto *ptr = iter->Get<uint32_t, true>(col_idx, &null);
@@ -478,7 +491,19 @@ VM_OP_HOT void OpPCIGetDateNull(terrier::execution::sql::Date *out,
 
   // Set
   out->is_null_ = null;
-  out->int_val_ = *ptr;
+  out->val_ = null ? terrier::execution::sql::Date() : terrier::execution::sql::Date::FromNative(*ptr);
+}
+
+VM_OP_HOT void OpPCIGetTimestampValNull(terrier::execution::sql::TimestampVal *out,
+                                        terrier::execution::sql::ProjectedColumnsIterator *iter, uint16_t col_idx) {
+  // Read
+  bool null = false;
+  auto *ptr = iter->Get<uint64_t, true>(col_idx, &null);
+  TERRIER_ASSERT(ptr != nullptr, "Null pointer when trying to read date");
+
+  // Set
+  out->is_null_ = null;
+  out->val_ = null ? terrier::execution::sql::Timestamp() : terrier::execution::sql::Timestamp::FromNative(*ptr);
 }
 
 VM_OP_HOT void OpPCIGetVarlenNull(terrier::execution::sql::StringVal *out,
@@ -579,9 +604,20 @@ VM_OP_HOT void OpInitReal(terrier::execution::sql::Real *result, double input) {
   result->val_ = input;
 }
 
-VM_OP_HOT void OpInitDate(terrier::execution::sql::Date *result, int16_t year, uint8_t month, uint8_t day) {
+VM_OP_HOT void OpInitDate(terrier::execution::sql::DateVal *result, int32_t year, uint32_t month, uint32_t day) {
   result->is_null_ = false;
-  result->ymd_ = date::year(year) / month / day;
+  result->val_ = terrier::execution::sql::Date::FromYMD(year, month, day);
+}
+
+VM_OP_HOT void OpInitTimestamp(terrier::execution::sql::TimestampVal *result, uint64_t usec) {
+  result->is_null_ = false;
+  result->val_ = terrier::execution::sql::Timestamp::FromMicroseconds(usec);
+}
+
+VM_OP_HOT void OpInitTimestampHMSu(terrier::execution::sql::TimestampVal *result, int32_t year, uint32_t month,
+                                   uint32_t day, uint8_t hour, uint8_t minute, uint8_t sec, uint64_t usec) {
+  result->is_null_ = false;
+  result->val_ = terrier::execution::sql::Timestamp::FromHMSu(year, month, day, hour, minute, sec, usec);
 }
 
 VM_OP_HOT void OpInitString(terrier::execution::sql::StringVal *result, uint64_t length, uintptr_t data) {
@@ -629,7 +665,8 @@ GEN_SQL_COMPARISONS(BoolVal)
 GEN_SQL_COMPARISONS(Integer)
 GEN_SQL_COMPARISONS(Real)
 GEN_SQL_COMPARISONS(StringVal)
-GEN_SQL_COMPARISONS(Date)
+GEN_SQL_COMPARISONS(DateVal)
+GEN_SQL_COMPARISONS(TimestampVal)
 #undef GEN_SQL_COMPARISONS
 
 // ----------------------------------
@@ -1467,33 +1504,71 @@ VM_OP_HOT void OpPRSetVarlenNull(terrier::storage::ProjectedRow *pr, uint16_t co
   pr->Set<terrier::storage::VarlenEntry, true>(col_idx, varlen, val->is_null_);
 }
 
-VM_OP_HOT void OpPRSetDate(terrier::storage::ProjectedRow *pr, uint16_t col_idx, terrier::execution::sql::Date *val) {
-  pr->Set<uint32_t, false>(col_idx, val->int_val_, val->is_null_);
+VM_OP_HOT void OpPRSetDateVal(terrier::storage::ProjectedRow *pr, uint16_t col_idx,
+                              terrier::execution::sql::DateVal *val) {
+  auto pr_val = val->val_.ToNative();
+  pr->Set<uint32_t, false>(col_idx, pr_val, val->is_null_);
 }
 
-VM_OP_HOT void OpPRSetDateNull(terrier::storage::ProjectedRow *pr, uint16_t col_idx,
-                               terrier::execution::sql::Date *val) {
-  pr->Set<uint32_t, true>(col_idx, val->int_val_, val->is_null_);
+VM_OP_HOT void OpPRSetDateValNull(terrier::storage::ProjectedRow *pr, uint16_t col_idx,
+                                  terrier::execution::sql::DateVal *val) {
+  auto pr_val = val->is_null_ ? 0 : val->val_.ToNative();
+  pr->Set<uint32_t, true>(col_idx, pr_val, val->is_null_);
 }
 
-VM_OP_HOT void OpPRGetDate(terrier::execution::sql::Date *out, terrier::storage::ProjectedRow *pr, uint16_t col_idx) {
+VM_OP_HOT void OpPRSetTimestampVal(terrier::storage::ProjectedRow *pr, uint16_t col_idx,
+                                   terrier::execution::sql::TimestampVal *val) {
+  auto pr_val = val->val_.ToNative();
+  pr->Set<uint64_t, false>(col_idx, pr_val, val->is_null_);
+}
+
+VM_OP_HOT void OpPRSetTimestampValNull(terrier::storage::ProjectedRow *pr, uint16_t col_idx,
+                                       terrier::execution::sql::TimestampVal *val) {
+  auto pr_val = val->is_null_ ? 0 : val->val_.ToNative();
+  pr->Set<uint64_t, true>(col_idx, pr_val, val->is_null_);
+}
+
+VM_OP_HOT void OpPRGetDateVal(terrier::execution::sql::DateVal *out, terrier::storage::ProjectedRow *pr,
+                              uint16_t col_idx) {
   // Read
   auto *ptr = pr->Get<uint32_t, false>(col_idx, nullptr);
   TERRIER_ASSERT(ptr != nullptr, "Null pointer when trying to read date");
   // Set
   out->is_null_ = false;
-  out->int_val_ = *ptr;
+  out->val_ = terrier::execution::sql::Date::FromNative(*ptr);
 }
 
-VM_OP_HOT void OpPRGetDateNull(terrier::execution::sql::Date *out, terrier::storage::ProjectedRow *pr,
-                               uint16_t col_idx) {
+VM_OP_HOT void OpPRGetDateValNull(terrier::execution::sql::DateVal *out, terrier::storage::ProjectedRow *pr,
+                                  uint16_t col_idx) {
   // Read
   bool null = false;
   auto *ptr = pr->Get<uint32_t, true>(col_idx, &null);
 
   // Set
   out->is_null_ = null;
-  out->int_val_ = null ? 0 : *ptr;
+  out->val_ = null ? terrier::execution::sql::Date() : terrier::execution::sql::Date::FromNative(*ptr);
+}
+
+VM_OP_HOT void OpPRGetTimestampVal(terrier::execution::sql::TimestampVal *out, terrier::storage::ProjectedRow *pr,
+                                   uint16_t col_idx) {
+  // Read
+  auto *ptr = pr->Get<uint64_t, false>(col_idx, nullptr);
+  TERRIER_ASSERT(ptr != nullptr, "Null pointer when trying to read date");
+
+  // Set
+  out->is_null_ = false;
+  out->val_ = terrier::execution::sql::Timestamp::FromNative(*ptr);
+}
+
+VM_OP_HOT void OpPRGetTimestampValNull(terrier::execution::sql::TimestampVal *out, terrier::storage::ProjectedRow *pr,
+                                       uint16_t col_idx) {
+  // Read
+  bool null = false;
+  auto *ptr = pr->Get<uint64_t, true>(col_idx, &null);
+
+  // Set
+  out->is_null_ = null;
+  out->val_ = null ? terrier::execution::sql::Timestamp() : terrier::execution::sql::Timestamp::FromNative(*ptr);
 }
 
 VM_OP_HOT void OpPRGetVarlen(terrier::execution::sql::StringVal *out, terrier::storage::ProjectedRow *pr,
@@ -1585,13 +1660,27 @@ GEN_SCALAR_PARAM_GET(Real, Real, PeekDecimal)
 GEN_SCALAR_PARAM_GET(Double, Real, PeekDecimal)
 #undef GEN_SCALAR_PARAM_GET
 
-VM_OP_HOT void OpGetParamDate(terrier::execution::sql::Date *ret, terrier::execution::exec::ExecutionContext *exec_ctx,
-                              uint32_t param_idx) {
+VM_OP_HOT void OpGetParamDateVal(terrier::execution::sql::DateVal *ret,
+                                 terrier::execution::exec::ExecutionContext *exec_ctx, uint32_t param_idx) {
   const auto &trans_val = exec_ctx->GetParam(param_idx);
   if (trans_val.Null()) {
-    ret->is_null_ = false;
+    ret->is_null_ = true;
   } else {
-    *ret = terrier::execution::sql::Date(terrier::type::TransientValuePeeker::PeekDate(trans_val));
+    auto date = terrier::type::TransientValuePeeker::PeekDate(trans_val);
+    *ret = terrier::execution::sql::DateVal(!date);
+    ret->is_null_ = false;
+  }
+}
+
+VM_OP_HOT void OpGetParamTimestampVal(terrier::execution::sql::TimestampVal *ret,
+                                      terrier::execution::exec::ExecutionContext *exec_ctx, uint32_t param_idx) {
+  const auto &trans_val = exec_ctx->GetParam(param_idx);
+  if (trans_val.Null()) {
+    ret->is_null_ = true;
+  } else {
+    auto ts = terrier::type::TransientValuePeeker::PeekTimestamp(trans_val);
+    *ret = terrier::execution::sql::TimestampVal(!ts);
+    ret->is_null_ = false;
   }
 }
 
@@ -1599,10 +1688,11 @@ VM_OP_HOT void OpGetParamString(terrier::execution::sql::StringVal *ret,
                                 terrier::execution::exec::ExecutionContext *exec_ctx, uint32_t param_idx) {
   const auto &trans_val = exec_ctx->GetParam(param_idx);
   if (trans_val.Null()) {
-    ret->is_null_ = false;
+    ret->is_null_ = true;
   } else {
     auto val = terrier::type::TransientValuePeeker::PeekVarChar(trans_val);
     *ret = terrier::execution::sql::StringVal(val.data(), static_cast<uint32_t>(val.size()));
+    ret->is_null_ = false;
   }
 }
 

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -64,7 +64,7 @@ namespace terrier::execution::vm {
   CREATE_FOR_ALL_TYPES(F, LessThan, OperandType::Local, OperandType::Local, OperandType::Local)                       \
   CREATE_FOR_ALL_TYPES(F, LessThanEqual, OperandType::Local, OperandType::Local, OperandType::Local)                  \
   CREATE_FOR_ALL_TYPES(F, NotEqual, OperandType::Local, OperandType::Local, OperandType::Local)                       \
-  /* Boolean compliment */                                                                                            \
+  /* Boolean complement */                                                                                            \
   F(Not, OperandType::Local, OperandType::Local)                                                                      \
                                                                                                                       \
   /* Branching */                                                                                                     \
@@ -136,7 +136,8 @@ namespace terrier::execution::vm {
   F(PCIGetReal, OperandType::Local, OperandType::Local, OperandType::UImm2)                                           \
   F(PCIGetDouble, OperandType::Local, OperandType::Local, OperandType::UImm2)                                         \
   F(PCIGetDecimal, OperandType::Local, OperandType::Local, OperandType::UImm2)                                        \
-  F(PCIGetDate, OperandType::Local, OperandType::Local, OperandType::UImm2)                                           \
+  F(PCIGetDateVal, OperandType::Local, OperandType::Local, OperandType::UImm2)                                        \
+  F(PCIGetTimestampVal, OperandType::Local, OperandType::Local, OperandType::UImm2)                                   \
   F(PCIGetVarlen, OperandType::Local, OperandType::Local, OperandType::UImm2)                                         \
   F(PCIGetBoolNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                       \
   F(PCIGetTinyIntNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                    \
@@ -146,7 +147,8 @@ namespace terrier::execution::vm {
   F(PCIGetRealNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                       \
   F(PCIGetDoubleNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                     \
   F(PCIGetDecimalNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                    \
-  F(PCIGetDateNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                       \
+  F(PCIGetDateValNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                    \
+  F(PCIGetTimestampValNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                               \
   F(PCIGetVarlenNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                     \
   F(PCIFilterEqual, OperandType::Local, OperandType::Local, OperandType::UImm4, OperandType::Imm1, OperandType::Imm8) \
   F(PCIFilterGreaterThan, OperandType::Local, OperandType::Local, OperandType::UImm4, OperandType::Imm1,              \
@@ -174,6 +176,9 @@ namespace terrier::execution::vm {
   F(InitInteger, OperandType::Local, OperandType::Local)                                                              \
   F(InitReal, OperandType::Local, OperandType::Local)                                                                 \
   F(InitDate, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                         \
+  F(InitTimestamp, OperandType::Local, OperandType::Local)                                                            \
+  F(InitTimestampHMSu, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local,                \
+    OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                                   \
   F(InitString, OperandType::Local, OperandType::Imm8, OperandType::Imm8)                                             \
   F(InitVarlen, OperandType::Local, OperandType::Local)                                                               \
   F(LessThanBoolVal, OperandType::Local, OperandType::Local, OperandType::Local)                                      \
@@ -200,12 +205,18 @@ namespace terrier::execution::vm {
   F(GreaterThanEqualStringVal, OperandType::Local, OperandType::Local, OperandType::Local)                            \
   F(EqualStringVal, OperandType::Local, OperandType::Local, OperandType::Local)                                       \
   F(NotEqualStringVal, OperandType::Local, OperandType::Local, OperandType::Local)                                    \
-  F(LessThanDate, OperandType::Local, OperandType::Local, OperandType::Local)                                         \
-  F(LessThanEqualDate, OperandType::Local, OperandType::Local, OperandType::Local)                                    \
-  F(GreaterThanDate, OperandType::Local, OperandType::Local, OperandType::Local)                                      \
-  F(GreaterThanEqualDate, OperandType::Local, OperandType::Local, OperandType::Local)                                 \
-  F(EqualDate, OperandType::Local, OperandType::Local, OperandType::Local)                                            \
-  F(NotEqualDate, OperandType::Local, OperandType::Local, OperandType::Local)                                         \
+  F(LessThanDateVal, OperandType::Local, OperandType::Local, OperandType::Local)                                      \
+  F(LessThanEqualDateVal, OperandType::Local, OperandType::Local, OperandType::Local)                                 \
+  F(GreaterThanDateVal, OperandType::Local, OperandType::Local, OperandType::Local)                                   \
+  F(GreaterThanEqualDateVal, OperandType::Local, OperandType::Local, OperandType::Local)                              \
+  F(EqualDateVal, OperandType::Local, OperandType::Local, OperandType::Local)                                         \
+  F(NotEqualDateVal, OperandType::Local, OperandType::Local, OperandType::Local)                                      \
+  F(LessThanTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                                 \
+  F(LessThanEqualTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                            \
+  F(GreaterThanTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                              \
+  F(GreaterThanEqualTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                         \
+  F(EqualTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                                    \
+  F(NotEqualTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                                 \
                                                                                                                       \
   /* SQL value unary operations */                                                                                    \
   F(AbsInteger, OperandType::Local, OperandType::Local)                                                               \
@@ -364,7 +375,8 @@ namespace terrier::execution::vm {
   F(PRGetBigInt, OperandType::Local, OperandType::Local, OperandType::UImm2)                                          \
   F(PRGetReal, OperandType::Local, OperandType::Local, OperandType::UImm2)                                            \
   F(PRGetDouble, OperandType::Local, OperandType::Local, OperandType::UImm2)                                          \
-  F(PRGetDate, OperandType::Local, OperandType::Local, OperandType::UImm2)                                            \
+  F(PRGetDateVal, OperandType::Local, OperandType::Local, OperandType::UImm2)                                         \
+  F(PRGetTimestampVal, OperandType::Local, OperandType::Local, OperandType::UImm2)                                    \
   F(PRGetVarlen, OperandType::Local, OperandType::Local, OperandType::UImm2)                                          \
   F(PRGetBoolNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                        \
   F(PRGetTinyIntNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                     \
@@ -373,7 +385,8 @@ namespace terrier::execution::vm {
   F(PRGetBigIntNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                      \
   F(PRGetRealNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                        \
   F(PRGetDoubleNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                      \
-  F(PRGetDateNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                        \
+  F(PRGetDateValNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                     \
+  F(PRGetTimestampValNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                \
   F(PRGetVarlenNull, OperandType::Local, OperandType::Local, OperandType::UImm2)                                      \
   F(PRSetBool, OperandType::Local, OperandType::UImm2, OperandType::Local)                                            \
   F(PRSetTinyInt, OperandType::Local, OperandType::UImm2, OperandType::Local)                                         \
@@ -382,7 +395,8 @@ namespace terrier::execution::vm {
   F(PRSetBigInt, OperandType::Local, OperandType::UImm2, OperandType::Local)                                          \
   F(PRSetReal, OperandType::Local, OperandType::UImm2, OperandType::Local)                                            \
   F(PRSetDouble, OperandType::Local, OperandType::UImm2, OperandType::Local)                                          \
-  F(PRSetDate, OperandType::Local, OperandType::UImm2, OperandType::Local)                                            \
+  F(PRSetDateVal, OperandType::Local, OperandType::UImm2, OperandType::Local)                                         \
+  F(PRSetTimestampVal, OperandType::Local, OperandType::UImm2, OperandType::Local)                                    \
   F(PRSetVarlen, OperandType::Local, OperandType::UImm2, OperandType::Local)                                          \
   F(PRSetBoolNull, OperandType::Local, OperandType::UImm2, OperandType::Local)                                        \
   F(PRSetTinyIntNull, OperandType::Local, OperandType::UImm2, OperandType::Local)                                     \
@@ -391,7 +405,8 @@ namespace terrier::execution::vm {
   F(PRSetBigIntNull, OperandType::Local, OperandType::UImm2, OperandType::Local)                                      \
   F(PRSetRealNull, OperandType::Local, OperandType::UImm2, OperandType::Local)                                        \
   F(PRSetDoubleNull, OperandType::Local, OperandType::UImm2, OperandType::Local)                                      \
-  F(PRSetDateNull, OperandType::Local, OperandType::UImm2, OperandType::Local)                                        \
+  F(PRSetDateValNull, OperandType::Local, OperandType::UImm2, OperandType::Local)                                     \
+  F(PRSetTimestampValNull, OperandType::Local, OperandType::UImm2, OperandType::Local)                                \
   F(PRSetVarlenNull, OperandType::Local, OperandType::UImm2, OperandType::Local)                                      \
                                                                                                                       \
   /* StorageInterface */                                                                                              \
@@ -462,7 +477,8 @@ namespace terrier::execution::vm {
   F(GetParamBigInt, OperandType::Local, OperandType::Local, OperandType::Local)                                       \
   F(GetParamReal, OperandType::Local, OperandType::Local, OperandType::Local)                                         \
   F(GetParamDouble, OperandType::Local, OperandType::Local, OperandType::Local)                                       \
-  F(GetParamDate, OperandType::Local, OperandType::Local, OperandType::Local)                                         \
+  F(GetParamDateVal, OperandType::Local, OperandType::Local, OperandType::Local)                                      \
+  F(GetParamTimestampVal, OperandType::Local, OperandType::Local, OperandType::Local)                                 \
   F(GetParamString, OperandType::Local, OperandType::Local, OperandType::Local)
 
 /**

--- a/src/include/network/postgres/postgres_packet_writer.h
+++ b/src/include/network/postgres/postgres_packet_writer.h
@@ -7,6 +7,7 @@
 #include "execution/sql/value.h"
 #include "network/packet_writer.h"
 #include "planner/plannodes/output_schema.h"
+#include "util/time_util.h"
 
 namespace terrier::network {
 
@@ -351,9 +352,13 @@ class PostgresPacketWriter : public PacketWriter {
           break;
         }
         case type::TypeId::DATE: {
-          auto *date_val = reinterpret_cast<const execution::sql::Date *const>(val);
-          // TODO(Matt): would we ever use the ymd_ format for the wire?
-          AppendValue<int32_t>(static_cast<int32_t>(type_size)).AppendValue<uint32_t>(date_val->int_val_);
+          auto *date_val = reinterpret_cast<const execution::sql::DateVal *const>(val);
+          AppendValue<int32_t>(static_cast<int32_t>(type_size)).AppendValue<uint32_t>(date_val->val_.ToNative());
+          break;
+        }
+        case type::TypeId::TIMESTAMP: {
+          auto *ts_val = reinterpret_cast<const execution::sql::TimestampVal *const>(val);
+          AppendValue<int32_t>(static_cast<int32_t>(type_size)).AppendValue<uint64_t>(ts_val->val_.ToNative());
           break;
         }
         case type::TypeId::VARCHAR: {
@@ -412,9 +417,13 @@ class PostgresPacketWriter : public PacketWriter {
           break;
         }
         case type::TypeId::DATE: {
-          auto *date_val = reinterpret_cast<const execution::sql::Date *const>(val);
-          // TODO(Matt): would we ever use the ymd_ format for the wire?
-          string_value = std::to_string(date_val->int_val_);
+          auto *date_val = reinterpret_cast<const execution::sql::DateVal *const>(val);
+          string_value = date_val->val_.ToString();
+          break;
+        }
+        case type::TypeId::TIMESTAMP: {
+          auto *ts_val = reinterpret_cast<const execution::sql::TimestampVal *const>(val);
+          string_value = ts_val->val_.ToString();
           break;
         }
         case type::TypeId::VARCHAR: {

--- a/src/include/parser/expression/constant_value_expression.h
+++ b/src/include/parser/expression/constant_value_expression.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include "binder/bind_node_visitor.h"
 #include "common/hash_util.h"
 #include "parser/expression/abstract_expression.h"
 #include "type/transient_value.h"
@@ -55,6 +56,8 @@ class ConstantValueExpression : public AbstractExpression {
     return Copy();
   }
 
+  void DeriveReturnValueType() override { return_value_type_ = GetValue().Type(); }
+
   void DeriveExpressionName() override {
     if (!this->GetAlias().empty()) {
       this->SetExpressionName(this->GetAlias());
@@ -93,6 +96,7 @@ class ConstantValueExpression : public AbstractExpression {
   }
 
  private:
+  friend class binder::BindNodeVisitor; /* value_ may be modified, e.g., when parsing dates. */
   /** The constant held inside this ConstantValueExpression. */
   type::TransientValue value_;
 };

--- a/src/include/storage/projected_columns.h
+++ b/src/include/storage/projected_columns.h
@@ -9,10 +9,10 @@ namespace terrier::storage {
 /**
  * ProjectedColumns represents partial images of a collection of tuples, where columns from different
  * tuples are laid out continuously. This can be considered a collection of ProjectedRows, but optimized
- * for continuous column access like PAX. However, a ProjecetedRow is almost always externally coupled to a known
+ * for continuous column access like PAX. However, a ProjectedRow is almost always externally coupled to a known
  * tuple slot, so it is more compact in layout than MaterializedColumns, which has to also store the
  * TupleSlot information for each tuple. The inner class RowView provides access to the underlying logical
- * projected rows with the same interface as a real ProjecetedRow.
+ * projected rows with the same interface as a real ProjectedRow.
  * -------------------------------------------------------------------------------------
  * | size | max_tuples | num_tuples | num_cols | attr_end[4] | col_id1 | col_id2 | ... |
  * -------------------------------------------------------------------------------------

--- a/src/include/type/transient_value.h
+++ b/src/include/type/transient_value.h
@@ -248,7 +248,7 @@ class TransientValue {
    */
   explicit TransientValue(const TypeId type) : type_(type), data_(0) { SetNull(true); }
 
-  // The following tests make sure that json serialization  works, so they need to
+  // The following tests make sure that json serialization works, so they need to
   // be friends of the TransientValue class.
   FRIEND_TEST(ValueTests, BooleanJsonTest);
   FRIEND_TEST(ValueTests, TinyIntJsonTest);

--- a/src/include/type/type_id.h
+++ b/src/include/type/type_id.h
@@ -1,9 +1,22 @@
 #pragma once
 
 #include "common/strong_typedef.h"
+#include "date/date.h"
 
 namespace terrier::type {
+
+/**
+ * Julian date.
+ * Precision: days
+ * Range: 0 (Nov 24, -4713) to 2^31-1 (Jun 03, 5874898).
+ */
 STRONG_TYPEDEF(date_t, uint32_t);
+
+/**
+ * Julian timestamp.
+ * Precision: microseconds, 14 digits
+ * Range: 4713 BC to 294276 AD
+ */
 STRONG_TYPEDEF(timestamp_t, uint64_t);
 
 enum class TypeId : uint8_t {

--- a/src/include/util/time_util.h
+++ b/src/include/util/time_util.h
@@ -85,6 +85,7 @@ class TimeConvertor {
     bool parse_ok = false;
 
     // TODO(WAN): what formats does postgres support?
+    parse_ok = parse_ok || Parse("%F", str, &tp);       // 2020-01-01
     parse_ok = parse_ok || Parse("%F %T%z", str, &tp);  // 2020-01-01 11:11:11.123-0500
     parse_ok = parse_ok || Parse("%F %TZ", str, &tp);   // 2020-01-01 11:11:11.123Z
     parse_ok = parse_ok || Parse("%F %T", str, &tp);    // 2020-01-01 11:11:11.123

--- a/src/include/util/time_util.h
+++ b/src/include/util/time_util.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#include <chrono>  // NOLINT
+#include <string>
+#include <utility>
+#include "date/date.h"
+#include "type/type_id.h"
+
+namespace terrier::util {
+
+/**
+ * TimeConvertor handles time conversions between strings and the shared representation used by storage and execution.
+ *
+ * Internally, we store DATE and TIMESTAMP just like PostgreSQL does.
+ * - DATE, 4 bytes, Julian days
+ * - TIMESTAMP, 8 bytes, Julian microseconds
+ */
+class TimeConvertor {
+  // Note that C++20 greatly simplifies formatting of date and time. Punting on pretty formatting.
+
+ public:
+  /** Convert @p ymd into the internal date representation. */
+  static type::date_t DateFromYMD(date::year_month_day ymd) {
+    auto year = static_cast<int32_t>(ymd.year());
+    auto month = static_cast<uint32_t>(ymd.month());
+    auto day = static_cast<uint32_t>(ymd.day());
+    return type::date_t{PostgresDate2J(year, month, day)};
+  }
+
+  /** Convert @p date into a year_month_day object. */
+  static date::year_month_day YMDFromDate(type::date_t date) { return PostgresJ2Date(!date); }
+
+  /** Instantiate a timestamp with the given parameters. */
+  static type::timestamp_t TimestampFromHMSu(int32_t year, uint32_t month, uint32_t day, uint8_t hour, uint8_t minute,
+                                             uint8_t sec, uint64_t usec) {
+    date::year_month_day ymd{date::year(year), date::month(month), date::day(day)};
+    auto ts_val = TimestampFromDate(DateFromYMD(ymd));
+    ts_val += hour * MICROSECONDS_PER_HOUR;
+    ts_val += minute * MICROSECONDS_PER_MINUTE;
+    ts_val += sec * MICROSECONDS_PER_SECOND;
+    ts_val += usec;
+    return type::timestamp_t{ts_val};
+  }
+
+  /** Convert @p date into a year_month_day object. */
+  static type::timestamp_t TimestampFromDate(type::date_t date) {
+    return type::timestamp_t{!date * MICROSECONDS_PER_DAY};
+  }
+
+  /** Convert @p timestamp into a date. */
+  static type::date_t DateFromTimestamp(type::timestamp_t timestamp) {
+    return type::date_t{static_cast<uint32_t>(!timestamp / MICROSECONDS_PER_DAY)};
+  }
+
+  /** Extract the number of microseconds with respect to Julian time from @p timestamp. */
+  static uint64_t ExtractJulianMicroseconds(type::timestamp_t timestamp) { return !timestamp; }
+
+  /**
+   * Attempt to parse @p str into the internal date representation.
+   * @param str The string to be parsed.
+   * @return (True, parse result) if parse succeeded; (False, undefined) otherwise
+   */
+  static std::pair<bool, type::date_t> ParseDate(const std::string &str) {
+    date::sys_time<std::chrono::microseconds> tp;
+    bool parse_ok = false;
+
+    parse_ok = parse_ok || Parse("%F", str, &tp);  // 2020-01-01
+
+    if (!parse_ok) {
+      return std::make_pair(false, type::date_t{0});
+    }
+
+    auto days = date::floor<date::days>(tp);
+    auto julian_date = DateFromYMD(date::year_month_day{days});
+    return std::make_pair(true, julian_date);
+  }
+
+  /**
+   * Attempt to parse @p str into the internal timestamp representation.
+   * @param str The string to be parsed.
+   * @return (True, parse result) if parse succeeded; (False, undefined) otherwise
+   */
+  static std::pair<bool, type::timestamp_t> ParseTimestamp(const std::string &str) {
+    date::sys_time<std::chrono::microseconds> tp;
+    bool parse_ok = false;
+
+    // TODO(WAN): what formats does postgres support?
+    parse_ok = parse_ok || Parse("%F %T%z", str, &tp);  // 2020-01-01 11:11:11.123-0500
+    parse_ok = parse_ok || Parse("%F %TZ", str, &tp);   // 2020-01-01 11:11:11.123Z
+    parse_ok = parse_ok || Parse("%F %T", str, &tp);    // 2020-01-01 11:11:11.123
+    parse_ok = parse_ok || Parse("%FT%T%z", str, &tp);  // 2020-01-01T11:11:11.123-0500
+    parse_ok = parse_ok || Parse("%FT%TZ", str, &tp);   // 2020-01-01T11:11:11.123Z
+    parse_ok = parse_ok || Parse("%FT%T", str, &tp);    // 2020-01-01T11:11:11.123
+
+    if (!parse_ok) {
+      return std::make_pair(false, type::timestamp_t{0});
+    }
+
+    auto dp = date::floor<date::days>(tp);
+    date::year_month_day ymd{dp};
+    auto julian_date = DateFromYMD(ymd);
+
+    auto td = date::time_of_day<std::chrono::microseconds>(tp - dp);
+    auto day_us = !julian_date * MICROSECONDS_PER_DAY;
+    auto h_us = td.hours().count() * MICROSECONDS_PER_HOUR;
+    auto m_us = td.minutes().count() * MICROSECONDS_PER_MINUTE;
+    auto s_us = td.seconds().count() * MICROSECONDS_PER_SECOND;
+    auto remaining_us = td.subseconds().count();
+
+    auto julian_timestamp = type::timestamp_t{day_us + h_us + m_us + s_us + remaining_us};
+    return std::make_pair(true, julian_timestamp);
+  }
+
+  /** @return The @p date formatted as a string. */
+  static std::string FormatDate(const type::date_t date) {
+    std::stringstream ss;
+    ss << YMDFromDate(date);
+    return ss.str();
+  }
+
+  /** @return The @p timestamp formatted as a string. */
+  static std::string FormatTimestamp(const type::timestamp_t timestamp) {
+    auto date = DateFromTimestamp(timestamp);
+    auto ymd = YMDFromDate(date);
+    auto tp = date::sys_days(ymd) + std::chrono::microseconds{!timestamp - !date * MICROSECONDS_PER_DAY};
+
+    std::stringstream ss;
+    date::operator<<(ss, tp);
+    return ss.str();
+  }
+
+  /** PostgreSQL function for serializing dates to 32-bit Julian days. */
+  static uint32_t PostgresDate2J(int32_t year, uint32_t month, uint32_t day) {
+    /*
+     * PostgreSQL backend/utils/adt/datetime.c date2j()
+     * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
+     * Portions Copyright (c) 1994, Regents of the University of California
+     */
+    // Yoinked from Postgres. Overflow-safe serialization of a date to Julian uint32_t.
+
+    if (month > 2) {
+      month += 1;
+      year += 4800;
+    } else {
+      month += 13;
+      year += 4799;
+    }
+
+    uint32_t century = year / 100;
+    uint32_t julian = year * 365 - 32167;
+    julian += year / 4 - century + century / 4;
+    julian += 7834 * month / 256 + day;
+    return julian;
+  }
+
+  /** PostgreSQL functino for deserializing 32-bit Julian days to a date. */
+  static date::year_month_day PostgresJ2Date(uint32_t julian_days) {
+    /*
+     * PostgreSQL backend/utils/adt/datetime.c j2date()
+     * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
+     * Portions Copyright (c) 1994, Regents of the University of California
+     */
+    // Yoinked from Postgres. De-serialization of their Julian uint32_t encoding.
+
+    uint32_t julian = julian_days;
+    julian += 32044;
+
+    uint32_t quad = julian / 146097;
+    uint32_t extra = (julian - quad * 146097) * 4 + 3;
+
+    julian += 60 + quad * 3 + extra / 146097;
+    quad = julian / 1461;
+    julian -= quad * 1461;
+    int32_t y = julian * 4 / 1461;
+    julian = ((y != 0) ? ((julian + 305) % 365) : ((julian + 306) % 366)) + 123;
+    y += quad * 4;
+    quad = julian * 2141 / 65536;
+
+    int32_t year = y - 4800;
+    uint32_t month = (quad + 10) % 12 + 1;
+    uint32_t day = julian - 7834 * quad / 256;
+
+    date::year_month_day ymd{date::year{year}, date::month{month}, date::day{day}};
+    return ymd;
+  }
+
+ private:
+  static constexpr uint64_t MICROSECONDS_PER_SECOND = 1000 * 1000;
+  static constexpr uint64_t MICROSECONDS_PER_MINUTE = 60UL * MICROSECONDS_PER_SECOND;
+  static constexpr uint64_t MICROSECONDS_PER_HOUR = 60UL * MICROSECONDS_PER_MINUTE;
+  static constexpr uint64_t MICROSECONDS_PER_DAY = 24UL * MICROSECONDS_PER_HOUR;
+
+  /**
+   * Parse the provided string @p str according to the format string @p fmt, storing the result in @p tp.
+   * @param fmt Format string. See howardhinnant.github.io/date/date.html for format specifiers.
+   * @param str String to be parsed.
+   * @param[out] tp Result from parsing the string.
+   * @return True if the parse was successful, false otherwise.
+   */
+  static bool Parse(const std::string &fmt, const std::string &str, date::sys_time<std::chrono::microseconds> *tp) {
+    std::istringstream in(str);
+    in >> date::parse(fmt, *tp);
+    return !in.fail();
+  }
+};
+
+}  // namespace terrier::util

--- a/src/include/util/time_util.h
+++ b/src/include/util/time_util.h
@@ -64,6 +64,7 @@ class TimeConvertor {
     date::sys_time<std::chrono::microseconds> tp;
     bool parse_ok = false;
 
+    // WARNING: Must go from most restrictive to least restrictive!
     parse_ok = parse_ok || Parse("%F", str, &tp);  // 2020-01-01
 
     if (!parse_ok) {
@@ -85,13 +86,14 @@ class TimeConvertor {
     bool parse_ok = false;
 
     // TODO(WAN): what formats does postgres support?
-    parse_ok = parse_ok || Parse("%F", str, &tp);       // 2020-01-01
+    // WARNING: Must go from most restrictive to least restrictive!
     parse_ok = parse_ok || Parse("%F %T%z", str, &tp);  // 2020-01-01 11:11:11.123-0500
     parse_ok = parse_ok || Parse("%F %TZ", str, &tp);   // 2020-01-01 11:11:11.123Z
     parse_ok = parse_ok || Parse("%F %T", str, &tp);    // 2020-01-01 11:11:11.123
     parse_ok = parse_ok || Parse("%FT%T%z", str, &tp);  // 2020-01-01T11:11:11.123-0500
     parse_ok = parse_ok || Parse("%FT%TZ", str, &tp);   // 2020-01-01T11:11:11.123Z
     parse_ok = parse_ok || Parse("%FT%T", str, &tp);    // 2020-01-01T11:11:11.123
+    parse_ok = parse_ok || Parse("%F", str, &tp);       // 2020-01-01
 
     if (!parse_ok) {
       return std::make_pair(false, type::timestamp_t{0});

--- a/test/execution/compiler_test.cpp
+++ b/test/execution/compiler_test.cpp
@@ -1956,8 +1956,8 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
   // Make the parameter values.
   std::string str1("37 Strings");
   std::string str2("73 Strings");
-  sql::Date date1(1937, 3, 7);
-  sql::Date date2(1973, 7, 3);
+  sql::DateVal date1(sql::Date::FromYMD(1937, 3, 7));
+  sql::DateVal date2(sql::Date::FromYMD(1973, 7, 3));
   double real1 = 37.73;
   double real2 = 73.37;
   bool bool1 = true;
@@ -2020,7 +2020,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     std::vector<type::TransientValue> params;
     // First parameter list
     params.emplace_back(type::TransientValueFactory::GetVarChar(str1));
-    params.emplace_back(type::TransientValueFactory::GetDate(type::date_t(date1.int_val_)));
+    params.emplace_back(type::TransientValueFactory::GetDate(type::date_t(date1.val_.ToNative())));
     params.emplace_back(type::TransientValueFactory::GetDecimal(real1));
     params.emplace_back(type::TransientValueFactory::GetBoolean(bool1));
     params.emplace_back(type::TransientValueFactory::GetTinyInt(tinyint1));
@@ -2029,7 +2029,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     params.emplace_back(type::TransientValueFactory::GetBigInt(bigint1));
     // Second parameter list
     params.emplace_back(type::TransientValueFactory::GetVarChar(str2));
-    params.emplace_back(type::TransientValueFactory::GetDate(type::date_t(date2.int_val_)));
+    params.emplace_back(type::TransientValueFactory::GetDate(type::date_t(date2.val_.ToNative())));
     params.emplace_back(type::TransientValueFactory::GetDecimal(real2));
     params.emplace_back(type::TransientValueFactory::GetBoolean(bool2));
     params.emplace_back(type::TransientValueFactory::GetTinyInt(tinyint2));
@@ -2090,7 +2090,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
   RowChecker row_checker = [&](const std::vector<sql::Val *> &vals) {
     // Read cols
     auto col1 = static_cast<sql::StringVal *>(vals[0]);
-    auto col2 = static_cast<sql::Date *>(vals[1]);
+    auto col2 = static_cast<sql::DateVal *>(vals[1]);
     auto col3 = static_cast<sql::Real *>(vals[2]);
     auto col4 = static_cast<sql::BoolVal *>(vals[3]);
     auto col5 = static_cast<sql::Integer *>(vals[4]);
@@ -2112,7 +2112,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     if (num_output_rows == 0) {
       ASSERT_EQ(col1->len_, str1.size());
       ASSERT_EQ(std::memcmp(col1->Content(), str1.data(), col1->len_), 0);
-      ASSERT_EQ(col2->ymd_, date1.ymd_);
+      ASSERT_EQ(col2->val_, date1.val_);
       ASSERT_EQ(col3->val_, real1);
       ASSERT_EQ(col4->val_, bool1);
       ASSERT_EQ(col5->val_, tinyint1);
@@ -2122,7 +2122,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     } else {
       ASSERT_TRUE(col1->len_ == str2.size());
       ASSERT_EQ(std::memcmp(col1->Content(), str2.data(), col1->len_), 0);
-      ASSERT_EQ(col2->ymd_, date2.ymd_);
+      ASSERT_EQ(col2->val_, date2.val_);
       ASSERT_EQ(col3->val_, real2);
       ASSERT_EQ(col4->val_, bool2);
       ASSERT_EQ(col5->val_, tinyint2);

--- a/test/execution/date_functions_test.cpp
+++ b/test/execution/date_functions_test.cpp
@@ -8,125 +8,125 @@
 namespace terrier::execution::sql::test {
 class DateFunctionsTests : public TplTest {};
 
-#define CHECK_COMPARSION_NULL(comp, res, lhs, rhs) \
-  ComparisonFunctions::comp##Date(&res, lhs, rhs); \
+#define CHECK_COMPARISON_NULL(comp, res, lhs, rhs)    \
+  ComparisonFunctions::comp##DateVal(&res, lhs, rhs); \
   ASSERT_TRUE(res.is_null_)
 
-#define CHECK_COMPARSION_TRUE(comp, res, lhs, rhs) \
-  ComparisonFunctions::comp##Date(&res, lhs, rhs); \
+#define CHECK_COMPARISON_TRUE(comp, res, lhs, rhs)    \
+  ComparisonFunctions::comp##DateVal(&res, lhs, rhs); \
   ASSERT_TRUE(!res.is_null_ && res.val_)
 
-#define CHECK_COMPARSION_FALSE(comp, res, lhs, rhs) \
-  ComparisonFunctions::comp##Date(&res, lhs, rhs);  \
+#define CHECK_COMPARISON_FALSE(comp, res, lhs, rhs)   \
+  ComparisonFunctions::comp##DateVal(&res, lhs, rhs); \
   ASSERT_TRUE(!res.is_null_ && !res.val_)
 
 // NOLINTNEXTLINE
 TEST_F(DateFunctionsTests, DateNilTest) {
-  Date nil_date1(Date::Null());
-  Date nil_date2(Date::Null());
-  Date date(2019, 8, 11);
+  DateVal nil_date1(DateVal::Null());
+  DateVal nil_date2(DateVal::Null());
+  DateVal date(Date::FromYMD(2019, 8, 11));
   BoolVal res{false};
 
   // Nil comparison should return nil
   // Nil is lhs
-  CHECK_COMPARSION_NULL(Eq, res, nil_date1, date);
-  CHECK_COMPARSION_NULL(Ne, res, nil_date1, date);
-  CHECK_COMPARSION_NULL(Le, res, nil_date1, date);
-  CHECK_COMPARSION_NULL(Lt, res, nil_date1, date);
-  CHECK_COMPARSION_NULL(Ge, res, nil_date1, date);
-  CHECK_COMPARSION_NULL(Gt, res, nil_date1, date);
+  CHECK_COMPARISON_NULL(Eq, res, nil_date1, date);
+  CHECK_COMPARISON_NULL(Ne, res, nil_date1, date);
+  CHECK_COMPARISON_NULL(Le, res, nil_date1, date);
+  CHECK_COMPARISON_NULL(Lt, res, nil_date1, date);
+  CHECK_COMPARISON_NULL(Ge, res, nil_date1, date);
+  CHECK_COMPARISON_NULL(Gt, res, nil_date1, date);
 
   // Nil is rhs
-  CHECK_COMPARSION_NULL(Eq, res, date, nil_date1);
-  CHECK_COMPARSION_NULL(Ne, res, date, nil_date1);
-  CHECK_COMPARSION_NULL(Le, res, date, nil_date1);
-  CHECK_COMPARSION_NULL(Lt, res, date, nil_date1);
-  CHECK_COMPARSION_NULL(Ge, res, date, nil_date1);
-  CHECK_COMPARSION_NULL(Gt, res, date, nil_date1);
+  CHECK_COMPARISON_NULL(Eq, res, date, nil_date1);
+  CHECK_COMPARISON_NULL(Ne, res, date, nil_date1);
+  CHECK_COMPARISON_NULL(Le, res, date, nil_date1);
+  CHECK_COMPARISON_NULL(Lt, res, date, nil_date1);
+  CHECK_COMPARISON_NULL(Ge, res, date, nil_date1);
+  CHECK_COMPARISON_NULL(Gt, res, date, nil_date1);
 
   // Nil in both arguments
-  CHECK_COMPARSION_NULL(Eq, res, nil_date1, nil_date2);
-  CHECK_COMPARSION_NULL(Ne, res, nil_date1, nil_date2);
-  CHECK_COMPARSION_NULL(Le, res, nil_date1, nil_date2);
-  CHECK_COMPARSION_NULL(Lt, res, nil_date1, nil_date2);
-  CHECK_COMPARSION_NULL(Ge, res, nil_date1, nil_date2);
-  CHECK_COMPARSION_NULL(Gt, res, nil_date1, nil_date2);
+  CHECK_COMPARISON_NULL(Eq, res, nil_date1, nil_date2);
+  CHECK_COMPARISON_NULL(Ne, res, nil_date1, nil_date2);
+  CHECK_COMPARISON_NULL(Le, res, nil_date1, nil_date2);
+  CHECK_COMPARISON_NULL(Lt, res, nil_date1, nil_date2);
+  CHECK_COMPARISON_NULL(Ge, res, nil_date1, nil_date2);
+  CHECK_COMPARISON_NULL(Gt, res, nil_date1, nil_date2);
 }
 
 // NOLINTNEXTLINE
 TEST_F(DateFunctionsTests, EqualDateTest) {
-  Date base1(2019, 8, 11);
-  Date base2(2019, 8, 11);
+  DateVal base1(Date::FromYMD(2019, 8, 11));
+  DateVal base2(Date::FromYMD(2019, 8, 11));
 
   BoolVal res{false};
   // ==, <=, >= should be true
-  CHECK_COMPARSION_TRUE(Eq, res, base1, base2);
-  CHECK_COMPARSION_TRUE(Le, res, base1, base2);
-  CHECK_COMPARSION_TRUE(Ge, res, base1, base2);
+  CHECK_COMPARISON_TRUE(Eq, res, base1, base2);
+  CHECK_COMPARISON_TRUE(Le, res, base1, base2);
+  CHECK_COMPARISON_TRUE(Ge, res, base1, base2);
   // !=, <, > should be false
-  CHECK_COMPARSION_FALSE(Ne, res, base1, base2);
-  CHECK_COMPARSION_FALSE(Lt, res, base1, base2);
-  CHECK_COMPARSION_FALSE(Gt, res, base1, base2);
+  CHECK_COMPARISON_FALSE(Ne, res, base1, base2);
+  CHECK_COMPARISON_FALSE(Lt, res, base1, base2);
+  CHECK_COMPARISON_FALSE(Gt, res, base1, base2);
 }
 
 // NOLINTNEXTLINE
 TEST_F(DateFunctionsTests, DifferentDatesTest) {
-  Date base(2019, 8, 11);
-  Date past_day(2019, 8, 10);
-  Date past_month(2019, 7, 28);
-  Date past_year(2018, 12, 28);
+  DateVal base(Date::FromYMD(2019, 8, 11));
+  DateVal past_day(Date::FromYMD(2019, 8, 10));
+  DateVal past_month(Date::FromYMD(2019, 7, 28));
+  DateVal past_year(Date::FromYMD(2018, 12, 28));
 
   BoolVal res{false};
   // >, >=, != should be true if base is lhs
-  CHECK_COMPARSION_TRUE(Gt, res, base, past_day);
-  CHECK_COMPARSION_TRUE(Gt, res, base, past_month);
-  CHECK_COMPARSION_TRUE(Gt, res, base, past_year);
-  CHECK_COMPARSION_TRUE(Ge, res, base, past_day);
-  CHECK_COMPARSION_TRUE(Ge, res, base, past_month);
-  CHECK_COMPARSION_TRUE(Ge, res, base, past_year);
-  CHECK_COMPARSION_TRUE(Ne, res, base, past_day);
-  CHECK_COMPARSION_TRUE(Ne, res, base, past_month);
-  CHECK_COMPARSION_TRUE(Ne, res, base, past_year);
+  CHECK_COMPARISON_TRUE(Gt, res, base, past_day);
+  CHECK_COMPARISON_TRUE(Gt, res, base, past_month);
+  CHECK_COMPARISON_TRUE(Gt, res, base, past_year);
+  CHECK_COMPARISON_TRUE(Ge, res, base, past_day);
+  CHECK_COMPARISON_TRUE(Ge, res, base, past_month);
+  CHECK_COMPARISON_TRUE(Ge, res, base, past_year);
+  CHECK_COMPARISON_TRUE(Ne, res, base, past_day);
+  CHECK_COMPARISON_TRUE(Ne, res, base, past_month);
+  CHECK_COMPARISON_TRUE(Ne, res, base, past_year);
 
   // ==, <, <= should be false if base is lhs
-  CHECK_COMPARSION_FALSE(Eq, res, base, past_day);
-  CHECK_COMPARSION_FALSE(Eq, res, base, past_month);
-  CHECK_COMPARSION_FALSE(Eq, res, base, past_year);
-  CHECK_COMPARSION_FALSE(Lt, res, base, past_day);
-  CHECK_COMPARSION_FALSE(Lt, res, base, past_month);
-  CHECK_COMPARSION_FALSE(Lt, res, base, past_year);
-  CHECK_COMPARSION_FALSE(Le, res, base, past_day);
-  CHECK_COMPARSION_FALSE(Le, res, base, past_month);
-  CHECK_COMPARSION_FALSE(Le, res, base, past_year);
+  CHECK_COMPARISON_FALSE(Eq, res, base, past_day);
+  CHECK_COMPARISON_FALSE(Eq, res, base, past_month);
+  CHECK_COMPARISON_FALSE(Eq, res, base, past_year);
+  CHECK_COMPARISON_FALSE(Lt, res, base, past_day);
+  CHECK_COMPARISON_FALSE(Lt, res, base, past_month);
+  CHECK_COMPARISON_FALSE(Lt, res, base, past_year);
+  CHECK_COMPARISON_FALSE(Le, res, base, past_day);
+  CHECK_COMPARISON_FALSE(Le, res, base, past_month);
+  CHECK_COMPARISON_FALSE(Le, res, base, past_year);
 
   // <, <=, != should be true if base is rhs
-  CHECK_COMPARSION_TRUE(Lt, res, past_day, base);
-  CHECK_COMPARSION_TRUE(Lt, res, past_month, base);
-  CHECK_COMPARSION_TRUE(Lt, res, past_year, base);
-  CHECK_COMPARSION_TRUE(Le, res, past_day, base);
-  CHECK_COMPARSION_TRUE(Le, res, past_month, base);
-  CHECK_COMPARSION_TRUE(Le, res, past_year, base);
-  CHECK_COMPARSION_TRUE(Ne, res, past_day, base);
-  CHECK_COMPARSION_TRUE(Ne, res, past_month, base);
-  CHECK_COMPARSION_TRUE(Ne, res, past_year, base);
+  CHECK_COMPARISON_TRUE(Lt, res, past_day, base);
+  CHECK_COMPARISON_TRUE(Lt, res, past_month, base);
+  CHECK_COMPARISON_TRUE(Lt, res, past_year, base);
+  CHECK_COMPARISON_TRUE(Le, res, past_day, base);
+  CHECK_COMPARISON_TRUE(Le, res, past_month, base);
+  CHECK_COMPARISON_TRUE(Le, res, past_year, base);
+  CHECK_COMPARISON_TRUE(Ne, res, past_day, base);
+  CHECK_COMPARISON_TRUE(Ne, res, past_month, base);
+  CHECK_COMPARISON_TRUE(Ne, res, past_year, base);
 
   // >, >=, == should be false id base is rhs
-  CHECK_COMPARSION_FALSE(Gt, res, past_day, base);
-  CHECK_COMPARSION_FALSE(Gt, res, past_month, base);
-  CHECK_COMPARSION_FALSE(Gt, res, past_year, base);
-  CHECK_COMPARSION_FALSE(Ge, res, past_day, base);
-  CHECK_COMPARSION_FALSE(Ge, res, past_month, base);
-  CHECK_COMPARSION_FALSE(Ge, res, past_year, base);
-  CHECK_COMPARSION_FALSE(Eq, res, past_day, base);
-  CHECK_COMPARSION_FALSE(Eq, res, past_month, base);
-  CHECK_COMPARSION_FALSE(Eq, res, past_year, base);
+  CHECK_COMPARISON_FALSE(Gt, res, past_day, base);
+  CHECK_COMPARISON_FALSE(Gt, res, past_month, base);
+  CHECK_COMPARISON_FALSE(Gt, res, past_year, base);
+  CHECK_COMPARISON_FALSE(Ge, res, past_day, base);
+  CHECK_COMPARISON_FALSE(Ge, res, past_month, base);
+  CHECK_COMPARISON_FALSE(Ge, res, past_year, base);
+  CHECK_COMPARISON_FALSE(Eq, res, past_day, base);
+  CHECK_COMPARISON_FALSE(Eq, res, past_month, base);
+  CHECK_COMPARISON_FALSE(Eq, res, past_year, base);
 }
 
 // NOLINTNEXTLINE
 TEST_F(DateFunctionsTests, DateExtractTest) {
-  Date date(2019, 8, 11);
-  ASSERT_EQ(ValUtil::ExtractYear(date), 2019);
-  ASSERT_EQ(ValUtil::ExtractMonth(date), 8);
-  ASSERT_EQ(ValUtil::ExtractDay(date), 11);
+  DateVal date(Date::FromYMD(2019, 8, 11));
+  ASSERT_EQ(date.val_.ExtractYear(), 2019);
+  ASSERT_EQ(date.val_.ExtractMonth(), 8);
+  ASSERT_EQ(date.val_.ExtractDay(), 11);
 }
 }  // namespace terrier::execution::sql::test

--- a/test/execution/is_null_predicate_test.cpp
+++ b/test/execution/is_null_predicate_test.cpp
@@ -22,8 +22,8 @@ TEST_F(IsNullPredicateTests, IsNull) {
   CHECK_IS_NULL_FOR_TYPE(Integer);
   CHECK_IS_NULL_FOR_TYPE(Real);
   CHECK_IS_NULL_FOR_TYPE(StringVal);
-  CHECK_IS_NULL_FOR_TYPE(Date);
-  CHECK_IS_NULL_FOR_TYPE(Timestamp);
+  CHECK_IS_NULL_FOR_TYPE(DateVal);
+  CHECK_IS_NULL_FOR_TYPE(TimestampVal);
 
 #undef CHECK_IS_NULL_FOR_TYPE
 }
@@ -43,12 +43,8 @@ TEST_F(IsNullPredicateTests, IsNotNull) {
   CHECK_IS_NOT_NULL_FOR_TYPE(Integer, 44);
   CHECK_IS_NOT_NULL_FOR_TYPE(Real, 44.0);
   CHECK_IS_NOT_NULL_FOR_TYPE(StringVal, "44");
-  CHECK_IS_NOT_NULL_FOR_TYPE(Date, 44);
-  {
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    CHECK_IS_NOT_NULL_FOR_TYPE(Timestamp, ts);
-  }
+  CHECK_IS_NOT_NULL_FOR_TYPE(DateVal, 44);
+  CHECK_IS_NOT_NULL_FOR_TYPE(TimestampVal, 44);
 
 #undef CHECK_IS_NOT_NULL_FOR_TYPE
 }

--- a/test/include/execution/compiler/expression_util.h
+++ b/test/include/execution/compiler/expression_util.h
@@ -53,9 +53,9 @@ class ExpressionMaker {
   /**
    * Create a date constant expression
    */
-  ManagedExpression Constant(int16_t year, uint8_t month, uint8_t day) {
-    sql::Date date(year, month, day);
-    type::date_t int_val(date.int_val_);
+  ManagedExpression Constant(int32_t year, uint32_t month, uint32_t day) {
+    sql::DateVal date(sql::Date::FromYMD(year, month, day));
+    type::date_t int_val(date.val_.ToNative());
     return MakeManaged(
         std::make_unique<parser::ConstantValueExpression>(type::TransientValueFactory::GetDate(int_val)));
   }
@@ -64,10 +64,10 @@ class ExpressionMaker {
    * Create a date constant expression
    */
   ManagedExpression Constant(date::year_month_day ymd) {
-    sql::Date date(ymd.year(), ymd.month(), ymd.day());
-    type::date_t int_val(date.int_val_);
-    return MakeManaged(
-        std::make_unique<parser::ConstantValueExpression>(type::TransientValueFactory::GetDate(int_val)));
+    auto year = static_cast<int32_t>(ymd.year());
+    auto month = static_cast<uint32_t>(ymd.month());
+    auto day = static_cast<uint32_t>(ymd.day());
+    return Constant(year, month, day);
   }
 
   /**

--- a/test/include/execution/compiler/output_checker.h
+++ b/test/include/execution/compiler/output_checker.h
@@ -302,7 +302,12 @@ class OutputStore {
             break;
           }
           case terrier::type::TypeId::DATE: {
-            auto *val = reinterpret_cast<sql::Date *>(tuples + row * tuple_size + curr_offset);
+            auto *val = reinterpret_cast<sql::DateVal *>(tuples + row * tuple_size + curr_offset);
+            vals.emplace_back(val);
+            break;
+          }
+          case terrier::type::TypeId::TIMESTAMP: {
+            auto *val = reinterpret_cast<sql::TimestampVal *>(tuples + row * tuple_size + curr_offset);
             vals.emplace_back(val);
             break;
           }

--- a/test/optimizer/tpcc_plan_neworder_test.cpp
+++ b/test/optimizer/tpcc_plan_neworder_test.cpp
@@ -94,7 +94,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateDistrict) {
 TEST_F(TpccPlanNewOrderTests, InsertOOrder) {
   std::string query =
       "INSERT INTO \"ORDER\" (O_ID, O_D_ID, O_W_ID, O_C_ID, O_ENTRY_D, O_OL_CNT, O_ALL_LOCAL) "
-      "VALUES (1,2,3,4,0,6,7)";
+      "VALUES (1,2,3,4,'2020-01-02',6,7)";
   OptimizeInsert(query, tbl_order_);
 }
 
@@ -206,8 +206,8 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
 TEST_F(TpccPlanNewOrderTests, InsertOrderLine) {
   std::string query =
       "INSERT INTO \"ORDER LINE\" "
-      "(OL_O_ID, OL_D_ID, OL_W_ID, OL_NUMBER, OL_I_ID, OL_SUPPLY_W_ID, OL_QUANTITY, OL_AMOUNT, OL_DIST_INFO) "
-      "VALUES (1,2,3,4,5,6,7,8,'dist')";
+      "(OL_O_ID, OL_D_ID, OL_W_ID, OL_NUMBER, OL_I_ID, OL_SUPPLY_W_ID, OL_DELIVERY_D, OL_QUANTITY, OL_AMOUNT, OL_DIST_INFO) "
+      "VALUES (1,2,3,4,5,6,'2020-01-02',7,8,'dist')";
   OptimizeInsert(query, tbl_order_line_);
 }
 

--- a/test/optimizer/tpcc_plan_neworder_test.cpp
+++ b/test/optimizer/tpcc_plan_neworder_test.cpp
@@ -206,7 +206,8 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
 TEST_F(TpccPlanNewOrderTests, InsertOrderLine) {
   std::string query =
       "INSERT INTO \"ORDER LINE\" "
-      "(OL_O_ID, OL_D_ID, OL_W_ID, OL_NUMBER, OL_I_ID, OL_SUPPLY_W_ID, OL_DELIVERY_D, OL_QUANTITY, OL_AMOUNT, OL_DIST_INFO) "
+      "(OL_O_ID, OL_D_ID, OL_W_ID, OL_NUMBER, OL_I_ID, OL_SUPPLY_W_ID, OL_DELIVERY_D, OL_QUANTITY, OL_AMOUNT, "
+      "OL_DIST_INFO) "
       "VALUES (1,2,3,4,5,6,'2020-01-02',7,8,'dist')";
   OptimizeInsert(query, tbl_order_line_);
 }

--- a/test/optimizer/tpcc_plan_payment_test.cpp
+++ b/test/optimizer/tpcc_plan_payment_test.cpp
@@ -205,7 +205,7 @@ TEST_F(TpccPlanPaymentTests, InsertHistory) {
   std::string query =
       "INSERT INTO HISTORY "
       "(H_C_D_ID, H_C_W_ID, H_C_ID, H_D_ID, H_W_ID, H_DATE, H_AMOUNT, H_DATA) "
-      "VALUES (1,2,3,4,5,0,7,'data')";
+      "VALUES (1,2,3,4,5,'2020-01-02',7,'data')";
   OptimizeInsert(query, tbl_history_);
 }
 

--- a/test/util/time_util_test.cpp
+++ b/test/util/time_util_test.cpp
@@ -1,0 +1,26 @@
+#include "util/time_util.h"
+#include "test_util/test_harness.h"
+#include "type/transient_value_factory.h"
+
+namespace terrier {
+
+struct TimeUtilTests : public TerrierTest {};
+
+TEST_F(TimeUtilTests, DateTest) {
+  date::year_month_day d{date::year(2020), date::month(1), date::day(1)};
+  auto res = util::TimeConvertor::ParseDate("2020-01-01");
+  EXPECT_TRUE(res.first);
+  EXPECT_EQ(res.second, util::TimeConvertor::DateFromYMD(d));
+  EXPECT_EQ(util::TimeConvertor::YMDFromDate(res.second), d);
+  EXPECT_EQ(util::TimeConvertor::FormatDate(res.second), "2020-01-01");
+}
+
+TEST_F(TimeUtilTests, TimestampTest) {
+  auto res = util::TimeConvertor::ParseTimestamp("2020-01-01 11:22:33.123");
+  EXPECT_TRUE(res.first);
+  EXPECT_EQ(util::TimeConvertor::FormatTimestamp(res.second), "2020-01-01 11:22:33.123000");
+}
+
+// TODO(WAN): throw in some timezone tests
+
+}  // namespace terrier

--- a/util/execution/tpl.cpp
+++ b/util/execution/tpl.cpp
@@ -92,11 +92,11 @@ static void CompileAndRun(const std::string &source, const std::string &name = "
   exec::ExecutionContext exec_ctx{db_oid, common::ManagedPointer(txn), printer, output_schema,
                                   common::ManagedPointer(accessor)};
   // Add dummy parameters for tests
-  sql::Date date(1937, 3, 7);
+  sql::DateVal date(sql::Date::FromYMD(1937, 3, 7));
   std::vector<type::TransientValue> params;
   params.emplace_back(type::TransientValueFactory::GetInteger(37));
   params.emplace_back(type::TransientValueFactory::GetDecimal(37.73));
-  params.emplace_back(type::TransientValueFactory::GetDate(type::date_t(date.int_val_)));
+  params.emplace_back(type::TransientValueFactory::GetDate(type::date_t(date.val_.ToNative())));
   params.emplace_back(type::TransientValueFactory::GetVarChar("37 Strings"));
   exec_ctx.SetParams(std::move(params));
 


### PR DESCRIPTION
Ported Prashanth's latest DateVal and TimestampVal to the execution engine.

Date and Timestamp are now internally represented as 4-byte Julian days and 8-byte Julian microseconds respectively, just like in PostgreSQL. We use PostgreSQL's date2j() and j2date() functions.

New TPL builtins:
- @timestampToSql(julian_microseconds)
- @timestampToSqlHMSu(year, month, day, hour, minute, second, microseconds)

Some tests: `sample_tpl/types/timestamps.tpl`, `test/util/time_util_test.cpp`

We can extend the number of supported date/timestamp format strings in `src/include/util/time_util.h`, just a very basic set for now. Pretty-printing/formatting of timestamps becomes significantly easier in C++20 (or we can pull in another header from Howard's date library), I punted on that.

Currently, execution flow looks like
Parser: receives ConstantValueExpression with a string or a TypeCastExpression with a child containing the string
Binder (raw inserts only): creates a new ConstantValueExpression containing the date or timestamp, adds it to the `parse_result`, **does not** remove the old expression from the `parse_result`, replaces the old insert value in the insert values list
(shuttles off to optimizer land)
Execution: reconstructs its own internal representation (`runtime_types.h`) of dates or timestamps

Removed:
- I had added support for 4-byte yymd dates. Julian dates are generally better because they let you represent a much higher range of dates and enable very simple comparison operations, but you pay a price in serializing to/from calendar time.
- I had added support for 16-byte timespec-based nanosecond-precision Timestamp. If we need to add support for 16-byte types in the future, it is generally sufficient to modify offset calculations in StorageUtil::ComputeBaseAttributeOffsets. The current scan-based approach in that function is overkill. I was probably too hyped from 210 and should probably refactor that function to be something more readable and/or performant in the future.