### PR TITLE
Add SQLite3 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get -y update && \
       llvm-8 \
       pkg-config \
       postgresql-client \
+      sqlite3 \
+      libsqlite3-dev \
 	  ant && \
       apt-get -y install wget && \
       wget http://mirrors.kernel.org/ubuntu/pool/universe/libp/libpqxx/libpqxx-6.2_6.2.5-1_amd64.deb && \


### PR DESCRIPTION
SQLite3 is currently installed in packages.sh but is not installed by Dockerfile.
This creates issues when building in Docker Container:
```
In file included from /repo/src/include/network/connection_context.h:6:0,
                 from /repo/src/include/network/connection_handle.h:26,
                 from /repo/src/include/network/connection_handle_factory.h:6,
                 from /repo/src/include/network/connection_dispatcher_task.h:9,
                 from /repo/src/include/network/terrier_server.h:20,
                 from /repo/src/include/main/db_main.h:14,
                 from /repo/src/main/db_main.cpp:1:
/repo/src/include/traffic_cop/portal.h:3:10: fatal error: sqlite3.h: No such file or directory
 #include <sqlite3.h>
          ^~~~~~~~~~~
compilation terminated.
src/CMakeFiles/terrier_objlib.dir/build.make:2510: recipe for target 'src/CMakeFiles/terrier_objlib.dir/main/db_main.cpp.o' failed
make[2]: *** [src/CMakeFiles/terrier_objlib.dir/main/db_main.cpp.o] Error 1
make[1]: *** [src/CMakeFiles/terrier_objlib.dir/all] Error 2
CMakeFiles/Makefile2:624: recipe for target 'src/CMakeFiles/terrier_objlib.dir/all' failed
make: *** [all] Error 2
Makefile:140: recipe for target 'all' failed
```

This PR adds SQLite3 to Dockerfile.

Also idk how to add tags but I think this is infrastructure