### PR TITLE
Improved distribution checking in packages.sh

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -60,8 +60,6 @@ install() {
       # Check Ubuntu version
       case $VERSION in
         18.04) install_linux ;;
-        19.04) install_linux ;;
-        19.10) install_linux ;;
         *) give_up $DISTRO $VERSION;;
       esac
       ;;

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -25,35 +25,49 @@ main() {
     echo "Script complete."
 }
 
+give_up() {
+    set +x
+    OS=$1
+    VERSION=$2
+    [ ! -z "$VERSION" ] && VERSION=" $VERSION"
+    
+    echo
+    echo "Unsupported distribution '${OS}${VERSION}'"
+    echo "Please contact our support team for additional help."
+    echo "Be sure to include the contents of this message."
+    echo "Platform: $(uname -a)"
+    echo
+    echo "https://github.com/cmu-db/terrier/issues"
+    echo
+    exit 1
+}
+
 install() {
   set -x
   UNAME=$(uname | tr "[:lower:]" "[:upper:]" )
+  VERSION=""
 
   case $UNAME in
     DARWIN) install_mac ;;
 
     LINUX)
-      version=$(cat /etc/os-release | grep VERSION_ID | cut -d '"' -f 2)
-      case $version in
+      DISTRO=$(cat /etc/os-release | grep '^ID=' | cut -d '=' -f 2 | tr "[:lower:]" "[:upper:]" | tr -d '"')
+      VERSION=$(cat /etc/os-release | grep '^VERSION_ID=' | cut -d '"' -f 2)
+      
+      # We only support Ubuntu right now
+      [ "$DISTRO" != "UBUNTU" ] && give_up $DISTRO $VERSION
+      
+      # Check Ubuntu version
+      case $VERSION in
         18.04) install_linux ;;
-        *) give_up ;;
+        19.04) install_linux ;;
+        19.10) install_linux ;;
+        *) give_up $DISTRO $VERSION;;
       esac
       ;;
 
-    *) give_up ;;
+    *) give_up $UNAME $VERSION;;
   esac
-}
-
-give_up() {
-  set +x
-  echo "Unsupported distribution '$UNAME'"
-  echo "Please contact our support team for additional help."
-  echo "Be sure to include the contents of this message."
-  echo "Platform: $(uname -a)"
-  echo
-  echo "https://github.com/cmu-db/terrier/issues"
-  echo
-  exit 1
 }
 
 install_mac() {


### PR DESCRIPTION
Somebody in the class tried to install the system on Amazon's distro of Linux. Right now packages.sh only checks whether you are running Linux and not which distribution. This PR adds for checking that you are trying to install on Ubuntu. I tested on CentOS and the output format of the error report is correct.

This also adds support for Ubuntu 19.04/19.10, which we may not want to do right now.

https://youtu.be/an9Qqf9dxG4