### PR TITLE
bwtree_index_test: fix potential bad access in results vector

### DIFF
--- a/test/storage/bwtree_index_test.cpp
+++ b/test/storage/bwtree_index_test.cpp
@@ -1100,12 +1100,12 @@ TEST_F(BwTreeIndexTests, CommitUpdate1) {
   default_index_->ScanKey(*txn0, *scan_key_pr, &results);
   EXPECT_EQ(results.size(), 1);
   EXPECT_EQ(tuple_slot, results[0]);
-  results.clear();
 
   // txn 0 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
   default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
+  results.clear();
 
   insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
@@ -1354,12 +1354,12 @@ TEST_F(BwTreeIndexTests, AbortUpdate1) {
   default_index_->ScanKey(*txn0, *scan_key_pr, &results);
   EXPECT_EQ(results.size(), 1);
   EXPECT_EQ(tuple_slot, results[0]);
-  results.clear();
 
   // txn 0 updates in the table, which is really a delete and insert since it's an indexed attribute
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
   default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
+  results.clear();
 
   insert_redo = txn0->StageWrite(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, tuple_initializer_);
   insert_tuple = insert_redo->Delta();
@@ -1608,12 +1608,12 @@ TEST_F(BwTreeIndexTests, CommitDelete1) {
   default_index_->ScanKey(*txn0, *scan_key_pr, &results);
   EXPECT_EQ(results.size(), 1);
   EXPECT_EQ(tuple_slot, results[0]);
-  results.clear();
 
   // txn 0 deletes in the table and index
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
   default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
+  results.clear();
 
   // txn 0 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -1792,12 +1792,12 @@ TEST_F(BwTreeIndexTests, AbortDelete1) {
   default_index_->ScanKey(*txn0, *scan_key_pr, &results);
   EXPECT_EQ(results.size(), 1);
   EXPECT_EQ(tuple_slot, results[0]);
-  results.clear();
 
   // txn 0 deletes in the table and index
   txn0->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn0), results[0]));
   default_index_->Delete(common::ManagedPointer(txn0), *insert_key, results[0]);
+  results.clear();
 
   // txn 0 scans index for 15721 and gets no visible result
   *reinterpret_cast<int32_t *>(scan_key_pr->AccessForceNotNull(0)) = 15721;
@@ -1891,7 +1891,6 @@ TEST_F(BwTreeIndexTests, AbortDelete2) {
   txn1->StageDelete(CatalogTestUtil::TEST_DB_OID, CatalogTestUtil::TEST_TABLE_OID, results[0]);
   EXPECT_TRUE(sql_table_->Delete(common::ManagedPointer(txn1), results[0]));
   default_index_->Delete(common::ManagedPointer(txn1), *insert_key, results[0]);
-
   results.clear();
 
   // txn 0 scans index for 15721 and gets a visible, correct result


### PR DESCRIPTION
I don't think we've seen this error on master, which is odd. Regardless, a student pointed out that we're clearing the results vector in the test and then reading an element from it. I moved the `results.clear()` calls down to when it should be safe.