### PR TITLE
 Fix Having Clause (#793)

### DIFF
--- a/script/testing/junit/src/SelectTest.java
+++ b/script/testing/junit/src/SelectTest.java
@@ -130,11 +130,9 @@ public class SelectTest extends TestUtility {
         assertNoMoreRows(rs);
 
         /* Wrong count, wait for Having fix */
-        select_SQL = "SELECT COUNT(*) AS cnt FROM tbl HAVING COUNT() > 10;";
+        select_SQL = "SELECT COUNT(*) AS cnt FROM tbl HAVING COUNT(*) > 10;";
         stmt = conn.createStatement();
         rs = stmt.executeQuery(select_SQL);
-        rs.next();
-        checkRow(rs, new String [] {"cnt"}, new int [] {2});
         assertNoMoreRows(rs);
 
         /* self name */

--- a/src/optimizer/rules/implementation_rules.cpp
+++ b/src/optimizer/rules/implementation_rules.cpp
@@ -377,7 +377,7 @@ bool LogicalGroupByToPhysicalHashGroupBy::Check(common::ManagedPointer<OperatorN
                                                 OptimizationContext *context) const {
   (void)context;
   const auto agg_op = plan->GetOp().As<LogicalAggregateAndGroupBy>();
-  return !agg_op->GetColumns().empty();
+  return !agg_op->GetColumns().empty() || !agg_op->GetHaving().empty();
 }
 
 void LogicalGroupByToPhysicalHashGroupBy::Transform(common::ManagedPointer<OperatorNode> input,
@@ -412,7 +412,7 @@ bool LogicalAggregateToPhysicalAggregate::Check(common::ManagedPointer<OperatorN
                                                 OptimizationContext *context) const {
   (void)context;
   const auto agg_op = plan->GetOp().As<LogicalAggregateAndGroupBy>();
-  return agg_op->GetColumns().empty();
+  return agg_op->GetColumns().empty() && agg_op->GetHaving().empty();
 }
 
 void LogicalAggregateToPhysicalAggregate::Transform(common::ManagedPointer<OperatorNode> input,

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -846,17 +846,19 @@ std::unique_ptr<TableRef> PostgresParser::FromTransform(ParseResult *parse_resul
 // Postgres.SelectStmt.groupClause -> terrier.GroupByDescription
 std::unique_ptr<GroupByDescription> PostgresParser::GroupByTransform(ParseResult *parse_result, List *group,
                                                                      Node *having_node) {
-  if (group == nullptr) {
+  if (group == nullptr && having_node == nullptr) {
     return nullptr;
   }
 
   std::vector<common::ManagedPointer<AbstractExpression>> columns;
-  for (auto cell = group->head; cell != nullptr; cell = cell->next) {
-    auto temp = reinterpret_cast<Node *>(cell->data.ptr_value);
-    auto expr = ExprTransform(parse_result, temp, nullptr);
-    auto expr_ptr = common::ManagedPointer(expr);
-    parse_result->AddExpression(std::move(expr));
-    columns.emplace_back(expr_ptr);
+  if (group != nullptr) {
+    for (auto cell = group->head; cell != nullptr; cell = cell->next) {
+      auto temp = reinterpret_cast<Node *>(cell->data.ptr_value);
+      auto expr = ExprTransform(parse_result, temp, nullptr);
+      auto expr_ptr = common::ManagedPointer(expr);
+      parse_result->AddExpression(std::move(expr));
+      columns.emplace_back(expr_ptr);
+    }
   }
 
   // TODO(WAN): old system says, having clauses not implemented, depends on AExprTransform


### PR DESCRIPTION
Fix for #793 
Test:
```
terrier=# CREATE TABLE xxx (id INT);
CREATE TABLE
terrier=# INSERT INTO xxx VALUES (1),(2),(3),(4);
INSERT 0 4
terrier=# SELECT COUNT(*) AS cnt FROM xxx HAVING COUNT(*) > 10;

 cnt 
-----
(0 rows)
```