### PR TITLE
Enable ccache in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,14 +113,15 @@ pipeline {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
-                            args '--cap-add sys_ptrace'
+                            args '--cap-add sys_ptrace -v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
                     steps {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | sudo ./script/installation/packages.sh'
+                        sh 'sudo apt-get -y install ccache'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j$(nproc)'
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
@@ -137,7 +138,7 @@ pipeline {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
-                            args '--cap-add sys_ptrace'
+                            args '--cap-add sys_ptrace -v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
                     environment {
@@ -146,9 +147,9 @@ pipeline {
                     steps {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | sudo ./script/installation/packages.sh'
-                        sh 'sudo apt-get -y install curl lcov'
+                        sh 'sudo apt-get -y install curl lcov ccache'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=OFF -DTERRIER_GENERATE_COVERAGE=ON -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=OFF -DTERRIER_GENERATE_COVERAGE=ON -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py'
@@ -175,7 +176,7 @@ pipeline {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
-                            args '--cap-add sys_ptrace'
+                            args '--cap-add sys_ptrace -v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
                     environment {
@@ -185,8 +186,9 @@ pipeline {
                     steps {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | sudo ./script/installation/packages.sh'
+                        sh 'apt-get -y install ccache'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j$(nproc)'
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
@@ -225,13 +227,15 @@ pipeline {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
+                            args '-v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
                     steps {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | sudo ./script/installation/packages.sh'
+                        sh 'sudo apt-get -y install ccache'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j$(nproc)'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
@@ -247,6 +251,7 @@ pipeline {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
+                            args '-v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
                     environment {
@@ -256,8 +261,9 @@ pipeline {
                     steps {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | sudo ./script/installation/packages.sh'
+                        sh 'sudo apt-get -y install ccache'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j$(nproc)'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
                         sh 'cd build && python ../script/testing/junit/run_junit.py --build_type=release'
@@ -276,8 +282,9 @@ pipeline {
             steps {
                 sh 'echo $NODE_NAME'
                 sh 'echo y | sudo ./script/installation/packages.sh'
+                sh 'apt-get -y install ccache'
                 sh 'mkdir build'
-                sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) all'
+                sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) all'
                 // We want to use a ramdisk on Jenkins to avoid the overhead of disk writes.
                 sh 'cd script/micro_bench && timeout 1h ./run_micro_bench.py --run --num-threads=4 --logfile-path=/mnt/ramdisk/benchmark.log'
                 archiveArtifacts 'script/micro_bench/*.json'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,6 @@ pipeline {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
-                            args '--cap-add sys_ptrace'
                         }
                     }
                     steps {
@@ -58,7 +57,6 @@ pipeline {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
-                            args '--cap-add sys_ptrace'
                         }
                     }
                     environment {
@@ -138,7 +136,7 @@ pipeline {
                     agent {
                         docker {
                             image 'ubuntu:bionic'
-                            args '--cap-add sys_ptrace -v /jenkins/ccache:/home/jenkins/.ccache'
+                            args '-v /jenkins/ccache:/home/jenkins/.ccache'
                         }
                     }
                     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
                     steps {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | sudo ./script/installation/packages.sh'
-                        sh 'apt-get -y install ccache'
+                        sh 'sudo apt-get -y install ccache'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j$(nproc)'
                         sh 'cd build && make check-clang-tidy'
@@ -280,7 +280,7 @@ pipeline {
             steps {
                 sh 'echo $NODE_NAME'
                 sh 'echo y | sudo ./script/installation/packages.sh'
-                sh 'apt-get -y install ccache'
+                sh 'sudo apt-get -y install ccache'
                 sh 'mkdir build'
                 sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) all'
                 // We want to use a ramdisk on Jenkins to avoid the overhead of disk writes.

--- a/script/jenkins/benchmark-agent-setup.sh
+++ b/script/jenkins/benchmark-agent-setup.sh
@@ -33,10 +33,8 @@ systemctl daemon-reload
 systemctl enable jenkins
 
 # setup the working directory for jenkins
-mkfs.ext4 /dev/sda4
-echo "$(blkid /dev/sda4|awk '{print $2}') /jenkins               ext4    errors=remount-ro 0       2" >> /etc/fstab
-mkdir /jenkins
-mount /jenkins
+/share/testbed/bin/linux-fixpart all
+/share/testbed/bin/linux-localfs -d /dev/sda4 -t ext4 /jenkins
 chown jenkins:jenkins /jenkins
 
 # create the ramdisk

--- a/script/jenkins/benchmark-agent-setup.sh
+++ b/script/jenkins/benchmark-agent-setup.sh
@@ -37,6 +37,11 @@ systemctl enable jenkins
 /share/testbed/bin/linux-localfs -d /dev/sda4 -t ext4 /jenkins
 chown jenkins:jenkins /jenkins
 
+# setup the ccache cache_dir
+install -d -m 1777 /jenkins/ccache
+echo 'max_size = 250G' > /jenkins/ccache/ccache.conf
+ln -s /jenkins/ccache /home/jenkins/.ccache
+
 # create the ramdisk
 echo "tmpfs  /mnt/ramdisk  tmpfs  nodev,nosuid,noexec,nodiratime,size=20g 0 0" >> /etc/fstab
 mkdir /mnt/ramdisk

--- a/script/jenkins/docker-agent-setup.sh
+++ b/script/jenkins/docker-agent-setup.sh
@@ -45,6 +45,10 @@ chown jenkins:jenkins /jenkins
 # setup the working directory for docker
 /share/testbed/bin/linux-localfs -d /dev/sdb1 -t ext4 /var/lib/docker
 
+# setup the ccache cache_dir
+install -d -m 1777 /jenkins/ccache
+echo 'max_size = 250G' > /jenkins/ccache/ccache.conf
+
 # install docker community edition from upstream
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"


### PR DESCRIPTION
@portablesounds pinged me recently about using ccache in the CI environment.  This PR does that.
Here's a sample of the time savings for a single stage, `-DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON && time make -j$(nproc)`:
First run:
```
...
[100%] Built target recovery_benchmark

real    7m11.187s
user    116m16.729s
sys     10m35.875s
```

Second run in a new container on the same Docker host:
```
...
[100%] Built target tpch_runner

real    1m56.294s
user    26m8.217s
sys     4m22.803s
```

Running on the full pipeline saved 30 minutes (comparing branches master to ccache):
http://jenkins.db.cs.cmu.edu:8080/job/crd/job/terrier-crd/

It should get a little better as more things wind up in the cache but I was surprised how much of the total time is consumed by the tests; ccache won't help those run faster.

The key details are as follows:

1. since terrier already uses CMake, it turned out to be trivial to invoke ccache.  All I had to do was add `-DCMAKE_CXX_COMPILER_LAUNCHER=ccache` to the cmake invocation and it just works.  CMake is a true gem...
1. the `ccache_dir` is shared on the local filesystem of each worker. That means that there is no need to do anything special from the Jenkins pipeline in order to take advantage of the ccache - no rsync, no `archiveArtifacts`, nothing.  The downside is that the cache will only contain object files for build types that have already occurred on that particular jenkins worker node.  While this is not quite as ideal as having a completely centralized cache directory, it make things much simpler to implement and it will improve over time.
1. the way that the docker containers share the cache on the host is by using the `-v /jenkins/ccache:/home/jenkins/.ccache` bind mount.
1. you might notice that I just arbitrarily picked 250GB for the size of the cache directory based on knowledge of the resources for the workers.  I'm not sure what the retention policy should be and how that policy should be enforced (e.g., crontab, etc.).  That's a point for discussion, I guess.
1. this does not enable ccache on the macOS workers.  It can be done but those nodes have much less local storage and the configuration would have to be a little different.
