### PR TITLE
Compiled query caching added to PostgresProtocolInterpreter

### DIFF
--- a/src/execution/executable_query.cpp
+++ b/src/execution/executable_query.cpp
@@ -39,6 +39,15 @@ ExecutableQuery::ExecutableQuery(const common::ManagedPointer<planner::AbstractP
   ast_ctx_ = codegen.ReleaseContext();
   pipeline_operating_units_ = codegen.ReleasePipelineOperatingUnits();
   exec_ctx->SetPipelineOperatingUnits(common::ManagedPointer(pipeline_operating_units_));
+
+  TERRIER_ASSERT(tpl_module_ != nullptr, "Trying to run a module that failed to compile.");
+
+  // Compile the main function
+  if (!tpl_module_->GetFunction("main", execution::vm::ExecutionMode::Compiled, &main_)) {
+    EXECUTION_LOG_ERROR(
+        "Missing 'main' entry function with signature "
+        "(*ExecutionContext)->int32");
+  }
 }
 
 ExecutableQuery::ExecutableQuery(const std::string &filename,
@@ -89,16 +98,10 @@ ExecutableQuery::ExecutableQuery(const std::string &filename,
 void ExecutableQuery::Run(const common::ManagedPointer<exec::ExecutionContext> exec_ctx, const vm::ExecutionMode mode) {
   TERRIER_ASSERT(tpl_module_ != nullptr, "Trying to run a module that failed to compile.");
   exec_ctx->SetExecutionMode(static_cast<uint8_t>(mode));
+  exec_ctx->SetPipelineOperatingUnits(common::ManagedPointer(pipeline_operating_units_));
 
   // Run the main function
-  std::function<int64_t(exec::ExecutionContext *)> main;
-  if (!tpl_module_->GetFunction("main", mode, &main)) {
-    EXECUTION_LOG_ERROR(
-        "Missing 'main' entry function with signature "
-        "(*ExecutionContext)->int32");
-    return;
-  }
-  auto result = main(exec_ctx.Get());
+  auto result = main_(exec_ctx.Get());
   EXECUTION_LOG_DEBUG("main() returned: {}", result);
   exec_ctx->SetPipelineOperatingUnits(nullptr);
 }

--- a/src/execution/executable_query.cpp
+++ b/src/execution/executable_query.cpp
@@ -96,7 +96,6 @@ void ExecutableQuery::Run(const common::ManagedPointer<exec::ExecutionContext> e
         "Missing 'main' entry function with signature "
         "(*ExecutionContext)->int32");
   }
-
   auto result = main_(exec_ctx.Get());
   EXECUTION_LOG_DEBUG("main() returned: {}", result);
   exec_ctx->SetPipelineOperatingUnits(nullptr);

--- a/src/include/execution/executable_query.h
+++ b/src/include/execution/executable_query.h
@@ -8,6 +8,7 @@
 #include "common/strong_typedef.h"
 #include "execution/ast/context.h"
 #include "execution/exec_defs.h"
+#include "execution/vm/module.h"
 
 namespace terrier::planner {
 class AbstractPlanNode;
@@ -92,6 +93,8 @@ class ExecutableQuery {
 
   // TPL bytecodes for this query.
   std::unique_ptr<vm::Module> tpl_module_ = nullptr;
+
+  std::function<int64_t(exec::ExecutionContext *)> main_;
 
   // Memory region and AST context from the code generation stage that need to stay alive as long as the TPL module will
   // be executed. Direct access to these objects is likely unneeded from this class, we just want to tie the life cycles

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -352,7 +352,7 @@ class DBMain {
         TERRIER_ASSERT(use_execution_ && execution_layer != DISABLED, "TrafficCopLayer needs ExecutionLayer.");
         traffic_cop = std::make_unique<trafficcop::TrafficCop>(
             txn_layer->GetTransactionManager(), catalog_layer->GetCatalog(), DISABLED,
-            common::ManagedPointer(stats_storage), optimizer_timeout_);
+            common::ManagedPointer(stats_storage), optimizer_timeout_, use_query_cache_);
       }
 
       std::unique_ptr<NetworkLayer> network_layer = DISABLED;
@@ -592,6 +592,15 @@ class DBMain {
      * @param value use component
      * @return self reference for chaining
      */
+    Builder &SetUseQueryCache(const bool value) {
+      ues_query_cache_ = value;
+      return *this;
+    }
+
+    /**
+     * @param value use component
+     * @return self reference for chaining
+     */
     Builder &SetUseExecution(const bool value) {
       use_execution_ = value;
       return *this;
@@ -627,6 +636,7 @@ class DBMain {
     bool use_execution_ = false;
     bool use_traffic_cop_ = false;
     uint64_t optimizer_timeout_ = 5000;
+    bool use_query_cache_ = true;
     uint16_t network_port_ = 15721;
     uint16_t connection_thread_count_ = 4;
     bool use_network_ = false;
@@ -661,6 +671,7 @@ class DBMain {
       connection_thread_count_ =
           static_cast<uint16_t>(settings_manager->GetInt(settings::Param::connection_thread_count));
       optimizer_timeout_ = static_cast<uint64_t>(settings_manager->GetInt(settings::Param::task_execution_timeout));
+      use_query_cache_ = settings_manager->GetInt(settings::Param::use_query_cache);
 
       return settings_manager;
     }

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -593,7 +593,7 @@ class DBMain {
      * @return self reference for chaining
      */
     Builder &SetUseQueryCache(const bool value) {
-      ues_query_cache_ = value;
+      use_query_cache_ = value;
       return *this;
     }
 
@@ -671,7 +671,7 @@ class DBMain {
       connection_thread_count_ =
           static_cast<uint16_t>(settings_manager->GetInt(settings::Param::connection_thread_count));
       optimizer_timeout_ = static_cast<uint64_t>(settings_manager->GetInt(settings::Param::task_execution_timeout));
-      use_query_cache_ = settings_manager->GetInt(settings::Param::use_query_cache);
+      use_query_cache_ = settings_manager->GetBool(settings::Param::use_query_cache);
 
       return settings_manager;
     }

--- a/src/include/network/postgres/portal.h
+++ b/src/include/network/postgres/portal.h
@@ -23,14 +23,12 @@ class Portal {
   /**
    * Constructor that doesnt have params or result_formats, i.e. Simple Query protocol
    * @param statement statement that this Portal refers to
-   * @param physical_plan optimized plan ready for execution
    */
   explicit Portal(const common::ManagedPointer<Statement> statement) : Portal(statement, {}, {FieldFormat::text}) {}
 
   /**
    * Constructor that doesnt have params or result_formats, i.e. Extended Query protocol
    * @param statement statement that this Portal refers to
-   * @param physical_plan optimized plan ready for execution
    * @param params params for this query
    * @param result_formats output formats for this query
    */

--- a/src/include/network/postgres/portal.h
+++ b/src/include/network/postgres/portal.h
@@ -25,7 +25,7 @@ class Portal {
    * @param statement statement that this Portal refers to
    * @param physical_plan optimized plan ready for execution
    */
-  Portal(const common::ManagedPointer<Statement> statement) : Portal(statement, {}, {FieldFormat::text}) {}
+  explicit Portal(const common::ManagedPointer<Statement> statement) : Portal(statement, {}, {FieldFormat::text}) {}
 
   /**
    * Constructor that doesnt have params or result_formats, i.e. Extended Query protocol

--- a/src/include/network/postgres/portal.h
+++ b/src/include/network/postgres/portal.h
@@ -25,8 +25,7 @@ class Portal {
    * @param statement statement that this Portal refers to
    * @param physical_plan optimized plan ready for execution
    */
-  Portal(const common::ManagedPointer<Statement> statement, std::unique_ptr<planner::AbstractPlanNode> &&physical_plan)
-      : Portal(statement, std::move(physical_plan), {}, {FieldFormat::text}) {}
+  Portal(const common::ManagedPointer<Statement> statement) : Portal(statement, {}, {FieldFormat::text}) {}
 
   /**
    * Constructor that doesnt have params or result_formats, i.e. Extended Query protocol
@@ -35,12 +34,9 @@ class Portal {
    * @param params params for this query
    * @param result_formats output formats for this query
    */
-  Portal(const common::ManagedPointer<Statement> statement, std::unique_ptr<planner::AbstractPlanNode> &&physical_plan,
-         std::vector<type::TransientValue> &&params, std::vector<FieldFormat> &&result_formats)
-      : statement_(statement),
-        physical_plan_(std::move(physical_plan)),
-        params_(std::move(params)),
-        result_formats_(std::move(result_formats)) {}
+  Portal(const common::ManagedPointer<Statement> statement, std::vector<type::TransientValue> &&params,
+         std::vector<FieldFormat> &&result_formats)
+      : statement_(statement), params_(std::move(params)), result_formats_(std::move(result_formats)) {}
 
   /**
    * @return Statement that this Portal references
@@ -50,9 +46,7 @@ class Portal {
   /**
    * @return the optimized physical plan for this query
    */
-  common::ManagedPointer<planner::AbstractPlanNode> PhysicalPlan() const {
-    return common::ManagedPointer(physical_plan_);
-  }
+  common::ManagedPointer<planner::AbstractPlanNode> PhysicalPlan() const { return statement_->PhysicalPlan(); }
 
   /**
    * @return output formats for this query
@@ -68,7 +62,6 @@ class Portal {
 
  private:
   const common::ManagedPointer<network::Statement> statement_;
-  std::unique_ptr<planner::AbstractPlanNode> physical_plan_;
   const std::vector<type::TransientValue> params_;
   const std::vector<FieldFormat> result_formats_;
 };

--- a/src/include/network/postgres/postgres_protocol_interpreter.h
+++ b/src/include/network/postgres/postgres_protocol_interpreter.h
@@ -165,6 +165,10 @@ class PostgresProtocolInterpreter : public ProtocolInterpreter {
     statement_cache_[fingerprint] = std::move(statement);
   }
 
+  /**
+   * @param fingerprint key
+   * @return Statement if it exists in the cache, otherwise nullptr
+   */
   common::ManagedPointer<network::Statement> LookupStatementInCache(const std::string &fingerprint) const {
     const auto it = statement_cache_.find(fingerprint);
     if (it != statement_cache_.end()) return common::ManagedPointer(it->second);

--- a/src/include/network/postgres/statement.h
+++ b/src/include/network/postgres/statement.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "common/managed_pointer.h"
+#include "execution/executable_query.h"
 #include "network/postgres/statement.h"
 #include "parser/postgresparser.h"
 #include "traffic_cop/traffic_cop_util.h"
@@ -81,11 +82,36 @@ class Statement {
    */
   QueryType GetQueryType() const { return type_; }
 
+  /**
+   * @return the optimized physical plan for this query
+   */
+  common::ManagedPointer<planner::AbstractPlanNode> PhysicalPlan() const {
+    return common::ManagedPointer(physical_plan_);
+  }
+
+  /**
+   * @return the compiled executable query
+   */
+  common::ManagedPointer<execution::ExecutableQuery> GetExecutableQuery() const {
+    return common::ManagedPointer(executable_query_);
+  }
+
+  void SetPhysicalPlan(std::unique_ptr<planner::AbstractPlanNode> &&physical_plan) {
+    physical_plan_ = std::move(physical_plan);
+  }
+
+  void SetExecutableQuery(std::unique_ptr<execution::ExecutableQuery> &&executable_query) {
+    executable_query_ = std::move(executable_query);
+  }
+
  private:
   const std::unique_ptr<parser::ParseResult> parse_result_ = nullptr;
   const std::vector<type::TypeId> param_types_;
   common::ManagedPointer<parser::SQLStatement> root_statement_ = nullptr;
   enum QueryType type_ = QueryType::QUERY_INVALID;
+
+  std::unique_ptr<planner::AbstractPlanNode> physical_plan_ = nullptr;
+  std::unique_ptr<execution::ExecutableQuery> executable_query_ = nullptr;
 };
 
 }  // namespace terrier::network

--- a/src/include/network/postgres/statement.h
+++ b/src/include/network/postgres/statement.h
@@ -96,10 +96,16 @@ class Statement {
     return common::ManagedPointer(executable_query_);
   }
 
+  /**
+   * @param physical_plan physical plan to take ownership of
+   */
   void SetPhysicalPlan(std::unique_ptr<planner::AbstractPlanNode> &&physical_plan) {
     physical_plan_ = std::move(physical_plan);
   }
 
+  /**
+   * @param executable_query executable query to take ownership of
+   */
   void SetExecutableQuery(std::unique_ptr<execution::ExecutableQuery> &&executable_query) {
     executable_query_ = std::move(executable_query);
   }

--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -168,3 +168,11 @@ SETTING_bool(
     true,
     terrier::settings::Callbacks::MetricsPipeline
 )
+
+SETTING_bool(
+    use_query_cache,
+    "Extended Query protocol caches physical plans and generated code after first execution. Warning: bugs with DDL changes.",
+    true,
+    false,
+    terrier::settings::Callbacks::NoOp
+)

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -164,18 +164,6 @@ class TrafficCop {
    * @param portal to be executed, may contain parameters
    * @return result of the operation
    */
-  //  TrafficCopResult CodegenAndRunPhysicalPlan(common::ManagedPointer<network::ConnectionContext> connection_ctx,
-  //                                             common::ManagedPointer<network::PostgresPacketWriter> out,
-  //                                             common::ManagedPointer<network::Portal> portal) const;
-
-  /**
-   * Contains the logic to reason about DML execution. Responsible for outputting results because we don't want to
-   * (can't) stick it in TrafficCopResult.
-   * @param connection_ctx context to be used to access the internal txn
-   * @param out packet writer to return results
-   * @param portal to be executed, may contain parameters
-   * @return result of the operation
-   */
   TrafficCopResult CodegenPhysicalPlan(common::ManagedPointer<network::ConnectionContext> connection_ctx,
                                        common::ManagedPointer<network::PostgresPacketWriter> out,
                                        common::ManagedPointer<network::Portal> portal) const;

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -188,6 +188,9 @@ class TrafficCop {
    */
   void SetOptimizerTimeout(const uint64_t optimizer_timeout) { optimizer_timeout_ = optimizer_timeout; }
 
+  /**
+   * @return true if query caching enabled, false otherwise
+   */
   bool UseQueryCache() const { return use_query_cache_; }
 
  private:

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -44,16 +44,19 @@ class TrafficCop {
    * @param replication_log_provider if given, the tcop will forward replication logs to this provider
    * @param stats_storage for optimizer calls
    * @param optimizer_timeout for optimizer calls
+   * @param use_query_cache whether to cache physical plans and generated code for Extended Query protocol
    */
   TrafficCop(common::ManagedPointer<transaction::TransactionManager> txn_manager,
              common::ManagedPointer<catalog::Catalog> catalog,
              common::ManagedPointer<storage::ReplicationLogProvider> replication_log_provider,
-             common::ManagedPointer<optimizer::StatsStorage> stats_storage, uint64_t optimizer_timeout)
+             common::ManagedPointer<optimizer::StatsStorage> stats_storage, uint64_t optimizer_timeout,
+             bool use_query_cache)
       : txn_manager_(txn_manager),
         catalog_(catalog),
         replication_log_provider_(replication_log_provider),
         stats_storage_(stats_storage),
-        optimizer_timeout_(optimizer_timeout) {}
+        optimizer_timeout_(optimizer_timeout),
+        use_query_cache_(use_query_cache) {}
 
   virtual ~TrafficCop() = default;
 
@@ -185,6 +188,8 @@ class TrafficCop {
    */
   void SetOptimizerTimeout(const uint64_t optimizer_timeout) { optimizer_timeout_ = optimizer_timeout; }
 
+  bool UseQueryCache() const { return use_query_cache_; }
+
  private:
   common::ManagedPointer<transaction::TransactionManager> txn_manager_;
   common::ManagedPointer<catalog::Catalog> catalog_;
@@ -192,6 +197,7 @@ class TrafficCop {
   common::ManagedPointer<storage::ReplicationLogProvider> replication_log_provider_;
   common::ManagedPointer<optimizer::StatsStorage> stats_storage_;
   uint64_t optimizer_timeout_;
+  bool use_query_cache_;
 };
 
 }  // namespace terrier::trafficcop

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -164,9 +164,32 @@ class TrafficCop {
    * @param portal to be executed, may contain parameters
    * @return result of the operation
    */
-  TrafficCopResult CodegenAndRunPhysicalPlan(common::ManagedPointer<network::ConnectionContext> connection_ctx,
-                                             common::ManagedPointer<network::PostgresPacketWriter> out,
-                                             common::ManagedPointer<network::Portal> portal) const;
+//  TrafficCopResult CodegenAndRunPhysicalPlan(common::ManagedPointer<network::ConnectionContext> connection_ctx,
+//                                             common::ManagedPointer<network::PostgresPacketWriter> out,
+//                                             common::ManagedPointer<network::Portal> portal) const;
+
+  /**
+   * Contains the logic to reason about DML execution. Responsible for outputting results because we don't want to
+   * (can't) stick it in TrafficCopResult.
+   * @param connection_ctx context to be used to access the internal txn
+   * @param out packet writer to return results
+   * @param portal to be executed, may contain parameters
+   * @return result of the operation
+   */
+  TrafficCopResult CodegenPhysicalPlan(common::ManagedPointer<network::ConnectionContext> connection_ctx,
+                                       common::ManagedPointer<network::PostgresPacketWriter> out,
+                                       common::ManagedPointer<network::Portal> portal) const;
+  /**
+   * Contains the logic to reason about DML execution. Responsible for outputting results because we don't want to
+   * (can't) stick it in TrafficCopResult.
+   * @param connection_ctx context to be used to access the internal txn
+   * @param out packet writer to return results
+   * @param portal to be executed, may contain parameters
+   * @return result of the operation
+   */
+  TrafficCopResult RunExecutableQuery(common::ManagedPointer<network::ConnectionContext> connection_ctx,
+                                      common::ManagedPointer<network::PostgresPacketWriter> out,
+                                      common::ManagedPointer<network::Portal> portal) const;
 
   /**
    * Adjust the TrafficCop's optimizer timeout value (for use by SettingsManager)

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -164,9 +164,9 @@ class TrafficCop {
    * @param portal to be executed, may contain parameters
    * @return result of the operation
    */
-//  TrafficCopResult CodegenAndRunPhysicalPlan(common::ManagedPointer<network::ConnectionContext> connection_ctx,
-//                                             common::ManagedPointer<network::PostgresPacketWriter> out,
-//                                             common::ManagedPointer<network::Portal> portal) const;
+  //  TrafficCopResult CodegenAndRunPhysicalPlan(common::ManagedPointer<network::ConnectionContext> connection_ctx,
+  //                                             common::ManagedPointer<network::PostgresPacketWriter> out,
+  //                                             common::ManagedPointer<network::Portal> portal) const;
 
   /**
    * Contains the logic to reason about DML execution. Responsible for outputting results because we don't want to

--- a/src/network/postgres/postgres_network_commands.cpp
+++ b/src/network/postgres/postgres_network_commands.cpp
@@ -216,7 +216,7 @@ Transition ParseCommand::Exec(const common::ManagedPointer<ProtocolInterpreter> 
     out->WriteNoticeResponse("NOTICE:  we don't yet support that query type.");
   }
 
-  const auto fingerprint_result UNUSED_ATTRIBUTE = pg_query_fingerprint(query.c_str());
+  const auto fingerprint_result = pg_query_fingerprint(query.c_str());
   auto cached_statement = postgres_interpreter->LookupStatementInCache(fingerprint_result.hexdigest);
   if (cached_statement == nullptr) {
     // Not in the cache, add to cache

--- a/src/network/postgres/postgres_network_commands.cpp
+++ b/src/network/postgres/postgres_network_commands.cpp
@@ -271,6 +271,7 @@ Transition BindCommand::Exec(const common::ManagedPointer<ProtocolInterpreter> i
   TERRIER_ASSERT(param_formats.size() == 1 || param_formats.size() == statement->ParamTypes().size(),
                  "Incorrect number of parameter format codes. Should either be 1 (all the same) or the number of "
                  "parameters required for this statement.");
+  // TODO(Matt): probably shouldn't be an assert, but rather an error response
 
   // read the params
   auto params =

--- a/src/network/postgres/postgres_network_commands.cpp
+++ b/src/network/postgres/postgres_network_commands.cpp
@@ -319,7 +319,7 @@ Transition BindCommand::Exec(const common::ManagedPointer<ProtocolInterpreter> i
   const auto bind_result = t_cop->BindQuery(connection, statement, common::ManagedPointer(&params));
   if (bind_result.type_ == trafficcop::ResultType::COMPLETE) {
     // Binding succeeded, optimize to generate a physical plan
-    if (statement->PhysicalPlan() == nullptr) {
+    if (statement->PhysicalPlan() == nullptr || !t_cop->UseQueryCache()) {
       // it's not cached, optimize it
       auto physical_plan = t_cop->OptimizeBoundQuery(connection, statement->ParseResult());
       statement->SetPhysicalPlan(std::move(physical_plan));

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -265,10 +265,44 @@ TrafficCopResult TrafficCop::BindQuery(
   return {ResultType::COMPLETE, 0};
 }
 
-TrafficCopResult TrafficCop::CodegenAndRunPhysicalPlan(
+TrafficCopResult TrafficCop::CodegenPhysicalPlan(
     const common::ManagedPointer<network::ConnectionContext> connection_ctx,
     const common::ManagedPointer<network::PostgresPacketWriter> out,
     const common::ManagedPointer<network::Portal> portal) const {
+  TERRIER_ASSERT(connection_ctx->TransactionState() == network::NetworkTransactionStateType::BLOCK,
+                 "Not in a valid txn. This should have been caught before calling this function.");
+  const auto query_type UNUSED_ATTRIBUTE = portal->GetStatement()->GetQueryType();
+  const auto physical_plan = portal->PhysicalPlan();
+  TERRIER_ASSERT(query_type == network::QueryType::QUERY_SELECT || query_type == network::QueryType::QUERY_INSERT ||
+                     query_type == network::QueryType::QUERY_UPDATE || query_type == network::QueryType::QUERY_DELETE,
+                 "CodegenAndRunPhysicalPlan called with invalid QueryType.");
+
+  if (portal->GetStatement()->GetExecutableQuery() != nullptr) {
+    // We've already codegen'd this, move on...
+    return {ResultType::COMPLETE, 0};
+  }
+
+  // TODO(Matt): We should get rid of the need of an OutputWriter to ExecutionContext since we just throw this one away
+  execution::exec::OutputWriter writer(physical_plan->GetOutputSchema(), out, portal->ResultFormats());
+
+  // TODO(Matt): We should get rid of the need of an ExecutionContext to perform codegen since we just throw this one
+  // away
+  auto exec_ctx = std::make_unique<execution::exec::ExecutionContext>(
+      connection_ctx->GetDatabaseOid(), connection_ctx->Transaction(), writer, physical_plan->GetOutputSchema().Get(),
+      connection_ctx->Accessor());
+
+  auto exec_query = std::make_unique<execution::ExecutableQuery>(common::ManagedPointer(physical_plan),
+                                                                 common::ManagedPointer(exec_ctx));
+
+  // TODO(Matt): handle code generation failing
+  portal->GetStatement()->SetExecutableQuery(std::move(exec_query));
+
+  return {ResultType::COMPLETE, 0};
+}
+
+TrafficCopResult TrafficCop::RunExecutableQuery(const common::ManagedPointer<network::ConnectionContext> connection_ctx,
+                                                const common::ManagedPointer<network::PostgresPacketWriter> out,
+                                                const common::ManagedPointer<network::Portal> portal) const {
   TERRIER_ASSERT(connection_ctx->TransactionState() == network::NetworkTransactionStateType::BLOCK,
                  "Not in a valid txn. This should have been caught before calling this function.");
   const auto query_type = portal->GetStatement()->GetQueryType();
@@ -284,9 +318,9 @@ TrafficCopResult TrafficCop::CodegenAndRunPhysicalPlan(
 
   exec_ctx->SetParams(portal->Parameters());
 
-  auto exec_query = execution::ExecutableQuery(common::ManagedPointer(physical_plan), common::ManagedPointer(exec_ctx));
+  const auto exec_query = portal->GetStatement()->GetExecutableQuery();
 
-  exec_query.Run(common::ManagedPointer(exec_ctx), execution::vm::ExecutionMode::Interpret);
+  exec_query->Run(common::ManagedPointer(exec_ctx), execution::vm::ExecutionMode::Compiled);
 
   if (connection_ctx->TransactionState() == network::NetworkTransactionStateType::BLOCK) {
     // Execution didn't set us to FAIL state, go ahead and return command complete

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -277,7 +277,7 @@ TrafficCopResult TrafficCop::CodegenPhysicalPlan(
                      query_type == network::QueryType::QUERY_UPDATE || query_type == network::QueryType::QUERY_DELETE,
                  "CodegenAndRunPhysicalPlan called with invalid QueryType.");
 
-  if (portal->GetStatement()->GetExecutableQuery() != nullptr) {
+  if (portal->GetStatement()->GetExecutableQuery() != nullptr && use_query_cache_) {
     // We've already codegen'd this, move on...
     return {ResultType::COMPLETE, 0};
   }

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -320,7 +320,7 @@ TrafficCopResult TrafficCop::RunExecutableQuery(const common::ManagedPointer<net
 
   const auto exec_query = portal->GetStatement()->GetExecutableQuery();
 
-  exec_query->Run(common::ManagedPointer(exec_ctx), execution::vm::ExecutionMode::Compiled);
+  exec_query->Run(common::ManagedPointer(exec_ctx), execution::vm::ExecutionMode::Interpret);
 
   if (connection_ctx->TransactionState() == network::NetworkTransactionStateType::BLOCK) {
     // Execution didn't set us to FAIL state, go ahead and return command complete

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -68,7 +68,7 @@ class NetworkTests : public TerrierTest {
                                     common::ManagedPointer(gc_));
 
     tcop_ = new trafficcop::TrafficCop(common::ManagedPointer(txn_manager_), common::ManagedPointer(catalog_), DISABLED,
-                                       DISABLED, 0);
+                                       DISABLED, 0, false);
 
     auto txn = txn_manager_->BeginTransaction();
     catalog_->CreateDatabase(common::ManagedPointer(txn), catalog::DEFAULT_DATABASE, true);


### PR DESCRIPTION
At a high level, this implements a mechanism to cache physical plans and `ExecutableQuery` (TPL module, AST context, etc.) from code generation in `PostgresProtocolInterpreter`. It relies on libpgquery's pg_fingerprint functionality to identify statements. It builds on top of the Postgres extended query protocol, and doesn't change anything for simple query.

Changes:
- `ExecutableQuery` stashes the main function as a member.
- `Portal` no longer owns the physical plan, but holds a `ManagedPointer` to it.
- `Statement` owns the physical plan and `ExecutableQuery` of its bound `Portal`s. A `Portal` just describes the parameters and output format for that invocation of the `Statement`.
- A new map in `PostgresProtocolInterpreter` from fingerprint to owned `Statement`. The old `Statement` map from name to statement is now not owning.
` After first code generation of a `Statement` at the execute phase, we stash the physical plan and `ExecutableQuery` upstream to be reused at later invocations.

Limitations:
- We have no cache invalidation scheme. This will introduce bugs with DDL changes.
- We should figure out how to do code generation without an `ExecutionContext`. It would allow us to perform that step at the bind phase, rather than execution, which seems more natural to me. Perhaps that goes against adaptive execution though.