### PR TITLE
Race Condition Fix in ConnectionHandlerTask

### DIFF
--- a/src/include/network/connection_handler_task.h
+++ b/src/include/network/connection_handler_task.h
@@ -51,16 +51,19 @@ class ConnectionHandlerTask : public common::NotifiableTask {
    * This method will create the necessary data structure for the client and
    * register its event base to receive updates with appropriate callbacks
    * when the client writes to the socket.
-   *
+   *[
    * @param new_conn_recv_fd the socket fd of the new connection
    * @param flags unused. For compliance with libevent callback interface.
    */
   void HandleDispatch(int new_conn_recv_fd, int16_t flags);
 
  private:
-  // TODO(Tianyu): This is broken and needs to be fixed. See #413
-  int client_fd_;
-  std::unique_ptr<ProtocolInterpreter> protocol_interpreter_;
+  // using this instead of the Common::ConcurrentQueue as the overhead is not worth
+  // for the common case where there is no contention
+  common::SpinLatch jobs_latch_;
+  std::deque<std::pair<int, std::unique_ptr<ProtocolInterpreter>>> jobs_;
+  //  client_fd_;
+  //  std::unique_ptr<ProtocolInterpreter> protocol_interpreter_;
   event *notify_event_;
   common::ManagedPointer<ConnectionHandleFactory> connection_handle_factory_;
 };

--- a/src/network/connection_handler_task.cpp
+++ b/src/network/connection_handler_task.cpp
@@ -15,6 +15,9 @@ ConnectionHandlerTask::ConnectionHandlerTask(const int task_id,
 
 void ConnectionHandlerTask::Notify(int conn_fd, std::unique_ptr<ProtocolInterpreter> protocol_interpreter) {
   {
+    /**
+     * this latch is needed to avoid a race condition with HandleDispatch consuming this deque in another thread
+     */
     common::SpinLatch::ScopedSpinLatch guard(&jobs_latch_);
     jobs_.emplace_back(conn_fd, std::move(protocol_interpreter));
   }

--- a/src/network/connection_handler_task.cpp
+++ b/src/network/connection_handler_task.cpp
@@ -14,17 +14,22 @@ ConnectionHandlerTask::ConnectionHandlerTask(const int task_id,
 }
 
 void ConnectionHandlerTask::Notify(int conn_fd, std::unique_ptr<ProtocolInterpreter> protocol_interpreter) {
-  client_fd_ = conn_fd;
-  protocol_interpreter_ = std::move(protocol_interpreter);
+  {
+    common::SpinLatch::ScopedSpinLatch guard(&jobs_latch_);
+    jobs_.emplace_back(conn_fd, std::move(protocol_interpreter));
+  }
   int res = 0;         // Flags, unused attribute in event_active
   int16_t ncalls = 0;  // Unused attribute in event_active
   event_active(notify_event_, res, ncalls);
 }
 
 void ConnectionHandlerTask::HandleDispatch(int, int16_t) {  // NOLINT as we don't use the flags arg nor the fd
-  connection_handle_factory_
-      ->NewConnectionHandle(client_fd_, std::move(protocol_interpreter_), common::ManagedPointer(this))
-      .RegisterToReceiveEvents();
+  common::SpinLatch::ScopedSpinLatch guard(&jobs_latch_);
+  for (auto &job : jobs_) {
+    connection_handle_factory_->NewConnectionHandle(job.first, std::move(job.second), common::ManagedPointer(this))
+        .RegisterToReceiveEvents();
+  }
+  jobs_.clear();
 }
 
 }  // namespace terrier::network


### PR DESCRIPTION
Aims to close issue #413 where more connections than CONNECTION_THREAD_COUNT would overwrite an existing ConnectionHandlerTasks client_fd_ and protocol_handler_ fields before it is able to create a valid ConnectionHandle and start it. The fix was turning these fields into queues that are protected by a SpinLatch. The contention is expected to be low on this.