### PR TITLE
Fix bug in OpGetParamString in bytecode_handlers

### DIFF
--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1720,7 +1720,7 @@ VM_OP_HOT void OpGetParamString(terrier::execution::sql::StringVal *ret,
   if (val->is_null_) {
     ret->is_null_ = true;
   } else {
-    *ret = terrier::execution::sql::StringVal(val->ptr_, val->len_);
+    *ret = terrier::execution::sql::StringVal(val->Content(), val->len_);
     ret->is_null_ = false;
   }
 }


### PR DESCRIPTION
Introduced by #911. Caught this while trying to run TPC-C in Extended Query mode locally. Should use Content() to access StringVal, not assume it's the inlined pointer.