### PR TITLE
Improved distribution checking in packages.sh

### DIFF
--- a/sample_tpl/distinct-agg.tpl
+++ b/sample_tpl/distinct-agg.tpl
@@ -1,0 +1,93 @@
+// Perform:
+//
+// SELECT SUM(DISTINCT colB) from test_1;
+
+
+struct State {
+  sum: IntegerSumAggregate
+  distinct_table: AggregationHashTable
+  count: int32
+}
+
+
+struct Values {
+  sum: Integer
+}
+
+struct DistinctEntry {
+  elem: Integer
+}
+
+
+fun distinctKeyCheck(old: *DistinctEntry, new: *Values) -> bool {
+  return @sqlToBool(old.elem == new.sum)
+}
+
+
+fun setUpState(execCtx: *ExecutionContext, state: *State) -> nil {
+  @aggInit(&state.sum)
+  @aggHTInit(&state.distinct_table, @execCtxGetMem(execCtx), @sizeOf(DistinctEntry))
+  state.count = 0
+}
+
+fun tearDownState(state: *State) -> nil {
+  @aggHTFree(&state.distinct_table)
+}
+
+fun pipeline_1(execCtx: *ExecutionContext, state: *State) -> nil {
+  var tvi: TableVectorIterator
+  var col_oids : [2]uint32
+  col_oids[0] = 1
+  col_oids[1] = 2
+  @tableIterInitBind(&tvi, execCtx, "test_1", col_oids)
+  for (@tableIterAdvance(&tvi)) {
+    var vec = @tableIterGetPCI(&tvi)
+    for (; @pciHasNext(vec); @pciAdvance(vec)) {
+      var values : Values
+      values.sum = @pciGetInt(vec, 1)
+
+      // Check if the value is distinct
+      var hash_val = @hash(values.sum)
+      var is_distinct = @ptrCast(*DistinctEntry, @aggHTLookup(&state.distinct_table, hash_val, distinctKeyCheck, &values))
+      if (is_distinct == nil) {
+        // Update the sum only if the value is distinct.
+        var agg = @ptrCast(*DistinctEntry, @aggHTInsert(&state.distinct_table, hash_val))
+        agg.elem = values.sum
+	var i = @intToSql(1)
+        @aggAdvance(&state.sum, &agg.elem)
+      }
+    }
+  }
+  @tableIterClose(&tvi)
+}
+
+fun pipeline_2(execCtx: *ExecutionContext, state: *State) -> nil {
+  var out = @ptrCast(*Values, @outputAlloc(execCtx))
+  out.sum = @aggResult(&state.sum)
+  for (var i : int64 = 0; @sqlToBool(i < out.sum); i = i + 1) {
+    state.count = state.count + 1
+  }
+  @outputFinalize(execCtx)
+}
+
+fun main(execCtx: *ExecutionContext) -> int32 {
+  var state: State
+  state.count = 0
+
+  // Initialize state
+  setUpState(execCtx, &state)
+
+  // Run pipeline 1
+  pipeline_1(execCtx, &state)
+
+  // Run pipeline 2
+  pipeline_2(execCtx, &state)
+
+  var ret = state.count
+
+  // Cleanup
+  tearDownState(&state)
+
+  return ret
+}
+

--- a/sample_tpl/sort-limit.tpl
+++ b/sample_tpl/sort-limit.tpl
@@ -1,0 +1,85 @@
+// Perform
+//
+// SELECT colA, colB FROM test_1 WHERE colA < 2000 ORDER BY colA LIMIT 100
+//
+// Should return 100 (number of output tuples).
+
+struct State {
+  sorter: Sorter
+}
+
+struct Row {
+  a: Integer
+  b: Integer
+}
+
+fun compareFn(lhs: *Row, rhs: *Row) -> int32 {
+  if (lhs.a < rhs.a) {
+    return -1
+  } else {
+    return 1
+  }
+}
+
+fun setUpState(execCtx: *ExecutionContext, state: *State) -> nil {
+  @sorterInit(&state.sorter, @execCtxGetMem(execCtx), compareFn, @sizeOf(Row))
+}
+
+fun tearDownState(state: *State) -> nil {
+  @sorterFree(&state.sorter)
+}
+
+fun pipeline_1(execCtx: *ExecutionContext, state: *State) -> nil {
+  var sorter = &state.sorter
+  var tvi: TableVectorIterator
+  var oids: [2]uint32
+  oids[0] = 1 // colA
+  oids[1] = 2 // colB
+  @tableIterInitBind(&tvi, execCtx, "test_1", oids)
+  for (@tableIterAdvance(&tvi)) {
+    var pci = @tableIterGetPCI(&tvi)
+    @filterLt(pci, 0, 4, 2000)
+    for (; @pciHasNextFiltered(pci); @pciAdvanceFiltered(pci)) {
+      var row = @ptrCast(*Row, @sorterInsertTopK(sorter, 100))
+      row.a = @pciGetInt(pci, 0)
+      row.b = @pciGetInt(pci, 1)
+      @sorterInsertTopKFinish(sorter, 100)
+    }
+    @pciResetFiltered(pci)
+  }
+  @tableIterClose(&tvi)
+}
+
+fun pipeline_2(state: *State) -> int32 {
+  var ret = 0
+  var sort_iter: SorterIterator
+  for (@sorterIterInit(&sort_iter, &state.sorter);
+       @sorterIterHasNext(&sort_iter);
+       @sorterIterNext(&sort_iter)) {
+    var row = @ptrCast(*Row, @sorterIterGetRow(&sort_iter))
+    ret = ret + 1
+  }
+  @sorterIterClose(&sort_iter)
+  return ret
+}
+
+fun main(execCtx: *ExecutionContext) -> int32 {
+  var state: State
+
+  // Initialize
+  setUpState(execCtx, &state)
+
+  // Pipeline 1
+  pipeline_1(execCtx, &state)
+
+  // Pipeline 1 end
+  @sorterSort(&state.sorter)
+
+  // Pipeline 2
+  var ret = pipeline_2(&state)
+
+  // Cleanup
+  tearDownState(&state)
+
+  return ret
+}

--- a/sample_tpl/static-agg.tpl
+++ b/sample_tpl/static-agg.tpl
@@ -1,0 +1,68 @@
+// Perform:
+//
+// SELECT SUM(colA) from test_1;
+
+struct State {
+  sum: IntegerSumAggregate
+  count: int32
+}
+
+
+struct Values {
+  sum: Integer
+}
+
+fun setUpState(execCtx: *ExecutionContext, state: *State) -> nil {
+  @aggInit(&state.sum)
+  state.count = 0
+}
+
+fun tearDownState(state: *State) -> nil {
+}
+
+fun pipeline_1(execCtx: *ExecutionContext, state: *State) -> nil {
+  var tvi: TableVectorIterator
+  var col_oids : [2]uint32
+  col_oids[0] = 1
+  col_oids[1] = 2
+  @tableIterInitBind(&tvi, execCtx, "test_1", col_oids)
+  for (@tableIterAdvance(&tvi)) {
+    var vec = @tableIterGetPCI(&tvi)
+    for (; @pciHasNext(vec); @pciAdvance(vec)) {
+      var values : Values
+      values.sum = @pciGetInt(vec, 0)
+      @aggAdvance(&state.sum, &values.sum)
+    }
+  }
+  @tableIterClose(&tvi)
+}
+
+fun pipeline_2(execCtx: *ExecutionContext, state: *State) -> nil {
+  var out = @ptrCast(*Values, @outputAlloc(execCtx))
+  out.sum = @aggResult(&state.sum)
+  for (var i : int64 = 0; @sqlToBool(i < out.sum); i = i + 1) {
+    state.count = state.count + 1
+  }
+  @outputFinalize(execCtx)
+}
+
+fun main(execCtx: *ExecutionContext) -> int32 {
+  var state: State
+  state.count = 0
+
+  // Initialize state
+  setUpState(execCtx, &state)
+
+  // Run pipeline 1
+  pipeline_1(execCtx, &state)
+
+  // Run pipeline 2
+  pipeline_2(execCtx, &state)
+
+  var ret = state.count
+
+  // Cleanup
+  tearDownState(&state)
+
+  return ret
+}

--- a/sample_tpl/tpl_tests.txt
+++ b/sample_tpl/tpl_tests.txt
@@ -50,6 +50,8 @@ types/timestamps.tpl,false,0
 agg.tpl,true,10
 agg-vec.tpl,true,10
 agg-vec-filter.tpl,true,10
+static-agg.tpl,true,49995000
+distinct-agg.tpl,true,45
 delete.tpl,true,0
 insert.tpl,true,11
 update.tpl,true,11
@@ -63,6 +65,7 @@ scan-table-3.tpl,true,9950
 scan-alltypes.tpl,true,500
 scan-vpi-iter.tpl,true,500
 sort.tpl,true,2000
+sort-limit.tpl,true,100
 vec-filter.tpl,true,3000
 #output1.tpl,true,500 <Relies on output buffer>
 scan-index.tpl,true,1

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -25,35 +25,51 @@ main() {
     echo "Script complete."
 }
 
+give_up() {
+    set +x
+    OS=$1
+    VERSION=$2
+    if [ ! -z "$VERSION" ]; then
+        VERSION=" $VERSION"
+    fi
+    
+    echo
+    echo "Unsupported distribution '${OS}${VERSION}'"
+    echo "Please contact our support team for additional help."
+    echo "Be sure to include the contents of this message."
+    echo "Platform: $(uname -a)"
+    echo
+    echo "https://github.com/cmu-db/terrier/issues"
+    echo
+    exit 1
+}
+
 install() {
   set -x
   UNAME=$(uname | tr "[:lower:]" "[:upper:]" )
+  VERSION=""
 
   case $UNAME in
     DARWIN) install_mac ;;
 
     LINUX)
-      version=$(cat /etc/os-release | grep VERSION_ID | cut -d '"' -f 2)
-      case $version in
-        18.04) install_linux ;;
-        *) give_up ;;
+      DISTRO=$(cat /etc/os-release | grep '^ID=' | cut -d '=' -f 2 | tr "[:lower:]" "[:upper:]" | tr -d '"')
+      VERSION=$(cat /etc/os-release | grep '^VERSION_ID=' | cut -d '"' -f 2)
+      
+      # We only support Ubuntu right now
+      [ "$DISTRO" != "UBUNTU" ] && give_up $DISTRO $VERSION
+      
+      # Check Ubuntu version
+      case $VERSION in
+        X8.04) install_linux ;;
+        19.04) install_linux ;;
+        X9.10) install_linux ;;
+        *) give_up $DISTRO $VERSION;;
       esac
       ;;
 
-    *) give_up ;;
+    *) give_up $UNAME $VERSION;;
   esac
