### PR TITLE
Binder logic to convert mismatched types in update statements.

### DIFF
--- a/script/testing/junit/src/UpdateTest.java
+++ b/script/testing/junit/src/UpdateTest.java
@@ -44,6 +44,8 @@ public class UpdateTest extends TestUtility {
         String insertSQL1 = "INSERT INTO xxx (c1, c2) VALUES (1, '" + ts1 + "');";
         String insertSQL2 = "INSERT INTO xxx (c1, c2) VALUES (2, '" + ts1 + "');";
         String updateSQL = "UPDATE xxx SET c2 = '" + ts2 + "' WHERE c1 = 2;";
+        String selectSQL = "SELECT * from xxx ORDER BY c1 ASC;";
+        String dropSQL = "DROP TABLE xxx";
 
         conn.setAutoCommit(false);
         Statement stmt = conn.createStatement();
@@ -55,7 +57,6 @@ public class UpdateTest extends TestUtility {
         conn.commit();
         conn.setAutoCommit(true);
 
-        String selectSQL = "SELECT * from xxx ORDER BY c1 ASC;";
         stmt = conn.createStatement();
         rs = stmt.executeQuery(selectSQL);
 
@@ -68,9 +69,8 @@ public class UpdateTest extends TestUtility {
 
         assertNoMoreRows(rs);
 
-        String drop_SQL = "DROP TABLE xxx";
         stmt = conn.createStatement();
-        stmt.execute(drop_SQL);
+        stmt.execute(dropSQL);
     }
 
 }

--- a/script/testing/junit/src/UpdateTest.java
+++ b/script/testing/junit/src/UpdateTest.java
@@ -1,0 +1,76 @@
+/**
+ * Update statement tests.
+ */
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class UpdateTest extends TestUtility {
+    private Connection conn;
+    private ResultSet rs;
+
+    /**
+     * Setup for each test, make the default connection.
+     */
+    @Before
+    public void setup() throws SQLException {
+        conn = makeDefaultConnection();
+        conn.setAutoCommit(true);
+    }
+
+    /*
+     * ---------------------------------------------
+     * Update statement tests
+     * ---------------------------------------------
+     */
+
+   /**
+     * Test that timestamps can be updated.
+     * Fix #783: update query that modifies timestamp attribute fails.
+     */
+    @Test
+    public void testUpdateTimestamp() throws SQLException {
+        String ts1 = "2020-01-02 12:23:34.56789";
+        String ts2 = "2020-01-02 11:22:33.721-05";
+        String createSQL = "CREATE TABLE xxx (c1 int, c2 timestamp);";
+        String insertSQL1 = "INSERT INTO xxx (c1, c2) VALUES (1, '" + ts1 + "');";
+        String insertSQL2 = "INSERT INTO xxx (c1, c2) VALUES (2, '" + ts1 + "');";
+        String updateSQL = "UPDATE xxx SET c2 = '" + ts2 + "' WHERE c1 = 2;";
+
+        conn.setAutoCommit(false);
+        Statement stmt = conn.createStatement();
+        stmt.addBatch(createSQL);
+        stmt.addBatch(insertSQL1);
+        stmt.addBatch(insertSQL2);
+        stmt.addBatch(updateSQL);
+        stmt.executeBatch();
+        conn.commit();
+        conn.setAutoCommit(true);
+
+        String selectSQL = "SELECT * from xxx ORDER BY c1 ASC;";
+        stmt = conn.createStatement();
+        rs = stmt.executeQuery(selectSQL);
+
+        rs.next();
+        assertEquals(1, rs.getInt("c1"));
+        assertEquals(ts1, rs.getTimestamp("c2").toString());
+        rs.next();
+        assertEquals(2, rs.getInt("c1"));
+        assertEquals("2020-01-02 16:22:33.721", rs.getTimestamp("c2").toString());
+
+        assertNoMoreRows(rs);
+
+        String drop_SQL = "DROP TABLE xxx";
+        stmt = conn.createStatement();
+        stmt.execute(drop_SQL);
+    }
+
+}

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -152,7 +152,9 @@ void BindNodeVisitor::Visit(parser::UpdateStatement *node, parser::ParseResult *
 
     if (mismatched_type || is_cast_expression) {
       auto converted = BinderUtil::Convert(update->GetUpdateValue(), expected_ret_type);
-      TERRIER_ASSERT(converted != nullptr, "Conversion cannot be null!");
+      if (converted != nullptr) {
+        throw BINDER_EXCEPTION("Conversion cannot be NULL!");
+      }
       update->ResetValue(common::ManagedPointer<parser::AbstractExpression>(converted));
       parse_result->AddExpression(std::move(converted));
     }
@@ -452,7 +454,9 @@ void BindNodeVisitor::Visit(parser::InsertStatement *node, parser::ParseResult *
               parse_result->AddExpression(std::move(temp));
             } else {
               auto converted = BinderUtil::Convert(values[i], expected_ret_type);
-              TERRIER_ASSERT(converted != nullptr, "Conversion cannot be null!");
+              if (converted != nullptr) {
+                throw BINDER_EXCEPTION("Conversion cannot be NULL!");
+              }
               values[i] = common::ManagedPointer(converted);
               parse_result->AddExpression(std::move(converted));
             }

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -147,6 +147,8 @@ void BindNodeVisitor::Visit(parser::UpdateStatement *node, parser::ParseResult *
     auto is_cast_expression = update->GetUpdateValue()->GetExpressionType() == parser::ExpressionType::OPERATOR_CAST;
     auto expected_ret_type = table_schema.GetColumn(update->GetColumnName()).Type();
     auto mismatched_type = expected_ret_type != update->GetUpdateValue()->GetReturnValueType();
+    // TODO(WAN): Unfortunately, arbitrary expressions can't be figured out yet and are hard to identify.
+    mismatched_type = mismatched_type && update->GetUpdateValue()->GetReturnValueType() != type::TypeId::INVALID;
 
     if (mismatched_type || is_cast_expression) {
       auto converted = BinderUtil::Convert(update->GetUpdateValue(), expected_ret_type);

--- a/test/optimizer/tpcc_plan_delivery_test.cpp
+++ b/test/optimizer/tpcc_plan_delivery_test.cpp
@@ -13,6 +13,7 @@
 #include "planner/plannodes/update_plan_node.h"
 #include "test_util/test_harness.h"
 #include "test_util/tpcc/tpcc_plan_test.h"
+#include "util/time_util.h"
 
 namespace terrier {
 
@@ -119,7 +120,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryUpdateCarrierId) {
     auto expr = update->GetSetClauses()[0].second;
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
     auto cve = expr.CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);
+    EXPECT_EQ(type::TransientValuePeeker::PeekTinyInt(cve->GetValue()), 1);
 
     // Idx Scan, full output schema
     EXPECT_EQ(update->GetChildren().size(), 1);
@@ -169,7 +170,8 @@ TEST_F(TpccPlanDeliveryTests, DeliveryUpdateDeliveryDate) {
     auto expr = update->GetSetClauses()[0].second;
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
     auto cve = expr.CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(type::TransientValuePeeker::PeekInteger(cve->GetValue()), 1);
+    EXPECT_EQ(type::TransientValuePeeker::PeekTimestamp(cve->GetValue()),
+              util::TimeConvertor::TimestampFromHMSu(2020, 1, 2, 11, 22, 33, 456000));
 
     // Idx Scan, full output schema
     EXPECT_EQ(update->GetChildren().size(), 1);
@@ -199,7 +201,9 @@ TEST_F(TpccPlanDeliveryTests, DeliveryUpdateDeliveryDate) {
     test->CheckOids(idx_scan->GetColumnOids(), oids);
   };
 
-  std::string query = "UPDATE \"ORDER LINE\" SET OL_DELIVERY_D = 1 WHERE OL_O_ID = 1 AND OL_D_ID = 2 AND OL_W_ID = 3";
+  std::string query =
+      "UPDATE \"ORDER LINE\" SET OL_DELIVERY_D = '2020-01-02 11:22:33.456' WHERE OL_O_ID = 1 AND OL_D_ID = 2 AND "
+      "OL_W_ID = 3";
   OptimizeUpdate(query, tbl_order_line_, check);
 }
 

--- a/test/optimizer/tpcc_plan_neworder_test.cpp
+++ b/test/optimizer/tpcc_plan_neworder_test.cpp
@@ -138,7 +138,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
 
     {
       auto expr = update->GetSetClauses()[0].second.CastManagedPointerTo<parser::ConstantValueExpression>();
-      EXPECT_EQ(type::TransientValuePeeker::PeekInteger(expr->GetValue()), 1);
+      EXPECT_EQ(type::TransientValuePeeker::PeekSmallInt(expr->GetValue()), 1);
     }
 
     {

--- a/test/optimizer/tpcc_plan_payment_test.cpp
+++ b/test/optimizer/tpcc_plan_payment_test.cpp
@@ -167,9 +167,9 @@ TEST_F(TpccPlanPaymentTests, UpdateCustomerBalance) {
     auto set1 = update->GetSetClauses()[1].second.CastManagedPointerTo<parser::ConstantValueExpression>();
     auto set2 = update->GetSetClauses()[2].second.CastManagedPointerTo<parser::ConstantValueExpression>();
     auto set3 = update->GetSetClauses()[3].second.CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(type::TransientValuePeeker::PeekInteger(set0->GetValue()), 1);
-    EXPECT_EQ(type::TransientValuePeeker::PeekInteger(set1->GetValue()), 2);
-    EXPECT_EQ(type::TransientValuePeeker::PeekInteger(set2->GetValue()), 3);
+    EXPECT_EQ(type::TransientValuePeeker::PeekDecimal(set0->GetValue()), 1);
+    EXPECT_EQ(type::TransientValuePeeker::PeekDecimal(set1->GetValue()), 2);
+    EXPECT_EQ(type::TransientValuePeeker::PeekSmallInt(set2->GetValue()), 3);
     EXPECT_EQ(type::TransientValuePeeker::PeekVarChar(set3->GetValue()), "4");
 
     // Idx Scan, full output schema


### PR DESCRIPTION
Fix #783, includes a JUnit test.

This also fixes bad types in old tests, e.g. in the optimizer/tpcc_ family of tests, there were cases where the transient value returned was of the wrong type (such as INTEGER instead of SMALLINT).

Just more binder hacks..