### PR TITLE
Change connection thread count to be a setting instead of a `#define`

### DIFF
--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -228,7 +228,8 @@ class DBMain {
     /**
      * @param thread_registry argument to the TerrierServer
      * @param traffic_cop argument to the ConnectionHandleFactor
-     * @param port needed for safe destruction of CatalogLayer if logging is enabled
+     * @param port argument to TerrierServer
+     * @param connection_thread_count argument to TerrierServer
      */
     NetworkLayer(const common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry,
                  const common::ManagedPointer<trafficcop::TrafficCop> traffic_cop, const uint16_t port,

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -231,13 +231,15 @@ class DBMain {
      * @param port needed for safe destruction of CatalogLayer if logging is enabled
      */
     NetworkLayer(const common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry,
-                 const common::ManagedPointer<trafficcop::TrafficCop> traffic_cop, const uint16_t port) {
+                 const common::ManagedPointer<trafficcop::TrafficCop> traffic_cop, const uint16_t port,
+                 const uint16_t connection_thread_count) {
       connection_handle_factory_ = std::make_unique<network::ConnectionHandleFactory>(traffic_cop);
       command_factory_ = std::make_unique<network::PostgresCommandFactory>();
       provider_ =
           std::make_unique<network::PostgresProtocolInterpreter::Provider>(common::ManagedPointer(command_factory_));
-      server_ = std::make_unique<network::TerrierServer>(
-          common::ManagedPointer(provider_), common::ManagedPointer(connection_handle_factory_), thread_registry, port);
+      server_ = std::make_unique<network::TerrierServer>(common::ManagedPointer(provider_),
+                                                         common::ManagedPointer(connection_handle_factory_),
+                                                         thread_registry, port, connection_thread_count);
     }
 
     /**
@@ -355,8 +357,9 @@ class DBMain {
       std::unique_ptr<NetworkLayer> network_layer = DISABLED;
       if (use_network_) {
         TERRIER_ASSERT(use_traffic_cop_ && traffic_cop != DISABLED, "NetworkLayer needs TrafficCopLayer.");
-        network_layer = std::make_unique<NetworkLayer>(common::ManagedPointer(thread_registry),
-                                                       common::ManagedPointer(traffic_cop), network_port_);
+        network_layer =
+            std::make_unique<NetworkLayer>(common::ManagedPointer(thread_registry), common::ManagedPointer(traffic_cop),
+                                           network_port_, connection_thread_count_);
       }
 
       db_main->settings_manager_ = std::move(settings_manager);
@@ -624,6 +627,7 @@ class DBMain {
     bool use_traffic_cop_ = false;
     uint64_t optimizer_timeout_ = 5000;
     uint16_t network_port_ = 15721;
+    uint16_t connection_thread_count_ = 4;
     bool use_network_ = false;
 
     /**
@@ -653,6 +657,8 @@ class DBMain {
       gc_interval_ = settings_manager->GetInt(settings::Param::gc_interval);
 
       network_port_ = static_cast<uint16_t>(settings_manager->GetInt(settings::Param::port));
+      connection_thread_count_ =
+          static_cast<uint16_t>(settings_manager->GetInt(settings::Param::connection_thread_count));
       optimizer_timeout_ = static_cast<uint64_t>(settings_manager->GetInt(settings::Param::task_execution_timeout));
 
       return settings_manager;

--- a/src/include/network/network_defs.h
+++ b/src/include/network/network_defs.h
@@ -29,9 +29,6 @@ class ReadBuffer;
 // want anyone using it to directly access the socket downstream
 STRONG_TYPEDEF(connection_id_t, uint16_t);
 
-// For threads
-#define CONNECTION_THREAD_COUNT 4
-
 // Number of seconds to timeout on a client read
 #define READ_TIMEOUT (20 * 60)
 

--- a/src/include/network/terrier_server.h
+++ b/src/include/network/terrier_server.h
@@ -33,7 +33,8 @@ class TerrierServer : public common::DedicatedThreadOwner {
    */
   TerrierServer(common::ManagedPointer<ProtocolInterpreter::Provider> protocol_provider,
                 common::ManagedPointer<ConnectionHandleFactory> connection_handle_factory,
-                common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry, uint16_t port);
+                common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry, uint16_t port,
+                uint16_t connection_thread_count);
 
   ~TerrierServer() override = default;
 

--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -11,6 +11,17 @@ SETTING_int(
     terrier::settings::Callbacks::NoOp
 )
 
+// Preallocated connection handler threads and maximum number of connected clients
+SETTING_int(
+    connection_thread_count,
+    "Preallocated connection handler threads and maximum number of connected clients (default: 4)",
+    4,
+    1,
+    256,
+    false,
+    terrier::settings::Callbacks::NoOp
+)
+
 // RecordBufferSegmentPool size limit
 SETTING_int(
     record_buffer_segment_size,

--- a/src/network/terrier_server.cpp
+++ b/src/network/terrier_server.cpp
@@ -16,11 +16,11 @@ namespace terrier::network {
 TerrierServer::TerrierServer(common::ManagedPointer<ProtocolInterpreter::Provider> protocol_provider,
                              common::ManagedPointer<ConnectionHandleFactory> connection_handle_factory,
                              common::ManagedPointer<common::DedicatedThreadRegistry> thread_registry,
-                             const uint16_t port)
+                             const uint16_t port, const uint16_t connection_thread_count)
     : DedicatedThreadOwner(thread_registry),
       running_(false),
       port_(port),
-      max_connections_(CONNECTION_THREAD_COUNT),
+      max_connections_(connection_thread_count),
       connection_handle_factory_(connection_handle_factory),
       provider_(protocol_provider) {
   // For logging purposes

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -30,6 +30,10 @@ class FakeCommandFactory : public PostgresCommandFactory {
   }
 };
 
+/**
+ * This test should be refactored to use DBMain, since there's a bunch of redundant setup here. However we don't have a
+ * way to inject a new CommandFactory.
+ */
 class NetworkTests : public TerrierTest {
  protected:
   trafficcop::TrafficCop *tcop_;
@@ -45,6 +49,7 @@ class NetworkTests : public TerrierTest {
   std::unique_ptr<ConnectionHandleFactory> handle_factory_;
   common::DedicatedThreadRegistry thread_registry_ = common::DedicatedThreadRegistry(DISABLED);
   uint16_t port_ = 15721;
+  uint16_t connection_thread_count_ = 4;
   FakeCommandFactory fake_command_factory_;
   PostgresProtocolInterpreter::Provider protocol_provider_{
       common::ManagedPointer<PostgresCommandFactory>(&fake_command_factory_)};
@@ -74,9 +79,10 @@ class NetworkTests : public TerrierTest {
 
     try {
       handle_factory_ = std::make_unique<ConnectionHandleFactory>(common::ManagedPointer(tcop_));
-      server_ = std::make_unique<TerrierServer>(
-          common::ManagedPointer<ProtocolInterpreter::Provider>(&protocol_provider_),
-          common::ManagedPointer(handle_factory_.get()), common::ManagedPointer(&thread_registry_), port_);
+      server_ =
+          std::make_unique<TerrierServer>(common::ManagedPointer<ProtocolInterpreter::Provider>(&protocol_provider_),
+                                          common::ManagedPointer(handle_factory_.get()),
+                                          common::ManagedPointer(&thread_registry_), port_, connection_thread_count_);
       server_->RunServer();
     } catch (NetworkProcessException &exception) {
       NETWORK_LOG_ERROR("[LaunchServer] exception when launching server");
@@ -254,10 +260,10 @@ TEST_F(NetworkTests, LargePacketsTest) {
 // NOLINTNEXTLINE
 TEST_F(NetworkTests, MultipleConnectionTest) {
   std::vector<std::unique_ptr<NetworkIoWrapper>> io_sockets;
-  io_sockets.reserve(CONNECTION_THREAD_COUNT * 2);
+  io_sockets.reserve(connection_thread_count_ * 2);
 
   for (size_t i = 0; i < 2; i++) {
-    for (size_t i = 0; i < CONNECTION_THREAD_COUNT * 2; i++) {
+    for (size_t i = 0; i < connection_thread_count_ * 2; i++) {
       auto io_socket_unique_ptr = network::ManualPacketUtil::StartConnection(port_);
       EXPECT_NE(io_socket_unique_ptr, nullptr);
       io_sockets.emplace_back(std::move(io_socket_unique_ptr));
@@ -285,9 +291,9 @@ TEST_F(NetworkTests, DISABLED_RacerTest) {
   std::vector<size_t> thread_counts = {
       // clang-format off
       2,
-      CONNECTION_THREAD_COUNT,
-      CONNECTION_THREAD_COUNT * 2,
-      CONNECTION_THREAD_COUNT * 3
+      connection_thread_count_,
+      connection_thread_count_ * 2ul,
+      connection_thread_count_ * 3ul
       // clang-format on
   };
 


### PR DESCRIPTION
`connection_thread_count` will now change the default number of client connection thread handlers to whatever the command line argument value is. Default is still 4.

For future reference, the model of changing something to a setting: add to `settings_defs.h`, read the value back out where needed, and added it as a member to `DBMain` since it needs a default value to use whenever the `SettingsManager` is not being used.