-}
-
-give_up() {
-  set +x
-  echo "Unsupported distribution '$UNAME'"
-  echo "Please contact our support team for additional help."
-  echo "Be sure to include the contents of this message."
-  echo "Platform: $(uname -a)"
-  echo
-  echo "https://github.com/cmu-db/terrier/issues"
-  echo
-  exit 1
 }
 
 install_mac() {

--- a/src/execution/compiler/operator/aggregate_translator.cpp
+++ b/src/execution/compiler/operator/aggregate_translator.cpp
@@ -7,47 +7,34 @@
 
 namespace terrier::execution::compiler {
 AggregateBottomTranslator::AggregateBottomTranslator(const terrier::planner::AggregatePlanNode *op, CodeGen *codegen)
-    : OperatorTranslator(codegen),
-      num_group_by_terms_{static_cast<uint32_t>(op->GetGroupByTerms().size())},
-      op_(op),
-      hash_val_(codegen->NewIdentifier("hash_val")),
-      agg_values_(codegen->NewIdentifier("agg_value")),
-      values_struct_(codegen->NewIdentifier("AggValues")),
-      payload_struct_(codegen->NewIdentifier("AggPayload")),
-      agg_payload_(codegen->NewIdentifier("agg_payload")),
-      key_check_(codegen->NewIdentifier("aggKeyCheckFn")),
-      agg_ht_(codegen->NewIdentifier("agg_ht")) {}
+    : OperatorTranslator(codegen), op_(op), helper_(codegen, op) {}
 
-// Declare the hash table
 void AggregateBottomTranslator::InitializeStateFields(util::RegionVector<ast::FieldDecl *> *state_fields) {
-  // agg_hash_table : AggregationHashTable
-  ast::Expr *ht_type = codegen_->BuiltinType(ast::BuiltinType::Kind::AggregationHashTable);
-  state_fields->emplace_back(codegen_->MakeField(agg_ht_, ht_type));
+  // There is one global hash table.
+  // In addition, each distinct aggregate needs a hash table.
+  helper_.DeclareAHTs(state_fields);
 }
 
-// Declare payload and decls struct
 void AggregateBottomTranslator::InitializeStructs(util::RegionVector<ast::Decl *> *decls) {
-  GenPayloadStruct(decls);
-  GenValuesStruct(decls);
+  // Declare the values struct.
+  helper_.GenValuesStruct(decls);
+  // Declare the struct of each distinct aggregate.
+  helper_.GenAHTStructs(decls);
 }
 
-// Create the key check function.
 void AggregateBottomTranslator::InitializeHelperFunctions(util::RegionVector<ast::Decl *> *decls) {
-  GenSingleKeyCheckFn(decls);
+  // Generate the key check functions.
+  helper_.GenKeyChecks(decls);
 }
 
-// Call @aggHTInit on the hash table
 void AggregateBottomTranslator::InitializeSetup(util::RegionVector<ast::Stmt *> *setup_stmts) {
-  // @aggHTInit(&state.agg_hash_table, @execCtxGetMem(execCtx), @sizeOf(AggPayload))
-  ast::Expr *init_call = codegen_->HTInitCall(ast::Builtin::AggHashTableInit, agg_ht_, payload_struct_);
-  // Add it the setup statements
-  setup_stmts->emplace_back(codegen_->MakeStmt(init_call));
+  // Initialize all hash tables.
+  helper_.InitAHTs(setup_stmts);
 }
 
-// Call @aggHTFree
 void AggregateBottomTranslator::InitializeTeardown(util::RegionVector<ast::Stmt *> *teardown_stmts) {
-  ast::Expr *free_call = codegen_->OneArgStateCall(ast::Builtin::AggHashTableFree, agg_ht_);
-  teardown_stmts->emplace_back(codegen_->MakeStmt(free_call));
+  // Free all hash tables
+  helper_.FreeAHTs(teardown_stmts);
 }
 
 void AggregateBottomTranslator::Produce(FunctionBuilder *builder) { child_translator_->Produce(builder); }
@@ -55,249 +42,30 @@ void AggregateBottomTranslator::Produce(FunctionBuilder *builder) { child_transl
 void AggregateBottomTranslator::Abort(FunctionBuilder *builder) { child_translator_->Abort(builder); }
 
 void AggregateBottomTranslator::Consume(FunctionBuilder *builder) {
-  // Generate values to aggregate
-  FillValues(builder);
-  // Hash Call
-  GenHashCall(builder);
-  // Make Lookup call
-  GenLookupCall(builder);
-  // Construct aggregates if needed
-  GenConstruct(builder);
-  // Advance aggregates
-  GenAdvance(builder);
+  // Generate Values
+  helper_.FillValues(builder, this);
+  // Generate hashes
+  helper_.GenHashCalls(builder);
+  // Construct new hash table entries
+  helper_.GenConstruct(builder);
+  // Advance non distinct aggregates
+  helper_.GenAdvanceNonDistinct(builder);
 }
 
-ast::Expr *AggregateBottomTranslator::GetOutput(uint32_t attr_idx) {
-  // Either access a scalar group by term
-  if (attr_idx < num_group_by_terms_) {
-    return GetGroupByTerm(agg_payload_, attr_idx);
-  }
-  // Or access an aggregate
-  // Here, we need to call @aggResult(&agg_payload.expr_i)
-  ast::Expr *agg_term = GetAggTerm(agg_payload_, attr_idx - num_group_by_terms_, true);
-  return codegen_->BuiltinCall(ast::Builtin::AggResult, {agg_term});
+ast::Expr *AggregateBottomTranslator::GetGroupByOutput(uint32_t term_idx) {
+  auto global_aht = helper_.GetGlobalAHT();
+  return codegen_->MemberExpr(global_aht->Entry(), helper_.GetGroupBy(term_idx));
+}
+
+ast::Expr *AggregateBottomTranslator::GetAggregateOutput(uint32_t term_idx) {
+  auto global_aht = helper_.GetGlobalAHT();
+  auto agg = codegen_->MemberExpr(global_aht->Entry(), helper_.GetAggregate(term_idx));
+  return codegen_->OneArgCall(ast::Builtin::AggResult, codegen_->PointerTo(agg));
 }
 
 ast::Expr *AggregateBottomTranslator::GetChildOutput(uint32_t child_idx, uint32_t attr_idx,
                                                      terrier::type::TypeId type) {
   return child_translator_->GetOutput(attr_idx);
-}
-
-ast::Expr *AggregateBottomTranslator::GetGroupByTerm(ast::Identifier object, uint32_t idx) {
-  ast::Identifier member = codegen_->Context()->GetIdentifier(GROUP_BY_TERM_NAMES + std::to_string(idx));
-  return codegen_->MemberExpr(object, member);
-}
-
-ast::Expr *AggregateBottomTranslator::GetAggTerm(ast::Identifier object, uint32_t idx, bool ptr) {
-  ast::Identifier member = codegen_->Context()->GetIdentifier(AGG_TERM_NAMES + std::to_string(idx));
-  ast::Expr *agg_term = codegen_->MemberExpr(object, member);
-  if (ptr) {
-    // Return a pointer to the term
-    return codegen_->UnaryOp(parsing::Token::Type::AMPERSAND, agg_term);
-  }
-  // Return the term itself
-  return agg_term;
-}
-
-/*
- * Generate the aggregation hash table's payload struct
- */
-void AggregateBottomTranslator::GenPayloadStruct(util::RegionVector<ast::Decl *> *decls) {
-  util::RegionVector<ast::FieldDecl *> fields{codegen_->Region()};
-  // Create a field for every group by term
-  uint32_t term_idx = 0;
-  for (const auto &term : op_->GetGroupByTerms()) {
-    ast::Identifier field_name = codegen_->Context()->GetIdentifier(GROUP_BY_TERM_NAMES + std::to_string(term_idx));
-    ast::Expr *type = codegen_->TplType(term->GetReturnValueType());
-    fields.emplace_back(codegen_->MakeField(field_name, type));
-    term_idx++;
-  }
-
-  // Create a field for every aggregate term
-  term_idx = 0;
-  for (const auto &term : op_->GetAggregateTerms()) {
-    ast::Identifier field_name = codegen_->Context()->GetIdentifier(AGG_TERM_NAMES + std::to_string(term_idx));
-    ast::Expr *type = codegen_->AggregateType(term->GetExpressionType(), term->GetChild(0)->GetReturnValueType());
-    fields.emplace_back(codegen_->MakeField(field_name, type));
-    term_idx++;
-  }
-
-  // Make the struct
-  decls->emplace_back(codegen_->MakeStruct(payload_struct_, std::move(fields)));
-}
-
-/*
- * Generate the aggregation's input values
- */
-void AggregateBottomTranslator::GenValuesStruct(util::RegionVector<ast::Decl *> *decls) {
-  util::RegionVector<ast::FieldDecl *> fields{codegen_->Region()};
-  // Create a field for every group by term
-  uint32_t term_idx = 0;
-  for (const auto &term : op_->GetGroupByTerms()) {
-    ast::Identifier field_name = codegen_->Context()->GetIdentifier(GROUP_BY_TERM_NAMES + std::to_string(term_idx));
-    ast::Expr *type = codegen_->TplType(term->GetReturnValueType());
-    fields.emplace_back(codegen_->MakeField(field_name, type));
-    term_idx++;
-  }
-
-  // Create a field of every aggregate term.
-  // Unlike the payload, these are scalar types, not aggregate types
-  term_idx = 0;
-  for (const auto &term : op_->GetAggregateTerms()) {
-    ast::Identifier field_name = codegen_->Context()->GetIdentifier(AGG_TERM_NAMES + std::to_string(term_idx));
-    ast::Expr *type = codegen_->TplType(term->GetChild(0)->GetReturnValueType());
-    fields.emplace_back(codegen_->MakeField(field_name, type));
-    term_idx++;
-  }
-
-  // Make the struct
-  decls->emplace_back(codegen_->MakeStruct(values_struct_, std::move(fields)));
-}
-
-/*
- * Generate the key check logic
- */
-void AggregateBottomTranslator::GenKeyCheck(FunctionBuilder *builder) {
-  // Compare group by terms one by one
-  // Generate if (payload.term_i )
-  for (uint32_t term_idx = 0; term_idx < op_->GetGroupByTerms().size(); term_idx++) {
-    ast::Expr *lhs = GetGroupByTerm(agg_payload_, term_idx);
-    ast::Expr *rhs = GetGroupByTerm(agg_values_, term_idx);
-    ast::Expr *cond = codegen_->Compare(parsing::Token::Type::BANG_EQUAL, lhs, rhs);
-    builder->StartIfStmt(cond);
-    builder->Append(codegen_->ReturnStmt(codegen_->BoolLiteral(false)));
-    builder->FinishBlockStmt();
-  }
-  builder->Append(codegen_->ReturnStmt(codegen_->BoolLiteral(true)));
-}
-
-/*
- * First declare var agg_values : AggValues
- * For each group by term, generate agg_values.term_i = group_by_term_i
- * For each aggregation expression, agg_values.expr_i = agg_expr_i
- */
-void AggregateBottomTranslator::FillValues(FunctionBuilder *builder) {
-  // First declare var agg_values: AggValues
-  builder->Append(codegen_->DeclareVariable(agg_values_, codegen_->MakeExpr(values_struct_), nullptr));
-
-  // Add group by terms
-  uint32_t term_idx = 0;
-  for (const auto &term : op_->GetGroupByTerms()) {
-    // Set agg_values.term_i = group_term_i
-    ast::Expr *lhs = GetGroupByTerm(agg_values_, term_idx);
-    auto term_translator = TranslatorFactory::CreateExpressionTranslator(term.Get(), codegen_);
-    ast::Expr *rhs = term_translator->DeriveExpr(this);
-    builder->Append(codegen_->Assign(lhs, rhs));
-    term_idx++;
-  }
-  // Add aggregates
-  term_idx = 0;
-  for (const auto &term : op_->GetAggregateTerms()) {
-    // Set agg_values.expr_i = agg_expr_i
-    ast::Expr *lhs = GetAggTerm(agg_values_, term_idx, false);
-    auto term_translator = TranslatorFactory::CreateExpressionTranslator(term->GetChild(0).Get(), codegen_);
-    ast::Expr *rhs = term_translator->DeriveExpr(this);
-    builder->Append(codegen_->Assign(lhs, rhs));
-    term_idx++;
-  }
-}
-
-// Generate var agg_payload = @ptrCast(*AggPayload, @aggHTLookup(&state.agg_ht, agg_hash_val, keyCheck, &agg_values))
-void AggregateBottomTranslator::GenLookupCall(FunctionBuilder *builder) {
-  // First create @aggHTLookup((&state.agg_ht, agg_hash_val, keyCheck, &agg_values)
-  std::vector<ast::Expr *> lookup_args{codegen_->GetStateMemberPtr(agg_ht_), codegen_->MakeExpr(hash_val_),
-                                       codegen_->MakeExpr(key_check_), codegen_->PointerTo(agg_values_)};
-  ast::Expr *lookup_call = codegen_->BuiltinCall(ast::Builtin::AggHashTableLookup, std::move(lookup_args));
-
-  // Gen create @ptrcast(*AggPayload, ...)
-  ast::Expr *cast_call = codegen_->PtrCast(payload_struct_, lookup_call);
-
-  // Declare var agg_payload
-  builder->Append(codegen_->DeclareVariable(agg_payload_, nullptr, cast_call));
-}
-
-/*
- * First check if agg_payload == nil
- * If so, set agg_payload.term_i = agg_values.term_i for each group by terms
- * Add call @aggInit(&agg_payload.expr_i) for each expression
- */
-void AggregateBottomTranslator::GenConstruct(FunctionBuilder *builder) {
-  // Make the if statement
-  ast::Expr *nil = codegen_->NilLiteral();
-  ast::Expr *payload = codegen_->MakeExpr(agg_payload_);
-  ast::Expr *cond = codegen_->Compare(parsing::Token::Type::EQUAL_EQUAL, nil, payload);
-  builder->StartIfStmt(cond);
-
-  // Set agg_payload = @ptrCast(*AggPayload, @aggHTInsert(&state.agg_table, agg_hash_val))
-  std::vector<ast::Expr *> insert_args{codegen_->GetStateMemberPtr(agg_ht_), codegen_->MakeExpr(hash_val_)};
-  ast::Expr *insert_call = codegen_->BuiltinCall(ast::Builtin::AggHashTableInsert, std::move(insert_args));
-  ast::Expr *cast_call = codegen_->PtrCast(payload_struct_, insert_call);
-  builder->Append(codegen_->Assign(codegen_->MakeExpr(agg_payload_), cast_call));
-
-  // Set the Aggregate Keys (agg_payload.term_i = agg_value.term_i)
-  for (uint32_t term_idx = 0; term_idx < op_->GetGroupByTerms().size(); term_idx++) {
-    ast::Expr *lhs = GetGroupByTerm(agg_payload_, term_idx);
-    ast::Expr *rhs = GetGroupByTerm(agg_values_, term_idx);
-    builder->Append(codegen_->Assign(lhs, rhs));
-  }
-  // Call @aggInit(&agg_payload.expr_i) for each expression
-  for (uint32_t term_idx = 0; term_idx < op_->GetAggregateTerms().size(); term_idx++) {
-    ast::Expr *init_call = codegen_->BuiltinCall(ast::Builtin::AggInit, {GetAggTerm(agg_payload_, term_idx, true)});
-    builder->Append(codegen_->MakeStmt(init_call));
-  }
-  // Finish the if stmt
-  builder->FinishBlockStmt();
-}
-
-/*
- * For each aggregate expression, call @aggAdvance(&agg_payload.expr_i, &agg_values.expr_i)
- */
-void AggregateBottomTranslator::GenAdvance(FunctionBuilder *builder) {
-  // Call @aggAdvance(&agg_payload.expr_i) for each expression
-  for (uint32_t term_idx = 0; term_idx < op_->GetAggregateTerms().size(); term_idx++) {
-    ast::Expr *arg1 = GetAggTerm(agg_payload_, term_idx, true);
-    ast::Expr *arg2 = GetAggTerm(agg_values_, term_idx, true);
-    ast::Expr *advance_call = codegen_->BuiltinCall(ast::Builtin::AggAdvance, {arg1, arg2});
-    builder->Append(codegen_->MakeStmt(advance_call));
-  }
-}
-
-// Generate var agg_hash_val = @hash(groub_by_term1, group_by_term2, ...)
-void AggregateBottomTranslator::GenHashCall(FunctionBuilder *builder) {
-  // Create the @hash(group_by_term1, group_by_term2, ...) call
-  std::vector<ast::Expr *> hash_args{};
-  for (uint32_t term_idx = 0; term_idx < op_->GetGroupByTerms().size(); term_idx++) {
-    hash_args.emplace_back(GetGroupByTerm(agg_values_, term_idx));
-  }
-  // TODO(Amadou): In case there is no group by term, we can actually bypass the hash table.
-  // For now, I am passing in a constant hash value.
-  if (hash_args.empty()) {
-    hash_args.emplace_back(codegen_->IntToSql(0));
-  }
-  ast::Expr *hash_call = codegen_->BuiltinCall(ast::Builtin::Hash, std::move(hash_args));
-
-  // Create the variable declaration
-  builder->Append(codegen_->DeclareVariable(hash_val_, nullptr, hash_call));
-}
-
-void AggregateBottomTranslator::GenSingleKeyCheckFn(util::RegionVector<terrier::execution::ast::Decl *> *decls) {
-  // Generate the function type (*AggPayload, *AggValues) -> bool
-  // First make agg_payload: *AggPayload
-  ast::Expr *payload_struct_ptr = codegen_->PointerType(payload_struct_);
-  ast::FieldDecl *param1 = codegen_->MakeField(agg_payload_, payload_struct_ptr);
-
-  // Then make agg_values: *AggValues
-  ast::Expr *values_struct_ptr = codegen_->PointerType(values_struct_);
-  ast::FieldDecl *param2 = codegen_->MakeField(agg_values_, values_struct_ptr);
-
-  // Now create the function
-  util::RegionVector<ast::FieldDecl *> params({param1, param2}, codegen_->Region());
-  ast::Expr *ret_type = codegen_->BuiltinType(ast::BuiltinType::Kind::Bool);
-  FunctionBuilder builder(codegen_, key_check_, std::move(params), ret_type);
-  // Fill up the function
-  GenKeyCheck(&builder);
-  // Add it to top level declarations
-  decls->emplace_back(builder.Finish());
 }
 
 ///////////////////////////////////////////////
@@ -338,7 +106,8 @@ void AggregateTopTranslator::Abort(FunctionBuilder *builder) {
 }
 
 ast::Expr *AggregateTopTranslator::GetChildOutput(uint32_t child_idx, uint32_t attr_idx, terrier::type::TypeId type) {
-  return bottom_->GetOutput(attr_idx + child_idx * bottom_->num_group_by_terms_);
+  if (child_idx == 0) return bottom_->GetGroupByOutput(attr_idx);
+  return bottom_->GetAggregateOutput(attr_idx);
 }
 
 // Let the bottom translator handle this call
@@ -356,8 +125,9 @@ void AggregateTopTranslator::DeclareIterator(FunctionBuilder *builder) {
 
 // for (@aggHTIterInit(&agg_iter, &state.table); @aggHTIterHasNext(&agg_iter); @aggHTIterNext(&agg_iter)) {...}
 void AggregateTopTranslator::GenHTLoop(FunctionBuilder *builder) {
+  auto global_aht = bottom_->helper_.GetGlobalAHT();
   // Loop Initialization
-  std::vector<ast::Expr *> init_args{codegen_->PointerTo(agg_iterator_), codegen_->GetStateMemberPtr(bottom_->agg_ht_)};
+  std::vector<ast::Expr *> init_args{codegen_->PointerTo(agg_iterator_), codegen_->GetStateMemberPtr(global_aht->HT())};
   ast::Expr *init_call = codegen_->BuiltinCall(ast::Builtin::AggHashTableIterInit, std::move(init_args));
   ast::Stmt *loop_init = codegen_->MakeStmt(init_call);
   // Loop condition
@@ -371,14 +141,15 @@ void AggregateTopTranslator::GenHTLoop(FunctionBuilder *builder) {
 
 // Declare var agg_payload = @ptrCast(*AggPayload, @aggHTIterGetRow(&agg_iter))
 void AggregateTopTranslator::DeclareResult(FunctionBuilder *builder) {
+  auto global_aht = bottom_->helper_.GetGlobalAHT();
   // @aggHTIterGetRow(&agg_iter)
   ast::Expr *get_row_call = codegen_->OneArgCall(ast::Builtin::AggHashTableIterGetRow, agg_iterator_, true);
 
   // @ptrcast(*AggPayload, ...)
-  ast::Expr *cast_call = codegen_->PtrCast(bottom_->payload_struct_, get_row_call);
+  ast::Expr *cast_call = codegen_->PtrCast(global_aht->StructType(), get_row_call);
 
   // Declare var agg_payload
-  builder->Append(codegen_->DeclareVariable(bottom_->agg_payload_, nullptr, cast_call));
+  builder->Append(codegen_->DeclareVariable(global_aht->Entry(), nullptr, cast_call));
 }
 
 void AggregateTopTranslator::CloseIterator(FunctionBuilder *builder) {

--- a/src/execution/compiler/operator/aggregate_util.cpp
+++ b/src/execution/compiler/operator/aggregate_util.cpp
@@ -1,0 +1,316 @@
+#include "execution/compiler/operator/aggregate_util.h"
+#include <utility>
+#include <vector>
+#include "execution/compiler/function_builder.h"
+#include "execution/compiler/translator_factory.h"
+
+namespace terrier::execution::compiler {
+
+AggregateHelper::AggregateHelper(CodeGen *codegen, const planner::AggregatePlanNode *op)
+    : codegen_(codegen),
+      op_(op),
+      global_info_(codegen),
+      agg_values_(codegen->NewIdentifier("agg_values")),
+      values_struct_(codegen->NewIdentifier("ValuesStruct")) {
+  for (uint32_t i = 0; i < op_->GetGroupByTerms().size(); i++) {
+    group_bys_.emplace_back(codegen->NewIdentifier("group_by"));
+  }
+  for (uint32_t i = 0; i < op_->GetAggregateTerms().size(); i++) {
+    aggregates_.emplace_back(codegen->NewIdentifier("aggregate"));
+    if (op_->GetAggregateTerms()[i]->IsDistinct()) {
+      distinct_aggs_.emplace(i, std::make_unique<AHTInfo>(codegen, true, i));
+    }
+  }
+}
+
+void AggregateHelper::InitAHTs(util::RegionVector<ast::Stmt *> *stmts) {
+  // Function to initialize an arbitary hash table.
+  auto init_ht = [&](const AHTInfo *info) {
+    ast::Expr *ht_init_call = codegen_->HTInitCall(ast::Builtin::AggHashTableInit, info->HT(), info->StructType());
+    stmts->emplace_back(codegen_->MakeStmt(ht_init_call));
+  };
+
+  // Initialize the global hash table.
+  if (!op_->GetGroupByTerms().empty()) init_ht(&global_info_);
+  // Then initialize each distinct hash table.
+  for (const auto &distinct_info : distinct_aggs_) {
+    init_ht(distinct_info.second.get());
+  }
+}
+
+void AggregateHelper::FreeAHTs(util::RegionVector<ast::Stmt *> *stmts) {
+  // Function to free an arbitary hash table.
+  auto free_ht = [&](const AHTInfo *info) {
+    ast::Expr *ht_free_call = codegen_->OneArgStateCall(ast::Builtin::AggHashTableFree, info->HT());
+    stmts->emplace_back(codegen_->MakeStmt(ht_free_call));
+  };
+
+  // Free the global hash table.
+  if (!op_->GetGroupByTerms().empty()) free_ht(&global_info_);
+  // Then Free each distinct hash table.
+  for (const auto &distinct_info : distinct_aggs_) {
+    free_ht(distinct_info.second.get());
+  }
+}
+
+void AggregateHelper::DeclareAHTs(util::RegionVector<ast::FieldDecl *> *fields) {
+  // Function to add an arbitrary hash table.
+  auto gen_field = [&](const AHTInfo *info) {
+    ast::Expr *ht_type = codegen_->BuiltinType(ast::BuiltinType::Kind::AggregationHashTable);
+    fields->emplace_back(codegen_->MakeField(info->HT(), ht_type));
+  };
+
+  // Add the global hash table.
+  if (!op_->GetGroupByTerms().empty()) gen_field(&global_info_);
+  // Add each distinct hash table.
+  for (const auto &distinct_info : distinct_aggs_) {
+    gen_field(distinct_info.second.get());
+  }
+}
+
+void AggregateHelper::GenAHTStructs(util::RegionVector<ast::Decl *> *decls) {
+  // Generic function to add a struct
+  auto gen_struct = [&](const AHTInfo *info) {
+    // First make the fields
+    util::RegionVector<ast::FieldDecl *> fields{codegen_->Region()};
+    // All hash tables need the groub by terms.
+    for (uint32_t i = 0; i < op_->GetGroupByTerms().size(); i++) {
+      auto term = op_->GetGroupByTerms()[i];
+      ast::Expr *gby_type = codegen_->TplType(term->GetReturnValueType());
+      fields.emplace_back(codegen_->MakeField(group_bys_[i], gby_type));
+    }
+    if (info->IsDistinct()) {
+      // Distinct hash tables only need the distinct aggregate values.
+      auto agg = op_->GetAggregateTerms()[info->TermIdx()];
+      ast::Expr *distinct_type = codegen_->TplType(agg->GetChild(0)->GetReturnValueType());
+      fields.emplace_back(codegen_->MakeField(aggregates_[info->TermIdx()], distinct_type));
+    } else {
+      // The global hash table needs all aggregators.
+      for (uint32_t term_idx = 0; term_idx < op_->GetAggregateTerms().size(); term_idx++) {
+        auto agg = op_->GetAggregateTerms()[term_idx];
+        ast::Expr *agg_type = codegen_->AggregateType(agg->GetExpressionType(), agg->GetChild(0)->GetReturnValueType());
+        fields.emplace_back(codegen_->MakeField(aggregates_[term_idx], agg_type));
+      }
+    }
+    // Then declare the struct
+    decls->emplace_back(codegen_->MakeStruct(info->StructType(), std::move(fields)));
+  };
+
+  // Add the global hash table's struct.
+  if (!op_->GetGroupByTerms().empty()) gen_struct(&global_info_);
+  // Add each distinct hash table's struct.
+  for (const auto &distinct_info : distinct_aggs_) {
+    gen_struct(distinct_info.second.get());
+  }
+}
+
+void AggregateHelper::GenValuesStruct(util::RegionVector<ast::Decl *> *decls) {
+  util::RegionVector<ast::FieldDecl *> fields{codegen_->Region()};
+  // Create a field for every group by term
+  for (uint32_t i = 0; i < op_->GetGroupByTerms().size(); i++) {
+    auto gby = op_->GetGroupByTerms()[i];
+    ast::Expr *type = codegen_->TplType(gby->GetReturnValueType());
+    fields.emplace_back(codegen_->MakeField(group_bys_[i], type));
+  }
+
+  // Create a field of every aggregate term.
+  for (uint32_t i = 0; i < op_->GetAggregateTerms().size(); i++) {
+    auto agg = op_->GetAggregateTerms()[i];
+    ast::Expr *type = codegen_->TplType(agg->GetChild(0)->GetReturnValueType());
+    fields.emplace_back(codegen_->MakeField(aggregates_[i], type));
+  }
+
+  // Make the struct
+  decls->emplace_back(codegen_->MakeStruct(values_struct_, std::move(fields)));
+}
+
+void AggregateHelper::GenHashCalls(FunctionBuilder *builder) {
+  // Generic function to make a hash call.
+  auto make_hash_call = [&](const AHTInfo *info) {
+    // First add group by terms
+    std::vector<ast::Expr *> hash_args{};
+    for (uint32_t i = 0; i < op_->GetGroupByTerms().size(); i++) {
+      hash_args.emplace_back(codegen_->MemberExpr(agg_values_, group_bys_[i]));
+    }
+    if (info->IsDistinct()) {
+      // For distinct aggregates, we also need to add the distinct term
+      hash_args.emplace_back(codegen_->MemberExpr(agg_values_, aggregates_[info->TermIdx()]));
+    }
+    // Make the hash call.
+    ast::Expr *hash_call = codegen_->BuiltinCall(ast::Builtin::Hash, std::move(hash_args));
+    builder->Append(codegen_->DeclareVariable(info->HashVal(), nullptr, hash_call));
+  };
+
+  // Make the hash call for the global hash table.
+  if (!op_->GetGroupByTerms().empty()) make_hash_call(&global_info_);
+  // Make the hash call for each distinct table.
+  for (const auto &distinct_info : distinct_aggs_) {
+    make_hash_call(distinct_info.second.get());
+  }
+}
+
+void AggregateHelper::GenConstruct(FunctionBuilder *builder) {
+  auto construct_entry = [&](const AHTInfo *info) {
+    // For lookup the entry in the table.
+    {
+      std::vector<ast::Expr *> lookup_args{codegen_->GetStateMemberPtr(info->HT()), codegen_->MakeExpr(info->HashVal()),
+                                           codegen_->MakeExpr(info->KeyCheck()), codegen_->PointerTo(agg_values_)};
+      ast::Expr *lookup_call = codegen_->BuiltinCall(ast::Builtin::AggHashTableLookup, std::move(lookup_args));
+      ast::Expr *cast_call = codegen_->PtrCast(info->StructType(), lookup_call);
+      builder->Append(codegen_->DeclareVariable(info->Entry(), nullptr, cast_call));
+    }
+    // Then check if the returned entry is null.
+    {
+      ast::Expr *nil = codegen_->NilLiteral();
+      ast::Expr *payload = codegen_->MakeExpr(info->Entry());
+      ast::Expr *cond = codegen_->Compare(parsing::Token::Type::EQUAL_EQUAL, nil, payload);
+      builder->StartIfStmt(cond);
+    }
+    // If it is null, then insert a new entry into the table.
+    {
+      std::vector<ast::Expr *> insert_args{codegen_->GetStateMemberPtr(info->HT()),
+                                           codegen_->MakeExpr(info->HashVal())};
+      ast::Expr *insert_call = codegen_->BuiltinCall(ast::Builtin::AggHashTableInsert, std::move(insert_args));
+      auto cast_call = codegen_->PtrCast(info->StructType(), insert_call);
+      builder->Append(codegen_->Assign(codegen_->MakeExpr(info->Entry()), cast_call));
+      // Initialize the group by values.
+      InitGroupByValues(builder, info);
+    }
+
+    if (info->IsDistinct()) {
+      // For distinct aggregates, we advance only upon a new insertion (inside the if statement).
+      AdvanceDistinct(builder, info);
+    } else {
+      // For the global hash table, we initialize the payload's aggregates.
+      InitGlobalAggregates(builder);
+    }
+    // Close the if statement
+    builder->FinishBlockStmt();
+  };
+
+  // Construct the entry of the global hash table.
+  if (!op_->GetGroupByTerms().empty()) construct_entry(&global_info_);
+  // Make the hash call for each distinct table.
+  for (const auto &distinct_info : distinct_aggs_) {
+    construct_entry(distinct_info.second.get());
+  }
+}
+
+void AggregateHelper::GenKeyChecks(util::RegionVector<ast::Decl *> *decls) {
+  auto gen_key_check = [&](const AHTInfo *info) {
+    // Create a function (entry: *StructType, values: *ValuesStruct) -> bool
+    ast::Expr *struct_ptr = codegen_->PointerType(info->StructType());
+    ast::FieldDecl *param1 = codegen_->MakeField(info->Entry(), struct_ptr);
+    // Then make agg_values: *AggValues
+    ast::Expr *values_struct_ptr = codegen_->PointerType(values_struct_);
+    ast::FieldDecl *param2 = codegen_->MakeField(agg_values_, values_struct_ptr);
+    // Now create the function
+    util::RegionVector<ast::FieldDecl *> params({param1, param2}, codegen_->Region());
+    ast::Expr *ret_type = codegen_->BuiltinType(ast::BuiltinType::Kind::Bool);
+    FunctionBuilder builder(codegen_, info->KeyCheck(), std::move(params), ret_type);
+    // Compare the groub by terms
+    for (uint32_t term_idx = 0; term_idx < op_->GetGroupByTerms().size(); term_idx++) {
+      ast::Expr *lhs = codegen_->MemberExpr(info->Entry(), group_bys_[term_idx]);
+      ast::Expr *rhs = codegen_->MemberExpr(agg_values_, group_bys_[term_idx]);
+      ast::Expr *cond = codegen_->Compare(parsing::Token::Type::BANG_EQUAL, lhs, rhs);
+      builder.StartIfStmt(cond);
+      builder.Append(codegen_->ReturnStmt(codegen_->BoolLiteral(false)));
+      builder.FinishBlockStmt();
+    }
+    // For distinct aggregates, also compare the distinct terms.
+    if (info->IsDistinct()) {
+      ast::Expr *lhs = codegen_->MemberExpr(info->Entry(), aggregates_[info->TermIdx()]);
+      ast::Expr *rhs = codegen_->MemberExpr(agg_values_, aggregates_[info->TermIdx()]);
+      ast::Expr *comp = codegen_->Compare(parsing::Token::Type::EQUAL_EQUAL, lhs, rhs);
+      builder.Append(codegen_->ReturnStmt(codegen_->OneArgCall(ast::Builtin::SqlToBool, comp)));
+    } else {
+      // For non distinct aggregates, just return true.
+      builder.Append(codegen_->ReturnStmt(codegen_->BoolLiteral(true)));
+    }
+    decls->emplace_back(builder.Finish());
+  };
+
+  // Make the key check function for the global hash table.
+  if (!op_->GetGroupByTerms().empty()) gen_key_check(&global_info_);
+  // Make the key check function for each distinct table.
+  for (const auto &distinct_info : distinct_aggs_) {
+    gen_key_check(distinct_info.second.get());
+  }
+}
+
+void AggregateHelper::GenAdvanceNonDistinct(FunctionBuilder *builder) {
+  for (uint32_t term_idx = 0; term_idx < op_->GetAggregateTerms().size(); term_idx++) {
+    auto term = op_->GetAggregateTerms()[term_idx];
+    if (!term->IsDistinct()) {
+      ast::Expr *arg1;
+      if (!op_->GetGroupByTerms().empty()) {
+        arg1 = codegen_->PointerTo(codegen_->MemberExpr(global_info_.Entry(), aggregates_[term_idx]));
+      } else {
+        arg1 = codegen_->GetStateMemberPtr(aggregates_[term_idx]);
+      }
+      ast::Expr *arg2 = codegen_->PointerTo(codegen_->MemberExpr(agg_values_, aggregates_[term_idx]));
+      ast::Expr *advance_call = codegen_->BuiltinCall(ast::Builtin::AggAdvance, {arg1, arg2});
+      builder->Append(codegen_->MakeStmt(advance_call));
+    }
+  }
+}
+
+void AggregateHelper::FillValues(FunctionBuilder *builder, OperatorTranslator *translator) {
+  // First declare var agg_values: AggValues
+  builder->Append(codegen_->DeclareVariable(agg_values_, codegen_->MakeExpr(values_struct_), nullptr));
+
+  // Add group by terms
+  for (uint32_t i = 0; i < op_->GetGroupByTerms().size(); i++) {
+    auto gby = op_->GetGroupByTerms()[i];
+    ast::Expr *lhs = codegen_->MemberExpr(agg_values_, group_bys_[i]);
+    auto expr_translator = TranslatorFactory::CreateExpressionTranslator(gby.Get(), codegen_);
+    ast::Expr *rhs = expr_translator->DeriveExpr(translator);
+    builder->Append(codegen_->Assign(lhs, rhs));
+  }
+  // Add aggregates
+  for (uint32_t i = 0; i < op_->GetAggregateTerms().size(); i++) {
+    auto agg_term = op_->GetAggregateTerms()[i];
+    ast::Expr *lhs = codegen_->MemberExpr(agg_values_, aggregates_[i]);
+    auto term_translator = TranslatorFactory::CreateExpressionTranslator(agg_term->GetChild(0).Get(), codegen_);
+    ast::Expr *rhs = term_translator->DeriveExpr(translator);
+    builder->Append(codegen_->Assign(lhs, rhs));
+  }
+}
+
+void AggregateHelper::InitGroupByValues(FunctionBuilder *builder, const AHTInfo *info) {
+  for (uint32_t i = 0; i < op_->GetGroupByTerms().size(); i++) {
+    ast::Expr *lhs = codegen_->MemberExpr(info->Entry(), group_bys_[i]);
+    ast::Expr *rhs = codegen_->MemberExpr(agg_values_, group_bys_[i]);
+    builder->Append(codegen_->Assign(lhs, rhs));
+  }
+}
+
+void AggregateHelper::AdvanceDistinct(FunctionBuilder *builder, const AHTInfo *info) {
+  TERRIER_ASSERT(info->IsDistinct(), "Should not be called with non distinct aggregates!");
+  // Set the distinct term in the hash table entry
+  ast::Expr *lhs = codegen_->MemberExpr(info->Entry(), aggregates_[info->TermIdx()]);
+  ast::Expr *rhs = codegen_->MemberExpr(agg_values_, aggregates_[info->TermIdx()]);
+  builder->Append(codegen_->Assign(lhs, rhs));
+
+  // The advance the global aggregate.
+  ast::Expr *arg1;
+  if (!op_->GetGroupByTerms().empty()) {
+    arg1 = codegen_->PointerTo(codegen_->MemberExpr(global_info_.Entry(), aggregates_[info->TermIdx()]));
+  } else {
+    arg1 = codegen_->GetStateMemberPtr(aggregates_[info->TermIdx()]);
+  }
+  ast::Expr *arg2 = codegen_->PointerTo(codegen_->MemberExpr(agg_values_, aggregates_[info->TermIdx()]));
+  ast::Expr *advance_call = codegen_->BuiltinCall(ast::Builtin::AggAdvance, {arg1, arg2});
+  builder->Append(codegen_->MakeStmt(advance_call));
+}
+
+void AggregateHelper::InitGlobalAggregates(FunctionBuilder *builder) {
+  // Call @aggInit(&agg_payload.expr_i) for each expression
+  for (uint32_t term_idx = 0; term_idx < op_->GetAggregateTerms().size(); term_idx++) {
+    ast::Expr *agg = codegen_->MemberExpr(global_info_.Entry(), aggregates_[term_idx]);
+    ast::Expr *init_call = codegen_->OneArgCall(ast::Builtin::AggInit, codegen_->PointerTo(agg));
+    builder->Append(codegen_->MakeStmt(init_call));
+  }
+}
+
+}  // namespace terrier::execution::compiler

--- a/src/execution/compiler/operator/limit_translator.cpp
+++ b/src/execution/compiler/operator/limit_translator.cpp
@@ -1,0 +1,28 @@
+#include "execution/compiler/operator/limit_translator.h"
+#include "execution/compiler/function_builder.h"
+#include "execution/compiler/translator_factory.h"
+
+namespace terrier::execution::compiler {
+void LimitTranslator::Produce(FunctionBuilder *builder) {
+  builder->Append(codegen_->DeclareVariable(num_tuples_, nullptr, codegen_->IntLiteral(0)));
+  child_translator_->Produce(builder);
+}
+
+void LimitTranslator::Consume(FunctionBuilder *builder) {
+  // Check for offset and limit.
+  // if (num_tuples_ > offset && num_tuples_ < limit + offset)
+  auto offset_comp = codegen_->Compare(parsing::Token::Type::GREATER_EQUAL, codegen_->MakeExpr(num_tuples_),
+                                       codegen_->IntLiteral(op_->GetOffset()));
+  auto limit_comp = codegen_->Compare(parsing::Token::Type::LESS, codegen_->MakeExpr(num_tuples_),
+                                      codegen_->IntLiteral(op_->GetLimit() + op_->GetOffset()));
+  auto if_cond = codegen_->BinaryOp(parsing::Token::Type::AND, offset_comp, limit_comp);
+  builder->StartIfStmt(if_cond);
+  parent_translator_->Consume(builder);
+  // Close if stmt
+  builder->FinishBlockStmt();
+  // Increment num tuples
+  auto lhs = codegen_->MakeExpr(num_tuples_);
+  auto rhs = codegen_->BinaryOp(parsing::Token::Type::PLUS, codegen_->MakeExpr(num_tuples_), codegen_->IntLiteral(1));
+  builder->Append(codegen_->Assign(lhs, rhs));
+}
+}  // namespace terrier::execution::compiler

--- a/src/execution/compiler/operator/static_aggregate_translator.cpp
+++ b/src/execution/compiler/operator/static_aggregate_translator.cpp
@@ -1,0 +1,95 @@
+#include "execution/compiler/operator/static_aggregate_translator.h"
+#include <utility>
+#include <vector>
+#include "execution/compiler/function_builder.h"
+#include "execution/compiler/operator/seq_scan_translator.h"
+#include "execution/compiler/translator_factory.h"
+
+namespace terrier::execution::compiler {
+StaticAggregateBottomTranslator::StaticAggregateBottomTranslator(const terrier::planner::AggregatePlanNode *op,
+                                                                 CodeGen *codegen)
+    : OperatorTranslator(codegen), op_(op), helper_(codegen, op) {}
+
+void StaticAggregateBottomTranslator::InitializeStateFields(util::RegionVector<ast::FieldDecl *> *state_fields) {
+  // Static aggregations add their aggregates directly in the state.
+  for (uint32_t term_idx = 0; term_idx < op_->GetAggregateTerms().size(); term_idx++) {
+    auto term = op_->GetAggregateTerms()[term_idx];
+    ast::Expr *agg_type = codegen_->AggregateType(term->GetExpressionType(), term->GetChild(0)->GetReturnValueType());
+    state_fields->emplace_back(codegen_->MakeField(helper_.GetAggregate(term_idx), agg_type));
+  }
+  // Each distinct aggregate needs its own hash table.
+  helper_.DeclareAHTs(state_fields);
+}
+
+void StaticAggregateBottomTranslator::InitializeStructs(util::RegionVector<ast::Decl *> *decls) {
+  // The values struct contains values that will be aggregated and groubed by.
+  helper_.GenValuesStruct(decls);
+  // Distinct aggregate each need a hash table.
+  helper_.GenAHTStructs(decls);
+}
+
+void StaticAggregateBottomTranslator::InitializeHelperFunctions(util::RegionVector<ast::Decl *> *decls) {
+  // Each distinct aggregate needs its own key check function.
+  helper_.GenKeyChecks(decls);
+}
+
+void StaticAggregateBottomTranslator::InitializeSetup(util::RegionVector<ast::Stmt *> *setup_stmts) {
+  // Static aggregations initialize their aggregates in the setup function.
+  for (uint32_t term_idx = 0; term_idx < op_->GetAggregateTerms().size(); term_idx++) {
+    ast::Expr *agg = codegen_->GetStateMemberPtr(helper_.GetAggregate(term_idx));
+    ast::Expr *agg_init_call = codegen_->OneArgCall(ast::Builtin::AggInit, agg);
+    setup_stmts->emplace_back(codegen_->MakeStmt(agg_init_call));
+  }
+  // Distinct aggregates each initialize their hash tables.
+  helper_.InitAHTs(setup_stmts);
+}
+
+void StaticAggregateBottomTranslator::InitializeTeardown(util::RegionVector<ast::Stmt *> *teardown_stmts) {
+  // Distinct aggregates each free their hash tables.
+  helper_.FreeAHTs(teardown_stmts);
+}
+
+void StaticAggregateBottomTranslator::Consume(FunctionBuilder *builder) {
+  // Generate Values
+  helper_.FillValues(builder, this);
+  // Generate hashes
+  helper_.GenHashCalls(builder);
+  // Construct new hash table entries
+  helper_.GenConstruct(builder);
+  // Advance non distinct aggregates
+  helper_.GenAdvanceNonDistinct(builder);
+}
+
+///////////////////////
+//// Top
+//////////////////////
+
+void StaticAggregateTopTranslator::Produce(FunctionBuilder *builder) {
+  bool has_having = op_->GetHavingClausePredicate() != nullptr;
+  // Generate the having condition
+  if (has_having) {
+    auto predicate = op_->GetHavingClausePredicate().Get();
+    auto translator = TranslatorFactory::CreateExpressionTranslator(predicate, codegen_);
+    ast::Expr *cond = translator->DeriveExpr(this);
+    builder->StartIfStmt(cond);
+  }
+
+  if (child_translator_ != nullptr) {
+    child_translator_->Produce(builder);
+  } else {
+    parent_translator_->Consume(builder);
+  }
+
+  // Close the if statement
+  if (has_having) {
+    builder->FinishBlockStmt();
+  }
+}
+
+ast::Expr *StaticAggregateTopTranslator::GetOutput(uint32_t attr_idx) {
+  auto output_expr = op_->GetOutputSchema()->GetColumn(attr_idx).GetExpr();
+  auto translator = TranslatorFactory::CreateExpressionTranslator(output_expr.Get(), codegen_);
+  return translator->DeriveExpr(this);
+}
+
+}  // namespace terrier::execution::compiler

--- a/src/execution/compiler/operator/update_translator.cpp
+++ b/src/execution/compiler/operator/update_translator.cpp
@@ -77,6 +77,12 @@ ast::Expr *UpdateTranslator::GetChildOutput(uint32_t child_idx, uint32_t attr_id
   return child_translator_->GetOutput(attr_idx);
 }
 
+ast::Expr *UpdateTranslator::GetTableColumn(const catalog::col_oid_t &col_oid) {
+  // TODO(Amadou): This relies on the fact that update plan nodes come after table or index scans.
+  // If that turns out to not be the case, then update plans should use DVEs instead of CVEs.
+  return child_translator_->GetTableColumn(col_oid);
+}
+
 void UpdateTranslator::SetOids(FunctionBuilder *builder) {
   // Declare: var col_oids: [num_cols]uint32
   ast::Expr *arr_type = codegen_->ArrayType(all_oids_.size(), ast::BuiltinType::Kind::Uint32);

--- a/src/execution/compiler/translator_factory.cpp
+++ b/src/execution/compiler/translator_factory.cpp
@@ -20,10 +20,12 @@
 #include "execution/compiler/operator/index_join_translator.h"
 #include "execution/compiler/operator/index_scan_translator.h"
 #include "execution/compiler/operator/insert_translator.h"
+#include "execution/compiler/operator/limit_translator.h"
 #include "execution/compiler/operator/nested_loop_translator.h"
 #include "execution/compiler/operator/projection_translator.h"
 #include "execution/compiler/operator/seq_scan_translator.h"
 #include "execution/compiler/operator/sort_translator.h"
+#include "execution/compiler/operator/static_aggregate_translator.h"
 #include "execution/compiler/operator/update_translator.h"
 #include "execution/compiler/pipeline.h"
 
@@ -55,6 +57,9 @@ std::unique_ptr<OperatorTranslator> TranslatorFactory::CreateRegularTranslator(
     case terrier::planner::PlanNodeType::PROJECTION: {
       return std::make_unique<ProjectionTranslator>(static_cast<const planner::ProjectionPlanNode *>(op), codegen);
     }
+    case terrier::planner::PlanNodeType::LIMIT: {
+      return std::make_unique<LimitTranslator>(static_cast<const planner::LimitPlanNode *>(op), codegen);
+    }
     default:
       UNREACHABLE("Unsupported plan nodes");
   }
@@ -63,8 +68,13 @@ std::unique_ptr<OperatorTranslator> TranslatorFactory::CreateRegularTranslator(
 std::unique_ptr<OperatorTranslator> TranslatorFactory::CreateBottomTranslator(
     const terrier::planner::AbstractPlanNode *op, CodeGen *codegen) {
   switch (op->GetPlanNodeType()) {
-    case terrier::planner::PlanNodeType::AGGREGATE:
-      return std::make_unique<AggregateBottomTranslator>(static_cast<const planner::AggregatePlanNode *>(op), codegen);
+    case terrier::planner::PlanNodeType::AGGREGATE: {
+      auto agg_op = static_cast<const planner::AggregatePlanNode *>(op);
+      if (agg_op->GetGroupByTerms().empty()) {
+        return std::make_unique<StaticAggregateBottomTranslator>(agg_op, codegen);
+      }
+      return std::make_unique<AggregateBottomTranslator>(agg_op, codegen);
+    }
     case terrier::planner::PlanNodeType::ORDERBY:
       return std::make_unique<SortBottomTranslator>(static_cast<const planner::OrderByPlanNode *>(op), codegen);
     default:
@@ -76,9 +86,13 @@ std::unique_ptr<OperatorTranslator> TranslatorFactory::CreateTopTranslator(const
                                                                            OperatorTranslator *bottom,
                                                                            CodeGen *codegen) {
   switch (op->GetPlanNodeType()) {
-    case terrier::planner::PlanNodeType::AGGREGATE:
-      return std::make_unique<AggregateTopTranslator>(static_cast<const planner::AggregatePlanNode *>(op), codegen,
-                                                      bottom);
+    case terrier::planner::PlanNodeType::AGGREGATE: {
+      auto agg_op = static_cast<const planner::AggregatePlanNode *>(op);
+      if (agg_op->GetGroupByTerms().empty()) {
+        return std::make_unique<StaticAggregateTopTranslator>(agg_op, codegen, bottom);
+      }
+      return std::make_unique<AggregateTopTranslator>(agg_op, codegen, bottom);
+    }
     case terrier::planner::PlanNodeType::ORDERBY:
       return std::make_unique<SortTopTranslator>(static_cast<const planner::OrderByPlanNode *>(op), codegen, bottom);
     default:

--- a/src/execution/executable_query.cpp
+++ b/src/execution/executable_query.cpp
@@ -17,9 +17,9 @@ ExecutableQuery::ExecutableQuery(const common::ManagedPointer<planner::AbstractP
   compiler::Compiler compiler(&codegen, physical_plan.Get());
   auto root = compiler.Compile();
   if (codegen.Reporter()->HasErrors()) {
+    EXECUTION_LOG_ERROR(execution::ast::AstDump::Dump(root));
     EXECUTION_LOG_ERROR("Type-checking error! \n {}", codegen.Reporter()->SerializeErrors());
     EXECUTION_LOG_ERROR("Dumping AST:");
-    EXECUTION_LOG_ERROR(execution::ast::AstDump::Dump(root));
     return;
   }
 

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1258,6 +1258,19 @@ void BytecodeGenerator::VisitBuiltinSorterCall(ast::CallExpr *call, ast::Builtin
       Emitter()->Emit(Bytecode::SorterAllocTuple, dest, sorter);
       break;
     }
+    case ast::Builtin::SorterInsertTopK: {
+      LocalVar dest = ExecutionResult()->GetOrCreateDestination(call->GetType());
+      LocalVar sorter = VisitExpressionForRValue(call->Arguments()[0]);
+      LocalVar top_k = VisitExpressionForRValue(call->Arguments()[1]);
+      Emitter()->Emit(Bytecode::SorterAllocTupleTopK, dest, sorter, top_k);
+      break;
+    }
+    case ast::Builtin::SorterInsertTopKFinish: {
+      LocalVar sorter = VisitExpressionForRValue(call->Arguments()[0]);
+      LocalVar top_k = VisitExpressionForRValue(call->Arguments()[1]);
+      Emitter()->Emit(Bytecode::SorterAllocTupleTopKFinish, sorter, top_k);
+      break;
+    }
     case ast::Builtin::SorterSort: {
       LocalVar sorter = VisitExpressionForRValue(call->Arguments()[0]);
       Emitter()->Emit(Bytecode::SorterSort, sorter);
@@ -2086,6 +2099,8 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     }
     case ast::Builtin::SorterInit:
     case ast::Builtin::SorterInsert:
+    case ast::Builtin::SorterInsertTopK:
+    case ast::Builtin::SorterInsertTopKFinish:
     case ast::Builtin::SorterSort:
     case ast::Builtin::SorterSortParallel:
     case ast::Builtin::SorterSortTopKParallel:

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -120,6 +120,8 @@ namespace terrier::execution::ast {
   /* Sorting */                                                         \
   F(SorterInit, sorterInit)                                             \
   F(SorterInsert, sorterInsert)                                         \
+  F(SorterInsertTopK, sorterInsertTopK)                                 \
+  F(SorterInsertTopKFinish, sorterInsertTopKFinish)                     \
   F(SorterSort, sorterSort)                                             \
   F(SorterSortParallel, sorterSortParallel)                             \
   F(SorterSortTopKParallel, sorterSortTopKParallel)                     \

--- a/src/include/execution/compiler/operator/aggregate_translator.h
+++ b/src/include/execution/compiler/operator/aggregate_translator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+#include "execution/compiler/operator/aggregate_util.h"
 #include "execution/compiler/operator/operator_translator.h"
 #include "planner/plannodes/aggregate_plan_node.h"
 
@@ -22,19 +23,19 @@ class AggregateBottomTranslator : public OperatorTranslator {
    */
   AggregateBottomTranslator(const terrier::planner::AggregatePlanNode *op, CodeGen *codegen);
 
-  // Declare the hash table
+  // Declare the hash tables
   void InitializeStateFields(util::RegionVector<ast::FieldDecl *> *state_fields) override;
 
-  // Declare payload and probe structs
+  // Declare the values and payload structs
   void InitializeStructs(util::RegionVector<ast::Decl *> *decls) override;
 
-  // Create the key check function.
+  // Create the key check functions.
   void InitializeHelperFunctions(util::RegionVector<ast::Decl *> *decls) override;
 
-  // Call @aggHTInit on the hash table
+  // Initialize all hash tables.
   void InitializeSetup(util::RegionVector<ast::Stmt *> *setup_stmts) override;
 
-  // Call @aggHTFree
+  // Free all hash tables.
   void InitializeTeardown(util::RegionVector<ast::Stmt *> *teardown_stmts) override;
 
   void Produce(FunctionBuilder *builder) override;
@@ -44,8 +45,10 @@ class AggregateBottomTranslator : public OperatorTranslator {
   // Pass through to the child
   ast::Expr *GetChildOutput(uint32_t child_idx, uint32_t attr_idx, terrier::type::TypeId type) override;
 
-  // Return the attribute at idx
-  ast::Expr *GetOutput(uint32_t attr_idx) override;
+  // Should not be called.
+  ast::Expr *GetOutput(uint32_t attr_idx) override {
+    UNREACHABLE("Use the more descriptive 'GetGroupByOutput' and 'GetAggregateOutput instead'");
+  }
 
   // This is materializer
   bool IsMaterializer(bool *is_ptr) override {
@@ -54,92 +57,34 @@ class AggregateBottomTranslator : public OperatorTranslator {
   }
 
   // Return the payload and its type
-  std::pair<ast::Identifier *, ast::Identifier *> GetMaterializedTuple() override {
-    return {&agg_payload_, &payload_struct_};
+  std::pair<const ast::Identifier *, const ast::Identifier *> GetMaterializedTuple() override {
+    auto global_aht = helper_.GetGlobalAHT();
+    return {&global_aht->Entry(), &global_aht->StructType()};
   }
 
   const planner::AbstractPlanNode *Op() override { return op_; }
 
  private:
   /**
-   * Return the group by term at the given index
-   * @param object either agg_payload_ or agg_values_
+   * Return the group by output at the given index
    * @param idx index of the term
    * @return the group by term at the given index
    */
-  ast::Expr *GetGroupByTerm(ast::Identifier object, uint32_t idx);
+  ast::Expr *GetGroupByOutput(uint32_t idx);
 
   /**
-   * Return the aggregate term at the given index
-   * @param object with agg_payload_ or agg_value_
+   * Return the aggregate output at the given index
    * @param idx index of the term
-   * @param ptr whether to return a pointer to the term or not
-   * @return the group by term at the given index
+   * @return the agg by term at the given index
    */
-  ast::Expr *GetAggTerm(ast::Identifier object, uint32_t idx, bool ptr);
-
-  /*
-   * Generate the aggregation hash table's payload struct
-   */
-  void GenPayloadStruct(util::RegionVector<ast::Decl *> *decls);
-
-  /*
-   * Generate the aggregation's input values
-   */
-  void GenValuesStruct(util::RegionVector<ast::Decl *> *decls);
-
-  /*
-   * Generate the key check logic
-   */
-  void GenKeyCheck(FunctionBuilder *builder);
-
-  /*
-   * First declare var agg_values : AggValues
-   * For each group by term, generate agg_values.term_i = group_by_term_i
-   * For each aggregation expression, agg_values.expr_i = agg_expr_i
-   */
-  void FillValues(FunctionBuilder *builder);
-
-  // Generate var agg_payload = @ptrCast(*AggPayload, @aggHTLookup(&state.agg_ht, agg_hash_val, keyCheck, &agg_values))
-  void GenLookupCall(FunctionBuilder *builder);
-
-  /*
-   * First check if agg_payload == nil
-   * If so, set agg_payload.term_i = agg_values.term_i for each group by terms
-   * Add call @aggInit(&agg_payload.expr_i) for each expression
-   */
-  void GenConstruct(FunctionBuilder *builder);
-
-  /*
-   * For each aggregate expression, call @aggAdvance(&agg_payload.expr_i, &agg_values.expr_i)
-   */
-  void GenAdvance(FunctionBuilder *builder);
-
-  // Generate var agg_hash_val = @hash(groub_by_term1, group_by_term2, ...)
-  void GenHashCall(FunctionBuilder *builder);
-
-  // Tuple at a time key check
-  void GenSingleKeyCheckFn(util::RegionVector<ast::Decl *> *decls);
+  ast::Expr *GetAggregateOutput(uint32_t idx);
 
   // Make the top translator a friend class.
   friend class AggregateTopTranslator;
 
  private:
-  // The number of group by terms.
-  uint32_t num_group_by_terms_;
   const planner::AggregatePlanNode *op_;
-
-  // Structs, Functions, and local variables needed.
-  // TODO(Amadou): This list is blowing up. Figure out a different to manage local variable names.
-  static constexpr const char *GROUP_BY_TERM_NAMES = "group_by_term";
-  static constexpr const char *AGG_TERM_NAMES = "agg_term";
-  ast::Identifier hash_val_;
-  ast::Identifier agg_values_;
-  ast::Identifier values_struct_;
-  ast::Identifier payload_struct_;
-  ast::Identifier agg_payload_;
-  ast::Identifier key_check_;
-  ast::Identifier agg_ht_;
+  AggregateHelper helper_;
 };
 
 /**
@@ -190,7 +135,7 @@ class AggregateTopTranslator : public OperatorTranslator {
   }
 
   // Pass the call to the bottom translator.
-  std::pair<ast::Identifier *, ast::Identifier *> GetMaterializedTuple() override {
+  std::pair<const ast::Identifier *, const ast::Identifier *> GetMaterializedTuple() override {
     return bottom_->GetMaterializedTuple();
   }
 

--- a/src/include/execution/compiler/operator/aggregate_util.h
+++ b/src/include/execution/compiler/operator/aggregate_util.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "execution/compiler/operator/operator_translator.h"
+#include "planner/plannodes/aggregate_plan_node.h"
+
+namespace terrier::execution::compiler {
+
+/**
+ * Contains all information needed for an aggregation hash table..
+ */
+class AHTInfo {
+ public:
+  /**
+   * Non distinct constructor.
+   * @param codegen The code generator
+   */
+  explicit AHTInfo(CodeGen *codegen) : AHTInfo(codegen, false, 0) {}
+
+  /**
+   * Generic constructor
+   * @param codegen The code generator
+   * @param is_distinct Whether this hash table is for a distinct aggregate.
+   * @param term_idx Index of the distinct aggregate.
+   */
+  explicit AHTInfo(CodeGen *codegen, bool is_distinct, uint32_t term_idx)
+      : is_distinct_(is_distinct),
+        term_idx_(term_idx),
+        ht_(codegen->NewIdentifier("aht")),
+        struct_(codegen->NewIdentifier("AHTStruct")),
+        key_check_(codegen->NewIdentifier("ahtKeyCheckFn")),
+        entry_(codegen->NewIdentifier("aht_entry")),
+        hash_val_(codegen->NewIdentifier("aht_hash_val")) {}
+
+  /**
+   * @return Whether the hash table is for a distinct aggregate.
+   */
+  bool IsDistinct() const { return is_distinct_; }
+
+  /**
+   * @return Index of the distinct aggregate.
+   */
+  uint32_t TermIdx() const {
+    TERRIER_ASSERT(is_distinct_, "Only Valid for distinct aggregates");
+    return term_idx_;
+  }
+
+  /**
+   * @return The hash table identifier
+   */
+  const ast::Identifier &HT() const { return ht_; }
+
+  /**
+   * @return The type of the struct
+   */
+  const ast::Identifier &StructType() const { return struct_; }
+
+  /**
+   * @return The key check function
+   */
+  const ast::Identifier &KeyCheck() const { return key_check_; }
+
+  /**
+   * @return Identifier of a hash table entry
+   */
+  const ast::Identifier &Entry() const { return entry_; }
+
+  /**
+   * @return Identifier of the hash value
+   */
+  const ast::Identifier &HashVal() const { return hash_val_; }
+
+ private:
+  // Whether this is a distinct aggregate
+  bool is_distinct_;
+  // Index of the distinct aggregate.
+  uint32_t term_idx_;
+  // Name of the hash table.
+  ast::Identifier ht_;
+  // Types of entries of the hash table
+  ast::Identifier struct_;
+  // Key check function
+  ast::Identifier key_check_;
+  // Single entry from the hash table.
+  ast::Identifier entry_;
+  // Hash values for the hash table
+  ast::Identifier hash_val_;
+};
+
+/**
+ * This class contains functionality needed by regular aggregations and static aggregations.
+ */
+class AggregateHelper {
+ public:
+  /**
+   * Constructor
+   * @param codegen The code generator
+   * @param op The aggregate plan node
+   */
+  AggregateHelper(CodeGen *codegen, const planner::AggregatePlanNode *op);
+
+  /**
+   * Initialize all hash tables.
+   * @param stmts List of setup statements.
+   */
+  void InitAHTs(util::RegionVector<ast::Stmt *> *stmts);
+
+  /**
+   * Free all hash tables.
+   * @param stmts List of teardown statements.
+   */
+  void FreeAHTs(util::RegionVector<ast::Stmt *> *stmts);
+
+  /**
+   * Declare all hash tables.
+   * @param fields List of state fields.
+   */
+  void DeclareAHTs(util::RegionVector<ast::FieldDecl *> *fields);
+
+  /**
+   * Generate the key check function of each hash table.
+   * @param decls List of top level declarations.
+   */
+  void GenKeyChecks(util::RegionVector<ast::Decl *> *decls);
+
+  /**
+   * Generate the input structs of each hash table.
+   * @param decls List of top level declarations.
+   */
+  void GenAHTStructs(util::RegionVector<ast::Decl *> *decls);
+
+  /**
+   * Generate the struct containing the values to aggregate and groub by.
+   * @param decls List of top level declarations.
+   */
+  void GenValuesStruct(util::RegionVector<ast::Decl *> *decls);
+
+  /**
+   * Generate the hash value for each hash table.
+   * @param builder Current function builder
+   */
+  void GenHashCalls(FunctionBuilder *builder);
+
+  /**
+   * Generate code to construct new hash table entries
+   * @param builder Current function builder
+   */
+  void GenConstruct(FunctionBuilder *builder);
+
+  /**
+   * Fill the values that will be used to aggregate and group
+   * @param builder Current function builder
+   * @param translator The translator requesting the values.
+   */
+  void FillValues(FunctionBuilder *builder, OperatorTranslator *translator);
+
+  /**
+   * Unconditionally advance non distinct aggregates.
+   * @param builder Current function builder.
+   */
+  void GenAdvanceNonDistinct(FunctionBuilder *builder);
+
+  /**
+   * @param term_idx Index of the aggregate.
+   * @return The identifier of the aggregate term.
+   */
+  const ast::Identifier &GetAggregate(uint32_t term_idx) const { return aggregates_[term_idx]; }
+
+  /**
+   * @param term_idx Index of the group by term.
+   * @return The identifer of the group by term.
+   */
+  const ast::Identifier &GetGroupBy(uint32_t term_idx) const { return group_bys_[term_idx]; }
+
+  /**
+   * @return The info of the global hash table.
+   */
+  const AHTInfo *GetGlobalAHT() const { return &global_info_; }
+
+ private:
+  /**
+   * Set groub by values in the given hash table entry.
+   * @param builder Current function builder.
+   * @param info The hash table to initialize
+   */
+  void InitGroupByValues(FunctionBuilder *builder, const AHTInfo *info);
+
+  /**
+   * Advance a distinct aggregate.
+   * @param builder Current function builder.
+   * @param info The hash table of the distinct aggregate
+   */
+  void AdvanceDistinct(FunctionBuilder *builder, const AHTInfo *info);
+
+  /**
+   * Initialize the aggregates of the global hash table.
+   * @param builder Current function builder.
+   */
+  void InitGlobalAggregates(FunctionBuilder *builder);
+
+  // The code generator
+  CodeGen *codegen_;
+  // The aggregate operator
+  const planner::AggregatePlanNode *op_;
+  // An entry into the global hash table.
+  AHTInfo global_info_;
+  // Values that will be aggregated.
+  ast::Identifier agg_values_;
+  // Type of the values' struct.
+  ast::Identifier values_struct_;
+  // Name of the groub by terms
+  std::vector<ast::Identifier> group_bys_;
+  // Name of the groub by aggregate terms
+  std::vector<ast::Identifier> aggregates_;
+  // Information about distinct aggregates.
+  std::unordered_map<uint32_t, std::unique_ptr<AHTInfo>> distinct_aggs_;
+};
+}  // namespace terrier::execution::compiler

--- a/src/include/execution/compiler/operator/index_scan_translator.h
+++ b/src/include/execution/compiler/operator/index_scan_translator.h
@@ -46,7 +46,9 @@ class IndexScanTranslator : public OperatorTranslator {
   }
 
   // Return the projected row and its type
-  std::pair<ast::Identifier *, ast::Identifier *> GetMaterializedTuple() override { return {&table_pr_, &pr_type_}; }
+  std::pair<const ast::Identifier *, const ast::Identifier *> GetMaterializedTuple() override {
+    return {&table_pr_, &pr_type_};
+  }
 
   ast::Expr *GetOutput(uint32_t attr_idx) override;
   ast::Expr *GetChildOutput(uint32_t child_idx, uint32_t attr_idx, terrier::type::TypeId type) override;

--- a/src/include/execution/compiler/operator/limit_translator.h
+++ b/src/include/execution/compiler/operator/limit_translator.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+#include "execution/compiler/operator/operator_translator.h"
+#include "execution/compiler/translator_factory.h"
+#include "planner/plannodes/limit_plan_node.h"
+
+namespace terrier::execution::compiler {
+
+/**
+ * Limit Translator
+ * TODO(Amadou): The limit should be pushed down to the child operators. That's only being done with OrderBy.
+ */
+class LimitTranslator : public OperatorTranslator {
+ public:
+  /**
+   * Constructor
+   * @param op The plan node
+   * @param codegen The code generator
+   */
+  LimitTranslator(const terrier::planner::LimitPlanNode *op, CodeGen *codegen)
+      : OperatorTranslator(codegen), op_(op), num_tuples_(codegen->NewIdentifier("num_tuples")) {}
+
+  // Pass through
+  void Produce(FunctionBuilder *builder) override;
+
+  // Pass through
+  void Abort(FunctionBuilder *builder) override { child_translator_->Abort(builder); }
+
+  // Pass through
+  void Consume(FunctionBuilder *builder) override;
+
+  // Does nothing
+  void InitializeStateFields(util::RegionVector<ast::FieldDecl *> *state_fields) override {}
+
+  // Does nothing
+  void InitializeStructs(util::RegionVector<ast::Decl *> *decls) override {}
+
+  // Does nothing
+  void InitializeHelperFunctions(util::RegionVector<ast::Decl *> *decls) override {}
+
+  // Does nothing
+  void InitializeSetup(util::RegionVector<ast::Stmt *> *setup_stmts) override {}
+
+  // Does nothing
+  void InitializeTeardown(util::RegionVector<ast::Stmt *> *teardown_stmts) override {}
+
+  ast::Expr *GetOutput(uint32_t attr_idx) override {
+    auto output_expr = op_->GetOutputSchema()->GetColumn(attr_idx).GetExpr();
+    auto translator = TranslatorFactory::CreateExpressionTranslator(output_expr.Get(), codegen_);
+    return translator->DeriveExpr(this);
+  }
+
+  ast::Expr *GetChildOutput(uint32_t child_idx, uint32_t attr_idx, terrier::type::TypeId type) override {
+    return child_translator_->GetOutput(attr_idx);
+  }
+
+  // Is always vectorizable.
+  bool IsVectorizable() override { return true; }
+
+  // Should not be called here
+  ast::Expr *GetTableColumn(const catalog::col_oid_t &col_oid) override {
+    UNREACHABLE("Projection nodes should not use column value expressions");
+  }
+
+  const planner::AbstractPlanNode *Op() override { return op_; }
+
+ private:
+  const planner::LimitPlanNode *op_;
+  ast::Identifier num_tuples_;
+};
+
+}  // namespace terrier::execution::compiler

--- a/src/include/execution/compiler/operator/operator_translator.h
+++ b/src/include/execution/compiler/operator/operator_translator.h
@@ -138,7 +138,9 @@ class OperatorTranslator : public ExpressionEvaluator {
    * Most operators should not be materializers.
    * @return a pair containing the identifiers of the output tuple and its type.
    */
-  virtual std::pair<ast::Identifier *, ast::Identifier *> GetMaterializedTuple() { return {nullptr, nullptr}; }
+  virtual std::pair<const ast::Identifier *, const ast::Identifier *> GetMaterializedTuple() {
+    return {nullptr, nullptr};
+  }
 
   /**
    * Used by operators when they need to generate a struct containing a child's output.

--- a/src/include/execution/compiler/operator/seq_scan_translator.h
+++ b/src/include/execution/compiler/operator/seq_scan_translator.h
@@ -61,7 +61,9 @@ class SeqScanTranslator : public OperatorTranslator {
   static bool IsVectorizable(const terrier::parser::AbstractExpression *predicate);
 
   // Return the pci and its type
-  std::pair<ast::Identifier *, ast::Identifier *> GetMaterializedTuple() override { return {&pci_, &pci_type_}; }
+  std::pair<const ast::Identifier *, const ast::Identifier *> GetMaterializedTuple() override {
+    return {&pci_, &pci_type_};
+  }
 
   // Used by column value expression to get a column.
   ast::Expr *GetTableColumn(const catalog::col_oid_t &col_oid) override;

--- a/src/include/execution/compiler/operator/sort_translator.h
+++ b/src/include/execution/compiler/operator/sort_translator.h
@@ -49,7 +49,7 @@ class SortBottomTranslator : public OperatorTranslator {
   }
 
   // Return the payload and its type
-  std::pair<ast::Identifier *, ast::Identifier *> GetMaterializedTuple() override {
+  std::pair<const ast::Identifier *, const ast::Identifier *> GetMaterializedTuple() override {
     return {&sorter_row_, &sorter_struct_};
   }
 
@@ -62,6 +62,8 @@ class SortBottomTranslator : public OperatorTranslator {
   ast::Expr *GetAttribute(ast::Identifier object, uint32_t attr_idx);
   // Insert into sorter
   void GenSorterInsert(FunctionBuilder *builder);
+  // Gen top k finish
+  void GenFinishTopK(FunctionBuilder *builder);
   // Fill the sorter row
   void FillSorterRow(FunctionBuilder *builder);
   // Call Sort()
@@ -71,6 +73,10 @@ class SortBottomTranslator : public OperatorTranslator {
 
   // The sort plan node
   const planner::OrderByPlanNode *op_;
+  // Whether to use topK.
+  // This will be true when there is a limit and the offset is 0. We can build a bounded heap instead of sorting all
+  // values.
+  bool use_top_k_;
 
   /**
    * GetChildOutput will need to return different results depending on the calling function.
@@ -135,7 +141,7 @@ class SortTopTranslator : public OperatorTranslator {
   }
 
   // Return the payload and its type
-  std::pair<ast::Identifier *, ast::Identifier *> GetMaterializedTuple() override {
+  std::pair<const ast::Identifier *, const ast::Identifier *> GetMaterializedTuple() override {
     return {&bottom_->sorter_row_, &bottom_->sorter_struct_};
   }
 
@@ -153,12 +159,16 @@ class SortTopTranslator : public OperatorTranslator {
 
   // The sort plan node
   const planner::OrderByPlanNode *op_;
+  // Whether to explicitly limit the number of output row.
+  // This will be true when there is a limit and an offset, because we can't use the bounded heap with an offset.
+  bool use_limit_;
 
   // The bottom translator
   SortBottomTranslator *bottom_;
 
   // Local variables
   ast::Identifier sort_iter_;
+  ast::Identifier num_tuples_;
 };
 
 }  // namespace terrier::execution::compiler

--- a/src/include/execution/compiler/operator/static_aggregate_translator.h
+++ b/src/include/execution/compiler/operator/static_aggregate_translator.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <unordered_map>
+#include <utility>
+#include "execution/compiler/operator/aggregate_util.h"
+#include "execution/compiler/operator/operator_translator.h"
+#include "planner/plannodes/aggregate_plan_node.h"
+
+namespace terrier::execution::compiler {
+
+// Forward declare
+class StaticAggregateTopTranslator;
+
+/**
+ * A static aggregation is one in which there is no group by term. It differs from a regular aggregation in that
+ * there is no aggregation hash table and that there must be an output.
+ */
+class StaticAggregateBottomTranslator : public OperatorTranslator {
+ public:
+  /**
+   * Constructor
+   * @param op plan node to translate
+   * @param codegen code generator
+   */
+  StaticAggregateBottomTranslator(const terrier::planner::AggregatePlanNode *op, CodeGen *codegen);
+
+  // Declare aggregates and distinct hash tables.
+  void InitializeStateFields(util::RegionVector<ast::FieldDecl *> *state_fields) override;
+
+  // Declare the values struct and the payload of each distinct aggregate
+  void InitializeStructs(util::RegionVector<ast::Decl *> *decls) override;
+
+  // Initialize comparison functions for distinct aggregates.
+  void InitializeHelperFunctions(util::RegionVector<ast::Decl *> *decls) override;
+
+  // Initialize the aggregates
+  void InitializeSetup(util::RegionVector<ast::Stmt *> *setup_stmts) override;
+
+  // Free Distinct
+  void InitializeTeardown(util::RegionVector<ast::Stmt *> *teardown_stmts) override;
+
+  // Pass Through
+  void Produce(FunctionBuilder *builder) override { child_translator_->Produce(builder); };
+  // Pass Through
+  void Abort(FunctionBuilder *builder) override { child_translator_->Abort(builder); }
+  void Consume(FunctionBuilder *builder) override;
+
+  // Pass through to the child
+  ast::Expr *GetChildOutput(uint32_t child_idx, uint32_t attr_idx, terrier::type::TypeId type) override {
+    return child_translator_->GetOutput(attr_idx);
+  }
+
+  // Return the attribute at idx
+  ast::Expr *GetOutput(uint32_t attr_idx) override {
+    ast::Expr *agg = codegen_->GetStateMemberPtr(helper_.GetAggregate(attr_idx));
+    return codegen_->OneArgCall(ast::Builtin::AggResult, agg);
+  }
+
+  const planner::AbstractPlanNode *Op() override { return op_; }
+
+ private:
+  friend class StaticAggregateTopTranslator;
+  const planner::AggregatePlanNode *op_;
+  AggregateHelper helper_;
+};
+
+/**
+ * The iteration side of the static aggregate.
+ */
+class StaticAggregateTopTranslator : public OperatorTranslator {
+ public:
+  /**
+   * Constructor
+   * @param op plan node
+   * @param codegen The code generator
+   * @param bottom The corresponding bottom translator
+   */
+  StaticAggregateTopTranslator(const terrier::planner::AggregatePlanNode *op, CodeGen *codegen,
+                               OperatorTranslator *bottom)
+      : OperatorTranslator(codegen), op_(op), bottom_(static_cast<StaticAggregateBottomTranslator *>(bottom)) {}
+
+  // Does nothing
+  void InitializeStateFields(util::RegionVector<ast::FieldDecl *> *state_fields) override {}
+
+  // Does nothing
+  void InitializeStructs(util::RegionVector<ast::Decl *> *decls) override {}
+
+  // Does nothing
+  void InitializeHelperFunctions(util::RegionVector<ast::Decl *> *decls) override {}
+
+  // Does nothing
+  void InitializeSetup(util::RegionVector<ast::Stmt *> *setup_stmts) override {}
+
+  // Does nothing
+  void InitializeTeardown(util::RegionVector<ast::Stmt *> *teardown_stmts) override {}
+
+  // Generate the havinf clause
+  void Produce(FunctionBuilder *builder) override;
+
+  // Pass through
+  void Abort(FunctionBuilder *builder) override {
+    if (child_translator_ != nullptr) child_translator_->Abort(builder);
+  }
+
+  // Pass through
+  void Consume(FunctionBuilder *builder) override { parent_translator_->Consume(builder); }
+
+  // Pass through to the child
+  ast::Expr *GetChildOutput(uint32_t child_idx, uint32_t attr_idx, terrier::type::TypeId type) override {
+    return bottom_->GetOutput(attr_idx);
+  }
+
+  // Return the attribute at idx
+  ast::Expr *GetOutput(uint32_t attr_idx) override;
+
+  const planner::AbstractPlanNode *Op() override { return op_; }
+
+ private:
+  const planner::AggregatePlanNode *op_;
+  StaticAggregateBottomTranslator *bottom_;
+};
+
+}  // namespace terrier::execution::compiler

--- a/src/include/execution/compiler/operator/update_translator.h
+++ b/src/include/execution/compiler/operator/update_translator.h
@@ -40,6 +40,7 @@ class UpdateTranslator : public OperatorTranslator {
 
   ast::Expr *GetOutput(uint32_t attr_idx) override { UNREACHABLE("Updates don't output anything"); };
   ast::Expr *GetChildOutput(uint32_t child_idx, uint32_t attr_idx, terrier::type::TypeId type) override;
+  ast::Expr *GetTableColumn(const catalog::col_oid_t &col_oid) override;
 
   const planner::AbstractPlanNode *Op() override { return op_; }
 

--- a/src/include/execution/sema/sema.h
+++ b/src/include/execution/sema/sema.h
@@ -132,7 +132,7 @@ class Sema : public ast::AstVisitor<Sema> {
   void CheckBuiltinJoinHashTableBuild(ast::CallExpr *call, ast::Builtin builtin);
   void CheckBuiltinJoinHashTableFree(ast::CallExpr *call);
   void CheckBuiltinSorterInit(ast::CallExpr *call);
-  void CheckBuiltinSorterInsert(ast::CallExpr *call);
+  void CheckBuiltinSorterInsert(ast::CallExpr *call, ast::Builtin builtin);
   void CheckBuiltinSorterSort(ast::CallExpr *call, ast::Builtin builtin);
   void CheckBuiltinSorterFree(ast::CallExpr *call);
   void CheckBuiltinSorterIterCall(ast::CallExpr *call, ast::Builtin builtin);

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -334,7 +334,7 @@ namespace terrier::execution::vm {
   /* Sorting */                                                                                                       \
   F(SorterInit, OperandType::Local, OperandType::Local, OperandType::FunctionId, OperandType::Local)                  \
   F(SorterAllocTuple, OperandType::Local, OperandType::Local)                                                         \
-  F(SorterAllocTupleTopK, OperandType::Local, OperandType::Local)                                                     \
+  F(SorterAllocTupleTopK, OperandType::Local, OperandType::Local, OperandType::Local)                                 \
   F(SorterAllocTupleTopKFinish, OperandType::Local, OperandType::Local)                                               \
   F(SorterSort, OperandType::Local)                                                                                   \
   F(SorterSortParallel, OperandType::Local, OperandType::Local, OperandType::Local)                                   \

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -38,6 +38,12 @@ class UpdateClause {
   common::ManagedPointer<AbstractExpression> GetUpdateValue() const { return value_; }
 
   /**
+   * Reset the update value.
+   * @param new_value New value of the update expression
+   */
+  void ResetValue(common::ManagedPointer<AbstractExpression> new_value) { value_ = new_value; }
+
+  /**
    * Logical equality check
    * @param r Right hand side; the other update clause
    * @return true if the two update clause are logically equal

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -134,8 +134,8 @@ void QueryToOperatorTransformer::Visit(parser::SelectStatement *op, parser::Pars
       }
     }
     auto limit_expr = std::make_unique<OperatorExpression>(
-        LogicalLimit::Make(op->GetSelectLimit()->GetOffset(), op->GetSelectLimit()->GetLimit(), std::move(sort_exprs),
-                           std::move(sort_direction)),
+        LogicalLimit::Make(std::max(op->GetSelectLimit()->GetOffset(), static_cast<int64_t>(0)),
+                           op->GetSelectLimit()->GetLimit(), std::move(sort_exprs), std::move(sort_direction)),
         std::vector<std::unique_ptr<OperatorExpression>>{});
     limit_expr->PushChild(std::move(output_expr_));
     output_expr_ = std::move(limit_expr);

--- a/test/execution/compiler_test.cpp
+++ b/test/execution/compiler_test.cpp
@@ -1,3 +1,4 @@
+#include <planner/plannodes/limit_plan_node.h>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -621,7 +622,7 @@ TEST_F(CompilerTest, SimpleAggregateTest) {
     planner::AggregatePlanNode::Builder builder;
     agg = builder.SetOutputSchema(std::move(schema))
               .AddGroupByTerm(agg_out.GetGroupByTerm("col2"))
-              .AddAggregateTerm(agg_out.GetAggTerm("col1"))
+              .AddAggregateTerm(agg_out.GetAggTerm("sum_col1"))
               .AddChild(std::move(seq_scan))
               .SetAggregateStrategyType(planner::AggregateStrategyType::HASH)
               .SetHavingClausePredicate(nullptr)
@@ -631,6 +632,97 @@ TEST_F(CompilerTest, SimpleAggregateTest) {
   NumChecker num_checker{10};
   SingleIntSumChecker sum_checker{1, (1000 * 999) / 2};
   MultiChecker multi_checker{std::vector<OutputChecker *>{&num_checker, &sum_checker}};
+
+  // Compile and Run
+  OutputStore store{&multi_checker, agg->GetOutputSchema().Get()};
+  exec::OutputPrinter printer(agg->GetOutputSchema().Get());
+  MultiOutputCallback callback{std::vector<exec::OutputCallback>{store, printer}};
+  auto exec_ctx = MakeExecCtx(std::move(callback), agg->GetOutputSchema().Get());
+
+  // Run & Check
+  auto executable = ExecutableQuery(common::ManagedPointer(agg), common::ManagedPointer(exec_ctx));
+  executable.Run(common::ManagedPointer(exec_ctx), MODE);
+  multi_checker.CheckCorrectness();
+}
+
+// NOLINTNEXTLINE
+TEST_F(CompilerTest, AggregateWithDistinctAndGroupByTest) {
+  // SELECT col2, SUM(col1), COUNT(DISTINCT col2), SUM(DISTINCT col1) FROM test_1 WHERE col1 < 1000 GROUP BY col2;
+  // Get accessor
+  auto accessor = MakeAccessor();
+  ExpressionMaker expr_maker;
+  auto table_oid = accessor->GetTableOid(NSOid(), "test_1");
+  auto table_schema = accessor->GetSchema(table_oid);
+  std::unique_ptr<planner::AbstractPlanNode> seq_scan;
+  OutputSchemaHelper seq_scan_out{0, &expr_maker};
+  {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
+    // Get Table columns
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
+    seq_scan_out.AddOutput("col1", col1);
+    seq_scan_out.AddOutput("col2", col2);
+    auto schema = seq_scan_out.MakeSchema();
+    // Make predicate
+    auto predicate = expr_maker.ComparisonLt(col1, expr_maker.Constant(1000));
+    // Build
+    planner::SeqScanPlanNode::Builder builder;
+    seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
+                   .SetScanPredicate(predicate)
+                   .SetIsForUpdateFlag(false)
+                   .SetNamespaceOid(NSOid())
+                   .SetTableOid(table_oid)
+                   .Build();
+  }
+  // Make the aggregate
+  std::unique_ptr<planner::AbstractPlanNode> agg;
+  OutputSchemaHelper agg_out{0, &expr_maker};
+  {
+    // Read previous output
+    auto col1 = seq_scan_out.GetOutput("col1");
+    auto col2 = seq_scan_out.GetOutput("col2");
+    // Add group by term
+    agg_out.AddGroupByTerm("col2", col2);
+    // Add aggregates
+    auto sum_col1 = expr_maker.AggSum(col1);
+    agg_out.AddAggTerm("sum_col1", sum_col1);
+    auto count_distinct_col2 = expr_maker.AggCount(col2, true);
+    agg_out.AddAggTerm("count_distinct_col2", count_distinct_col2);
+    auto sum_distinct_col1 = expr_maker.AggSum(col1, true);
+    agg_out.AddAggTerm("sum_distinct_col1", sum_distinct_col1);
+
+    // Make the output expressions
+    agg_out.AddOutput("col2", agg_out.GetGroupByTermForOutput("col2"));
+    agg_out.AddOutput("sum_col1", agg_out.GetAggTermForOutput("sum_col1"));
+    agg_out.AddOutput("count_distinct_col2", agg_out.GetAggTermForOutput("count_distinct_col2"));
+    agg_out.AddOutput("sum_distinct_col1", agg_out.GetAggTermForOutput("sum_distinct_col1"));
+    auto schema = agg_out.MakeSchema();
+    // Build
+    planner::AggregatePlanNode::Builder builder;
+    agg = builder.SetOutputSchema(std::move(schema))
+              .AddGroupByTerm(agg_out.GetGroupByTerm("col2"))
+              .AddAggregateTerm(agg_out.GetAggTerm("sum_col1"))
+              .AddAggregateTerm(agg_out.GetAggTerm("count_distinct_col2"))
+              .AddAggregateTerm(agg_out.GetAggTerm("sum_distinct_col1"))
+              .AddChild(std::move(seq_scan))
+              .SetAggregateStrategyType(planner::AggregateStrategyType::HASH)
+              .SetHavingClausePredicate(nullptr)
+              .Build();
+  }
+  // Make the checkers
+  // There should be 10 output rows.
+  NumChecker num_checker{10};
+  // The sum should be from 0 to 1000.
+  SingleIntSumChecker sum_checker{1, (1000 * 999) / 2};
+  // Group by key and count distinct aggregate are the same. So the output shouls always be one.
+  SingleIntComparisonChecker distinct_count_checker{std::equal_to<>(), 2, 1};
+  // Every key in col1 is unique, the sum and the sum(distinct) should be the same.
+  SingleIntSumChecker distinct_sum_checker{3, (1000 * 999) / 2};
+  MultiChecker multi_checker{
+      std::vector<OutputChecker *>{&num_checker, &sum_checker, &distinct_count_checker, &distinct_sum_checker}};
 
   // Compile and Run
   OutputStore store{&multi_checker, agg->GetOutputSchema().Get()};
@@ -685,9 +777,158 @@ TEST_F(CompilerTest, CountStarTest) {
               .Build();
   }
   // Make the checkers
+  // There should be only one output
   NumChecker num_checker{1};
-  SingleIntComparisonChecker sum_checker{std::equal_to<>(), 0, sql::TEST1_SIZE};
-  MultiChecker multi_checker{std::vector<OutputChecker *>{&num_checker, &sum_checker}};
+  // The count should be the size of the table.
+  SingleIntComparisonChecker count_checker{std::equal_to<>(), 0, sql::TEST1_SIZE};
+  MultiChecker multi_checker{std::vector<OutputChecker *>{&num_checker, &count_checker}};
+
+  // Compile and Run
+  OutputStore store{&multi_checker, agg->GetOutputSchema().Get()};
+  exec::OutputPrinter printer(agg->GetOutputSchema().Get());
+  MultiOutputCallback callback{std::vector<exec::OutputCallback>{store, printer}};
+  auto exec_ctx = MakeExecCtx(std::move(callback), agg->GetOutputSchema().Get());
+
+  // Run & Check
+  auto executable = ExecutableQuery(common::ManagedPointer(agg), common::ManagedPointer(exec_ctx));
+  executable.Run(common::ManagedPointer(exec_ctx), MODE);
+  multi_checker.CheckCorrectness();
+}
+
+// NOLINTNEXTLINE
+TEST_F(CompilerTest, StaticAggregateTest) {
+  // SELECT COUNT(*), SUM(cola) FROM test_1;
+  // Get accessor
+  auto accessor = MakeAccessor();
+  ExpressionMaker expr_maker;
+  auto table_oid = accessor->GetTableOid(NSOid(), "test_1");
+  auto table_schema = accessor->GetSchema(table_oid);
+  std::unique_ptr<planner::AbstractPlanNode> seq_scan;
+  OutputSchemaHelper seq_scan_out{0, &expr_maker};
+  {
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    seq_scan_out.AddOutput("col1", col1);
+    auto schema = seq_scan_out.MakeSchema();
+    // Build
+    planner::SeqScanPlanNode::Builder builder;
+    seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({})
+                   .SetScanPredicate(nullptr)
+                   .SetIsForUpdateFlag(false)
+                   .SetNamespaceOid(NSOid())
+                   .SetTableOid(table_oid)
+                   .Build();
+  }
+  // Make the aggregate
+  std::unique_ptr<planner::AbstractPlanNode> agg;
+  OutputSchemaHelper agg_out{0, &expr_maker};
+  {
+    // Read previous output
+    auto col1 = seq_scan_out.GetOutput("col1");
+    // Add aggregates
+    agg_out.AddAggTerm("count_star", expr_maker.AggCount(expr_maker.Star()));
+    auto sum_col1 = expr_maker.AggSum(col1);
+    agg_out.AddAggTerm("sum_col1", sum_col1);
+    // Make the output expressions
+    agg_out.AddOutput("count_star", agg_out.GetAggTermForOutput("count_star"));
+    agg_out.AddOutput("sum_col1", agg_out.GetAggTermForOutput("sum_col1"));
+    auto schema = agg_out.MakeSchema();
+    // Build
+    planner::AggregatePlanNode::Builder builder;
+    agg = builder.SetOutputSchema(std::move(schema))
+              .AddAggregateTerm(agg_out.GetAggTerm("count_star"))
+              .AddAggregateTerm(agg_out.GetAggTerm("sum_col1"))
+              .AddChild(std::move(seq_scan))
+              .SetAggregateStrategyType(planner::AggregateStrategyType::HASH)
+              .SetHavingClausePredicate(nullptr)
+              .Build();
+  }
+  // Make the checkers
+  // There should be only one output
+  NumChecker num_checker{1};
+  // The count should be the size of the table.
+  SingleIntComparisonChecker count_checker{std::equal_to<>(), 0, sql::TEST1_SIZE};
+  // The sum should be from 1 to the size of the table.
+  SingleIntComparisonChecker sum_checker{std::equal_to<>(), 1, sql::TEST1_SIZE * (sql::TEST1_SIZE - 1) / 2};
+  MultiChecker multi_checker{std::vector<OutputChecker *>{&num_checker, &count_checker, &sum_checker}};
+
+  // Compile and Run
+  OutputStore store{&multi_checker, agg->GetOutputSchema().Get()};
+  exec::OutputPrinter printer(agg->GetOutputSchema().Get());
+  MultiOutputCallback callback{std::vector<exec::OutputCallback>{store, printer}};
+  auto exec_ctx = MakeExecCtx(std::move(callback), agg->GetOutputSchema().Get());
+
+  // Run & Check
+  auto executable = ExecutableQuery(common::ManagedPointer(agg), common::ManagedPointer(exec_ctx));
+  executable.Run(common::ManagedPointer(exec_ctx), MODE);
+  multi_checker.CheckCorrectness();
+}
+
+// NOLINTNEXTLINE
+TEST_F(CompilerTest, StaticDistinctAggregateTest) {
+  // SELECT COUNT(DISTINCT colb), SUM(DISTINCT colb), COUNT(*) FROM test_1;
+  // Get accessor
+  auto accessor = MakeAccessor();
+  ExpressionMaker expr_maker;
+  auto table_oid = accessor->GetTableOid(NSOid(), "test_1");
+  auto table_schema = accessor->GetSchema(table_oid);
+  std::unique_ptr<planner::AbstractPlanNode> seq_scan;
+  OutputSchemaHelper seq_scan_out{0, &expr_maker};
+  {
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
+    auto col1 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
+    seq_scan_out.AddOutput("col1", col1);
+    auto schema = seq_scan_out.MakeSchema();
+    // Build
+    planner::SeqScanPlanNode::Builder builder;
+    seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({colb_oid})
+                   .SetScanPredicate(nullptr)
+                   .SetIsForUpdateFlag(false)
+                   .SetNamespaceOid(NSOid())
+                   .SetTableOid(table_oid)
+                   .Build();
+  }
+  // Make the aggregate
+  std::unique_ptr<planner::AbstractPlanNode> agg;
+  OutputSchemaHelper agg_out{0, &expr_maker};
+  {
+    // Read previous output
+    auto col1 = seq_scan_out.GetOutput("col1");
+    // Add aggregates
+    auto distinct_count1 = expr_maker.AggCount(col1, true);
+    auto distinct_sum1 = expr_maker.AggSum(col1, true);
+    agg_out.AddAggTerm("distinct_count1", distinct_count1);
+    agg_out.AddAggTerm("distinct_sum1", distinct_sum1);
+    agg_out.AddAggTerm("count_star", expr_maker.AggCount(expr_maker.Star()));
+    // Make the output expressions
+    agg_out.AddOutput("distinct_count1", agg_out.GetAggTermForOutput("distinct_count1"));
+    agg_out.AddOutput("distinct_sum1", agg_out.GetAggTermForOutput("distinct_sum1"));
+    agg_out.AddOutput("count_star", agg_out.GetAggTermForOutput("count_star"));
+    auto schema = agg_out.MakeSchema();
+    // Build
+    planner::AggregatePlanNode::Builder builder;
+    agg = builder.SetOutputSchema(std::move(schema))
+              .AddAggregateTerm(agg_out.GetAggTerm("distinct_count1"))
+              .AddAggregateTerm(agg_out.GetAggTerm("distinct_sum1"))
+              .AddAggregateTerm(agg_out.GetAggTerm("count_star"))
+              .AddChild(std::move(seq_scan))
+              .SetAggregateStrategyType(planner::AggregateStrategyType::HASH)
+              .SetHavingClausePredicate(nullptr)
+              .Build();
+  }
+  // Make the checkers
+  // There should be only one output
+  NumChecker num_checker{1};
+  // The count distinct should be the number of distinct elements (10).
+  SingleIntComparisonChecker distinct_count_checker{std::equal_to<>(), 0, 10};
+  // The sum  should be from 1 to 10, which is 45.
+  SingleIntComparisonChecker distinct_sum_checker{std::equal_to<>(), 1, 45};
+  // The count star should be the size of the table
+  SingleIntComparisonChecker count_star_checker{std::equal_to<>(), 2, sql::TEST1_SIZE};
+  MultiChecker multi_checker{
+      std::vector<OutputChecker *>{&num_checker, &distinct_count_checker, &distinct_sum_checker, &count_star_checker}};
 
   // Compile and Run
   OutputStore store{&multi_checker, agg->GetOutputSchema().Get()};
@@ -757,7 +998,7 @@ TEST_F(CompilerTest, SimpleAggregateHavingTest) {
     planner::AggregatePlanNode::Builder builder;
     agg = builder.SetOutputSchema(std::move(schema))
               .AddGroupByTerm(agg_out.GetGroupByTerm("col2"))
-              .AddAggregateTerm(agg_out.GetAggTerm("col1"))
+              .AddAggregateTerm(agg_out.GetAggTerm("sum_col1"))
               .AddChild(std::move(seq_scan))
               .SetAggregateStrategyType(planner::AggregateStrategyType::HASH)
               .SetHavingClausePredicate(having)
@@ -787,6 +1028,66 @@ TEST_F(CompilerTest, SimpleAggregateHavingTest) {
   auto executable = ExecutableQuery(common::ManagedPointer(agg), common::ManagedPointer(exec_ctx));
   executable.Run(common::ManagedPointer(exec_ctx), MODE);
   checker.CheckCorrectness();
+}
+
+// NOLINTNEXTLINE
+TEST_F(CompilerTest, StaticAggregateHavingTest) {
+  // SELECT COUNT(*) FROM test_1 HAVING COUNT(*) < 0;
+  // Get accessor
+  auto accessor = MakeAccessor();
+  ExpressionMaker expr_maker;
+  auto table_oid = accessor->GetTableOid(NSOid(), "test_1");
+  auto table_schema = accessor->GetSchema(table_oid);
+  std::unique_ptr<planner::AbstractPlanNode> seq_scan;
+  OutputSchemaHelper seq_scan_out{0, &expr_maker};
+  {
+    auto schema = seq_scan_out.MakeSchema();
+    // Build
+    planner::SeqScanPlanNode::Builder builder;
+    seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({})
+                   .SetScanPredicate(nullptr)
+                   .SetIsForUpdateFlag(false)
+                   .SetNamespaceOid(NSOid())
+                   .SetTableOid(table_oid)
+                   .Build();
+  }
+  // Make the aggregate
+  std::unique_ptr<planner::AbstractPlanNode> agg;
+  OutputSchemaHelper agg_out{0, &expr_maker};
+  {
+    // Add aggregates
+    agg_out.AddAggTerm("count_star", expr_maker.AggCount(expr_maker.Star()));
+    // Make the output expressions
+    agg_out.AddOutput("count_star", agg_out.GetAggTermForOutput("count_star"));
+    auto schema = agg_out.MakeSchema();
+    // Having
+    auto having = expr_maker.ComparisonLt(agg_out.GetAggTermForOutput("count_star"), expr_maker.Constant(0));
+    // Build
+    planner::AggregatePlanNode::Builder builder;
+    agg = builder.SetOutputSchema(std::move(schema))
+              .AddAggregateTerm(agg_out.GetAggTerm("count_star"))
+              .AddChild(std::move(seq_scan))
+              .SetAggregateStrategyType(planner::AggregateStrategyType::HASH)
+              .SetHavingClausePredicate(having)
+              .Build();
+  }
+  // Make the checkers
+  // Should not output anything
+  NumChecker num_checker{0};
+  // The count should be the size of the table.
+  MultiChecker multi_checker{std::vector<OutputChecker *>{&num_checker}};
+
+  // Compile and Run
+  OutputStore store{&multi_checker, agg->GetOutputSchema().Get()};
+  exec::OutputPrinter printer(agg->GetOutputSchema().Get());
+  MultiOutputCallback callback{std::vector<exec::OutputCallback>{store, printer}};
+  auto exec_ctx = MakeExecCtx(std::move(callback), agg->GetOutputSchema().Get());
+
+  // Run & Check
+  auto executable = ExecutableQuery(common::ManagedPointer(agg), common::ManagedPointer(exec_ctx));
+  executable.Run(common::ManagedPointer(exec_ctx), MODE);
+  multi_checker.CheckCorrectness();
 }
 
 // NOLINTNEXTLINE
@@ -1181,6 +1482,278 @@ TEST_F(CompilerTest, SimpleSortTest) {
 
   // Run & Check
   auto executable = ExecutableQuery(common::ManagedPointer(order_by), common::ManagedPointer(exec_ctx));
+  executable.Run(common::ManagedPointer(exec_ctx), MODE);
+  checker.CheckCorrectness();
+}
+
+// NOLINTNEXTLINE
+TEST_F(CompilerTest, SortWithLimitTest) {
+  // SELECT col1, col2, col1 + col2 FROM test_1 WHERE col1 < 500 ORDER BY col2 ASC, col1 - col2 DESC LIMIT 10
+  // Get accessor
+  auto accessor = MakeAccessor();
+  ExpressionMaker expr_maker;
+  auto table_oid = accessor->GetTableOid(NSOid(), "test_1");
+  auto table_schema = accessor->GetSchema(table_oid);
+  std::unique_ptr<planner::AbstractPlanNode> seq_scan;
+  OutputSchemaHelper seq_scan_out{0, &expr_maker};
+  {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    auto colb_oid = table_schema.GetColumn("colB").Oid();
+    // Get Table columns
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    auto col2 = expr_maker.CVE(colb_oid, type::TypeId::INTEGER);
+    seq_scan_out.AddOutput("col1", col1);
+    seq_scan_out.AddOutput("col2", col2);
+    auto schema = seq_scan_out.MakeSchema();
+    // Make predicate
+    auto predicate = expr_maker.ComparisonLt(col1, expr_maker.Constant(500));
+    // Build
+    planner::SeqScanPlanNode::Builder builder;
+    seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid, colb_oid})
+                   .SetScanPredicate(predicate)
+                   .SetIsForUpdateFlag(false)
+                   .SetNamespaceOid(NSOid())
+                   .SetTableOid(table_oid)
+                   .Build();
+  }
+  // Order By
+  std::unique_ptr<planner::AbstractPlanNode> order_by;
+  OutputSchemaHelper order_by_out{0, &expr_maker};
+  {
+    // Output Colums col1, col2, col1 + col2
+    auto col1 = seq_scan_out.GetOutput("col1");
+    auto col2 = seq_scan_out.GetOutput("col2");
+    auto sum = expr_maker.OpSum(col1, col2);
+    order_by_out.AddOutput("col1", col1);
+    order_by_out.AddOutput("col2", col2);
+    order_by_out.AddOutput("sum", sum);
+    auto schema = order_by_out.MakeSchema();
+    // Order By Clause
+    planner::SortKey clause1{col2, optimizer::OrderByOrderingType::ASC};
+    auto diff = expr_maker.OpMin(col1, col2);
+    planner::SortKey clause2{diff, optimizer::OrderByOrderingType::DESC};
+    // Build
+    planner::OrderByPlanNode::Builder builder;
+    order_by = builder.SetOutputSchema(std::move(schema))
+                   .AddChild(std::move(seq_scan))
+                   .AddSortKey(clause1.first, clause1.second)
+                   .AddSortKey(clause2.first, clause2.second)
+                   .SetLimit(10)
+                   .Build();
+  }
+  // Checkers:
+  // There should be 10 output rows because of the limit.
+  // The output should be sorted by col2 ASC, then col1 DESC.
+  uint32_t num_output_rows{0};
+  uint32_t num_expected_rows{10};
+  int64_t curr_col1{std::numeric_limits<int64_t>::max()};
+  int64_t curr_col2{std::numeric_limits<int64_t>::min()};
+  RowChecker row_checker = [&num_output_rows, &curr_col1, &curr_col2,
+                            num_expected_rows](const std::vector<sql::Val *> &vals) {
+    // Read cols
+    auto col1 = static_cast<sql::Integer *>(vals[0]);
+    auto col2 = static_cast<sql::Integer *>(vals[1]);
+    ASSERT_FALSE(col1->is_null_ || col2->is_null_);
+    // Check col1 and number of outputs
+    ASSERT_LT(col1->val_, 500);
+    num_output_rows++;
+    ASSERT_LE(num_output_rows, num_expected_rows);
+
+    // Check that output is sorted by col2 ASC, then col1 DESC
+    ASSERT_LE(curr_col2, col2->val_);
+    if (curr_col2 == col2->val_) {
+      ASSERT_GE(curr_col1, col1->val_);
+    }
+    curr_col1 = col1->val_;
+    curr_col2 = col2->val_;
+  };
+  CorrectnessFn correcteness_fn = [&num_output_rows, num_expected_rows]() {
+    ASSERT_EQ(num_output_rows, num_expected_rows);
+  };
+  GenericChecker checker(row_checker, correcteness_fn);
+
+  // Create exec ctx
+  OutputStore store{&checker, order_by->GetOutputSchema().Get()};
+  exec::OutputPrinter printer(order_by->GetOutputSchema().Get());
+  MultiOutputCallback callback{std::vector<exec::OutputCallback>{store, printer}};
+  auto exec_ctx = MakeExecCtx(std::move(callback), order_by->GetOutputSchema().Get());
+
+  // Run & Check
+  auto executable = ExecutableQuery(common::ManagedPointer(order_by), common::ManagedPointer(exec_ctx));
+  executable.Run(common::ManagedPointer(exec_ctx), MODE);
+  checker.CheckCorrectness();
+}
+
+// NOLINTNEXTLINE
+TEST_F(CompilerTest, SortWithLimitAndOffsetTest) {
+  // SELECT col1 FROM test_1 WHERE col1 < 500 ORDER BY col1 DESC LIMIT 100 OFFSET 100
+  // Get accessor
+  auto accessor = MakeAccessor();
+  ExpressionMaker expr_maker;
+  auto table_oid = accessor->GetTableOid(NSOid(), "test_1");
+  auto table_schema = accessor->GetSchema(table_oid);
+  std::unique_ptr<planner::AbstractPlanNode> seq_scan;
+  OutputSchemaHelper seq_scan_out{0, &expr_maker};
+  int32_t upper = 500;
+  {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    // Get Table columns
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    seq_scan_out.AddOutput("col1", col1);
+    auto schema = seq_scan_out.MakeSchema();
+    // Make predicate
+    auto predicate = expr_maker.ComparisonLt(col1, expr_maker.Constant(upper));
+    // Build
+    planner::SeqScanPlanNode::Builder builder;
+    seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid})
+                   .SetScanPredicate(predicate)
+                   .SetIsForUpdateFlag(false)
+                   .SetNamespaceOid(NSOid())
+                   .SetTableOid(table_oid)
+                   .Build();
+  }
+  // Order By
+  std::unique_ptr<planner::AbstractPlanNode> order_by;
+  OutputSchemaHelper order_by_out{0, &expr_maker};
+  {
+    // Output Colums col1
+    auto col1 = seq_scan_out.GetOutput("col1");
+    order_by_out.AddOutput("col1", col1);
+    auto schema = order_by_out.MakeSchema();
+    // Order By Clause
+    planner::SortKey clause1{col1, optimizer::OrderByOrderingType::DESC};
+    // Build
+    planner::OrderByPlanNode::Builder builder;
+    order_by = builder.SetOutputSchema(std::move(schema))
+                   .AddChild(std::move(seq_scan))
+                   .AddSortKey(clause1.first, clause1.second)
+                   .SetLimit(100)
+                   .SetOffset(100)
+                   .Build();
+  }
+  // Checkers:
+  // There should be 100 output rows because of the limit.
+  // The output should be sorted by col1 DESC.
+  uint32_t num_output_rows{0};
+  uint32_t num_expected_rows{100};
+  int64_t curr_col1{std::numeric_limits<int64_t>::max()};
+  RowChecker row_checker = [&num_output_rows, &curr_col1, num_expected_rows,
+                            upper](const std::vector<sql::Val *> &vals) {
+    // Read cols
+    auto col1 = static_cast<sql::Integer *>(vals[0]);
+    ASSERT_FALSE(col1->is_null_);
+    // Check col1 and number of outputs
+    ASSERT_LT(col1->val_, upper);
+    // This equality holds because of the offset of 100 and the descending order.
+    ASSERT_EQ(col1->val_, (upper - 1) - (num_output_rows + 100));
+    // Check that output is sorted by col1
+    ASSERT_GT(curr_col1, col1->val_);
+    curr_col1 = col1->val_;
+
+    // Check limit
+    num_output_rows++;
+    ASSERT_LE(num_output_rows, num_expected_rows);
+  };
+  CorrectnessFn correcteness_fn = [&num_output_rows, num_expected_rows]() {
+    ASSERT_EQ(num_output_rows, num_expected_rows);
+  };
+  GenericChecker checker(row_checker, correcteness_fn);
+
+  // Create exec ctx
+  OutputStore store{&checker, order_by->GetOutputSchema().Get()};
+  exec::OutputPrinter printer(order_by->GetOutputSchema().Get());
+  MultiOutputCallback callback{std::vector<exec::OutputCallback>{store, printer}};
+  auto exec_ctx = MakeExecCtx(std::move(callback), order_by->GetOutputSchema().Get());
+
+  // Run & Check
+  auto executable = ExecutableQuery(common::ManagedPointer(order_by), common::ManagedPointer(exec_ctx));
+  executable.Run(common::ManagedPointer(exec_ctx), MODE);
+  checker.CheckCorrectness();
+}
+
+// NOLINTNEXTLINE
+TEST_F(CompilerTest, LimitAndOffsetTest) {
+  // SELECT col1 FROM test_1 WHERE col1 < 500 LIMIT 100 OFFSET 100
+  // This test uses an explicit limit node.
+  // Get accessor
+  auto accessor = MakeAccessor();
+  ExpressionMaker expr_maker;
+  auto table_oid = accessor->GetTableOid(NSOid(), "test_1");
+  auto table_schema = accessor->GetSchema(table_oid);
+  std::unique_ptr<planner::AbstractPlanNode> seq_scan;
+  OutputSchemaHelper seq_scan_out{0, &expr_maker};
+  {
+    // OIDs
+    auto cola_oid = table_schema.GetColumn("colA").Oid();
+    // Get Table columns
+    auto col1 = expr_maker.CVE(cola_oid, type::TypeId::INTEGER);
+    seq_scan_out.AddOutput("col1", col1);
+    auto schema = seq_scan_out.MakeSchema();
+    // Make predicate
+    auto predicate = expr_maker.ComparisonLt(col1, expr_maker.Constant(500));
+    // Build
+    planner::SeqScanPlanNode::Builder builder;
+    seq_scan = builder.SetOutputSchema(std::move(schema))
+                   .SetColumnOids({cola_oid})
+                   .SetScanPredicate(predicate)
+                   .SetIsForUpdateFlag(false)
+                   .SetNamespaceOid(NSOid())
+                   .SetTableOid(table_oid)
+                   .Build();
+  }
+  // Limit
+  std::unique_ptr<planner::AbstractPlanNode> limit;
+  OutputSchemaHelper limit_out{0, &expr_maker};
+  {
+    // Output Colums col1
+    auto col1 = seq_scan_out.GetOutput("col1");
+    limit_out.AddOutput("col1", col1);
+    auto schema = limit_out.MakeSchema();
+    // Build
+    planner::LimitPlanNode::Builder builder;
+    limit =
+        builder.SetOutputSchema(std::move(schema)).AddChild(std::move(seq_scan)).SetLimit(100).SetOffset(100).Build();
+  }
+  // Checkers:
+  // There should be 100 output rows because of the limit.
+  // The output should be sorted by col1.
+  uint32_t num_output_rows{0};
+  uint32_t num_expected_rows{100};
+  int64_t curr_col1{std::numeric_limits<int64_t>::min()};
+  RowChecker row_checker = [&num_output_rows, &curr_col1, num_expected_rows](const std::vector<sql::Val *> &vals) {
+    // Read cols
+    auto col1 = static_cast<sql::Integer *>(vals[0]);
+    ASSERT_FALSE(col1->is_null_);
+    // Check col1 and number of outputs
+    ASSERT_LT(col1->val_, 500);
+    // This equality holds because of the offset of 100.
+    // The output should be (399, ..., 300).
+    ASSERT_EQ(col1->val_, num_output_rows + 100);
+    // Check that output is sorted by col1
+    ASSERT_LT(curr_col1, col1->val_);
+    curr_col1 = col1->val_;
+
+    // Check limit
+    num_output_rows++;
+    ASSERT_LE(num_output_rows, num_expected_rows);
+  };
+  CorrectnessFn correcteness_fn = [&num_output_rows, num_expected_rows]() {
+    ASSERT_EQ(num_output_rows, num_expected_rows);
+  };
+  GenericChecker checker(row_checker, correcteness_fn);
+
+  // Create exec ctx
+  OutputStore store{&checker, limit->GetOutputSchema().Get()};
+  exec::OutputPrinter printer(limit->GetOutputSchema().Get());
+  MultiOutputCallback callback{std::vector<exec::OutputCallback>{store, printer}};
+  auto exec_ctx = MakeExecCtx(std::move(callback), limit->GetOutputSchema().Get());
+
+  // Run & Check
+  auto executable = ExecutableQuery(common::ManagedPointer(limit), common::ManagedPointer(exec_ctx));
   executable.Run(common::ManagedPointer(exec_ctx), MODE);
   checker.CheckCorrectness();
 }
@@ -1640,6 +2213,7 @@ TEST_F(CompilerTest, SimpleDeleteTest) {
   }
 }
 
+// NOLINTNEXTLINE
 TEST_F(CompilerTest, SimpleUpdateTest) {
   // UPDATE test_1 SET colA = -colA, colB = 500 WHERE colA BETWEEN 495 AND 505
   // Then check that the following finds the tuples:

--- a/test/include/execution/compiler/expression_util.h
+++ b/test/include/execution/compiler/expression_util.h
@@ -228,31 +228,31 @@ class ExpressionMaker {
   /**
    * Create an aggregate expression
    */
-  ManagedAggExpression AggregateTerm(parser::ExpressionType agg_type, ManagedExpression child) {
+  ManagedAggExpression AggregateTerm(parser::ExpressionType agg_type, ManagedExpression child, bool distinct) {
     std::vector<OwnedExpression> children;
     children.emplace_back(child->Copy());
-    return MakeAggManaged(std::make_unique<parser::AggregateExpression>(agg_type, std::move(children), false));
+    return MakeAggManaged(std::make_unique<parser::AggregateExpression>(agg_type, std::move(children), distinct));
   }
 
   /**
    * Create a sum aggregate expression
    */
-  ManagedAggExpression AggSum(ManagedExpression child) {
-    return AggregateTerm(parser::ExpressionType::AGGREGATE_SUM, child);
+  ManagedAggExpression AggSum(ManagedExpression child, bool distinct = false) {
+    return AggregateTerm(parser::ExpressionType::AGGREGATE_SUM, child, distinct);
   }
 
   /**
    * Create a avg aggregate expression
    */
-  ManagedAggExpression AggAvg(ManagedExpression child) {
-    return AggregateTerm(parser::ExpressionType::AGGREGATE_AVG, child);
+  ManagedAggExpression AggAvg(ManagedExpression child, bool distinct = false) {
+    return AggregateTerm(parser::ExpressionType::AGGREGATE_AVG, child, distinct);
   }
 
   /**
    * Create a count aggregate expression
    */
-  ManagedAggExpression AggCount(ManagedExpression child) {
-    return AggregateTerm(parser::ExpressionType::AGGREGATE_COUNT, child);
+  ManagedAggExpression AggCount(ManagedExpression child, bool distinct = false) {
+    return AggregateTerm(parser::ExpressionType::AGGREGATE_COUNT, child, distinct);
   }
 
  private:

--- a/test/include/execution/compiler/output_schema_util.h
+++ b/test/include/execution/compiler/output_schema_util.h
@@ -30,7 +30,7 @@ class OutputSchemaHelper {
    * @return The attribute at the given index.
    */
   ExpressionMaker::ManagedExpression GetOutput(uint32_t attr_idx) {
-    return expr_maker_->DVE(cols_[attr_idx].GetType(), child_idx_, attr_idx);
+    return expr_maker_->DVE(cols_.at(attr_idx).GetType(), child_idx_, attr_idx);
   }
 
   /**
@@ -38,7 +38,7 @@ class OutputSchemaHelper {
    * @return The attribute with the given name.
    */
   ExpressionMaker::ManagedExpression GetOutput(const std::string &col_name) {
-    return GetOutput(name_to_idx_[col_name]);
+    return GetOutput(name_to_idx_.at(col_name));
   }
 
   /**
@@ -56,9 +56,9 @@ class OutputSchemaHelper {
    * @return The derived value expression that accesses the given aggregate term.
    */
   ExpressionMaker::ManagedExpression GetAggTermForOutput(const std::string &agg_name) {
-    const auto &agg = aggs_[name_to_agg_[agg_name]];
+    const auto &agg = aggs_.at(name_to_agg_.at(agg_name));
     auto ret_type = agg->GetChild(0)->GetReturnValueType();
-    auto tve_idx = name_to_agg_[agg_name];
+    auto tve_idx = name_to_agg_.at(agg_name);
     return expr_maker_->DVE(ret_type, 1, tve_idx);
   }
 
@@ -67,9 +67,9 @@ class OutputSchemaHelper {
    * @return The derived value expression that accesses the given group by term
    */
   ExpressionMaker::ManagedExpression GetGroupByTermForOutput(const std::string &gby_name) {
-    const auto &gby = gbys_[name_to_gby_[gby_name]];
+    const auto &gby = gbys_.at(name_to_gby_.at(gby_name));
     auto ret_type = gby->GetReturnValueType();
-    auto tve_idx = name_to_gby_[gby_name];
+    auto tve_idx = name_to_gby_.at(gby_name);
     return expr_maker_->DVE(ret_type, 0, tve_idx);
   }
 
@@ -88,7 +88,7 @@ class OutputSchemaHelper {
    * @return The group by expression
    */
   ExpressionMaker::ManagedExpression GetGroupByTerm(const std::string &col_name) {
-    return gbys_[name_to_gby_[col_name]];
+    return gbys_.at(name_to_gby_.at(col_name));
   }
 
   /**
@@ -106,7 +106,7 @@ class OutputSchemaHelper {
    * @return The aggregate term
    */
   ExpressionMaker::ManagedAggExpression GetAggTerm(const std::string &agg_name) {
-    return aggs_[name_to_agg_[agg_name]];
+    return aggs_.at(name_to_agg_.at(agg_name));
   }
 
   /**


### PR DESCRIPTION
Somebody in the class tried to install the system on Amazon's distro of Linux. Right now `packages.sh` only checks whether you are running Linux and not which distribution. This PR adds for checking that you are trying to install on Ubuntu. I tested on CentOS and the output format of the error report is correct.

This also adds support for Ubuntu 19.04/19.10, which we may not want to do right now.
