### PR TITLE
CI Test, ignore this

### DIFF
--- a/util/execution/tpl.cpp
+++ b/util/execution/tpl.cpp
@@ -325,7 +325,7 @@ void SignalHandler(int32_t sig_num) {
   }
 }
 
-int main(int argc, char **argv) {  // NOLINT (bugprone-exception-escape)
+int main(int argc, char **argv) {  // (bugprone-exception-escape)
   terrier::LoggersUtil::Initialize();
 
   // Parse options


### PR DESCRIPTION
I need to see how Jenkins responds to code that is expected to fail clang-tidy for #726. 