### PR TITLE
IndexScan Table Alias Fix

### DIFF
--- a/src/include/optimizer/physical_operators.h
+++ b/src/include/optimizer/physical_operators.h
@@ -147,17 +147,18 @@ class IndexScan : public OperatorNode<IndexScan> {
   /**
    * @param database_oid OID of the database
    * @param namespace_oid OID of the namespace
+   * @param tbl_oid OID of the table
    * @param index_oid OID of the index
    * @param predicates query predicates
-   * @param table_alias alias of the table
    * @param is_for_update whether the scan is used for update
    * @param scan_type IndexScanType
    * @param bounds Bounds for IndexScan
    * @return an IndexScan operator
    */
   static Operator Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
-                       catalog::index_oid_t index_oid, std::vector<AnnotatedExpression> &&predicates,
-                       std::string table_alias, bool is_for_update, planner::IndexScanType scan_type,
+                       catalog::table_oid_t tbl_oid, catalog::index_oid_t index_oid,
+                       std::vector<AnnotatedExpression> &&predicates, bool is_for_update,
+                       planner::IndexScanType scan_type,
                        std::unordered_map<catalog::indexkeycol_oid_t, std::vector<planner::IndexExpression>> bounds);
 
   /**
@@ -183,17 +184,17 @@ class IndexScan : public OperatorNode<IndexScan> {
   /**
    * @return the OID of the table
    */
+  const catalog::table_oid_t &GetTableOID() const { return tbl_oid_; }
+
+  /**
+   * @return the OID of the index
+   */
   const catalog::index_oid_t &GetIndexOID() const { return index_oid_; }
 
   /**
    * @return the vector of predicates for get
    */
   const std::vector<AnnotatedExpression> &GetPredicates() const { return predicates_; }
-
-  /**
-   * @return the alias of the table to get from
-   */
-  const std::string &GetTableAlias() const { return table_alias_; }
 
   /**
    * @return whether the get operation is used for update
@@ -224,6 +225,11 @@ class IndexScan : public OperatorNode<IndexScan> {
   catalog::namespace_oid_t namespace_oid_;
 
   /**
+   * OID of the table
+   */
+  catalog::table_oid_t tbl_oid_;
+
+  /**
    * OID of the index
    */
   catalog::index_oid_t index_oid_;
