### PR TITLE
Arrow Database Compression

### DIFF
--- a/sample_tpl/compaction-insert-into.tpl
+++ b/sample_tpl/compaction-insert-into.tpl
@@ -1,26 +1,24 @@
-// Modifies the insert.tpl file to add 100,000 to the value of the tuples just inserted by the query below
+// Allocates new slots and inserts into the block using CompactionInsertInto
+// Mimics behaviour of insert.tpl, but inserts into a specific TupleSlot
 
-// INSERT INTO empty_table SELECT colA FROM test_1 WHERE colA BETWEEN 495 AND 505 (should result in 100495 to 100505)
-// Returns true if the first value of the updated empty_table has had 100,000 added to it (was properly updated)
-// Returns false if the first values was not properly updated
-fun main(execCtx: *ExecutionContext) -> bool {
+// INSERT INTO empty_table SELECT colA FROM test_1 WHERE colA BETWEEN 495 AND 505
+// Returns the number of tuples inserted (11)
+fun main(execCtx: *ExecutionContext) -> int64 {
+  var count = 0 // output count
   // Init inserter
   var col_oids: [1]uint32
   col_oids[0] = 1 // colA
   var inserter: StorageInterface
   @storageInterfaceInitBind(&inserter, execCtx, "empty_table", col_oids, true)
-
-  // Init index iterator for the table the tuples are currently in
+  // Iterate through rows with colA between 495 and 505
+  // Init index iterator
   var index : IndexIterator
   @indexIteratorInitBind(&index, execCtx, 1, "test_1", "index_1", col_oids)
-
   // Set iteration bounds
   var lo_index_pr = @indexIteratorGetLoPR(&index)
   var hi_index_pr = @indexIteratorGetHiPR(&index)
   @prSetInt(lo_index_pr, 0, @intToSql(495)) // Set colA in lo
   @prSetInt(hi_index_pr, 0, @intToSql(505)) // Set colA in hi
-
-  // Iterate through rows with colA between 495 and 505
   for (@indexIteratorScanAscending(&index, 0, 0); @indexIteratorAdvance(&index);) {
     // Materialize the current match.
     var table_pr = @indexIteratorGetTablePR(&index)
@@ -30,18 +28,8 @@ fun main(execCtx: *ExecutionContext) -> bool {
     // Insert into empty_table
     var insert_pr = @getTablePR(&inserter)
     @prSetInt(insert_pr, 0, colA)
-    var insert_slot = @tableInsert(&inserter)
-
-    // Delete from the empty table
-    if (!@tableDelete(&inserter, &insert_slot)) {
-      @indexIteratorFree(&index)
-      @storageInterfaceFree(&inserter)
-      return false
-    }
-
-    // Update the value that was just inserted/deleted and reinsert it
-    // at its original tuple slot using compactionInsertInto
-    @prSetInt(insert_pr, 0, colA + @intToSql(100000))
+    var insert_slot = @tableAllocateSlot(&inserter)
+    // Insert into the newly allocated slot
     @tableCompactionInsertInto(&inserter, &insert_slot)
 
     // Insert into index
@@ -50,18 +38,11 @@ fun main(execCtx: *ExecutionContext) -> bool {
     if (!@indexInsert(&inserter)) {
       @indexIteratorFree(&index)
       @storageInterfaceFree(&inserter)
-      return false
+      return 37
     }
+    count = count + 1
   }
   @indexIteratorFree(&index)
   @storageInterfaceFree(&inserter)
-
-  // check that the values in the empty table are all between 100495 and 100505
-  // Init index iterator
-  var verification_index : IndexIterator
-  @indexIteratorInitBind(&verification_index, execCtx, 1, "empty_table", "index_1", col_oids)
-  @indexIteratorScanAscending(&verification_index, 0, 0)
-  var verification_table_pr = @indexIteratorGetTablePR(&verification_index)
-  var colA = @prGetInt(verification_table_pr, 0)
-  return @sqlToBool(@intToSql(100495) == colA)
+  return count
 }

--- a/sample_tpl/compaction-insert-into.tpl
+++ b/sample_tpl/compaction-insert-into.tpl
@@ -3,7 +3,7 @@
 // INSERT INTO empty_table SELECT colA FROM test_1 WHERE colA BETWEEN 495 AND 505 (should result in 100495 to 100505)
 // Returns true if the first value of the updated empty_table has had 100,000 added to it (was properly updated)
 // Returns false if the first values was not properly updated
-fun main(execCtx: *ExecutionContext) -> Integer {
+fun main(execCtx: *ExecutionContext) -> bool {
   // Init inserter
   var col_oids: [1]uint32
   col_oids[0] = 1 // colA
@@ -36,7 +36,7 @@ fun main(execCtx: *ExecutionContext) -> Integer {
     if (!@tableDelete(&inserter, &insert_slot)) {
       @indexIteratorFree(&index)
       @storageInterfaceFree(&inserter)
-      return -505
+      return false
     }
 
     // Update the value that was just inserted/deleted and reinsert it
@@ -50,7 +50,7 @@ fun main(execCtx: *ExecutionContext) -> Integer {
     if (!@indexInsert(&inserter)) {
       @indexIteratorFree(&index)
       @storageInterfaceFree(&inserter)
-      return @intToSql(37)
+      return false
     }
   }
   @indexIteratorFree(&index)
@@ -63,6 +63,5 @@ fun main(execCtx: *ExecutionContext) -> Integer {
   @indexIteratorScanAscending(&verification_index, 0, 0)
   var verification_table_pr = @indexIteratorGetTablePR(&verification_index)
   var colA = @prGetInt(verification_table_pr, 0)
-  // return @sqlToBool(@intToSql(100495) == colA)
-  return colA
+  return @sqlToBool(@intToSql(100495) == colA)
 }

--- a/sample_tpl/compaction-insert-into.tpl
+++ b/sample_tpl/compaction-insert-into.tpl
@@ -2,22 +2,25 @@
 
 // INSERT INTO empty_table SELECT colA FROM test_1 WHERE colA BETWEEN 495 AND 505 (should result in 100495 to 100505)
 // Returns true if the first value of the updated empty_table has had 100,000 added to it (was properly updated)
-// Returns false if not all the values were properly updated
+// Returns false if the first values was not properly updated
 fun main(execCtx: *ExecutionContext) -> Integer {
   // Init inserter
   var col_oids: [1]uint32
   col_oids[0] = 1 // colA
   var inserter: StorageInterface
   @storageInterfaceInitBind(&inserter, execCtx, "empty_table", col_oids, true)
-  // Iterate through rows with colA between 495 and 505
-  // Init index iterator
+
+  // Init index iterator for the table the tuples are currently in
   var index : IndexIterator
   @indexIteratorInitBind(&index, execCtx, 1, "test_1", "index_1", col_oids)
+
   // Set iteration bounds
   var lo_index_pr = @indexIteratorGetLoPR(&index)
   var hi_index_pr = @indexIteratorGetHiPR(&index)
   @prSetInt(lo_index_pr, 0, @intToSql(495)) // Set colA in lo
   @prSetInt(hi_index_pr, 0, @intToSql(505)) // Set colA in hi
+
+  // Iterate through rows with colA between 495 and 505
   for (@indexIteratorScanAscending(&index, 0, 0); @indexIteratorAdvance(&index);) {
     // Materialize the current match.
     var table_pr = @indexIteratorGetTablePR(&index)
@@ -29,9 +32,17 @@ fun main(execCtx: *ExecutionContext) -> Integer {
     @prSetInt(insert_pr, 0, colA)
     var insert_slot = @tableInsert(&inserter)
 
-    // Update the value at the tuple slot that was just inserted into using insertInto
+    // Delete from the empty table
+    if (!@tableDelete(&inserter, &insert_slot)) {
+      @indexIteratorFree(&index)
+      @storageInterfaceFree(&inserter)
+      return -505
+    }
+
+    // Update the value that was just inserted/deleted and reinsert it
+    // at its original tuple slot using compactionInsertInto
     @prSetInt(insert_pr, 0, colA + @intToSql(100000))
-    @tableInsertInto(&inserter, &insert_slot)
+    @tableCompactionInsertInto(&inserter, &insert_slot)
 
     // Insert into index
     var index_pr = @getIndexPRBind(&inserter, "index_empty")
@@ -52,6 +63,6 @@ fun main(execCtx: *ExecutionContext) -> Integer {
   @indexIteratorScanAscending(&verification_index, 0, 0)
   var verification_table_pr = @indexIteratorGetTablePR(&verification_index)
   var colA = @prGetInt(verification_table_pr, 0)
-  //return @sqlToBool(@intToSql(100495) == colA)
+  // return @sqlToBool(@intToSql(100495) == colA)
   return colA
 }

--- a/sample_tpl/insertInto.tpl
+++ b/sample_tpl/insertInto.tpl
@@ -3,7 +3,7 @@
 // INSERT INTO empty_table SELECT colA FROM test_1 WHERE colA BETWEEN 495 AND 505 (should result in 100495 to 100505)
 // Returns true if the first value of the updated empty_table has had 100,000 added to it (was properly updated)
 // Returns false if not all the values were properly updated
-fun main(execCtx: *ExecutionContext) -> bool {
+fun main(execCtx: *ExecutionContext) -> Integer {
   // Init inserter
   var col_oids: [1]uint32
   col_oids[0] = 1 // colA
@@ -31,7 +31,7 @@ fun main(execCtx: *ExecutionContext) -> bool {
 
     // Update the value at the tuple slot that was just inserted into using insertInto
     @prSetInt(insert_pr, 0, colA + @intToSql(100000))
-    @tableInsertInto(&inserter, insert_slot)
+    @tableInsertInto(&inserter, &insert_slot)
 
     // Insert into index
     var index_pr = @getIndexPRBind(&inserter, "index_empty")
@@ -39,7 +39,7 @@ fun main(execCtx: *ExecutionContext) -> bool {
     if (!@indexInsert(&inserter)) {
       @indexIteratorFree(&index)
       @storageInterfaceFree(&inserter)
-      return false
+      return @intToSql(37)
     }
   }
   @indexIteratorFree(&index)
@@ -51,6 +51,7 @@ fun main(execCtx: *ExecutionContext) -> bool {
   @indexIteratorInitBind(&verification_index, execCtx, 1, "empty_table", "index_1", col_oids)
   @indexIteratorScanAscending(&verification_index, 0, 0)
   var verification_table_pr = @indexIteratorGetTablePR(&verification_index)
-  var colA = @prGetInt(table_pr, 0)
-  return @sqlToBool(@intToSql(100495) == colA)
+  var colA = @prGetInt(verification_table_pr, 0)
+  //return @sqlToBool(@intToSql(100495) == colA)
+  return colA
 }

--- a/sample_tpl/insertInto.tpl
+++ b/sample_tpl/insertInto.tpl
@@ -1,0 +1,18 @@
+// Problem: the tuple slot that will be inserted into must already have been allocated/reallocated before this is run
+// Problem: @todo: FIX! where is the projected row defined/set? Otherwise, nothing is actually being inserted...
+// Inserts tuples into a specific tuple slot of an empty table
+// Does not return anything
+
+fun main(execCtx: *ExecutionContext, insert_slot: *TupleSlot) -> nil {
+  // Init storage_interface
+  var col_oids: [1]uint32
+  col_oids[0] = 1 // colA
+  var storage_interface: StorageInterface
+  @storageInterfaceInitBind(&storage_interface, execCtx, "empty_table", col_oids, true)
+
+  // Insert into the empty table
+  @tableInsertInto(&storage_interface, insert_slot)
+
+  // Unbind/Free the storage_interface
+  @storageInterfaceFree(&storage_interface)
+}

--- a/sample_tpl/insertInto.tpl
+++ b/sample_tpl/insertInto.tpl
@@ -1,18 +1,56 @@
-// Problem: the tuple slot that will be inserted into must already have been allocated/reallocated before this is run
-// Problem: @todo: FIX! where is the projected row defined/set? Otherwise, nothing is actually being inserted...
-// Inserts tuples into a specific tuple slot of an empty table
-// Does not return anything
+// Modifies the insert.tpl file to add 100,000 to the value of the tuples just inserted by the query below
 
-fun main(execCtx: *ExecutionContext, insert_slot: *TupleSlot) -> nil {
-  // Init storage_interface
+// INSERT INTO empty_table SELECT colA FROM test_1 WHERE colA BETWEEN 495 AND 505 (should result in 100495 to 100505)
+// Returns true if the first value of the updated empty_table has had 100,000 added to it (was properly updated)
+// Returns false if not all the values were properly updated
+fun main(execCtx: *ExecutionContext) -> bool {
+  // Init inserter
   var col_oids: [1]uint32
   col_oids[0] = 1 // colA
-  var storage_interface: StorageInterface
-  @storageInterfaceInitBind(&storage_interface, execCtx, "empty_table", col_oids, true)
+  var inserter: StorageInterface
+  @storageInterfaceInitBind(&inserter, execCtx, "empty_table", col_oids, true)
+  // Iterate through rows with colA between 495 and 505
+  // Init index iterator
+  var index : IndexIterator
+  @indexIteratorInitBind(&index, execCtx, 1, "test_1", "index_1", col_oids)
+  // Set iteration bounds
+  var lo_index_pr = @indexIteratorGetLoPR(&index)
+  var hi_index_pr = @indexIteratorGetHiPR(&index)
+  @prSetInt(lo_index_pr, 0, @intToSql(495)) // Set colA in lo
+  @prSetInt(hi_index_pr, 0, @intToSql(505)) // Set colA in hi
+  for (@indexIteratorScanAscending(&index, 0, 0); @indexIteratorAdvance(&index);) {
+    // Materialize the current match.
+    var table_pr = @indexIteratorGetTablePR(&index)
+    var colA = @prGetInt(table_pr, 0)
+    var slot = @indexIteratorGetSlot(&index)
 
-  // Insert into the empty table
-  @tableInsertInto(&storage_interface, insert_slot)
+    // Insert into empty_table
+    var insert_pr = @getTablePR(&inserter)
+    @prSetInt(insert_pr, 0, colA)
+    var insert_slot = @tableInsert(&inserter)
 
-  // Unbind/Free the storage_interface
-  @storageInterfaceFree(&storage_interface)
+    // Update the value at the tuple slot that was just inserted into using insertInto
+    @prSetInt(insert_pr, 0, colA + @intToSql(100000))
+    @tableInsertInto(&inserter, insert_slot)
+
+    // Insert into index
+    var index_pr = @getIndexPRBind(&inserter, "index_empty")
+    @prSetInt(index_pr, 0, colA)
+    if (!@indexInsert(&inserter)) {
+      @indexIteratorFree(&index)
+      @storageInterfaceFree(&inserter)
+      return false
+    }
+  }
+  @indexIteratorFree(&index)
+  @storageInterfaceFree(&inserter)
+
+  // check that the values in the empty table are all between 100495 and 100505
+  // Init index iterator
+  var verification_index : IndexIterator
+  @indexIteratorInitBind(&verification_index, execCtx, 1, "empty_table", "index_1", col_oids)
+  @indexIteratorScanAscending(&verification_index, 0, 0)
+  var verification_table_pr = @indexIteratorGetTablePR(&verification_index)
+  var colA = @prGetInt(table_pr, 0)
+  return @sqlToBool(@intToSql(100495) == colA)
 }

--- a/sample_tpl/tpl_tests.txt
+++ b/sample_tpl/tpl_tests.txt
@@ -75,4 +75,4 @@ scan-index.tpl,true,1
 scan-index-2.tpl,true,1
 scan-index-3.tpl,true,32
 join-index.tpl,true,0
-insertInto.tpl,true,true
+insertInto.tpl,true,100495

--- a/sample_tpl/tpl_tests.txt
+++ b/sample_tpl/tpl_tests.txt
@@ -56,6 +56,7 @@ agg-vec-filter.tpl,true,10
 static-agg.tpl,true,49995000
 distinct-agg.tpl,true,45
 delete.tpl,true,0
+compaction-insert-into.tpl,true,11
 insert.tpl,true,11
 update.tpl,true,11
 join.tpl,true,0
@@ -75,4 +76,3 @@ scan-index.tpl,true,1
 scan-index-2.tpl,true,1
 scan-index-3.tpl,true,32
 join-index.tpl,true,0
-insertInto.tpl,true,100495

--- a/sample_tpl/tpl_tests.txt
+++ b/sample_tpl/tpl_tests.txt
@@ -75,3 +75,4 @@ scan-index.tpl,true,1
 scan-index-2.tpl,true,1
 scan-index-3.tpl,true,32
 join-index.tpl,true,0
+insertInto.tpl,true,true

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2073,6 +2073,25 @@ void Sema::CheckBuiltinStorageInterfaceCall(ast::CallExpr *call, ast::Builtin bu
       call->SetType(GetBuiltinType(tuple_slot_type));
       break;
     }
+    case ast::Builtin::TableInsertInto: {
+      // The Built-in has two arguments:
+      // 1) pointer to the storage interface
+      // 2) pointer to the tuple slot where the tuple will be inserted
+      if (!CheckArgCount(call, 2)) {
+        return;
+      }
+
+      // Second argument is a tuple slot. If it is not, report that it is not.
+      auto tuple_slot_type = ast::BuiltinType::TupleSlot;
+      if (!IsPointerToSpecificBuiltin(call_args[1]->GetType(), tuple_slot_type)) {
+        ReportIncorrectCallArg(call, 1, GetBuiltinType(tuple_slot_type)->PointerTo());
+        return;
+      }
+
+      // Set the return type as Nil (which is TPL's equivalent for void return types)
+      call->SetType(GetBuiltinType(ast::BuiltinType::Nil));
+      break;
+    }
     case ast::Builtin::TableDelete: {
       if (!CheckArgCount(call, 2)) {
         return;
@@ -2577,6 +2596,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::StorageInterfaceInitBind:
     case ast::Builtin::GetTablePR:
     case ast::Builtin::TableInsert:
+    case ast::Builtin::TableInsertInto:
     case ast::Builtin::TableDelete:
     case ast::Builtin::TableUpdate:
     case ast::Builtin::GetIndexPR:

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2064,6 +2064,17 @@ void Sema::CheckBuiltinStorageInterfaceCall(ast::CallExpr *call, ast::Builtin bu
       call->SetType(GetBuiltinType(ast::BuiltinType::ProjectedRow)->PointerTo());
       break;
     }
+    case ast::Builtin::TableAllocateSlot: {
+      // TableAllocateSlot has only 1 argument: Pointer to the storage interface
+      if(!CheckArgCount(call, 1)) {
+        return;
+      }
+
+      // Set return type as TupleSlot
+      auto tuple_slot_type = ast::BuiltinType::TupleSlot;
+      call->SetType(GetBuiltinType(tuple_slot_type));
+      break;
+    }
     case ast::Builtin::TableInsert: {
       if (!CheckArgCount(call, 1)) {
         return;
@@ -2595,6 +2606,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::StorageInterfaceInit:
     case ast::Builtin::StorageInterfaceInitBind:
     case ast::Builtin::GetTablePR:
+    case ast::Builtin::TableAllocateSlot:
     case ast::Builtin::TableInsert:
     case ast::Builtin::TableCompactionInsertInto:
     case ast::Builtin::TableDelete:

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2596,7 +2596,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::StorageInterfaceInitBind:
     case ast::Builtin::GetTablePR:
     case ast::Builtin::TableInsert:
-    case ast::Builtin::TableInsertInto:
+    case ast::Builtin::TableCompactionInsertInto:
     case ast::Builtin::TableDelete:
     case ast::Builtin::TableUpdate:
     case ast::Builtin::GetIndexPR:

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2073,7 +2073,7 @@ void Sema::CheckBuiltinStorageInterfaceCall(ast::CallExpr *call, ast::Builtin bu
       call->SetType(GetBuiltinType(tuple_slot_type));
       break;
     }
-    case ast::Builtin::TableInsertInto: {
+    case ast::Builtin::TableCompactionInsertInto: {
       // The Built-in has two arguments:
       // 1) pointer to the storage interface
       // 2) pointer to the tuple slot where the tuple will be inserted

--- a/src/execution/sql/storage_interface.cpp
+++ b/src/execution/sql/storage_interface.cpp
@@ -52,6 +52,10 @@ storage::TupleSlot StorageInterface::TableInsert() {
   return table_->Insert(exec_ctx_->GetTxn(), table_redo_);
 }
 
+void StorageInterface::TableInsertInto(storage::TupleSlot table_tuple_slot) {
+  return table_->InsertInto(exec_ctx_->GetTxn(), table_redo_, table_tuple_slot);
+}
+
 bool StorageInterface::TableDelete(storage::TupleSlot table_tuple_slot) {
   exec_ctx_->RowsAffected()++;  // believe this should only happen in root plan nodes, so should reflect count of query
   auto txn = exec_ctx_->GetTxn();

--- a/src/execution/sql/storage_interface.cpp
+++ b/src/execution/sql/storage_interface.cpp
@@ -52,8 +52,8 @@ storage::TupleSlot StorageInterface::TableInsert() {
   return table_->Insert(exec_ctx_->GetTxn(), table_redo_);
 }
 
-void StorageInterface::TableInsertInto(storage::TupleSlot table_tuple_slot) {
-  return table_->InsertInto(exec_ctx_->GetTxn(), table_redo_, table_tuple_slot);
+void StorageInterface::TableCompactionInsertInto(storage::TupleSlot table_tuple_slot) {
+  return table_->CompactionInsertInto(exec_ctx_->GetTxn(), table_redo_, table_tuple_slot);
 }
 
 bool StorageInterface::TableDelete(storage::TupleSlot table_tuple_slot) {

--- a/src/execution/sql/storage_interface.cpp
+++ b/src/execution/sql/storage_interface.cpp
@@ -47,6 +47,10 @@ storage::ProjectedRow *StorageInterface::GetIndexPR(catalog::index_oid_t index_o
   return index_pr_;
 }
 
+storage::TupleSlot StorageInterface::TableAllocateSlot() {
+  return table_->AllocateSlot();
+}
+
 storage::TupleSlot StorageInterface::TableInsert() {
   exec_ctx_->RowsAffected()++;  // believe this should only happen in root plan nodes, so should reflect count of query
   return table_->Insert(exec_ctx_->GetTxn(), table_redo_);

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1944,9 +1944,9 @@ void BytecodeGenerator::VisitBuiltinStorageInterfaceCall(ast::CallExpr *call, as
       Emitter()->Emit(Bytecode::StorageInterfaceTableInsert, tuple_slot, storage_interface);
       break;
     }
-    case ast::Builtin::TableInsertInto: {
+    case ast::Builtin::TableCompactionInsertInto: {
       LocalVar tuple_slot = VisitExpressionForRValue(call->Arguments()[1]);
-      Emitter()->Emit(Bytecode::StorageInterfaceTableInsertInto, storage_interface, tuple_slot);
+      Emitter()->Emit(Bytecode::StorageInterfaceTableCompactionInsertInto, storage_interface, tuple_slot);
       break;
     }
     case ast::Builtin::TableDelete: {

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1944,6 +1944,12 @@ void BytecodeGenerator::VisitBuiltinStorageInterfaceCall(ast::CallExpr *call, as
       Emitter()->Emit(Bytecode::StorageInterfaceTableInsert, tuple_slot, storage_interface);
       break;
     }
+    case ast::Builtin::TableInsertInto: {
+      ast::Type *tuple_slot_type = ast::BuiltinType::Get(ctx, ast::BuiltinType::TupleSlot);
+      LocalVar tuple_slot = ExecutionResult()->GetOrCreateDestination(tuple_slot_type);
+      Emitter()->Emit(Bytecode::StorageInterfaceTableInsertInto, storage_interface, tuple_slot);
+      break;
+    }
     case ast::Builtin::TableDelete: {
       LocalVar cond = ExecutionResult()->GetOrCreateDestination(ast::BuiltinType::Get(ctx, ast::BuiltinType::Bool));
       LocalVar tuple_slot = VisitExpressionForRValue(call->Arguments()[1]);
@@ -2312,6 +2318,7 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     case ast::Builtin::StorageInterfaceInitBind:
     case ast::Builtin::GetTablePR:
     case ast::Builtin::TableInsert:
+    case ast::Builtin::TableInsertInto:
     case ast::Builtin::TableDelete:
     case ast::Builtin::TableUpdate:
     case ast::Builtin::GetIndexPR:

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2317,7 +2317,7 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     case ast::Builtin::StorageInterfaceInitBind:
     case ast::Builtin::GetTablePR:
     case ast::Builtin::TableInsert:
-    case ast::Builtin::TableInsertInto:
+    case ast::Builtin::TableCompactionInsertInto:
     case ast::Builtin::TableDelete:
     case ast::Builtin::TableUpdate:
     case ast::Builtin::GetIndexPR:

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1945,8 +1945,7 @@ void BytecodeGenerator::VisitBuiltinStorageInterfaceCall(ast::CallExpr *call, as
       break;
     }
     case ast::Builtin::TableInsertInto: {
-      ast::Type *tuple_slot_type = ast::BuiltinType::Get(ctx, ast::BuiltinType::TupleSlot);
-      LocalVar tuple_slot = ExecutionResult()->GetOrCreateDestination(tuple_slot_type);
+      LocalVar tuple_slot = VisitExpressionForRValue(call->Arguments()[1]);
       Emitter()->Emit(Bytecode::StorageInterfaceTableInsertInto, storage_interface, tuple_slot);
       break;
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1938,6 +1938,12 @@ void BytecodeGenerator::VisitBuiltinStorageInterfaceCall(ast::CallExpr *call, as
       Emitter()->Emit(Bytecode::StorageInterfaceGetTablePR, pr, storage_interface);
       break;
     }
+    case ast::Builtin::TableAllocateSlot: {
+      ast::Type *tuple_slot_type = ast::BuiltinType::Get(ctx, ast::BuiltinType::TupleSlot);
+      LocalVar tuple_slot = ExecutionResult()->GetOrCreateDestination(tuple_slot_type);
+      Emitter()->Emit(Bytecode::StorageInterfaceTableAllocateSlot, tuple_slot, storage_interface);
+      break;
+    }
     case ast::Builtin::TableInsert: {
       ast::Type *tuple_slot_type = ast::BuiltinType::Get(ctx, ast::BuiltinType::TupleSlot);
       LocalVar tuple_slot = ExecutionResult()->GetOrCreateDestination(tuple_slot_type);
@@ -2316,6 +2322,7 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     case ast::Builtin::StorageInterfaceInit:
     case ast::Builtin::StorageInterfaceInitBind:
     case ast::Builtin::GetTablePR:
+    case ast::Builtin::TableAllocateSlot:
     case ast::Builtin::TableInsert:
     case ast::Builtin::TableCompactionInsertInto:
     case ast::Builtin::TableDelete:

--- a/src/execution/vm/bytecode_handlers.cpp
+++ b/src/execution/vm/bytecode_handlers.cpp
@@ -214,6 +214,11 @@ void OpStorageInterfaceTableInsert(terrier::storage::TupleSlot *tuple_slot,
   *tuple_slot = storage_interface->TableInsert();
 }
 
+void OpStorageInterfaceTableInsertInto(terrier::execution::sql::StorageInterface *storage_interface,
+                                             terrier::storage::TupleSlot *tuple_slot) {
+  storage_interface->TableInsertInto(*tuple_slot);
+}
+
 void OpStorageInterfaceGetIndexPR(terrier::storage::ProjectedRow **pr_result,
                                   terrier::execution::sql::StorageInterface *storage_interface, uint32_t index_oid) {
   *pr_result = storage_interface->GetIndexPR(terrier::catalog::index_oid_t(index_oid));

--- a/src/execution/vm/bytecode_handlers.cpp
+++ b/src/execution/vm/bytecode_handlers.cpp
@@ -209,6 +209,11 @@ void OpStorageInterfaceTableDelete(bool *result, terrier::execution::sql::Storag
   *result = storage_interface->TableDelete(*tuple_slot);
 }
 
+void OpStorageInterfaceTableAllocateSlot(terrier::storage::TupleSlot *tuple_slot,
+                                         terrier::execution::sql::StorageInterface *storage_interface) {
+  *tuple_slot = storage_interface->TableAllocateSlot();
+}
+
 void OpStorageInterfaceTableInsert(terrier::storage::TupleSlot *tuple_slot,
                                    terrier::execution::sql::StorageInterface *storage_interface) {
   *tuple_slot = storage_interface->TableInsert();

--- a/src/execution/vm/bytecode_handlers.cpp
+++ b/src/execution/vm/bytecode_handlers.cpp
@@ -214,9 +214,9 @@ void OpStorageInterfaceTableInsert(terrier::storage::TupleSlot *tuple_slot,
   *tuple_slot = storage_interface->TableInsert();
 }
 
-void OpStorageInterfaceTableInsertInto(terrier::execution::sql::StorageInterface *storage_interface,
+void OpStorageInterfaceTableCompactionInsertInto(terrier::execution::sql::StorageInterface *storage_interface,
                                              terrier::storage::TupleSlot *tuple_slot) {
-  storage_interface->TableInsertInto(*tuple_slot);
+  storage_interface->TableCompactionInsertInto(*tuple_slot);
 }
 
 void OpStorageInterfaceGetIndexPR(terrier::storage::ProjectedRow **pr_result,

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1674,6 +1674,14 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     DISPATCH_NEXT();
   }
 
+  OP(StorageInterfaceTableAllocateSlot) : {
+    auto *tuple_slot = frame->LocalAt<storage::TupleSlot *>(READ_LOCAL_ID());
+    auto *storage_interface = frame->LocalAt<sql::StorageInterface *>(READ_LOCAL_ID());
+
+    OpStorageInterfaceTableAllocateSlot(tuple_slot, storage_interface);
+    DISPATCH_NEXT();
+  }
+
   OP(StorageInterfaceTableInsert) : {
     auto *tuple_slot = frame->LocalAt<storage::TupleSlot *>(READ_LOCAL_ID());
     auto *storage_interface = frame->LocalAt<sql::StorageInterface *>(READ_LOCAL_ID());

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1682,6 +1682,14 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     DISPATCH_NEXT();
   }
 
+  OP(StorageInterfaceTableInsertInto) : {
+    auto *storage_interface = frame->LocalAt<sql::StorageInterface *>(READ_LOCAL_ID());
+    auto *tuple_slot = frame->LocalAt<storage::TupleSlot *>(READ_LOCAL_ID());
+
+    OpStorageInterfaceTableInsertInto(storage_interface, tuple_slot);
+    DISPATCH_NEXT();
+  }
+
   OP(StorageInterfaceTableDelete) : {
     auto *result = frame->LocalAt<bool *>(READ_LOCAL_ID());
     auto *storage_interface = frame->LocalAt<sql::StorageInterface *>(READ_LOCAL_ID());

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -1682,11 +1682,11 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     DISPATCH_NEXT();
   }
 
-  OP(StorageInterfaceTableInsertInto) : {
+  OP(StorageInterfaceTableCompactionInsertInto) : {
     auto *storage_interface = frame->LocalAt<sql::StorageInterface *>(READ_LOCAL_ID());
     auto *tuple_slot = frame->LocalAt<storage::TupleSlot *>(READ_LOCAL_ID());
 
-    OpStorageInterfaceTableInsertInto(storage_interface, tuple_slot);
+    OpStorageInterfaceTableCompactionInsertInto(storage_interface, tuple_slot);
     DISPATCH_NEXT();
   }
 

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -221,6 +221,7 @@ namespace terrier::execution::ast {
   F(StorageInterfaceInit, storageInterfaceInit)                         \
   F(StorageInterfaceInitBind, storageInterfaceInitBind)                 \
   F(GetTablePR, getTablePR)                                             \
+  F(TableAllocateSlot, tableAllocateSlot)                                             \
   F(TableInsert, tableInsert)                                           \
   F(TableCompactionInsertInto, tableCompactionInsertInto)               \
   F(TableDelete, tableDelete)                                           \

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -222,6 +222,7 @@ namespace terrier::execution::ast {
   F(StorageInterfaceInitBind, storageInterfaceInitBind)                 \
   F(GetTablePR, getTablePR)                                             \
   F(TableInsert, tableInsert)                                           \
+  F(TableInsertInto, tableInsertInto)                                   \
   F(TableDelete, tableDelete)                                           \
   F(TableUpdate, tableUpdate)                                           \
   F(GetIndexPR, getIndexPR)                                             \

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -222,7 +222,7 @@ namespace terrier::execution::ast {
   F(StorageInterfaceInitBind, storageInterfaceInitBind)                 \
   F(GetTablePR, getTablePR)                                             \
   F(TableInsert, tableInsert)                                           \
-  F(TableInsertInto, tableInsertInto)                                   \
+  F(TableCompactionInsertInto, tableCompactionInsertInto)               \
   F(TableDelete, tableDelete)                                           \
   F(TableUpdate, tableUpdate)                                           \
   F(GetIndexPR, getIndexPR)                                             \

--- a/src/include/execution/sql/storage_interface.h
+++ b/src/include/execution/sql/storage_interface.h
@@ -48,6 +48,12 @@ class EXPORT StorageInterface {
   bool TableUpdate(storage::TupleSlot table_tuple_slot);
 
   /**
+   * Allocate and return a new slot in the Data Table
+   * @return the allocated TupleSlot
+   */
+  storage::TupleSlot TableAllocateSlot();
+
+  /**
    * Reinsert tuple into table.
    * @return slot where the insertion occurred.
    */

--- a/src/include/execution/sql/storage_interface.h
+++ b/src/include/execution/sql/storage_interface.h
@@ -54,6 +54,12 @@ class EXPORT StorageInterface {
   storage::TupleSlot TableInsert();
 
   /**
+   * Insert tuple into the table in the tuple slot specified
+   * @param table_tuple_slot where the tuple will be inserted
+   */
+  void TableInsertInto(storage::TupleSlot table_tuple_slot);
+
+  /**
    * @param index_oid OID of the index to access.
    * @return PR of the index.
    */

--- a/src/include/execution/sql/storage_interface.h
+++ b/src/include/execution/sql/storage_interface.h
@@ -55,9 +55,11 @@ class EXPORT StorageInterface {
 
   /**
    * Insert tuple into the table in the tuple slot specified
+   * Should only be used by the compaction process (block compactor)
+   * because it assumes that the tuple slot can be reallocated
    * @param table_tuple_slot where the tuple will be inserted
    */
-  void TableInsertInto(storage::TupleSlot table_tuple_slot);
+  void TableCompactionInsertInto(storage::TupleSlot table_tuple_slot);
 
   /**
    * @param index_oid OID of the index to access.

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1645,6 +1645,9 @@ VM_OP void OpStorageInterfaceTableUpdate(bool *result, terrier::execution::sql::
 VM_OP void OpStorageInterfaceTableDelete(bool *result, terrier::execution::sql::StorageInterface *storage_interface,
                                          terrier::storage::TupleSlot *tuple_slot);
 
+VM_OP void OpStorageInterfaceTableAllocateSlot(terrier::storage::TupleSlot *tuple_slot,
+                                               terrier::execution::sql::StorageInterface *storage_interface);
+
 VM_OP void OpStorageInterfaceTableInsert(terrier::storage::TupleSlot *tuple_slot,
                                          terrier::execution::sql::StorageInterface *storage_interface);
 

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1648,7 +1648,7 @@ VM_OP void OpStorageInterfaceTableDelete(bool *result, terrier::execution::sql::
 VM_OP void OpStorageInterfaceTableInsert(terrier::storage::TupleSlot *tuple_slot,
                                          terrier::execution::sql::StorageInterface *storage_interface);
 
-VM_OP void OpStorageInterfaceTableInsertInto(terrier::execution::sql::StorageInterface *storage_interface,
+VM_OP void OpStorageInterfaceTableCompactionInsertInto(terrier::execution::sql::StorageInterface *storage_interface,
                                           terrier::storage::TupleSlot *tuple_slot);
 
 VM_OP void OpStorageInterfaceGetIndexPR(terrier::storage::ProjectedRow **pr_result,

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1648,6 +1648,9 @@ VM_OP void OpStorageInterfaceTableDelete(bool *result, terrier::execution::sql::
 VM_OP void OpStorageInterfaceTableInsert(terrier::storage::TupleSlot *tuple_slot,
                                          terrier::execution::sql::StorageInterface *storage_interface);
 
+VM_OP void OpStorageInterfaceTableInsertInto(terrier::execution::sql::StorageInterface *storage_interface,
+                                          terrier::storage::TupleSlot *tuple_slot);
+
 VM_OP void OpStorageInterfaceGetIndexPR(terrier::storage::ProjectedRow **pr_result,
                                         terrier::execution::sql::StorageInterface *storage_interface,
                                         uint32_t index_oid);

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -422,7 +422,7 @@ namespace terrier::execution::vm {
   F(StorageInterfaceGetTablePR, OperandType::Local, OperandType::Local)                                               \
   F(StorageInterfaceTableUpdate, OperandType::Local, OperandType::Local, OperandType::Local)                          \
   F(StorageInterfaceTableInsert, OperandType::Local, OperandType::Local)                                              \
-  F(StorageInterfaceTableInsertInto, OperandType::Local, OperandType::Local)                                          \
+  F(StorageInterfaceTableCompactionInsertInto, OperandType::Local, OperandType::Local)                                          \
   F(StorageInterfaceTableDelete, OperandType::Local, OperandType::Local, OperandType::Local)                          \
   F(StorageInterfaceGetIndexPR, OperandType::Local, OperandType::Local, OperandType::UImm4)                           \
   F(StorageInterfaceIndexInsert, OperandType::Local, OperandType::Local)                                              \

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -421,6 +421,7 @@ namespace terrier::execution::vm {
     OperandType::UImm4, OperandType::Local)                                                                           \
   F(StorageInterfaceGetTablePR, OperandType::Local, OperandType::Local)                                               \
   F(StorageInterfaceTableUpdate, OperandType::Local, OperandType::Local, OperandType::Local)                          \
+  F(StorageInterfaceTableAllocateSlot, OperandType::Local, OperandType::Local)                                        \
   F(StorageInterfaceTableInsert, OperandType::Local, OperandType::Local)                                              \
   F(StorageInterfaceTableCompactionInsertInto, OperandType::Local, OperandType::Local)                                          \
   F(StorageInterfaceTableDelete, OperandType::Local, OperandType::Local, OperandType::Local)                          \

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -422,6 +422,7 @@ namespace terrier::execution::vm {
   F(StorageInterfaceGetTablePR, OperandType::Local, OperandType::Local)                                               \
   F(StorageInterfaceTableUpdate, OperandType::Local, OperandType::Local, OperandType::Local)                          \
   F(StorageInterfaceTableInsert, OperandType::Local, OperandType::Local)                                              \
+  F(StorageInterfaceTableInsertInto, OperandType::Local, OperandType::Local)                                          \
   F(StorageInterfaceTableDelete, OperandType::Local, OperandType::Local, OperandType::Local)                          \
   F(StorageInterfaceGetIndexPR, OperandType::Local, OperandType::Local, OperandType::UImm4)                           \
   F(StorageInterfaceIndexInsert, OperandType::Local, OperandType::Local)                                              \

--- a/src/include/storage/block_compactor.h
+++ b/src/include/storage/block_compactor.h
@@ -7,6 +7,9 @@
 #include "storage/data_table.h"
 #include "storage/storage_defs.h"
 #include "transaction/transaction_manager.h"
+#include "execution/vm/module.h"
+#include "execution/vm/module_compiler.h"
+
 namespace terrier::storage {
 
 /**
@@ -49,6 +52,64 @@ class BlockCompactor {
   };
 
  public:
+  BlockCompactor() {
+    // tpl code for use in moveTuple. It deletes the tuple from the table and from the index and then inserts the tuple
+    // to the table (a specific block) and to the index. It returns true if the delete succeeds (because delete returns
+    // false if a concurrent transaction is updating the tuple that is trying to be moved, the only condition where
+    // the block compaction should be stopped).
+    // This replaces with the index delete/insert added:
+    //      cg->table_->InsertInto(common::ManagedPointer(cg->txn_), *record->Delta(), to);
+    //      return cg->table_->Delete(common::ManagedPointer(cg->txn_), from);
+    // @todo: do we need to consider that insertIndex could fail? Do so now.
+    auto tpl_code = R"(
+    fun moveTuple(slot_from: TupleSlot*, slot_to: TupleSlot*) -> bool {
+      // Initialize and bind the storage_interface
+      // @todo: FIX! should the variables here be passed in as arguments to the function. Are they all needed?
+      // Do we need to define another storageInterfaceInitBind-like method? That seems not helpful.
+      var col_oids: [1]uint32
+      col_oids[0] = 1 // colA
+      var storage_interface: StorageInterface
+      @storageInterfaceInitBind(&storage_interface, execCtx, "empty_table", col_oids, true)
+
+      // Delete on Table
+      // If the table delete fails, unbind the storage interface and return false
+      if (!@tableDelete(&storage_interface, &slot_from)) {
+        @storageInterfaceFree(&storage_interface)
+        return false
+      }
+
+      // Insert on Table
+      // @todo: FIX! how is the redo being set (it is a member variable of the storage interface)?
+      // I'm not convinced the projected row is being used. Here is example code from update.tpl:
+      // var insert_pr = @getTablePR(&updater)
+      // @prSetInt(insert_pr, 0, colA + @intToSql(100000))
+      @tableInsertInto(&storage_interface, &slot_to)
+
+
+      // Delete on Index
+      // @todo: FIX! are any of these commented-out-lines needed? They are example code from update.tpl:
+      // var index_pr = @getIndexPRBind(&storage_interface, "index_1")
+      // @prSetInt(index_pr, 0, colA)
+      @indexDelete(&storage_interface, &slot_from)
+
+      // Insert on Index
+      // @todo: FIX! is something like this needed? It is example code from update.tpl:
+      // @prSetInt(index_pr, 0, colA + @intToSql(100000))
+      // if the index insert fails, unbind the storage interface and return false
+      if (!@indexInsert(&storage_interface)) {
+        @storageInterfaceFree(&storage_interface)
+        return false
+      }
+
+      // If the function gets to the end, all processes succeeded. Return true
+      return true
+    })";
+    auto compiler = execution::vm::test::ModuleCompiler();
+    auto module = compiler.CompileToModule(tpl_code);
+
+    module->GetFunction("moveTuple", execution::vm::ExecutionMode::Interpret, &move_tuple_);
+  }
+
   FAKED_IN_TEST ~BlockCompactor() = default;
 
   /**
@@ -95,5 +156,8 @@ class BlockCompactor {
   }
 
   std::queue<RawBlock *> compaction_queue_;
+
+  // stores compiled bytecode that can be called with different arguments (look in the blockcompactor constructor for details)
+  std::function<bool(TupleSlot*, TupleSlot*)> move_tuple_;
 };
 }  // namespace terrier::storage

--- a/src/include/storage/block_compactor.h
+++ b/src/include/storage/block_compactor.h
@@ -66,7 +66,7 @@ class BlockCompactor {
     // table name
     // col_oids
     // projected row
-    fun moveTuple(slot_from: TupleSlot*, slot_to: TupleSlot*) -> bool {
+    fun moveTuple(execCtx: *ExecutionContext, slot_from: TupleSlot*, slot_to: TupleSlot*) -> bool {
       // Initialize and bind the storage_interface
       // @todo: FIX! should the variables here be passed in as arguments to the function. Are they all needed?
       // Do we need to define another storageInterfaceInitBind-like method? That seems not helpful.

--- a/src/include/storage/block_compactor.h
+++ b/src/include/storage/block_compactor.h
@@ -62,6 +62,10 @@ class BlockCompactor {
     //      return cg->table_->Delete(common::ManagedPointer(cg->txn_), from);
     // @todo: do we need to consider that insertIndex could fail? Do so now.
     auto tpl_code = R"(
+    // execution context
+    // table name
+    // col_oids
+    // projected row
     fun moveTuple(slot_from: TupleSlot*, slot_to: TupleSlot*) -> bool {
       // Initialize and bind the storage_interface
       // @todo: FIX! should the variables here be passed in as arguments to the function. Are they all needed?

--- a/src/include/storage/block_compactor.h
+++ b/src/include/storage/block_compactor.h
@@ -68,18 +68,14 @@ class BlockCompactor {
     //      return cg->table_->Delete(common::ManagedPointer(cg->txn_), from);
     // @todo: do we need to consider that insertIndex could fail? Do so now.
     auto tpl_code = R"(
-    fun moveTuple(execCtx: *ExecutionContext, slot_from: *TupleSlot, slot_to: *TupleSlot, col_oids: *uint16, table_name: *char) -> bool {
+    fun moveTuple(execCtx: *ExecutionContext, slot_from: *TupleSlot, slot_to: *TupleSlot, col_oids: *uint16, table_name: *uint8) -> bool {
       var storage_interface: StorageInterface
-      @storageInterfaceInitBind(&storage_interface, execCtx, table_name, col_oids, true)
-
-      if (!@tableDelete(&storage_interface, &slot_from)) {
-        @storageInterfaceFree(&storage_interface)
-        return false
-      }
-
-      @tableCompactionInsertInto(&storage_interface, &slot_to)
-      }
-
+      //@storageInterfaceInitBind(&storage_interface, execCtx, table_name, col_oids, true)
+      //if (!@tableDelete(&storage_interface, &slot_from)) {
+        //@storageInterfaceFree(&storage_interface)
+        //return false
+      //}
+      //@tableCompactionInsertInto(&storage_interface, &slot_to)
       return true
     })";
     auto compiler = execution::vm::test::ModuleCompiler();

--- a/src/include/storage/block_compactor.h
+++ b/src/include/storage/block_compactor.h
@@ -68,7 +68,7 @@ class BlockCompactor {
     //      return cg->table_->Delete(common::ManagedPointer(cg->txn_), from);
     // @todo: do we need to consider that insertIndex could fail? Do so now.
     auto tpl_code = R"(
-    fun moveTuple(execCtx: *ExecutionContext, slot_from: TupleSlot*, slot_to: TupleSlot*, col_oids: uint16*, table_name: char*) -> bool {
+    fun moveTuple(execCtx: *ExecutionContext, slot_from: *TupleSlot, slot_to: *TupleSlot, col_oids: *uint16, table_name: *char) -> bool {
       var storage_interface: StorageInterface
       @storageInterfaceInitBind(&storage_interface, execCtx, table_name, col_oids, true)
 

--- a/src/include/storage/block_compactor.h
+++ b/src/include/storage/block_compactor.h
@@ -77,7 +77,7 @@ class BlockCompactor {
         return false
       }
 
-      @tableInsertInto(&storage_interface, &slot_to)
+      @tableCompactionInsertInto(&storage_interface, &slot_to)
       }
 
       return true

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -175,6 +175,12 @@ class DataTable {
   SlotIterator end() const;  // NOLINT for STL name compability
 
   /**
+   * Allocate a new tuple slot and return the allocated slot
+   * @return slot allocated
+   */
+  TupleSlot AllocateSlot();
+
+  /**
    * Update the tuple according to the redo buffer given, and update the version chain to link to an
    * undo record that is allocated in the txn. The undo record is populated with a before-image of the tuple in the
    * process. Update will only happen if there is no write-write conflict and tuple is visible, otherwise, this is

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -201,6 +201,15 @@ class DataTable {
   TupleSlot Insert(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo);
 
   /**
+   * Inserts a tuple, as given in the redo, into the slot specified by dest
+   * @param txn the calling transaction
+   * @param redo after-image of the inserted tuple
+   * @param dest the tuple slot that the tuple should be inserted into
+   */
+  void InsertInto(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo,
+                  TupleSlot dest);
+
+  /**
    * Creates a new block for compaction. When the block is created, the BlockStatus is set to FREEZING to prevent
    * any other transaction from accessing it.
    * @return block that has been newly created
@@ -285,8 +294,6 @@ class DataTable {
   bool SelectIntoBuffer(common::ManagedPointer<transaction::TransactionContext> txn, TupleSlot slot,
                         RowType *out_buffer) const;
 
-  void InsertInto(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo,
-                  TupleSlot dest);
   // Atomically read out the version pointer value.
   UndoRecord *AtomicallyReadVersionPtr(TupleSlot slot, const TupleAccessStrategy &accessor) const;
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -202,12 +202,13 @@ class DataTable {
 
   /**
    * Inserts a tuple, as given in the redo, into the slot specified by dest
+   * Should only be used by the compaction process (block compactor) because it assumes that the slot can be reallocated
    * @param txn the calling transaction
    * @param redo after-image of the inserted tuple
    * @param dest the tuple slot that the tuple should be inserted into
    */
-  void InsertInto(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo,
-                  TupleSlot dest);
+  void CompactionInsertInto(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo,
+                            TupleSlot dest);
 
   /**
    * Creates a new block for compaction. When the block is created, the BlockStatus is set to FREEZING to prevent
@@ -293,6 +294,15 @@ class DataTable {
   template <class RowType>
   bool SelectIntoBuffer(common::ManagedPointer<transaction::TransactionContext> txn, TupleSlot slot,
                         RowType *out_buffer) const;
+
+  /**
+   * Inserts a tuple, as given in the redo, into the slot specified by dest
+   * @param txn the calling transaction
+   * @param redo after-image of the inserted tuple
+   * @param dest the tuple slot that the tuple should be inserted into
+   */
+  void InsertInto(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo,
+                  TupleSlot dest);
 
   // Atomically read out the version pointer value.
   UndoRecord *AtomicallyReadVersionPtr(TupleSlot slot, const TupleAccessStrategy &accessor) const;

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -201,12 +201,22 @@ class DataTable {
   TupleSlot Insert(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo);
 
   /**
-   * Inserts a tuple, as given in the redo into the specified block.
+   * Creates a new block for compaction. When the block is created, the BlockStatus is set to FREEZING to prevent
+   * any other transaction from accessing it.
+   * @return block that has been newly created
+   */
+  RawBlock* CreateCompactedBlock();
+
+  /**
+   * Inserts a tuple, as given in the redo into the specified block. Normally, we do not allow insertion into a
+   * block while it is freezing. This function is used to specifically insert into a block while compaction process
+   * is happening. The FREEZING status flag ensures that no other transaction operates on the same block.
    * @param txn the calling transaction
    * @param redo after-image of the inserted tuple
    * @param block the block to which the tuple should be inserted into
+   * @return true if successful, false otherwise
    */
-  void InsertIntoBlock(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo, RawBlock *block);
+  bool InsertIntoFreezingBlock(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo, RawBlock *block);
 
   /**
    * Deletes the given TupleSlot, this will call StageDelete on the provided txn to generate the RedoRecord for delete.

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -201,6 +201,14 @@ class DataTable {
   TupleSlot Insert(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo);
 
   /**
+   * Inserts a tuple, as given in the redo into the specified block.
+   * @param txn the calling transaction
+   * @param redo after-image of the inserted tuple
+   * @param block the block to which the tuple should be inserted into
+   */
+  void InsertIntoBlock(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo, RawBlock *block);
+
+  /**
    * Deletes the given TupleSlot, this will call StageDelete on the provided txn to generate the RedoRecord for delete.
    * The rest of the behavior follows Update's behavior.
    * @param txn the calling transaction

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -205,7 +205,7 @@ class DataTable {
    * any other transaction from accessing it.
    * @return block that has been newly created
    */
-  RawBlock* CreateCompactedBlock();
+  RawBlock *CreateCompactedBlock();
 
   /**
    * Inserts a tuple, as given in the redo into the specified block. Normally, we do not allow insertion into a
@@ -216,7 +216,8 @@ class DataTable {
    * @param block the block to which the tuple should be inserted into
    * @return true if successful, false otherwise
    */
-  bool InsertIntoFreezingBlock(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo, RawBlock *block);
+  bool InsertIntoFreezingBlock(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo,
+                               RawBlock *block);
 
   /**
    * Deletes the given TupleSlot, this will call StageDelete on the provided txn to generate the RedoRecord for delete.

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -135,9 +135,9 @@ class SqlTable {
    * @param redo after-image of the inserted tuple.
    * @param TupleSlot that the tuple was inserted into.
    */
-  void InsertInto(const common::ManagedPointer<transaction::TransactionContext> txn, RedoRecord *const redo,
+  void CompactionInsertInto(const common::ManagedPointer<transaction::TransactionContext> txn, RedoRecord *const redo,
                  const TupleSlot dest) const {
-    table_.data_table_->InsertInto(txn, *(redo->Delta()), dest);
+    table_.data_table_->CompactionInsertInto(txn, *(redo->Delta()), dest);
     redo->SetTupleSlot(dest);
   }
 

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -137,11 +137,6 @@ class SqlTable {
    */
   void InsertInto(const common::ManagedPointer<transaction::TransactionContext> txn, RedoRecord *const redo,
                  const TupleSlot dest) const {
-    TERRIER_ASSERT(redo->GetTupleSlot() == TupleSlot(nullptr, 0), "TupleSlot was set in this RedoRecord.");
-    TERRIER_ASSERT(redo == reinterpret_cast<LogRecord *>(txn->redo_buffer_.LastRecord())
-        ->LogRecord::GetUnderlyingRecordBodyAs<RedoRecord>(),
-                   "This RedoRecord is not the most recent entry in the txn's RedoBuffer. Was StageWrite called "
-                   "immediately before?");
     table_.data_table_->InsertInto(txn, *(redo->Delta()), dest);
     redo->SetTupleSlot(dest);
   }

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -92,6 +92,16 @@ class SqlTable {
   }
 
   /**
+   * Allocates a new slot at the insertion head in the Data Table
+   * @return the allocated TupleSlot
+   */
+  TupleSlot AllocateSlot() {
+    // TODO (abhijithanilkumar): This function is probably only useful to test the TPL code for
+    // CompactionInsertInto. Is there an alternate way to do this?
+    return table_.data_table_->AllocateSlot();
+  }
+
+  /**
    * Inserts a tuple, as given in the redo, and return the slot allocated for the tuple. StageWrite must have been
    * called as well in order for the operation to be logged.
    *

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -111,15 +111,19 @@ class SqlTable {
   }
 
   /**
-   * Inserts a tuple into the specified block, this function will ALWAYS be called from the compaction logic and the block
-   * has to be in FREEZING state. To be used to interface with the execution engine and aid in the compaction process.
+   * Inserts a tuple into the specified block, this function will ALWAYS be called from the compaction logic and the
+   * block has to be in FREEZING state. To be used to interface with the execution engine and aid in the compaction
+   * process.
    * @param txn the calling transaction
    * @param redo after-image of the inserted tuple
    * @param block the block to which the tuple should be inserted to
    * @return true if insertion is successful, false otherwise
    */
-  bool InsertIntoFreezingBlock(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo, RawBlock *block) {
-    TERRIER_ASSERT(block->controller_.GetBlockState()->load() == BlockState::FREEZING, "InsertIntoFreezingBlock should be called only from the compactor, and the block should be FREEZING.");
+  bool InsertIntoFreezingBlock(const common::ManagedPointer<transaction::TransactionContext> txn,
+                               const ProjectedRow &redo, RawBlock *block) {
+    TERRIER_ASSERT(
+        block->controller_.GetBlockState()->load() == BlockState::FREEZING,
+        "InsertIntoFreezingBlock should be called only from the compactor, and the block should be FREEZING.");
     return table_.data_table_->InsertIntoFreezingBlock(txn, redo, block);
   }
 

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -111,6 +111,19 @@ class SqlTable {
   }
 
   /**
+   * Inserts a tuple into the specified block, this function will ALWAYS be called from the compaction logic and the block
+   * has to be in FREEZING state. To be used to interface with the execution engine and aid in the compaction process.
+   * @param txn the calling transaction
+   * @param redo after-image of the inserted tuple
+   * @param block the block to which the tuple should be inserted to
+   * @return true if insertion is successful, false otherwise
+   */
+  bool InsertIntoFreezingBlock(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo, RawBlock *block) {
+    TERRIER_ASSERT(block->controller_.GetBlockState()->load() == BlockState::FREEZING, "InsertIntoFreezingBlock should be called only from the compactor, and the block should be FREEZING.");
+    return table_.data_table_->InsertIntoFreezingBlock(txn, redo, block);
+  }
+
+  /**
    * Deletes the given TupleSlot. StageDelete must have been called as well in order for the operation to be logged.
    * @param txn the calling transaction
    * @param slot the slot of the tuple to delete

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -126,7 +126,7 @@ class SqlTable {
    *
    * @param txn the calling transaction.
    * @param redo after-image of the inserted tuple.
-   * @param TupleSlot that the tuple was inserted into.
+   * @param dest TupleSlot that the tuple was inserted into.
    */
   void CompactionInsertInto(const common::ManagedPointer<transaction::TransactionContext> txn, RedoRecord *const redo,
                             const TupleSlot dest) const {

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -248,6 +248,7 @@ class SqlTable {
   friend class terrier::RandomSqlTableTransaction;
   friend class terrier::LargeSqlTableTestObject;
   friend class RecoveryTests;
+  friend class BlockCompactorTests; // For accessing layout in block compactor tests
 
   const common::ManagedPointer<BlockStore>
       block_store_;  // TODO(Matt): do we need this stashed at this layer? We don't use it.

--- a/src/include/storage/sql_table.h
+++ b/src/include/storage/sql_table.h
@@ -248,7 +248,7 @@ class SqlTable {
   friend class terrier::RandomSqlTableTransaction;
   friend class terrier::LargeSqlTableTestObject;
   friend class RecoveryTests;
-  friend class BlockCompactorTests; // For accessing layout in block compactor tests
+  friend class BlockCompactorTests; // For accessing layout, table in block compactor tests
 
   const common::ManagedPointer<BlockStore>
       block_store_;  // TODO(Matt): do we need this stashed at this layer? We don't use it.

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -22,6 +22,7 @@ class SqlTable;
 class WriteAheadLoggingTests;
 class RecoveryManager;
 class RecoveryTests;
+class BlockCompactorTests;
 }  // namespace terrier::storage
 
 namespace terrier::transaction {
@@ -212,6 +213,8 @@ class TransactionContext {
   friend class storage::WriteAheadLoggingTests;  // Needs access to redo buffer
   friend class storage::RecoveryManager;         // Needs access to StageRecoveryUpdate
   friend class storage::RecoveryTests;           // Needs access to redo buffer
+  friend class storage::BlockCompactorTests;    // Needs access to redo buffer
+
   const timestamp_t start_time_;
   std::atomic<timestamp_t> finish_time_;
   storage::UndoBuffer undo_buffer_;

--- a/src/storage/block_compactor.cpp
+++ b/src/storage/block_compactor.cpp
@@ -185,11 +185,8 @@ bool BlockCompactor::MoveTuple(CompactionGroup *cg, TupleSlot from, TupleSlot to
   // Copy the tuple into the empty slot
   // This operation cannot fail since a logically deleted slot can only be reclaimed by the compaction thread
   accessor.Reallocate(to);
-  cg->table_->InsertInto(common::ManagedPointer(cg->txn_), *record->Delta(), to);
 
-  // The delete can fail if a concurrent transaction is updating said tuple. We will have to abort if this is
-  // the case.
-  return cg->table_->Delete(common::ManagedPointer(cg->txn_), from);
+  return move_tuple_(&from, &to);
 }
 
 bool BlockCompactor::CheckForVersionsAndGaps(const TupleAccessStrategy &accessor, RawBlock *block) {

--- a/src/storage/block_compactor.cpp
+++ b/src/storage/block_compactor.cpp
@@ -186,7 +186,7 @@ bool BlockCompactor::MoveTuple(CompactionGroup *cg, TupleSlot from, TupleSlot to
   // This operation cannot fail since a logically deleted slot can only be reclaimed by the compaction thread
   accessor.Reallocate(to);
 
-  return move_tuple_(&from, &to);
+  return move_tuple_(exec_, &from, &to, col_oids_, table_name_);
 }
 
 bool BlockCompactor::CheckForVersionsAndGaps(const TupleAccessStrategy &accessor, RawBlock *block) {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -220,6 +220,7 @@ RawBlock *DataTable::CreateCompactedBlock() {
 
 void DataTable::CompactionInsertInto(const common::ManagedPointer<transaction::TransactionContext> txn,
                             const ProjectedRow &redo, TupleSlot dest) {
+  accessor_.Deallocate(dest);
   accessor_.Reallocate(dest);
   InsertInto(txn, redo, dest);
 }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -217,6 +217,13 @@ RawBlock *DataTable::CreateCompactedBlock() {
   return block;
 }
 
+
+void DataTable::CompactionInsertInto(const common::ManagedPointer<transaction::TransactionContext> txn,
+                            const ProjectedRow &redo, TupleSlot dest) {
+  accessor_.Reallocate(dest);
+  InsertInto(txn, redo, dest);
+}
+
 bool DataTable::InsertIntoFreezingBlock(common::ManagedPointer<transaction::TransactionContext> txn,
                                         const ProjectedRow &redo, RawBlock *block) {
   // This function should be called only from the compactor, while the block is FREEZING.

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -210,6 +210,22 @@ TupleSlot DataTable::Insert(const common::ManagedPointer<transaction::Transactio
   return result;
 }
 
+void DataTable::InsertIntoBlock(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo, RawBlock *block) {
+
+  TupleSlot new_slot;
+  // Set block status to busy
+  accessor_.SetBlockBusyStatus(block);
+  // Allocate a new TupleSlot
+  accessor_.Allocate(block, &new_slot);
+  // Clear the busy status
+  accessor_.ClearBlockBusyStatus(block);
+
+  // Insert the redo into the new TupleSlot created
+  InsertInto(txn, redo, new_slot);
+
+  data_table_counter_.IncrementNumInsert(1);
+}
+
 void DataTable::InsertInto(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo,
                            TupleSlot dest) {
   TERRIER_ASSERT(accessor_.Allocated(dest), "destination slot must already be allocated");

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -210,16 +210,18 @@ TupleSlot DataTable::Insert(const common::ManagedPointer<transaction::Transactio
   return result;
 }
 
-RawBlock* DataTable::CreateCompactedBlock() {
-  RawBlock* block = NewBlock();
+RawBlock *DataTable::CreateCompactedBlock() {
+  RawBlock *block = NewBlock();
   // This function is ONLY called during the compaction process, set the status to FREEZING.
   block->controller_.GetBlockState()->store(BlockState::FREEZING);
   return block;
 }
 
-bool DataTable::InsertIntoFreezingBlock(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &redo, RawBlock *block) {
+bool DataTable::InsertIntoFreezingBlock(common::ManagedPointer<transaction::TransactionContext> txn,
+                                        const ProjectedRow &redo, RawBlock *block) {
   // This function should be called only from the compactor, while the block is FREEZING.
-  TERRIER_ASSERT(block->controller_.GetBlockState()->load() == BlockState::FREEZING, "InsertIntoFreezingBlock should be called only from the compactor, and the block should be FREEZING.");
+  TERRIER_ASSERT(block->controller_.GetBlockState()->load() == BlockState::FREEZING,
+                 "InsertIntoFreezingBlock should be called only from the compactor, and the block should be FREEZING.");
 
   bool status = false;
   TupleSlot new_slot;
@@ -228,8 +230,25 @@ bool DataTable::InsertIntoFreezingBlock(common::ManagedPointer<transaction::Tran
 
   // Allocate a new TupleSlot
   if (accessor_.Allocate(block, &new_slot)) {
-    // Insert the redo into the new TupleSlot created
-    InsertInto(txn, redo, new_slot);
+    // Logic to insert redo into the new TupleSlot created. Similar to InsertInto function, but we want to
+    // keep the logic separate from normal Inserts as normally, insertion is allowed only for HOT blocks.
+    TERRIER_ASSERT(accessor_.Allocated(new_slot), "destination slot must already be allocated");
+    TERRIER_ASSERT(accessor_.IsNull(new_slot, VERSION_POINTER_COLUMN_ID),
+                   "The slot needs to be logically deleted to every running transaction");
+    // At this point, sequential scan down the block can still see this, except it thinks it is logically deleted if we
+    // 0 the primary key column
+    UndoRecord *undo = txn->UndoRecordForInsert(this, new_slot);
+    AtomicallyWriteVersionPtr(new_slot, accessor_, undo);
+    // Set the logically deleted bit to present as the undo record is ready
+    accessor_.AccessForceNotNull(new_slot, VERSION_POINTER_COLUMN_ID);
+    // Update in place with the new value.
+    for (uint16_t i = 0; i < redo.NumColumns(); i++) {
+      TERRIER_ASSERT(redo.ColumnIds()[i] != VERSION_POINTER_COLUMN_ID,
+                     "Insert buffer should not change the version pointer column.");
+      StorageUtil::CopyAttrFromProjection(accessor_, new_slot, redo, i);
+    }
+
+    // Insertion is complete at this point
     data_table_counter_.IncrementNumInsert(1);
     status = true;
   }

--- a/test/storage/block_compactor_test.cpp
+++ b/test/storage/block_compactor_test.cpp
@@ -1,8 +1,6 @@
 #include "storage/block_compactor.h"
 
 #include <memory>
-#include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "execution/exec/execution_context.h"
@@ -11,17 +9,12 @@
 #include "common/hash_util.h"
 #include "gtest/gtest.h"
 #include "main/db_main.h"
-#include "storage/block_access_controller.h"
-#include "storage/garbage_collector.h"
-#include "storage/garbage_collector_thread.h"
 #include "storage/index/index_builder.h"
-#include "storage/recovery/disk_log_provider.h"
 #include "storage/recovery/recovery_manager.h"
 #include "storage/sql_table.h"
 #include "storage/storage_defs.h"
 #include "storage/tuple_access_strategy.h"
 #include "storage/write_ahead_log/log_manager.h"
-#include "test_util/catalog_test_util.h"
 #include "test_util/sql_table_test_util.h"
 #include "test_util/storage_test_util.h"
 #include "test_util/test_harness.h"

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -359,5 +359,9 @@ TEST_F(DataTableTests, InsertIntoFreezingBlock) {
 
   // Once the tuple is inserted, the insertion head should be incremented by 1
   EXPECT_EQ(block->GetInsertHead(), 1);
+
+  // Cleanup
+  delete txn;
+  delete block;
 }
 }  // namespace terrier


### PR DESCRIPTION
* TPL built-ins for the following use cases:
    * To copy a tuple from one location to another
    * To insert into a specific TupleSlot
    * To allocate a new TupleSlot 
* New test in `sample_tpl/` that demonstrates the working of the newly created built-ins which inserts into a specific slot along with index updates.
* Added a new test file: `block_compactor_tpl_test.cpp` to verify the working of the newly added TPL built-in.
The original behaviour of `BlockCompactor` is retained, and we added a new function, `MoveTupleTPL` to demonstrate the working of the newly added TPL built-ins. For now, we have used hard-coded TPL code inside the `BlockCompactor`, this needs to be changed to generate code via `CodeGen` once the dependency issue is resolved. As mentioned in Future Work, it should be redesigned to prevent the circular dependency to `catalog` so that an execution context can be constructed from within the `BlockCompactor`.


You can find the design doc for the Project [here](https://github.com/721-Project-Team/Design-Docs).
