### PR TITLE
TerrierServer throws on socket already in use, DBMain catches and returns

### DIFF
--- a/src/main/db_main.cpp
+++ b/src/main/db_main.cpp
@@ -10,7 +10,11 @@ namespace terrier {
 void DBMain::Run() {
   TERRIER_ASSERT(network_layer_ != DISABLED, "Trying to run without a NetworkLayer.");
   const auto server = network_layer_->GetServer();
-  server->RunServer();
+  try {
+    server->RunServer();
+  } catch (NetworkProcessException &e) {
+    return;
+  }
   {
     std::unique_lock<std::mutex> lock(server->RunningMutex());
     server->RunningCV().wait(lock, [=] { return !(server->Running()); });


### PR DESCRIPTION
System now properly handles failing to bind to a socket already in use:
```
[2020-02-03 15:07:45.951] [network_logger] [error] Failed to bind socket: Address already in use
```
Fix #732.