### PR TITLE
Rebind mismatched types in children of ComparisonExpression.

### DIFF
--- a/script/testing/junit/src/SelectTest.java
+++ b/script/testing/junit/src/SelectTest.java
@@ -175,4 +175,38 @@ public class SelectTest extends TestUtility {
         assertNoMoreRows(rs);
     }
 
+    /**
+     * Test for selecting with a timestamp in the where clause.
+     * Fix #782: selecting with timestamp in where clause will crash the system.
+     */
+    @Test
+    public void testSelectWhereTimestamp() throws SQLException {
+        String ts1 = "2020-01-02 12:23:34.56789";
+        String ts2 = "2020-01-02 11:22:33.721-05";
+        String createSQL = "CREATE TABLE xxx (c1 int, c2 timestamp);";
+        String insertSQL1 = "INSERT INTO xxx (c1, c2) VALUES (1, '" + ts1 + "');";
+        String insertSQL2 = "INSERT INTO xxx (c1, c2) VALUES (2, '" + ts2 + "');";
+        String selectSQL = "SELECT * FROM xxx WHERE c2 = '" + ts2 + "';";
+        String dropSQL = "DROP TABLE xxx;";
+
+        conn.setAutoCommit(false);
+        Statement stmt = conn.createStatement();
+        stmt.addBatch(createSQL);
+        stmt.addBatch(insertSQL1);
+        stmt.addBatch(insertSQL2);
+        stmt.executeBatch();
+        conn.commit();
+        conn.setAutoCommit(true);
+
+        stmt = conn.createStatement();
+        rs = stmt.executeQuery(selectSQL);
+        rs.next();
+        assertEquals(2, rs.getInt("c1"));
+        assertEquals("2020-01-02 16:22:33.721", rs.getTimestamp("c2").toString());
+        assertNoMoreRows(rs);
+
+        stmt = conn.createStatement();
+        stmt.execute(dropSQL);
+    }
+
 }

--- a/src/include/parser/expression/comparison_expression.h
+++ b/src/include/parser/expression/comparison_expression.h
@@ -76,7 +76,6 @@ class ComparisonExpression : public AbstractExpression {
       }
     }
 
-
     // -----------------------
     // | NULL REBINDING HACK |
     // -----------------------

--- a/src/include/parser/expression/comparison_expression.h
+++ b/src/include/parser/expression/comparison_expression.h
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "binder/binder_util.h"
 #include "parser/expression/abstract_expression.h"
 #include "parser/expression/constant_value_expression.h"
 #include "parser/postgresparser.h"
@@ -55,32 +56,58 @@ class ComparisonExpression : public AbstractExpression {
 
   void Accept(SqlNodeVisitor *v, ParseResult *parse_result) override {
     v->Visit(this, parse_result);
-    // TODO(WAN): This is basically a hack to rebind NULLs with the right type and I'm not sure it should stay.
-    // Generated NULL expressions are owned by the children vector, so the generated expressions do not need to be
-    // added to the parse result. The old expression that is kicked out will die a unique_ptr death.
-    auto left = GetChild(0);
-    auto right = GetChild(1);
-    auto left_type = left->GetReturnValueType();
-    auto right_type = right->GetReturnValueType();
 
-    auto is_left_subquery = left->GetExpressionType() == ExpressionType::ROW_SUBQUERY;
-    auto is_right_subquery = right->GetExpressionType() == ExpressionType::ROW_SUBQUERY;
+    // -----------------------
+    // | TYPE REBINDING HACK |
+    // -----------------------
+    {
+      // TODO(WAN): A hack to rebind types that are casted in C++ (binder).
+      auto left = GetChild(0);
+      auto right = GetChild(1);
+      auto left_type = left->GetReturnValueType();
+      auto right_type = right->GetReturnValueType();
 
-    // TODO(WAN): I don't know how to handle this case and casting to NULL is not it.
-    if (is_left_subquery || is_right_subquery) {
-      return;
+      if (left_type == type::TypeId::VARCHAR && right_type == type::TypeId::TIMESTAMP) {
+        auto new_left = binder::BinderUtil::Convert(left, type::TypeId::TIMESTAMP);
+        children_[0] = std::move(new_left);
+      } else if (left_type == type::TypeId::TIMESTAMP && right_type == type::TypeId::VARCHAR) {
+        auto new_right = binder::BinderUtil::Convert(right, type::TypeId::TIMESTAMP);
+        children_[1] = std::move(new_right);
+      }
     }
 
-    if (left_type == type::TypeId::INVALID && right_type != type::TypeId::INVALID) {
-      auto new_left_tv = type::TransientValueFactory::GetNull(right_type);
-      auto new_left = std::make_unique<ConstantValueExpression>(std::move(new_left_tv));
-      children_[0] = std::move(new_left);
-    }
 
-    if (left_type != type::TypeId::INVALID && right_type == type::TypeId::INVALID) {
-      auto new_right_tv = type::TransientValueFactory::GetNull(left_type);
-      auto new_right = std::make_unique<ConstantValueExpression>(std::move(new_right_tv));
-      children_[1] = std::move(new_right);
+    // -----------------------
+    // | NULL REBINDING HACK |
+    // -----------------------
+    {
+      // TODO(WAN): This is basically a hack to rebind NULLs with the right type and I'm not sure it should stay.
+      // Generated NULL expressions are owned by the children vector, so the generated expressions do not need to be
+      // added to the parse result. The old expression that is kicked out will die a unique_ptr death.
+      auto left = GetChild(0);
+      auto right = GetChild(1);
+      auto left_type = left->GetReturnValueType();
+      auto right_type = right->GetReturnValueType();
+
+      auto is_left_subquery = left->GetExpressionType() == ExpressionType::ROW_SUBQUERY;
+      auto is_right_subquery = right->GetExpressionType() == ExpressionType::ROW_SUBQUERY;
+
+      // TODO(WAN): I don't know how to handle this case and casting to NULL is not it.
+      if (is_left_subquery || is_right_subquery) {
+        return;
+      }
+
+      if (left_type == type::TypeId::INVALID && right_type != type::TypeId::INVALID) {
+        auto new_left_tv = type::TransientValueFactory::GetNull(right_type);
+        auto new_left = std::make_unique<ConstantValueExpression>(std::move(new_left_tv));
+        children_[0] = std::move(new_left);
+      }
+
+      if (left_type != type::TypeId::INVALID && right_type == type::TypeId::INVALID) {
+        auto new_right_tv = type::TransientValueFactory::GetNull(left_type);
+        auto new_right = std::make_unique<ConstantValueExpression>(std::move(new_right_tv));
+        children_[1] = std::move(new_right);
+      }
     }
   }
 };


### PR DESCRIPTION
Fix #782.

Another PR, another binder hack.