@@ -232,11 +238,6 @@ class IndexScan : public OperatorNode<IndexScan> {
    * Query predicates
    */
   std::vector<AnnotatedExpression> predicates_;
-
-  /**
-   * Table alias
-   */
-  std::string table_alias_;
 
   /**
    * Whether the scan is used for update

--- a/src/optimizer/child_property_deriver.cpp
+++ b/src/optimizer/child_property_deriver.cpp
@@ -32,7 +32,7 @@ void ChildPropertyDeriver::Visit(UNUSED_ATTRIBUTE const SeqScan *op) {
 
 void ChildPropertyDeriver::Visit(const IndexScan *op) {
   // Use GetIndexOids() to get all indexes on table_alias
-  auto tbl_id = accessor_->GetTableOid(op->GetNamespaceOID(), op->GetTableAlias());
+  auto tbl_id = op->GetTableOID();
   std::vector<catalog::index_oid_t> tbl_indexes = accessor_->GetIndexOids(tbl_id);
 
   auto *property_set = new PropertySet();

--- a/src/optimizer/physical_operators.cpp
+++ b/src/optimizer/physical_operators.cpp
@@ -79,14 +79,15 @@ common::hash_t SeqScan::Hash() const {
 BaseOperatorNode *IndexScan::Copy() const { return new IndexScan(*this); }
 
 Operator IndexScan::Make(catalog::db_oid_t database_oid, catalog::namespace_oid_t namespace_oid,
-                         catalog::index_oid_t index_oid, std::vector<AnnotatedExpression> &&predicates,
-                         std::string table_alias, bool is_for_update, planner::IndexScanType scan_type,
+                         catalog::table_oid_t tbl_oid, catalog::index_oid_t index_oid,
+                         std::vector<AnnotatedExpression> &&predicates, bool is_for_update,
+                         planner::IndexScanType scan_type,
                          std::unordered_map<catalog::indexkeycol_oid_t, std::vector<planner::IndexExpression>> bounds) {
   auto scan = std::make_unique<IndexScan>();
   scan->database_oid_ = database_oid;
   scan->namespace_oid_ = namespace_oid;
+  scan->tbl_oid_ = tbl_oid;
   scan->index_oid_ = index_oid;
-  scan->table_alias_ = std::move(table_alias);
   scan->is_for_update_ = is_for_update;
   scan->predicates_ = std::move(predicates);
   scan->scan_type_ = scan_type;
@@ -98,7 +99,7 @@ bool IndexScan::operator==(const BaseOperatorNode &r) {
   if (r.GetType() != OpType::INDEXSCAN) return false;
   const IndexScan &node = *dynamic_cast<const IndexScan *>(&r);
   if (database_oid_ != node.database_oid_ || namespace_oid_ != node.namespace_oid_ || index_oid_ != node.index_oid_ ||
-      table_alias_ != node.table_alias_ || predicates_.size() != node.predicates_.size() ||
+      tbl_oid_ != node.tbl_oid_ || predicates_.size() != node.predicates_.size() ||
       is_for_update_ != node.is_for_update_ || scan_type_ != node.scan_type_)
     return false;
 
@@ -127,8 +128,8 @@ common::hash_t IndexScan::Hash() const {
   common::hash_t hash = BaseOperatorNode::Hash();
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(database_oid_));
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(namespace_oid_));
+  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(tbl_oid_));
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(index_oid_));
-  hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(table_alias_));
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(is_for_update_));
   hash = common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(scan_type_));
   for (auto &pred : predicates_) {

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -191,7 +191,7 @@ void PlanGenerator::Visit(const IndexScan *op) {
   // An IndexScan (for now at least) will output all columns of its table
   std::vector<catalog::col_oid_t> column_ids = GenerateColumnsForScan();
 
-  catalog::table_oid_t tbl_oid = accessor_->GetTableOid(op->GetNamespaceOID(), op->GetTableAlias());
+  auto tbl_oid = op->GetTableOID();
   auto output_schema = GenerateScanOutputSchema(tbl_oid);
 
   // Generate the predicate in the scan

--- a/src/optimizer/rules/implementation_rules.cpp
+++ b/src/optimizer/rules/implementation_rules.cpp
@@ -127,7 +127,7 @@ void LogicalGetToPhysicalIndexScan::Transform(common::ManagedPointer<OperatorExp
         if (IndexUtil::SatisfiesSortWithIndex(accessor, sort_prop, get->GetTableOid(), index)) {
           std::vector<AnnotatedExpression> preds = get->GetPredicates();
           auto op = std::make_unique<OperatorExpression>(
-              IndexScan::Make(db_oid, ns_oid, index, std::move(preds), get->GetTableAlias(), is_update,
+              IndexScan::Make(db_oid, ns_oid, get->GetTableOid(), index, std::move(preds), is_update,
                               planner::IndexScanType::AscendingOpenBoth, {}),
               std::vector<std::unique_ptr<OperatorExpression>>());
           transformed->emplace_back(std::move(op));
@@ -146,7 +146,7 @@ void LogicalGetToPhysicalIndexScan::Transform(common::ManagedPointer<OperatorExp
       std::vector<AnnotatedExpression> preds = get->GetPredicates();
       if (IndexUtil::SatisfiesPredicateWithIndex(accessor, get->GetTableOid(), index, preds, &scan_type, &bounds)) {
         auto op = std::make_unique<OperatorExpression>(
-            IndexScan::Make(db_oid, ns_oid, index, std::move(preds), get->GetTableAlias(), is_update, scan_type,
+            IndexScan::Make(db_oid, ns_oid, get->GetTableOid(), index, std::move(preds), is_update, scan_type,
                             std::move(bounds)),
             std::vector<std::unique_ptr<OperatorExpression>>());
         transformed->emplace_back(std::move(op));

--- a/test/optimizer/physical_operator_test.cpp
+++ b/test/optimizer/physical_operator_test.cpp
@@ -141,42 +141,42 @@ TEST(OperatorTests, IndexScanTest) {
   auto type = planner::IndexScanType::AscendingClosed;
 
   // different from index_scan_1 in dbOID
-  Operator index_scan_01 = IndexScan::Make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
-                                           std::vector<AnnotatedExpression>(), "table", false, type, {});
+  Operator index_scan_01 = IndexScan::Make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
+                                           std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in namespace OID
-  Operator index_scan_02 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::index_oid_t(3),
-                                           std::vector<AnnotatedExpression>(), "table", false, type, {});
+  Operator index_scan_02 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::table_oid_t(4), catalog::index_oid_t(3),
+                                           std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in index OID
-  Operator index_scan_03 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(4),
-                                           std::vector<AnnotatedExpression>(), "table", false, type, {});
+  Operator index_scan_03 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(4),
+                                           std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in table alias
-  Operator index_scan_04 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
-                                           std::vector<AnnotatedExpression>(), "tableTable", false, type, {});
+  Operator index_scan_04 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(5), catalog::index_oid_t(3),
+                                           std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in 'is for update'
-  Operator index_scan_05 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
-                                           std::vector<AnnotatedExpression>(), "table", true, type, {});
-  Operator index_scan_1 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>(), "table", false, type, {});
-  Operator index_scan_2 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>(), "table", false, type, {});
+  Operator index_scan_05 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
+                                           std::vector<AnnotatedExpression>(), true, type, {});
+  Operator index_scan_1 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
+                                          std::vector<AnnotatedExpression>(), false, type, {});
+  Operator index_scan_2 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
+                                          std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in predicates
-  Operator index_scan_3 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>{annotated_expr_0}, "table", false, type, {});
-  Operator index_scan_4 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>{annotated_expr_1}, "table", false, type, {});
-  Operator index_scan_5 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>{annotated_expr_2}, "table", false, type, {});
-  Operator index_scan_6 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>{annotated_expr_3}, "table", false, type, {});
+  Operator index_scan_3 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
+                                          std::vector<AnnotatedExpression>{annotated_expr_0}, false, type, {});
+  Operator index_scan_4 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
+                                          std::vector<AnnotatedExpression>{annotated_expr_1}, false, type, {});
+  Operator index_scan_5 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
+                                          std::vector<AnnotatedExpression>{annotated_expr_2}, false, type, {});
+  Operator index_scan_6 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
+                                          std::vector<AnnotatedExpression>{annotated_expr_3}, false, type, {});
 
   EXPECT_EQ(index_scan_1.GetType(), OpType::INDEXSCAN);
   EXPECT_EQ(index_scan_1.As<IndexScan>()->GetDatabaseOID(), catalog::db_oid_t(1));
   EXPECT_EQ(index_scan_1.As<IndexScan>()->GetNamespaceOID(), catalog::namespace_oid_t(2));
+  EXPECT_EQ(index_scan_1.As<IndexScan>()->GetTableOID(), catalog::table_oid_t(4));
   EXPECT_EQ(index_scan_1.As<IndexScan>()->GetIndexOID(), catalog::index_oid_t(3));
   EXPECT_EQ(index_scan_1.As<IndexScan>()->GetPredicates(), std::vector<AnnotatedExpression>());
   EXPECT_EQ(index_scan_3.As<IndexScan>()->GetPredicates(), std::vector<AnnotatedExpression>{annotated_expr_0});
   EXPECT_EQ(index_scan_4.As<IndexScan>()->GetPredicates(), std::vector<AnnotatedExpression>{annotated_expr_1});
-  EXPECT_EQ(index_scan_1.As<IndexScan>()->GetTableAlias(), "table");
   EXPECT_EQ(index_scan_1.As<IndexScan>()->GetIsForUpdate(), false);
   EXPECT_EQ(index_scan_1.GetName(), "IndexScan");
   EXPECT_TRUE(index_scan_1 == index_scan_2);

--- a/test/optimizer/physical_operator_test.cpp
+++ b/test/optimizer/physical_operator_test.cpp
@@ -141,33 +141,41 @@ TEST(OperatorTests, IndexScanTest) {
   auto type = planner::IndexScanType::AscendingClosed;
 
   // different from index_scan_1 in dbOID
-  Operator index_scan_01 = IndexScan::Make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
-                                           std::vector<AnnotatedExpression>(), false, type, {});
+  Operator index_scan_01 =
+      IndexScan::Make(catalog::db_oid_t(2), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+                      catalog::index_oid_t(3), std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in namespace OID
-  Operator index_scan_02 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::table_oid_t(4), catalog::index_oid_t(3),
-                                           std::vector<AnnotatedExpression>(), false, type, {});
+  Operator index_scan_02 =
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(3), catalog::table_oid_t(4),
+                      catalog::index_oid_t(3), std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in index OID
-  Operator index_scan_03 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(4),
-                                           std::vector<AnnotatedExpression>(), false, type, {});
+  Operator index_scan_03 =
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+                      catalog::index_oid_t(4), std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in table alias
-  Operator index_scan_04 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(5), catalog::index_oid_t(3),
-                                           std::vector<AnnotatedExpression>(), false, type, {});
+  Operator index_scan_04 =
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(5),
+                      catalog::index_oid_t(3), std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in 'is for update'
-  Operator index_scan_05 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
-                                           std::vector<AnnotatedExpression>(), true, type, {});
-  Operator index_scan_1 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>(), false, type, {});
-  Operator index_scan_2 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>(), false, type, {});
+  Operator index_scan_05 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+                                           catalog::index_oid_t(3), std::vector<AnnotatedExpression>(), true, type, {});
+  Operator index_scan_1 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+                                          catalog::index_oid_t(3), std::vector<AnnotatedExpression>(), false, type, {});
+  Operator index_scan_2 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+                                          catalog::index_oid_t(3), std::vector<AnnotatedExpression>(), false, type, {});
   // different from index_scan_1 in predicates
-  Operator index_scan_3 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>{annotated_expr_0}, false, type, {});
-  Operator index_scan_4 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>{annotated_expr_1}, false, type, {});
-  Operator index_scan_5 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>{annotated_expr_2}, false, type, {});
-  Operator index_scan_6 = IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4), catalog::index_oid_t(3),
-                                          std::vector<AnnotatedExpression>{annotated_expr_3}, false, type, {});
+  Operator index_scan_3 =
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+                      catalog::index_oid_t(3), std::vector<AnnotatedExpression>{annotated_expr_0}, false, type, {});
+  Operator index_scan_4 =
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+                      catalog::index_oid_t(3), std::vector<AnnotatedExpression>{annotated_expr_1}, false, type, {});
+  Operator index_scan_5 =
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+                      catalog::index_oid_t(3), std::vector<AnnotatedExpression>{annotated_expr_2}, false, type, {});
+  Operator index_scan_6 =
+      IndexScan::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(2), catalog::table_oid_t(4),
+                      catalog::index_oid_t(3), std::vector<AnnotatedExpression>{annotated_expr_3}, false, type, {});
 
   EXPECT_EQ(index_scan_1.GetType(), OpType::INDEXSCAN);
   EXPECT_EQ(index_scan_1.As<IndexScan>()->GetDatabaseOID(), catalog::db_oid_t(1));


### PR DESCRIPTION
Prior to this commit, performing a query like `SELECT * from foo f where f.id = 1` that utilizes an index scan would trigger an assertion failure in the catalog. This PR replaces the table alias stored within the `IndexScan` with the actual table's oid.