### PR TITLE
Change CVE's underlying value to be a std::variant

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,11 +94,11 @@ pipeline {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | ./script/installation/packages.sh'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON .. && make -j4'
+                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j4'
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && gtimeout 1h make unittest'
                         sh 'cd build && gtimeout 1h make check-tpl'
-                        sh 'cd build && python3 ../script/testing/junit/run_junit.py --build-type=debug'
+                        sh 'cd build && gtimeout 1h python3 ../script/testing/junit/run_junit.py --build-type=debug'
                     }
                     post {
                         cleanup {
@@ -119,11 +119,11 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'sudo apt-get -y install ccache lsof'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && python3 ../script/testing/junit/run_junit.py --build-type=debug'
+                        sh 'cd build && timeout 1h python3 ../script/testing/junit/run_junit.py --build-type=debug'
                     }
                     post {
                         cleanup {
@@ -147,10 +147,10 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'sudo apt-get -y install curl lcov ccache'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=OFF -DTERRIER_GENERATE_COVERAGE=ON -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF -DTERRIER_GENERATE_COVERAGE=ON .. && make -j$(nproc)'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && python3 ../script/testing/junit/run_junit.py --build-type=debug'
+                        sh 'cd build && timeout 1h python3 ../script/testing/junit/run_junit.py --build-type=debug'
                         sh 'cd build && lcov --directory . --capture --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'/usr/*\' --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'*/build/*\' --output-file coverage.info'
@@ -186,11 +186,11 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'sudo apt-get -y install ccache lsof'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=ON -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && python3 ../script/testing/junit/run_junit.py --build-type=debug'
+                        sh 'cd build && timeout 1h python3 ../script/testing/junit/run_junit.py --build-type=debug'
                     }
                     post {
                         cleanup {
@@ -209,10 +209,10 @@ pipeline {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | ./script/installation/packages.sh'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j4'
+                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j4'
                         sh 'cd build && gtimeout 1h make unittest'
                         sh 'cd build && gtimeout 1h make check-tpl'
-                        sh 'cd build && python3 ../script/testing/junit/run_junit.py --build-type=release'
+                        sh 'cd build && gtimeout 1h python3 ../script/testing/junit/run_junit.py --build-type=release'
                     }
                     post {
                         cleanup {
@@ -233,10 +233,10 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'sudo apt-get -y install ccache'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && python3 ../script/testing/junit/run_junit.py --build-type=release'
+                        sh 'cd build && timeout 1h python3 ../script/testing/junit/run_junit.py --build-type=release'
                     }
                     post {
                         cleanup {
@@ -261,10 +261,10 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'sudo apt-get -y install ccache'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && python3 ../script/testing/junit/run_junit.py --build-type=release'
+                        sh 'cd build && timeout 1h python3 ../script/testing/junit/run_junit.py --build-type=release'
                     }
                     post {
                         cleanup {
@@ -274,7 +274,7 @@ pipeline {
                 }
             }
         }
-        
+
         stage('End-to-End') {
             parallel{
                 stage('macos-10.14/AppleClang-1001.0.46.4 (Debug/e2etest/oltpbench)') {
@@ -288,11 +288,11 @@ pipeline {
                         sh 'echo y | ./script/installation/packages.sh'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) all'
-                        sh 'cd build && python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=release --loader-threads=4'
+                        sh 'cd build && gtimeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=release --loader-threads=4'
                         // TODO: Loading the smallbank database with multiple threads is broken on OSX
-                        sh 'cd build && python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=release --loader-threads=1'
-                        sh 'cd build && python3 ../script/testing/oltpbench/run_oltpbench.py tpcc 45,43,4,4,4 --build-type=release --loader-threads=4'
-                        sh 'cd build && python3 ../script/testing/oltpbench/run_oltpbench.py noop 100 --build-type=release'
+                        sh 'cd build && gtimeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=release --loader-threads=1'
+                        sh 'cd build && gtimeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tpcc 45,43,4,4,4 --build-type=release --loader-threads=4'
+                        sh 'cd build && gtimeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py noop 100 --build-type=release'
                     }
                     post {
                         cleanup {
@@ -312,10 +312,10 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) all'
-                        sh 'cd build && python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=release --loader-threads=4'
-                        sh 'cd build && python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=release --loader-threads=4'
-                        sh 'cd build && python3 ../script/testing/oltpbench/run_oltpbench.py tpcc 45,43,4,4,4 --build-type=release --loader-threads=4'
-                        sh 'cd build && python3 ../script/testing/oltpbench/run_oltpbench.py noop 100 --build-type=release'
+                        sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=release --loader-threads=4'
+                        sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=release --loader-threads=4'
+                        sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tpcc 45,43,4,4,4 --build-type=release --loader-threads=4'
+                        sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py noop 100 --build-type=release'
                     }
                     post {
                         cleanup {

--- a/benchmark/runner/mini_runners.cpp
+++ b/benchmark/runner/mini_runners.cpp
@@ -360,8 +360,7 @@ BENCHMARK_DEFINE_F(MiniRunners, InsertRunners)(benchmark::State &state) {
       std::stringstream col_name;
       col_name << "col" << j;
       cols.emplace_back(col_name.str(), type::TypeId::INTEGER, false,
-                        terrier::parser::ConstantValueExpression(type::TypeId::INTEGER,
-                                                                 std::make_unique<execution::sql::Integer>(0)));
+                        terrier::parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(0)));
     }
     catalog::Schema tmp_schema(cols);
 

--- a/benchmark/storage/recovery_benchmark.cpp
+++ b/benchmark/storage/recovery_benchmark.cpp
@@ -163,9 +163,9 @@ BENCHMARK_DEFINE_F(RecoveryBenchmark, IndexRecovery)(benchmark::State &state) {
     auto namespace_oid = catalog_accessor->CreateNamespace(namespace_name);
 
     // Create random table
-    auto col = catalog::Schema::Column(
-        "col1", type::TypeId::INTEGER, false,
-        parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(0)));
+    auto col =
+        catalog::Schema::Column("col1", type::TypeId::INTEGER, false,
+                                parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(0)));
     catalog::Schema schema({col});
     auto table_oid = catalog_accessor->CreateTable(namespace_oid, table_name, schema);
     schema = catalog_accessor->GetSchema(table_oid);

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -344,8 +344,8 @@ void BindNodeVisitor::Visit(common::ManagedPointer<parser::InsertStatement> node
               cols.emplace_back(pair);
             } else {
               // Make a null value of the right type that we can either compare with the stored expression or insert.
-              auto null_ex = std::make_unique<parser::ConstantValueExpression>(
-                  schema_col.Type(), std::make_unique<execution::sql::Val>(true));
+              auto null_ex =
+                  std::make_unique<parser::ConstantValueExpression>(schema_col.Type(), execution::sql::Val(true));
 
               // TODO(WAN): We thought that you might be able to collapse these two cases into one, since currently
               // the catalog column's stored expression is always a NULL of the right type if not otherwise specified.

--- a/src/binder/binder_sherpa.cpp
+++ b/src/binder/binder_sherpa.cpp
@@ -111,7 +111,7 @@ void BinderSherpa::CheckAndTryPromoteType(const common::ManagedPointer<parser::C
 
         // DATE and TIMESTAMP conversion. String to numeric type conversion.
       case type::TypeId::VARCHAR: {
-        const auto str_view = value->GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView();
+        const auto str_view = value->Peek<std::string_view>();
 
         // TODO(WAN): A bit stupid to take the string view back into a string.
         switch (desired_type) {
@@ -120,9 +120,9 @@ void BinderSherpa::CheckAndTryPromoteType(const common::ManagedPointer<parser::C
             if (!parsed_date.first) {
               ReportFailure("Binder conversion from VARCHAR to DATE failed.");
             }
-            value->SetValue(type::TypeId::DATE,
-                            std::make_unique<execution::sql::DateVal>(
-                                execution::sql::Date::FromNative(static_cast<uint32_t>(parsed_date.second))));
+            value->SetValue(
+                type::TypeId::DATE,
+                execution::sql::DateVal(execution::sql::Date::FromNative(static_cast<uint32_t>(parsed_date.second))));
             break;
           }
           case type::TypeId::TIMESTAMP: {
@@ -130,9 +130,8 @@ void BinderSherpa::CheckAndTryPromoteType(const common::ManagedPointer<parser::C
             if (!parsed_timestamp.first) {
               ReportFailure("Binder conversion from VARCHAR to TIMESTAMP failed.");
             }
-            value->SetValue(type::TypeId::TIMESTAMP,
-                            std::make_unique<execution::sql::TimestampVal>(
-                                execution::sql::Timestamp::FromNative(static_cast<uint64_t>(parsed_timestamp.second))));
+            value->SetValue(type::TypeId::TIMESTAMP, execution::sql::TimestampVal(execution::sql::Timestamp::FromNative(
+                                                         static_cast<uint64_t>(parsed_timestamp.second))));
             break;
           }
           case type::TypeId::TINYINT: {
@@ -140,7 +139,7 @@ void BinderSherpa::CheckAndTryPromoteType(const common::ManagedPointer<parser::C
             if (!IsRepresentable<int8_t>(int_val)) {
               throw BINDER_EXCEPTION("BinderSherpa cannot fit that VARCHAR into the desired type!");
             }
-            value->SetValue(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(int_val));
+            value->SetValue(type::TypeId::TINYINT, execution::sql::Integer(int_val));
             break;
           }
           case type::TypeId::SMALLINT: {
@@ -148,7 +147,7 @@ void BinderSherpa::CheckAndTryPromoteType(const common::ManagedPointer<parser::C
             if (!IsRepresentable<int16_t>(int_val)) {
               throw BINDER_EXCEPTION("BinderSherpa cannot fit that VARCHAR into the desired type!");
             }
-            value->SetValue(type::TypeId::SMALLINT, std::make_unique<execution::sql::Integer>(int_val));
+            value->SetValue(type::TypeId::SMALLINT, execution::sql::Integer(int_val));
             break;
           }
           case type::TypeId::INTEGER: {
@@ -156,7 +155,7 @@ void BinderSherpa::CheckAndTryPromoteType(const common::ManagedPointer<parser::C
             if (!IsRepresentable<int32_t>(int_val)) {
               throw BINDER_EXCEPTION("BinderSherpa cannot fit that VARCHAR into the desired type!");
             }
-            value->SetValue(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(int_val));
+            value->SetValue(type::TypeId::INTEGER, execution::sql::Integer(int_val));
             break;
           }
           case type::TypeId::BIGINT: {
@@ -164,7 +163,7 @@ void BinderSherpa::CheckAndTryPromoteType(const common::ManagedPointer<parser::C
             if (!IsRepresentable<int64_t>(int_val)) {
               throw BINDER_EXCEPTION("BinderSherpa cannot fit that VARCHAR into the desired type!");
             }
-            value->SetValue(type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(int_val));
+            value->SetValue(type::TypeId::BIGINT, execution::sql::Integer(int_val));
             break;
           }
           case type::TypeId::DECIMAL: {
@@ -175,7 +174,7 @@ void BinderSherpa::CheckAndTryPromoteType(const common::ManagedPointer<parser::C
               } catch (std::exception &e) {
                 throw BINDER_EXCEPTION("BinderSherpa cannot fit that VARCHAR into the desired type!");
               }
-              value->SetValue(type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(double_val));
+              value->SetValue(type::TypeId::DECIMAL, execution::sql::Real(double_val));
               break;
             }
           }

--- a/src/binder/binder_sherpa.cpp
+++ b/src/binder/binder_sherpa.cpp
@@ -83,32 +83,28 @@ void BinderSherpa::CheckAndTryPromoteType(const common::ManagedPointer<parser::C
     switch (curr_type) {
       // NULL conversion.
       case type::TypeId::INVALID: {
-        value->SetValue(desired_type, std::make_unique<execution::sql::Val>(true));
+        value->SetValue(desired_type, execution::sql::Val(true));
         break;
       }
 
         // INTEGER casting (upwards and downwards).
       case type::TypeId::TINYINT: {
-        const auto int_val =
-            static_cast<int8_t>(value->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+        const auto int_val = value->Peek<int8_t>();
         TryCastNumericAll(value, int_val, desired_type);
         break;
       }
       case type::TypeId::SMALLINT: {
-        const auto int_val =
-            static_cast<int16_t>(value->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+        const auto int_val = value->Peek<int16_t>();
         TryCastNumericAll(value, int_val, desired_type);
         break;
       }
       case type::TypeId::INTEGER: {
-        const auto int_val =
-            static_cast<int32_t>(value->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+        const auto int_val = value->Peek<int32_t>();
         TryCastNumericAll(value, int_val, desired_type);
         break;
       }
       case type::TypeId::BIGINT: {
-        const auto int_val =
-            static_cast<int64_t>(value->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+        const auto int_val = value->Peek<int64_t>();
         TryCastNumericAll(value, int_val, desired_type);
         break;
       }

--- a/src/execution/compiler/operator/seq_scan_translator.cpp
+++ b/src/execution/compiler/operator/seq_scan_translator.cpp
@@ -209,7 +209,6 @@ void SeqScanTranslator::GenVectorizedPredicate(FunctionBuilder *builder,
     auto col_idx = pm_[left_cve->GetColumnOid()];
     auto col_type = schema_.GetColumn(left_cve->GetColumnOid()).Type();
     auto const_val = dynamic_cast<const terrier::parser::ConstantValueExpression *>(predicate->GetChild(1).Get());
-    auto val = const_val->GetValue();
     auto type = const_val->GetReturnValueType();
     ast::Expr *filter_val;
     switch (type) {
@@ -217,7 +216,7 @@ void SeqScanTranslator::GenVectorizedPredicate(FunctionBuilder *builder,
       case terrier::type::TypeId::SMALLINT:
       case terrier::type::TypeId::INTEGER:
       case terrier::type::TypeId::BIGINT:
-        filter_val = codegen_->IntLiteral(val.CastManagedPointerTo<execution::sql::Integer>()->val_);
+        filter_val = codegen_->IntLiteral(const_val->Peek<int64_t>());
         break;
       default:
         UNREACHABLE("Impossible vectorized predicate!");

--- a/src/execution/sql/value_util.cpp
+++ b/src/execution/sql/value_util.cpp
@@ -5,31 +5,27 @@
 
 namespace terrier::execution::sql {
 
-std::pair<std::unique_ptr<StringVal>, std::unique_ptr<byte>> ValueUtil::CreateStringVal(
+std::pair<StringVal, std::unique_ptr<byte[]>> ValueUtil::CreateStringVal(
     const common::ManagedPointer<const char> string, const uint32_t length) {
-  std::unique_ptr<StringVal> value = nullptr;
   if (length <= StringVal::InlineThreshold()) {
-    value = std::make_unique<StringVal>(string.Get(), length);
-    return {std::move(value), nullptr};
+    return {StringVal(string.Get(), length), nullptr};
   }
   // TODO(Matt): smarter allocation?
-  std::unique_ptr<byte> buffer = std::unique_ptr<byte>(common::AllocationUtil::AllocateAligned(length));
+  auto buffer = std::unique_ptr<byte[]>(common::AllocationUtil::AllocateAligned(length));
   std::memcpy(buffer.get(), string.Get(), length);
-  value = std::make_unique<StringVal>(reinterpret_cast<const char *>(buffer.get()), length);
-  return {std::move(value), std::move(buffer)};
+  return {StringVal(reinterpret_cast<const char *>(buffer.get()), length), std::move(buffer)};
 }
 
-std::pair<std::unique_ptr<StringVal>, std::unique_ptr<byte>> ValueUtil::CreateStringVal(const std::string &string) {
+std::pair<StringVal, std::unique_ptr<byte[]>> ValueUtil::CreateStringVal(const std::string &string) {
   return CreateStringVal(common::ManagedPointer(string.data()), string.length());
 }
 
-std::pair<std::unique_ptr<StringVal>, std::unique_ptr<byte>> ValueUtil::CreateStringVal(const std::string_view string) {
+std::pair<StringVal, std::unique_ptr<byte[]>> ValueUtil::CreateStringVal(const std::string_view string) {
   return CreateStringVal(common::ManagedPointer(string.data()), string.length());
 }
 
-std::pair<std::unique_ptr<StringVal>, std::unique_ptr<byte>> ValueUtil::CreateStringVal(
-    common::ManagedPointer<StringVal> string) {
-  return CreateStringVal(common::ManagedPointer(string->Content()), string->len_);
+std::pair<StringVal, std::unique_ptr<byte[]>> ValueUtil::CreateStringVal(const StringVal string) {
+  return CreateStringVal(common::ManagedPointer(string.Content()), string.len_);
 }
 
 }  // namespace terrier::execution::sql

--- a/src/include/binder/binder_sherpa.h
+++ b/src/include/binder/binder_sherpa.h
@@ -142,7 +142,7 @@ class BinderSherpa {
       }
       case type::TypeId::DECIMAL: {
         if (IsRepresentable<double>(int_val)) {
-          value->SetValue(desired_type, std::make_unique<execution::sql::Real>(static_cast<double>(int_val)));
+          value->SetValue(desired_type, execution::sql::Real(static_cast<double>(int_val)));
           return;
         }
         break;

--- a/src/include/execution/sql/value_util.h
+++ b/src/include/execution/sql/value_util.h
@@ -23,27 +23,26 @@ class ValueUtil {
    * @param length input length
    * @return a pair of owned pointers, first to the StringVal and second to an optionally-allocated buffer
    */
-  static std::pair<std::unique_ptr<StringVal>, std::unique_ptr<byte>> CreateStringVal(
-      common::ManagedPointer<const char> string, uint32_t length);
+  static std::pair<StringVal, std::unique_ptr<byte[]>> CreateStringVal(common::ManagedPointer<const char> string,
+                                                                       uint32_t length);
   /**
    * Construct a StringVal, optionally allocating a byte buffer if the input can't be inlined.
    * @param string input
    * @return a pair of owned pointers, first to the StringVal and second to an optionally-allocated buffer
    */
-  static std::pair<std::unique_ptr<StringVal>, std::unique_ptr<byte>> CreateStringVal(const std::string &string);
+  static std::pair<StringVal, std::unique_ptr<byte[]>> CreateStringVal(const std::string &string);
   /**
    * Construct a StringVal, optionally allocating a byte buffer if the input can't be inlined.
    * @param string input
    * @return a pair of owned pointers, first to the StringVal and second to an optionally-allocated buffer
    */
-  static std::pair<std::unique_ptr<StringVal>, std::unique_ptr<byte>> CreateStringVal(std::string_view string);
+  static std::pair<StringVal, std::unique_ptr<byte[]>> CreateStringVal(std::string_view string);
   /**
    * Construct a StringVal, optionally allocating a byte buffer if the input can't be inlined.
    * @param string input
    * @return a pair of owned pointers, first to the StringVal and second to an optionally-allocated buffer
    */
-  static std::pair<std::unique_ptr<StringVal>, std::unique_ptr<byte>> CreateStringVal(
-      common::ManagedPointer<StringVal> string);
+  static std::pair<StringVal, std::unique_ptr<byte[]>> CreateStringVal(StringVal string);
 };
 
 }  // namespace terrier::execution::sql

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1675,13 +1675,7 @@ VM_OP void OpOutputFinalize(terrier::execution::exec::ExecutionContext *exec_ctx
 #define GEN_SCALAR_PARAM_GET(Name, SqlType)                                                                   \
   VM_OP_HOT void OpGetParam##Name(terrier::execution::sql::SqlType *ret,                                      \
                                   terrier::execution::exec::ExecutionContext *exec_ctx, uint32_t param_idx) { \
-    const auto val =                                                                                          \
-        exec_ctx->GetParam(param_idx).GetValue().CastManagedPointerTo<terrier::execution::sql::SqlType>();    \
-    if (val->is_null_) {                                                                                      \
-      ret->is_null_ = true;                                                                                   \
-    } else {                                                                                                  \
-      *ret = terrier::execution::sql::SqlType(val->val_);                                                     \
-    }                                                                                                         \
+    *ret = exec_ctx->GetParam(param_idx).Get##SqlType();                                                      \
   }
 
 GEN_SCALAR_PARAM_GET(Bool, BoolVal)
@@ -1691,38 +1685,9 @@ GEN_SCALAR_PARAM_GET(Int, Integer)
 GEN_SCALAR_PARAM_GET(BigInt, Integer)
 GEN_SCALAR_PARAM_GET(Real, Real)
 GEN_SCALAR_PARAM_GET(Double, Real)
+GEN_SCALAR_PARAM_GET(DateVal, DateVal)
+GEN_SCALAR_PARAM_GET(TimestampVal, TimestampVal)
+GEN_SCALAR_PARAM_GET(String, StringVal)
 #undef GEN_SCALAR_PARAM_GET
-
-VM_OP_HOT void OpGetParamDateVal(terrier::execution::sql::DateVal *ret,
-                                 terrier::execution::exec::ExecutionContext *exec_ctx, uint32_t param_idx) {
-  const auto val = exec_ctx->GetParam(param_idx).GetValue().CastManagedPointerTo<terrier::execution::sql::DateVal>();
-  if (val->is_null_) {
-    ret->is_null_ = true;
-  } else {
-    *ret = terrier::execution::sql::DateVal(*val);
-  }
-}
-
-VM_OP_HOT void OpGetParamTimestampVal(terrier::execution::sql::TimestampVal *ret,
-                                      terrier::execution::exec::ExecutionContext *exec_ctx, uint32_t param_idx) {
-  const auto val =
-      exec_ctx->GetParam(param_idx).GetValue().CastManagedPointerTo<terrier::execution::sql::TimestampVal>();
-  if (val->is_null_) {
-    ret->is_null_ = true;
-  } else {
-    *ret = terrier::execution::sql::TimestampVal(*val);
-  }
-}
-
-VM_OP_HOT void OpGetParamString(terrier::execution::sql::StringVal *ret,
-                                terrier::execution::exec::ExecutionContext *exec_ctx, uint32_t param_idx) {
-  const auto val = exec_ctx->GetParam(param_idx).GetValue().CastManagedPointerTo<terrier::execution::sql::StringVal>();
-  if (val->is_null_) {
-    ret->is_null_ = true;
-  } else {
-    *ret = terrier::execution::sql::StringVal(val->Content(), val->len_);
-    ret->is_null_ = false;
-  }
-}
 
 }  // extern "C"

--- a/src/include/parser/expression/constant_value_expression.h
+++ b/src/include/parser/expression/constant_value_expression.h
@@ -105,31 +105,51 @@ class ConstantValueExpression : public AbstractExpression {
     }
   }
 
+  /**
+   * @return copy of the underlying Val
+   */
   execution::sql::BoolVal GetBoolVal() const {
     TERRIER_ASSERT(std::holds_alternative<execution::sql::BoolVal>(value_), "Invalid variant type for Get.");
     return std::get<execution::sql::BoolVal>(value_);
   }
 
+  /**
+   * @return copy of the underlying Val
+   */
   execution::sql::Integer GetInteger() const {
     TERRIER_ASSERT(std::holds_alternative<execution::sql::Integer>(value_), "Invalid variant type for Get.");
     return std::get<execution::sql::Integer>(value_);
   }
 
+  /**
+   * @return copy of the underlying Val
+   */
   execution::sql::Real GetReal() const {
     TERRIER_ASSERT(std::holds_alternative<execution::sql::Real>(value_), "Invalid variant type for Get.");
     return std::get<execution::sql::Real>(value_);
   }
 
+  /**
+   * @return copy of the underlying Val
+   */
   execution::sql::DateVal GetDateVal() const {
     TERRIER_ASSERT(std::holds_alternative<execution::sql::DateVal>(value_), "Invalid variant type for Get.");
     return std::get<execution::sql::DateVal>(value_);
   }
 
+  /**
+   * @return copy of the underlying Val
+   */
   execution::sql::TimestampVal GetTimestampVal() const {
     TERRIER_ASSERT(std::holds_alternative<execution::sql::TimestampVal>(value_), "Invalid variant type for Get.");
     return std::get<execution::sql::TimestampVal>(value_);
   }
 
+  /**
+   * @return copy of the underlying Val
+   * @warning StringVal may not have inlined its value, in which case the StringVal returned by this function will hold
+   * a pointer to the buffer in this CVE. In that case, do not destroy this CVE before the copied StringVal
+   */
   execution::sql::StringVal GetStringVal() const {
     TERRIER_ASSERT(std::holds_alternative<execution::sql::StringVal>(value_), "Invalid variant type for Get.");
     return std::get<execution::sql::StringVal>(value_);
@@ -154,6 +174,9 @@ class ConstantValueExpression : public AbstractExpression {
    */
   void SetValue(const type::TypeId type, const execution::sql::Val value) { SetValue(type, value, nullptr); }
 
+  /**
+   * @return true if CVE value represents a NULL
+   */
   bool IsNull() const {
     if (std::holds_alternative<execution::sql::Val>(value_) && std::get<execution::sql::Val>(value_).is_null_)
       return true;
@@ -185,6 +208,13 @@ class ConstantValueExpression : public AbstractExpression {
     }
   }
 
+  /**
+   * Extracts the underlying execution value as a C++ type
+   * @tparam T C++ type to extract
+   * @return copy of the underlying value as the requested type
+   * @warning std::string_view returned by this function will hold a pointer to the buffer in this CVE. In that case, do
+   * not destroy this CVE before the std::string_view
+   */
   template <typename T>
   T Peek() const;
 

--- a/src/include/parser/expression/constant_value_expression.h
+++ b/src/include/parser/expression/constant_value_expression.h
@@ -247,7 +247,7 @@ class ConstantValueExpression : public AbstractExpression {
                execution::sql::TimestampVal>
       value_;
   std::unique_ptr<byte[]> buffer_ = nullptr;
-};  // namespace terrier::parser
+};
 
 DEFINE_JSON_DECLARATIONS(ConstantValueExpression);
 

--- a/src/include/parser/expression/constant_value_expression.h
+++ b/src/include/parser/expression/constant_value_expression.h
@@ -251,6 +251,7 @@ class ConstantValueExpression : public AbstractExpression {
 
 DEFINE_JSON_DECLARATIONS(ConstantValueExpression);
 
+/// @cond DOXYGEN_IGNORE
 extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
                                                                  const execution::sql::Val value);
 extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
@@ -288,5 +289,6 @@ extern template double ConstantValueExpression::Peek() const;
 extern template execution::sql::Date ConstantValueExpression::Peek() const;
 extern template execution::sql::Timestamp ConstantValueExpression::Peek() const;
 extern template std::string_view ConstantValueExpression::Peek() const;
+/// @endcond
 
 }  // namespace terrier::parser

--- a/src/include/parser/expression/constant_value_expression.h
+++ b/src/include/parser/expression/constant_value_expression.h
@@ -32,8 +32,9 @@ class ConstantValueExpression : public AbstractExpression {
 
   /**
    * Construct a CVE of provided type and value
+   * @tparam T execution value type to copy from
    * @param type SQL type, apparently can be INVALID coming out of the parser for NULLs
-   * @param value underlying value to take ownership of
+   * @param value underlying value to copy
    */
   template <typename T>
   ConstantValueExpression(type::TypeId type, T value);
@@ -41,8 +42,8 @@ class ConstantValueExpression : public AbstractExpression {
   /**
    * Construct a CVE of provided type and value
    * @param type SQL type, apparently can be INVALID coming out of the parser for NULLs
-   * @param value underlying value to take ownership of
-   * @param buffer StringVal might not be inlined, so take ownership of that buffer as well
+   * @param value underlying value to copy
+   * @param buffer StringVal might not be inlined, so take ownership of that buffer
    */
   ConstantValueExpression(type::TypeId type, execution::sql::StringVal value, std::unique_ptr<byte[]> buffer);
 
@@ -158,21 +159,29 @@ class ConstantValueExpression : public AbstractExpression {
   /**
    * Change the underlying value of this CVE. Used by the BinderSherpa to promote parameters
    * @param type SQL type, apparently can be INVALID coming out of the parser for NULLs
-   * @param value underlying value to take ownership of
-   * @param buffer StringVal might not be inlined, so take ownership of that buffer as well
+   * @param value underlying value to copy
+   * @param buffer StringVal might not be inlined, so take ownership of that buffer
    */
-  void SetValue(const type::TypeId type, const execution::sql::Val value, std::unique_ptr<byte[]> buffer) {
+  void SetValue(const type::TypeId type, const execution::sql::StringVal value, std::unique_ptr<byte[]> buffer) {
     return_value_type_ = type;
     value_ = value;
     buffer_ = std::move(buffer);
     Validate();
   }
+
   /**
    * Change the underlying value of this CVE. Used by the BinderSherpa to promote parameters
+   * @tparam T execution value type to copy from
    * @param type SQL type, apparently can be INVALID coming out of the parser for NULLs
-   * @param value underlying value to take ownership of
+   * @param value underlying value to copy
    */
-  void SetValue(const type::TypeId type, const execution::sql::Val value) { SetValue(type, value, nullptr); }
+  template <typename T>
+  void SetValue(const type::TypeId type, const T value) {
+    return_value_type_ = type;
+    value_ = value;
+    buffer_ = nullptr;
+    Validate();
+  }
 
   /**
    * @return true if CVE value represents a NULL
@@ -241,5 +250,43 @@ class ConstantValueExpression : public AbstractExpression {
 };  // namespace terrier::parser
 
 DEFINE_JSON_DECLARATIONS(ConstantValueExpression);
+
+extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                                 const execution::sql::Val value);
+extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                                 const execution::sql::BoolVal value);
+extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                                 const execution::sql::Integer value);
+extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                                 const execution::sql::Real value);
+extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                                 const execution::sql::Decimal value);
+extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                                 const execution::sql::StringVal value);
+extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                                 const execution::sql::DateVal value);
+extern template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                                 const execution::sql::TimestampVal value);
+
+extern template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::Val value);
+extern template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::BoolVal value);
+extern template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::Integer value);
+extern template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::Real value);
+extern template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::Decimal value);
+extern template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::StringVal value);
+extern template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::DateVal value);
+extern template void ConstantValueExpression::SetValue(const type::TypeId type,
+                                                       const execution::sql::TimestampVal value);
+
+extern template bool ConstantValueExpression::Peek() const;
+extern template int8_t ConstantValueExpression::Peek() const;
+extern template int16_t ConstantValueExpression::Peek() const;
+extern template int32_t ConstantValueExpression::Peek() const;
+extern template int64_t ConstantValueExpression::Peek() const;
+extern template float ConstantValueExpression::Peek() const;
+extern template double ConstantValueExpression::Peek() const;
+extern template execution::sql::Date ConstantValueExpression::Peek() const;
+extern template execution::sql::Timestamp ConstantValueExpression::Peek() const;
+extern template std::string_view ConstantValueExpression::Peek() const;
 
 }  // namespace terrier::parser

--- a/src/include/parser/expression/constant_value_expression.h
+++ b/src/include/parser/expression/constant_value_expression.h
@@ -176,7 +176,7 @@ class ConstantValueExpression : public AbstractExpression {
    * @param value underlying value to copy
    */
   template <typename T>
-  void SetValue(const type::TypeId type, const T value) {
+  void SetValue(type::TypeId type, T value) {
     return_value_type_ = type;
     value_ = value;
     buffer_ = nullptr;

--- a/src/include/parser/expression_util.h
+++ b/src/include/parser/expression_util.h
@@ -28,6 +28,8 @@ namespace terrier::parser {
  */
 class ExpressionUtil {
  public:
+  ExpressionUtil() = delete;
+
   /**
    * Populate the given set with all of the column oids referenced
    * in this expression tree.

--- a/src/include/settings/settings_common.h
+++ b/src/include/settings/settings_common.h
@@ -128,24 +128,20 @@
 #ifdef SETTING_string
 #undef SETTING_string
 #endif
-#define SETTING_int(name, description, default_value, min_value, max_value, is_mutable, callback_fn) \
-  ValidateSetting(terrier::settings::Param::name,                                                    \
-                  {type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(min_value)},     \
-                  {type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(max_value)});
-#define SETTING_int64(name, description, default_value, min_value, max_value, is_mutable, callback_fn) \
-  ValidateSetting(terrier::settings::Param::name,                                                      \
-                  {type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(min_value)},        \
-                  {type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(max_value)});
+#define SETTING_int(name, description, default_value, min_value, max_value, is_mutable, callback_fn)           \
+  ValidateSetting(terrier::settings::Param::name, {type::TypeId::INTEGER, execution::sql::Integer(min_value)}, \
+                  {type::TypeId::INTEGER, execution::sql::Integer(max_value)});
+#define SETTING_int64(name, description, default_value, min_value, max_value, is_mutable, callback_fn)        \
+  ValidateSetting(terrier::settings::Param::name, {type::TypeId::BIGINT, execution::sql::Integer(min_value)}, \
+                  {type::TypeId::BIGINT, execution::sql::Integer(max_value)});
 
-#define SETTING_double(name, description, default_value, min_value, max_value, is_mutable, callback_fn) \
-  ValidateSetting(terrier::settings::Param::name,                                                       \
-                  {type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(min_value)},           \
-                  {type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(max_value)});
+#define SETTING_double(name, description, default_value, min_value, max_value, is_mutable, callback_fn)     \
+  ValidateSetting(terrier::settings::Param::name, {type::TypeId::DECIMAL, execution::sql::Real(min_value)}, \
+                  {type::TypeId::DECIMAL, execution::sql::Real(max_value)});
 
-#define SETTING_bool(name, description, default_value, is_mutable, callback_fn)                      \
-  ValidateSetting(terrier::settings::Param::name,                                                    \
-                  {type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(default_value)}, \
-                  {type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(default_value)});
+#define SETTING_bool(name, description, default_value, is_mutable, callback_fn)                                    \
+  ValidateSetting(terrier::settings::Param::name, {type::TypeId::BOOLEAN, execution::sql::BoolVal(default_value)}, \
+                  {type::TypeId::BOOLEAN, execution::sql::BoolVal(default_value)});
 
 #define SETTING_string(name, description, default_value, is_mutable, callback_fn)        \
   std::string default_value_string{default_value};                                       \
@@ -198,35 +194,33 @@
 #ifdef SETTING_string
 #undef SETTING_string
 #endif
-#define SETTING_int(name, description, default_value, min_value, max_value, is_mutable, callback_fn)                \
+#define SETTING_int(name, description, default_value, min_value, max_value, is_mutable, callback_fn)                   \
+  param_map.emplace(                                                                                                   \
+      terrier::settings::Param::name,                                                                                  \
+      terrier::settings::ParamInfo(#name, {type::TypeId::INTEGER, execution::sql::Integer(FLAGS_##name)}, description, \
+                                   {type::TypeId::INTEGER, execution::sql::Integer(default_value)}, is_mutable,        \
+                                   min_value, max_value, &callback_fn));
+
+#define SETTING_int64(name, description, default_value, min_value, max_value, is_mutable, callback_fn)                \
+  param_map.emplace(                                                                                                  \
+      terrier::settings::Param::name,                                                                                 \
+      terrier::settings::ParamInfo(#name, {type::TypeId::BIGINT, execution::sql::Integer(FLAGS_##name)}, description, \
+                                   {type::TypeId::BIGINT, execution::sql::Integer(default_value)}, is_mutable,        \
+                                   min_value, max_value, &callback_fn));
+
+#define SETTING_double(name, description, default_value, min_value, max_value, is_mutable, callback_fn)             \
   param_map.emplace(                                                                                                \
       terrier::settings::Param::name,                                                                               \
-      terrier::settings::ParamInfo(                                                                                 \
-          #name, {type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(FLAGS_##name)}, description,     \
-          {type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(default_value)}, is_mutable, min_value, \
-          max_value, &callback_fn));
+      terrier::settings::ParamInfo(#name, {type::TypeId::DECIMAL, execution::sql::Real(FLAGS_##name)}, description, \
+                                   {type::TypeId::DECIMAL, execution::sql::Real(default_value)}, is_mutable,        \
+                                   min_value, max_value, &callback_fn));
 
-#define SETTING_int64(name, description, default_value, min_value, max_value, is_mutable, callback_fn)                 \
-  param_map.emplace(terrier::settings::Param::name,                                                                    \
-                    terrier::settings::ParamInfo(                                                                      \
-                        #name, {type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(FLAGS_##name)},        \
-                        description, {type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(default_value)}, \
-                        is_mutable, min_value, max_value, &callback_fn));
-
-#define SETTING_double(name, description, default_value, min_value, max_value, is_mutable, callback_fn)              \
-  param_map.emplace(terrier::settings::Param::name,                                                                  \
-                    terrier::settings::ParamInfo(                                                                    \
-                        #name, {type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(FLAGS_##name)},        \
-                        description, {type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(default_value)}, \
-                        is_mutable, min_value, max_value, &callback_fn));
-
-#define SETTING_bool(name, description, default_value, is_mutable, callback_fn)                                 \
-  param_map.emplace(                                                                                            \
-      terrier::settings::Param::name,                                                                           \
-      terrier::settings::ParamInfo(                                                                             \
-          #name, {type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(FLAGS_##name)}, description, \
-          {type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(default_value)}, is_mutable, 0, 0,  \
-          &callback_fn));
+#define SETTING_bool(name, description, default_value, is_mutable, callback_fn)                                        \
+  param_map.emplace(                                                                                                   \
+      terrier::settings::Param::name,                                                                                  \
+      terrier::settings::ParamInfo(#name, {type::TypeId::BOOLEAN, execution::sql::BoolVal(FLAGS_##name)}, description, \
+                                   {type::TypeId::BOOLEAN, execution::sql::BoolVal(default_value)}, is_mutable, 0, 0,  \
+                                   &callback_fn));
 
 #define SETTING_string(name, description, default_value, is_mutable, callback_fn)                                 \
   const std::string_view value_string{FLAGS_##name};                                                              \

--- a/src/include/settings/settings_common.h
+++ b/src/include/settings/settings_common.h
@@ -143,11 +143,11 @@
   ValidateSetting(terrier::settings::Param::name, {type::TypeId::BOOLEAN, execution::sql::BoolVal(default_value)}, \
                   {type::TypeId::BOOLEAN, execution::sql::BoolVal(default_value)});
 
-#define SETTING_string(name, description, default_value, is_mutable, callback_fn)        \
-  std::string default_value_string{default_value};                                       \
-  auto string_val = execution::sql::ValueUtil::CreateStringVal(default_value_string);    \
-  auto default_value_cve = std::make_unique<parser::ConstantValueExpression>(            \
-      type::TypeId::VARCHAR, std::move(string_val.first), std::move(string_val.second)); \
+#define SETTING_string(name, description, default_value, is_mutable, callback_fn)                                     \
+  std::string default_value_string{default_value};                                                                    \
+  auto string_val = execution::sql::ValueUtil::CreateStringVal(default_value_string);                                 \
+  auto default_value_cve = std::make_unique<parser::ConstantValueExpression>(type::TypeId::VARCHAR, string_val.first, \
+                                                                             std::move(string_val.second));           \
   ValidateSetting(terrier::settings::Param::name, *default_value_cve, *default_value_cve);
 #endif
 
@@ -222,19 +222,18 @@
                                    {type::TypeId::BOOLEAN, execution::sql::BoolVal(default_value)}, is_mutable, 0, 0,  \
                                    &callback_fn));
 
-#define SETTING_string(name, description, default_value, is_mutable, callback_fn)                                 \
-  const std::string_view value_string{FLAGS_##name};                                                              \
-  auto string_val = execution::sql::ValueUtil::CreateStringVal(value_string);                                     \
-                                                                                                                  \
-  const std::string_view default_value_string{default_value};                                                     \
-  auto default_value_string_val = execution::sql::ValueUtil::CreateStringVal(default_value_string);               \
-                                                                                                                  \
-  param_map.emplace(                                                                                              \
-      terrier::settings::Param::name,                                                                             \
-      terrier::settings::ParamInfo(                                                                               \
-          #name, {type::TypeId::VARCHAR, std::move(string_val.first), std::move(string_val.second)}, description, \
-          {type::TypeId::VARCHAR, std::move(default_value_string_val.first),                                      \
-           std::move(default_value_string_val.second)},                                                           \
+#define SETTING_string(name, description, default_value, is_mutable, callback_fn)                              \
+  const std::string_view value_string{FLAGS_##name};                                                           \
+  auto string_val = execution::sql::ValueUtil::CreateStringVal(value_string);                                  \
+                                                                                                               \
+  const std::string_view default_value_string{default_value};                                                  \
+  auto default_value_string_val = execution::sql::ValueUtil::CreateStringVal(default_value_string);            \
+                                                                                                               \
+  param_map.emplace(                                                                                           \
+      terrier::settings::Param::name,                                                                          \
+      terrier::settings::ParamInfo(                                                                            \
+          #name, {type::TypeId::VARCHAR, string_val.first, std::move(string_val.second)}, description,         \
+          {type::TypeId::VARCHAR, default_value_string_val.first, std::move(default_value_string_val.second)}, \
           is_mutable, 0, 0, &callback_fn));
 
 #endif

--- a/src/network/postgres/postgres_packet_util.cpp
+++ b/src/network/postgres/postgres_packet_util.cpp
@@ -86,16 +86,16 @@ parser::ConstantValueExpression PostgresPacketUtil::TextValueToInternalValue(
       // with timestamps on inserting into the Customer table. Let's just try to parse it and fall back to VARCHAR?
       const auto ts_parse_result = util::TimeConvertor::ParseTimestamp(string);
       if (ts_parse_result.first) {
-        return {type, execution::sql::TimestampVal(static_cast<uint64_t>(ts_parse_result.second))};
+        return {type::TypeId::TIMESTAMP, execution::sql::TimestampVal(static_cast<uint64_t>(ts_parse_result.second))};
       }
       // try date?
       const auto date_parse_result = util::TimeConvertor::ParseDate(string);
       if (date_parse_result.first) {
-        return {type, execution::sql::DateVal(static_cast<uint32_t>(date_parse_result.second))};
+        return {type::TypeId::DATE, execution::sql::DateVal(static_cast<uint32_t>(date_parse_result.second))};
       }
       // fall back to VARCHAR?
       auto string_val = execution::sql::ValueUtil::CreateStringVal(string);
-      return {type, string_val.first, std::move(string_val.second)};
+      return {type::TypeId::VARCHAR, string_val.first, std::move(string_val.second)};
     }
     default:
       // TODO(Matt): Note that not all types are handled yet. Add them as we support them.

--- a/src/network/postgres/postgres_packet_util.cpp
+++ b/src/network/postgres/postgres_packet_util.cpp
@@ -45,7 +45,7 @@ parser::ConstantValueExpression PostgresPacketUtil::TextValueToInternalValue(
     const common::ManagedPointer<ReadBufferView> read_buffer, const int32_t size, const type::TypeId type) {
   if (size == -1) {
     // it's a NULL
-    return {type, std::make_unique<execution::sql::Val>(true)};
+    return {type, execution::sql::Val(true)};
   }
 
   const auto string = read_buffer->ReadString(size);
@@ -53,49 +53,49 @@ parser::ConstantValueExpression PostgresPacketUtil::TextValueToInternalValue(
     case type::TypeId::BOOLEAN: {
       // Matt: as best as I can tell, we only expect 'TRUE' of 'FALSE' coming in here, rather than the 't' or 'f' that
       // results use. We can simplify this logic a bit if that assumption can be verified
-      if (string == "TRUE") return {type, std::make_unique<execution::sql::BoolVal>(true)};
+      if (string == "TRUE") return {type, execution::sql::BoolVal(true)};
       TERRIER_ASSERT(string == "FALSE", "Input equals something other than TRUE or FALSE. We should check that.");
-      return {type, std::make_unique<execution::sql::BoolVal>(false)};
+      return {type, execution::sql::BoolVal(false)};
     }
     case type::TypeId::TINYINT:
-      return {type, std::make_unique<execution::sql::Integer>(static_cast<int8_t>(std::stoll(string)))};
+      return {type, execution::sql::Integer(static_cast<int8_t>(std::stoll(string)))};
     case type::TypeId::SMALLINT:
-      return {type, std::make_unique<execution::sql::Integer>(static_cast<int16_t>(std::stoll(string)))};
+      return {type, execution::sql::Integer(static_cast<int16_t>(std::stoll(string)))};
     case type::TypeId::INTEGER:
-      return {type, std::make_unique<execution::sql::Integer>(static_cast<int32_t>(std::stoll(string)))};
+      return {type, execution::sql::Integer(static_cast<int32_t>(std::stoll(string)))};
     case type::TypeId::BIGINT:
-      return {type, std::make_unique<execution::sql::Integer>(static_cast<int64_t>(std::stoll(string)))};
+      return {type, execution::sql::Integer(static_cast<int64_t>(std::stoll(string)))};
     case type::TypeId::DECIMAL:
-      return {type, std::make_unique<execution::sql::Real>(std::stod(string))};
+      return {type, execution::sql::Real(std::stod(string))};
     case type::TypeId::VARCHAR: {
       auto string_val = execution::sql::ValueUtil::CreateStringVal(string);
-      return {type, std::move(string_val.first), std::move(string_val.second)};
+      return {type, string_val.first, std::move(string_val.second)};
     }
     case type::TypeId::TIMESTAMP: {
       const auto parse_result = util::TimeConvertor::ParseTimestamp(string);
       TERRIER_ASSERT(parse_result.first, "Failed to parse the timestamp.");
-      return {type, std::make_unique<execution::sql::TimestampVal>(static_cast<uint64_t>(parse_result.second))};
+      return {type, execution::sql::TimestampVal(static_cast<uint64_t>(parse_result.second))};
     }
     case type::TypeId::DATE: {
       const auto parse_result = util::TimeConvertor::ParseDate(string);
       TERRIER_ASSERT(parse_result.first, "Failed to parse the date.");
-      return {type, std::make_unique<execution::sql::DateVal>(static_cast<uint32_t>(parse_result.second))};
+      return {type, execution::sql::DateVal(static_cast<uint32_t>(parse_result.second))};
     }
     case type::TypeId::INVALID: {
       // Postgres may not have told us the type in Parse message. Right now in oltpbench the JDBC driver is doing this
       // with timestamps on inserting into the Customer table. Let's just try to parse it and fall back to VARCHAR?
       const auto ts_parse_result = util::TimeConvertor::ParseTimestamp(string);
       if (ts_parse_result.first) {
-        return {type, std::make_unique<execution::sql::TimestampVal>(static_cast<uint64_t>(ts_parse_result.second))};
+        return {type, execution::sql::TimestampVal(static_cast<uint64_t>(ts_parse_result.second))};
       }
       // try date?
       const auto date_parse_result = util::TimeConvertor::ParseDate(string);
       if (date_parse_result.first) {
-        return {type, std::make_unique<execution::sql::DateVal>(static_cast<uint32_t>(date_parse_result.second))};
+        return {type, execution::sql::DateVal(static_cast<uint32_t>(date_parse_result.second))};
       }
       // fall back to VARCHAR?
       auto string_val = execution::sql::ValueUtil::CreateStringVal(string);
-      return {type, std::move(string_val.first), std::move(string_val.second)};
+      return {type, string_val.first, std::move(string_val.second)};
     }
     default:
       // TODO(Matt): Note that not all types are handled yet. Add them as we support them.
@@ -107,34 +107,33 @@ parser::ConstantValueExpression PostgresPacketUtil::BinaryValueToInternalValue(
     const common::ManagedPointer<ReadBufferView> read_buffer, const int32_t size, const type::TypeId type) {
   if (size == -1) {
     // it's a NULL
-    return {type, std::make_unique<execution::sql::Val>(true)};
+    return {type, execution::sql::Val(true)};
   }
 
   switch (type) {
     case type::TypeId::TINYINT: {
       TERRIER_ASSERT(size == 1, "Unexpected size for this type.");
-      return {type, std::make_unique<execution::sql::Integer>(read_buffer->ReadValue<int8_t>())};
+      return {type, execution::sql::Integer(read_buffer->ReadValue<int8_t>())};
     }
     case type::TypeId::SMALLINT: {
       TERRIER_ASSERT(size == 2, "Unexpected size for this type.");
-      return {type, std::make_unique<execution::sql::Integer>(read_buffer->ReadValue<int16_t>())};
+      return {type, execution::sql::Integer(read_buffer->ReadValue<int16_t>())};
     }
     case type::TypeId::INTEGER: {
       TERRIER_ASSERT(size == 4, "Unexpected size for this type.");
-      return {type, std::make_unique<execution::sql::Integer>(read_buffer->ReadValue<int32_t>())};
+      return {type, execution::sql::Integer(read_buffer->ReadValue<int32_t>())};
     }
     case type::TypeId::BIGINT: {
       TERRIER_ASSERT(size == 8, "Unexpected size for this type.");
-      return {type, std::make_unique<execution::sql::Integer>(read_buffer->ReadValue<int64_t>())};
+      return {type, execution::sql::Integer(read_buffer->ReadValue<int64_t>())};
     }
     case type::TypeId::DECIMAL: {
       TERRIER_ASSERT(size == 8, "Unexpected size for this type.");
-      return {type, std::make_unique<execution::sql::Real>(read_buffer->ReadValue<double>())};
+      return {type, execution::sql::Real(read_buffer->ReadValue<double>())};
     }
     case type::TypeId::DATE: {
       // TODO(Matt): unsure if this is correct. Need tests.
-      return {type,
-              std::make_unique<execution::sql::DateVal>(static_cast<uint32_t>(read_buffer->ReadValue<int32_t>()))};
+      return {type, execution::sql::DateVal(static_cast<uint32_t>(read_buffer->ReadValue<int32_t>()))};
     }
     default:
       // (Matt): from looking at jdbc source code, that seems like all the possible binary types

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -869,7 +869,7 @@ void PlanGenerator::Visit(const CreateTable *create_table) {
 
     auto val_type = col->GetValueType();
 
-    parser::ConstantValueExpression null_val{val_type, std::make_unique<execution::sql::Val>(true)};
+    parser::ConstantValueExpression null_val{val_type, execution::sql::Val(true)};
     auto &val = col->GetDefaultExpression() != nullptr ? *col->GetDefaultExpression() : null_val;
 
     if (val_type == type::TypeId::VARCHAR || val_type == type::TypeId::VARBINARY) {

--- a/src/optimizer/statistics/selectivity.cpp
+++ b/src/optimizer/statistics/selectivity.cpp
@@ -39,7 +39,7 @@ double Selectivity::LessThan(common::ManagedPointer<TableStats> table_stats, con
   // Convert value type to raw value (double)
   TERRIER_ASSERT(condition.GetPointerToValue()->GetReturnValueType() == type::TypeId::DECIMAL,
                  "It seems like there's an assumption that it's a DECIMAL type.");
-  const auto value = condition.GetPointerToValue()->GetValue().CastManagedPointerTo<execution::sql::Real>()->val_;
+  const auto value = condition.GetPointerToValue()->Peek<double>();
   if (std::isnan(value)) {
     OPTIMIZER_LOG_TRACE("Error computing less than for non-numeric type");
     return DEFAULT_SELECTIVITY;
@@ -68,7 +68,7 @@ double Selectivity::Equal(common::ManagedPointer<TableStats> table_stats, const 
   // Convert value type to raw value (double)
   TERRIER_ASSERT(condition.GetPointerToValue()->GetReturnValueType() == type::TypeId::DECIMAL,
                  "It seems like there's an assumption that it's a DECIMAL type.");
-  const auto value = condition.GetPointerToValue()->GetValue().CastManagedPointerTo<execution::sql::Real>()->val_;
+  const auto value = condition.GetPointerToValue()->Peek<double>();
   if (std::isnan(value) || !table_stats->HasColumnStats(condition.GetColumnID())) {
     OPTIMIZER_LOG_DEBUG("Calculate selectivity: return null");
     return DEFAULT_SELECTIVITY;

--- a/src/optimizer/statistics/stats_calculator.cpp
+++ b/src/optimizer/statistics/stats_calculator.cpp
@@ -254,8 +254,8 @@ double StatsCalculator::CalculateSelectivityForPredicate(common::ManagedPointer<
           reinterpret_cast<parser::ConstantValueExpression *>(cve->Copy().release())};
     } else {
       auto pve = expr->GetChild(right_index).CastManagedPointerTo<parser::ParameterValueExpression>();
-      value = std::make_unique<parser::ConstantValueExpression>(
-          type::TypeId::PARAMETER_OFFSET, std::make_unique<execution::sql::Integer>(pve->GetValueIdx()));
+      value = std::make_unique<parser::ConstantValueExpression>(type::TypeId::PARAMETER_OFFSET,
+                                                                execution::sql::Integer(pve->GetValueIdx()));
     }
 
     ValueCondition condition(col_name, expr_type, std::move(value));

--- a/src/parser/expression/constant_value_expression.cpp
+++ b/src/parser/expression/constant_value_expression.cpp
@@ -67,22 +67,28 @@ template ConstantValueExpression::ConstantValueExpression(const type::TypeId typ
 
 template <typename T>
 T ConstantValueExpression::Peek() const {
+  // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
   if constexpr (std::is_same_v<T, bool>) {
     return static_cast<T>(GetBoolVal().val_);
   }
+  // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
   if constexpr (std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t> || std::is_same_v<T, int32_t> ||
                 std::is_same_v<T, int64_t>) {
     return GetInteger().val_;
   }
+  // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
   if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
     return GetReal().val_;
   }
+  // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
   if constexpr (std::is_same_v<T, execution::sql::Date>) {
     return GetDateVal().val_;
   }
+  // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
   if constexpr (std::is_same_v<T, execution::sql::Timestamp>) {
     return GetTimestampVal().val_;
   }
+  // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
   if constexpr (std::is_same_v<T, std::string_view>) {
     return std::get<execution::sql::StringVal>(value_).StringView();
   }

--- a/src/parser/expression/constant_value_expression.cpp
+++ b/src/parser/expression/constant_value_expression.cpp
@@ -110,58 +110,30 @@ ConstantValueExpression &ConstantValueExpression::operator=(const ConstantValueE
     depth_ = other.depth_;
     has_subquery_ = other.has_subquery_;
     // ConstantValueExpression fields
-    if (other.value_->is_null_) {
-      value_ = std::make_unique<execution::sql::Val>(true);
-      buffer_ = nullptr;
+    if (other.GetReturnValueType() == type::TypeId::VARCHAR || other.GetReturnValueType() == type::TypeId::VARBINARY) {
+      auto string_val = execution::sql::ValueUtil::CreateStringVal(other.GetStringVal());
+
+      value_ = string_val.first;
+      buffer_ = std::move(string_val.second);
     } else {
-      switch (other.GetReturnValueType()) {
-        case type::TypeId::BOOLEAN: {
-          const auto val = other.GetValue().CastManagedPointerTo<execution::sql::BoolVal>()->val_;
-          value_ = std::make_unique<execution::sql::BoolVal>(val);
-          buffer_ = nullptr;
-          break;
-        }
-        case type::TypeId::TINYINT:
-        case type::TypeId::SMALLINT:
-        case type::TypeId::INTEGER:
-        case type::TypeId::BIGINT: {
-          const auto val = other.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_;
-          value_ = std::make_unique<execution::sql::Integer>(val);
-          buffer_ = nullptr;
-          break;
-        }
-        case type::TypeId::DECIMAL: {
-          const auto val = other.GetValue().CastManagedPointerTo<execution::sql::Real>()->val_;
-          value_ = std::make_unique<execution::sql::Real>(val);
-          buffer_ = nullptr;
-          break;
-        }
-        case type::TypeId::TIMESTAMP: {
-          const auto val = other.GetValue().CastManagedPointerTo<execution::sql::TimestampVal>()->val_;
-          value_ = std::make_unique<execution::sql::TimestampVal>(val);
-          buffer_ = nullptr;
-          break;
-        }
-        case type::TypeId::DATE: {
-          const auto val = other.GetValue().CastManagedPointerTo<execution::sql::DateVal>()->val_;
-          value_ = std::make_unique<execution::sql::DateVal>(val);
-          buffer_ = nullptr;
-          break;
-        }
-        case type::TypeId::VARCHAR:
-        case type::TypeId::VARBINARY: {
-          const auto val = other.GetValue().CastManagedPointerTo<execution::sql::StringVal>();
-          auto string_val = execution::sql::ValueUtil::CreateStringVal(val);
-          value_ = std::move(string_val.first);
-          buffer_ = std::move(string_val.second);
-          break;
-        }
-        default:
-          UNREACHABLE("Invalid TypeId.");
-      }
+      value_ = other.value_;
+      buffer_ = nullptr;
     }
   }
+  Validate();
   return *this;
+}
+
+ConstantValueExpression::ConstantValueExpression(const ConstantValueExpression &other) : AbstractExpression(other) {
+  if (other.GetReturnValueType() == type::TypeId::VARCHAR || other.GetReturnValueType() == type::TypeId::VARBINARY) {
+    auto string_val = execution::sql::ValueUtil::CreateStringVal(other.GetStringVal());
+
+    value_ = string_val.first;
+    buffer_ = std::move(string_val.second);
+  } else {
+    value_ = other.value_;
+  }
+  Validate();
 }
 
 ConstantValueExpression &ConstantValueExpression::operator=(ConstantValueExpression &&other) noexcept {
@@ -174,66 +146,50 @@ ConstantValueExpression &ConstantValueExpression::operator=(ConstantValueExpress
     depth_ = other.depth_;
     has_subquery_ = other.has_subquery_;
     // ConstantValueExpression fields
-    value_ = std::move(other.value_);
+    value_ = other.value_;
     buffer_ = std::move(other.buffer_);
     // Set other to NULL because unclear what else it would be in this case
-    other.value_ = std::make_unique<execution::sql::Val>(true);
+    other.value_ = execution::sql::Val(true);
   }
+  Validate();
   return *this;
 }
 
 ConstantValueExpression::ConstantValueExpression(ConstantValueExpression &&other) noexcept : AbstractExpression(other) {
-  value_ = std::move(other.value_);
+  value_ = other.value_;
   buffer_ = std::move(other.buffer_);
-  other.value_ = std::make_unique<execution::sql::Val>(true);
-}
-
-ConstantValueExpression::ConstantValueExpression(const ConstantValueExpression &other) : AbstractExpression(other) {
-  if (other.GetReturnValueType() == type::TypeId::VARCHAR || other.GetReturnValueType() == type::TypeId::VARBINARY) {
-    value_ = std::make_unique<execution::sql::Val>(true);
-  } else {
-    const auto val = other.GetStringVal();
-
-    auto string_val = execution::sql::ValueUtil::CreateStringVal(val);
-
-    value_ = string_val.first;
-    buffer_ = std::move(string_val.second);
-  }
+  // Set other to NULL because unclear what else it would be in this case
+  other.value_ = execution::sql::Val(true);
+  Validate();
 }
 
 common::hash_t ConstantValueExpression::Hash() const {
-  const auto hash =
-      common::HashUtil::CombineHashes(AbstractExpression::Hash(), common::HashUtil::Hash(value_->is_null_));
-  if (value_->is_null_) return hash;
+  const auto hash = common::HashUtil::CombineHashes(AbstractExpression::Hash(), common::HashUtil::Hash(IsNull()));
+  if (IsNull()) return hash;
 
   switch (GetReturnValueType()) {
     case type::TypeId::BOOLEAN: {
-      const auto val = GetValue().CastManagedPointerTo<execution::sql::BoolVal>()->val_;
-      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(val));
+      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(Peek<bool>()));
     }
     case type::TypeId::TINYINT:
     case type::TypeId::SMALLINT:
     case type::TypeId::INTEGER:
     case type::TypeId::BIGINT: {
-      const auto val = GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_;
-      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(val));
+      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(Peek<int64_t>()));
     }
     case type::TypeId::DECIMAL: {
-      const auto val = GetValue().CastManagedPointerTo<execution::sql::Real>()->val_;
-      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(val));
+      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(Peek<double>()));
     }
     case type::TypeId::TIMESTAMP: {
-      const auto val = GetValue().CastManagedPointerTo<execution::sql::TimestampVal>()->val_.ToNative();
-      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(val));
+      return common::HashUtil::CombineHashes(hash,
+                                             common::HashUtil::Hash(Peek<execution::sql::Timestamp>().ToNative()));
     }
     case type::TypeId::DATE: {
-      const auto val = GetValue().CastManagedPointerTo<execution::sql::DateVal>()->val_.ToNative();
-      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(val));
+      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(Peek<execution::sql::Date>().ToNative()));
     }
     case type::TypeId::VARCHAR:
     case type::TypeId::VARBINARY: {
-      const auto val = GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView();
-      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(val));
+      return common::HashUtil::CombineHashes(hash, common::HashUtil::Hash(Peek<std::string_view>()));
     }
     default:
       UNREACHABLE("Invalid TypeId.");
@@ -244,43 +200,31 @@ bool ConstantValueExpression::operator==(const AbstractExpression &other) const 
   if (!AbstractExpression::operator==(other)) return false;
   const auto &other_cve = dynamic_cast<const ConstantValueExpression &>(other);
 
-  if (value_->is_null_ != other_cve.value_->is_null_) return false;
-  if (value_->is_null_ && other_cve.value_->is_null_) return true;
+  if (IsNull() != other_cve.IsNull()) return false;
+  if (IsNull() && other_cve.IsNull()) return true;
 
   switch (other.GetReturnValueType()) {
     case type::TypeId::BOOLEAN: {
-      const auto this_val = GetValue().CastManagedPointerTo<execution::sql::BoolVal>()->val_;
-      const auto other_val = other_cve.GetValue().CastManagedPointerTo<execution::sql::BoolVal>()->val_;
-      return this_val == other_val;
+      return Peek<bool>() == other_cve.Peek<bool>();
     }
     case type::TypeId::TINYINT:
     case type::TypeId::SMALLINT:
     case type::TypeId::INTEGER:
     case type::TypeId::BIGINT: {
-      const auto this_val = GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_;
-      const auto other_val = other_cve.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_;
-      return this_val == other_val;
+      return Peek<int64_t>() == other_cve.Peek<int64_t>();
     }
     case type::TypeId::DECIMAL: {
-      const auto this_val = GetValue().CastManagedPointerTo<execution::sql::Real>()->val_;
-      const auto other_val = other_cve.GetValue().CastManagedPointerTo<execution::sql::Real>()->val_;
-      return this_val == other_val;
+      return Peek<double>() == other_cve.Peek<double>();
     }
     case type::TypeId::TIMESTAMP: {
-      const auto this_val = GetValue().CastManagedPointerTo<execution::sql::TimestampVal>()->val_;
-      const auto other_val = other_cve.GetValue().CastManagedPointerTo<execution::sql::TimestampVal>()->val_;
-      return this_val == other_val;
+      return Peek<execution::sql::Timestamp>() == other_cve.Peek<execution::sql::Timestamp>();
     }
     case type::TypeId::DATE: {
-      const auto this_val = GetValue().CastManagedPointerTo<execution::sql::DateVal>()->val_;
-      const auto other_val = other_cve.GetValue().CastManagedPointerTo<execution::sql::DateVal>()->val_;
-      return this_val == other_val;
+      return Peek<execution::sql::Date>() == other_cve.Peek<execution::sql::Date>();
     }
     case type::TypeId::VARCHAR:
     case type::TypeId::VARBINARY: {
-      const auto this_val = GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView();
-      const auto other_val = other_cve.GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView();
-      return this_val == other_val;
+      return Peek<std::string_view>() == other_cve.Peek<std::string_view>();
     }
     default:
       UNREACHABLE("Invalid TypeId.");
@@ -290,40 +234,34 @@ bool ConstantValueExpression::operator==(const AbstractExpression &other) const 
 nlohmann::json ConstantValueExpression::ToJson() const {
   nlohmann::json j = AbstractExpression::ToJson();
 
-  if (!value_->is_null_) {
+  if (!IsNull()) {
     switch (return_value_type_) {
       case type::TypeId::BOOLEAN: {
-        const auto val = GetValue().CastManagedPointerTo<execution::sql::BoolVal>()->val_;
-        j["value"] = val;
+        j["value"] = Peek<bool>();
         break;
       }
       case type::TypeId::TINYINT:
       case type::TypeId::SMALLINT:
       case type::TypeId::INTEGER:
       case type::TypeId::BIGINT: {
-        const auto val = GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_;
-        j["value"] = val;
+        j["value"] = Peek<int64_t>();
         break;
       }
       case type::TypeId::DECIMAL: {
-        const auto val = GetValue().CastManagedPointerTo<execution::sql::Real>()->val_;
-        j["value"] = val;
+        j["value"] = Peek<double>();
         break;
       }
       case type::TypeId::TIMESTAMP: {
-        const auto val = GetValue().CastManagedPointerTo<execution::sql::TimestampVal>()->val_.ToNative();
-        j["value"] = val;
+        j["value"] = Peek<execution::sql::Timestamp>().ToNative();
         break;
       }
       case type::TypeId::DATE: {
-        const auto val = GetValue().CastManagedPointerTo<execution::sql::DateVal>()->val_.ToNative();
-        j["value"] = val;
+        j["value"] = Peek<execution::sql::Date>().ToNative();
         break;
       }
       case type::TypeId::VARCHAR:
       case type::TypeId::VARBINARY: {
-        const auto val = GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView();
-        j["value"] = val;
+        j["value"] = Peek<std::string_view>();
         break;
       }
       default:
@@ -342,35 +280,33 @@ std::vector<std::unique_ptr<AbstractExpression>> ConstantValueExpression::FromJs
     // it's not NULL
     switch (return_value_type_) {
       case type::TypeId::BOOLEAN: {
-        value_ = std::make_unique<execution::sql::BoolVal>(j.at("value").get<bool>());
+        value_ = execution::sql::BoolVal(j.at("value").get<bool>());
         break;
       }
       case type::TypeId::TINYINT:
       case type::TypeId::SMALLINT:
       case type::TypeId::INTEGER:
       case type::TypeId::BIGINT: {
-        value_ = std::make_unique<execution::sql::Integer>(j.at("value").get<int64_t>());
+        value_ = execution::sql::Integer(j.at("value").get<int64_t>());
         break;
       }
       case type::TypeId::DECIMAL: {
-        value_ = std::make_unique<execution::sql::Real>(j.at("value").get<double>());
+        value_ = execution::sql::Real(j.at("value").get<double>());
         break;
       }
       case type::TypeId::TIMESTAMP: {
-        value_ = std::make_unique<execution::sql::TimestampVal>(
-            execution::sql::Timestamp::FromNative(j.at("value").get<uint64_t>()));
+        value_ = execution::sql::TimestampVal(execution::sql::Timestamp::FromNative(j.at("value").get<uint64_t>()));
         break;
       }
       case type::TypeId::DATE: {
-        value_ =
-            std::make_unique<execution::sql::DateVal>(execution::sql::Date::FromNative(j.at("value").get<uint32_t>()));
+        value_ = execution::sql::DateVal(execution::sql::Date::FromNative(j.at("value").get<uint32_t>()));
         break;
       }
       case type::TypeId::VARCHAR:
       case type::TypeId::VARBINARY: {
         auto string_val = execution::sql::ValueUtil::CreateStringVal(j.at("value").get<std::string>());
 
-        value_ = std::move(string_val.first);
+        value_ = string_val.first;
         buffer_ = std::move(string_val.second);
 
         break;
@@ -379,8 +315,10 @@ std::vector<std::unique_ptr<AbstractExpression>> ConstantValueExpression::FromJs
         UNREACHABLE("Invalid TypeId.");
     }
   } else {
-    value_ = std::make_unique<execution::sql::Val>(true);
+    value_ = execution::sql::Val(true);
   }
+
+  Validate();
 
   return exprs;
 }

--- a/src/parser/expression/constant_value_expression.cpp
+++ b/src/parser/expression/constant_value_expression.cpp
@@ -47,8 +47,8 @@ void ConstantValueExpression::Validate() const {
     TERRIER_ASSERT(GetStringVal().is_null_ ||
                        (buffer_ == nullptr && GetStringVal().len_ <= execution::sql::StringVal::InlineThreshold()) ||
                        (buffer_ != nullptr && GetStringVal().len_ > execution::sql::StringVal::InlineThreshold()),
-                   "StringVal should either be NULL, below the inline threshold with no owned buffer, or above the "
-                   "inline threshold with a provided buffer.");
+                   "StringVal should either be NULL, below the InlineThreshold with no owned buffer, or above the "
+                   "InlineThreshold with a provided buffer.");
   } else {
     UNREACHABLE("Unknown Val type!");
   }

--- a/src/parser/expression/constant_value_expression.cpp
+++ b/src/parser/expression/constant_value_expression.cpp
@@ -54,17 +54,6 @@ void ConstantValueExpression::Validate() const {
   }
 }
 
-template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::Val value);
-template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::BoolVal value);
-template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::Integer value);
-template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::Real value);
-template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::Decimal value);
-template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
-                                                          const execution::sql::StringVal value);
-template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::DateVal value);
-template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
-                                                          const execution::sql::TimestampVal value);
-
 template <typename T>
 T ConstantValueExpression::Peek() const {
   // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
@@ -75,11 +64,11 @@ T ConstantValueExpression::Peek() const {
   if constexpr (std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t> || std::is_same_v<T, int32_t> ||
                 std::is_same_v<T, int64_t>) {  // NOLINT: bugprone-suspicious-semicolon: seems like a false positive
                                                // because of constexpr
-    return GetInteger().val_;
+    return static_cast<T>(GetInteger().val_);
   }
   // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
   if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
-    return GetReal().val_;
+    return static_cast<T>(GetReal().val_);
   }
   // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
   if constexpr (std::is_same_v<T, execution::sql::Date>) {
@@ -95,17 +84,6 @@ T ConstantValueExpression::Peek() const {
   }
   UNREACHABLE("Invalid type for GetAs.");
 }
-
-template bool ConstantValueExpression::Peek() const;
-template int8_t ConstantValueExpression::Peek() const;
-template int16_t ConstantValueExpression::Peek() const;
-template int32_t ConstantValueExpression::Peek() const;
-template int64_t ConstantValueExpression::Peek() const;
-template float ConstantValueExpression::Peek() const;
-template double ConstantValueExpression::Peek() const;
-template execution::sql::Date ConstantValueExpression::Peek() const;
-template execution::sql::Timestamp ConstantValueExpression::Peek() const;
-template std::string_view ConstantValueExpression::Peek() const;
 
 ConstantValueExpression &ConstantValueExpression::operator=(const ConstantValueExpression &other) {
   if (this != &other) {  // self-assignment check expected
@@ -329,4 +307,36 @@ std::vector<std::unique_ptr<AbstractExpression>> ConstantValueExpression::FromJs
 
   return exprs;
 }
+
+template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::Val value);
+template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::BoolVal value);
+template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::Integer value);
+template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::Real value);
+template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::Decimal value);
+template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                          const execution::sql::StringVal value);
+template ConstantValueExpression::ConstantValueExpression(const type::TypeId type, const execution::sql::DateVal value);
+template ConstantValueExpression::ConstantValueExpression(const type::TypeId type,
+                                                          const execution::sql::TimestampVal value);
+
+template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::Val value);
+template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::BoolVal value);
+template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::Integer value);
+template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::Real value);
+template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::Decimal value);
+template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::StringVal value);
+template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::DateVal value);
+template void ConstantValueExpression::SetValue(const type::TypeId type, const execution::sql::TimestampVal value);
+
+template bool ConstantValueExpression::Peek() const;
+template int8_t ConstantValueExpression::Peek() const;
+template int16_t ConstantValueExpression::Peek() const;
+template int32_t ConstantValueExpression::Peek() const;
+template int64_t ConstantValueExpression::Peek() const;
+template float ConstantValueExpression::Peek() const;
+template double ConstantValueExpression::Peek() const;
+template execution::sql::Date ConstantValueExpression::Peek() const;
+template execution::sql::Timestamp ConstantValueExpression::Peek() const;
+template std::string_view ConstantValueExpression::Peek() const;
+
 }  // namespace terrier::parser

--- a/src/parser/expression/constant_value_expression.cpp
+++ b/src/parser/expression/constant_value_expression.cpp
@@ -72,19 +72,19 @@ T ConstantValueExpression::Peek() const {
   }
   if constexpr (std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t> || std::is_same_v<T, int32_t> ||
                 std::is_same_v<T, int64_t>) {
-    return static_cast<T>(GetInteger().val_);
+    return GetInteger().val_;
   }
   if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
-    return static_cast<T>(GetReal().val_);
+    return GetReal().val_;
   }
   if constexpr (std::is_same_v<T, execution::sql::Date>) {
-    return static_cast<T>(GetDateVal().val_);
+    return GetDateVal().val_;
   }
   if constexpr (std::is_same_v<T, execution::sql::Timestamp>) {
-    return static_cast<T>(GetTimestampVal().val_);
+    return GetTimestampVal().val_;
   }
   if constexpr (std::is_same_v<T, std::string_view>) {
-    return static_cast<T>(GetStringVal().StringView());
+    return std::get<execution::sql::StringVal>(value_).StringView();
   }
   UNREACHABLE("Invalid type for GetAs.");
 }
@@ -110,7 +110,7 @@ ConstantValueExpression &ConstantValueExpression::operator=(const ConstantValueE
     depth_ = other.depth_;
     has_subquery_ = other.has_subquery_;
     // ConstantValueExpression fields
-    if (other.GetReturnValueType() == type::TypeId::VARCHAR || other.GetReturnValueType() == type::TypeId::VARBINARY) {
+    if (std::holds_alternative<execution::sql::StringVal>(other.value_)) {
       auto string_val = execution::sql::ValueUtil::CreateStringVal(other.GetStringVal());
 
       value_ = string_val.first;
@@ -125,7 +125,7 @@ ConstantValueExpression &ConstantValueExpression::operator=(const ConstantValueE
 }
 
 ConstantValueExpression::ConstantValueExpression(const ConstantValueExpression &other) : AbstractExpression(other) {
-  if (other.GetReturnValueType() == type::TypeId::VARCHAR || other.GetReturnValueType() == type::TypeId::VARBINARY) {
+  if (std::holds_alternative<execution::sql::StringVal>(other.value_)) {
     auto string_val = execution::sql::ValueUtil::CreateStringVal(other.GetStringVal());
 
     value_ = string_val.first;

--- a/src/parser/expression/constant_value_expression.cpp
+++ b/src/parser/expression/constant_value_expression.cpp
@@ -73,7 +73,8 @@ T ConstantValueExpression::Peek() const {
   }
   // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr
   if constexpr (std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t> || std::is_same_v<T, int32_t> ||
-                std::is_same_v<T, int64_t>) {
+                std::is_same_v<T, int64_t>) {  // NOLINT: bugprone-suspicious-semicolon: seems like a false positive
+                                               // because of constexpr
     return GetInteger().val_;
   }
   // NOLINTNEXTLINE: bugprone-suspicious-semicolon: seems like a false positive because of constexpr

--- a/src/parser/expression/constant_value_expression.cpp
+++ b/src/parser/expression/constant_value_expression.cpp
@@ -82,7 +82,7 @@ T ConstantValueExpression::Peek() const {
   if constexpr (std::is_same_v<T, std::string_view>) {
     return std::get<execution::sql::StringVal>(value_).StringView();
   }
-  UNREACHABLE("Invalid type for GetAs.");
+  UNREACHABLE("Invalid type for Peek.");
 }
 
 ConstantValueExpression &ConstantValueExpression::operator=(const ConstantValueExpression &other) {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -696,15 +696,15 @@ std::unique_ptr<AbstractExpression> PostgresParser::ValueTransform(ParseResult *
   std::unique_ptr<AbstractExpression> result;
   switch (val.type_) {
     case T_Integer: {
-      result = std::make_unique<ConstantValueExpression>(type::TypeId::INTEGER,
-                                                         std::make_unique<execution::sql::Integer>(val.val_.ival_));
+      result =
+          std::make_unique<ConstantValueExpression>(type::TypeId::INTEGER, execution::sql::Integer(val.val_.ival_));
       break;
     }
 
     case T_String: {
       const auto string = std::string_view{val.val_.str_};
       auto string_val = execution::sql::ValueUtil::CreateStringVal(string);
-      result = std::make_unique<ConstantValueExpression>(type::TypeId::VARCHAR, std::move(string_val.first),
+      result = std::make_unique<ConstantValueExpression>(type::TypeId::VARCHAR, string_val.first,
                                                          std::move(string_val.second));
 
       break;
@@ -716,18 +716,17 @@ std::unique_ptr<AbstractExpression> PostgresParser::ValueTransform(ParseResult *
       // For this reason, a quick hack...
       // TODO(WAN): figure out how Postgres does it once we care about floating point
       if (std::strchr(val.val_.str_, '.') == nullptr) {
-        result = std::make_unique<ConstantValueExpression>(
-            type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(std::stoll(val.val_.str_)));
+        result = std::make_unique<ConstantValueExpression>(type::TypeId::BIGINT,
+                                                           execution::sql::Integer(std::stoll(val.val_.str_)));
       } else {
-        result = std::make_unique<ConstantValueExpression>(
-            type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(std::stod(val.val_.str_)));
+        result = std::make_unique<ConstantValueExpression>(type::TypeId::DECIMAL,
+                                                           execution::sql::Real(std::stod(val.val_.str_)));
       }
       break;
     }
 
     case T_Null: {
-      result =
-          std::make_unique<ConstantValueExpression>(type::TypeId::INVALID, std::make_unique<execution::sql::Val>(true));
+      result = std::make_unique<ConstantValueExpression>(type::TypeId::INVALID, execution::sql::Val(true));
       break;
     }
     default: {

--- a/src/settings/settings_manager.cpp
+++ b/src/settings/settings_manager.cpp
@@ -29,8 +29,8 @@ void SettingsManager::ValidateParams() {
   // all of the settings defined in settings.h.
   // Example:
   //   ValidateSetting(Param::port, parser::ConstantValueExpression(type::TypeID::INTEGER,
-  //   std::make_unique<execution::sql::Integer>(1024)), parser::ConstantValueExpression(type::TypeID::INTEGER,
-  //   std::make_unique<execution::sql::Integer>(65535)));
+  //   execution::sql::Integer(1024)), parser::ConstantValueExpression(type::TypeID::INTEGER,
+  //   execution::sql::Integer(65535)));
 
 #define __SETTING_VALIDATE__           // NOLINT
 #include "settings/settings_common.h"  // NOLINT
@@ -288,7 +288,7 @@ void SettingsManager::ConstructParamMap(                                        
    * param_map.emplace(
    *     terrier::settings::Param::port,
    *     terrier::settings::ParamInfo(port, parser::ConstantValueExpression(type::TypeID::INTEGER,
-   *     std::make_unique<execution::sql::Integer>(FLAGS_port)), "Terrier port (default: 15721)",
+   *     execution::sql::Integer(FLAGS_port)), "Terrier port (default: 15721)",
    *     parser::ConstantValueExpression(type::TypeID::INTEGER, execution::sql::Integer(15721)),
    *     is_mutable));
    */

--- a/src/settings/settings_manager.cpp
+++ b/src/settings/settings_manager.cpp
@@ -72,7 +72,8 @@ bool SettingsManager::GetBool(Param param) {
 
 std::string SettingsManager::GetString(Param param) {
   common::SharedLatch::ScopedSharedLatch guard(&latch_);
-  return std::string(GetValue(param).Peek<std::string_view>());
+  const auto &value = GetValue(param);
+  return std::string(value.Peek<std::string_view>());
 }
 
 void SettingsManager::SetInt(Param param, int32_t value, common::ManagedPointer<ActionContext> action_context,
@@ -93,13 +94,12 @@ void SettingsManager::SetInt(Param param, int32_t value, common::ManagedPointer<
     action_context->SetState(ActionState::FAILURE);
   } else {
     auto old_value = GetValue(param).Peek<int32_t>();
-    if (!SetValue(param, {type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(value)})) {
+    if (!SetValue(param, {type::TypeId::INTEGER, execution::sql::Integer(value)})) {
       action_context->SetState(ActionState::FAILURE);
     } else {
       ActionState action_state = InvokeCallback(param, &old_value, &value, action_context);
       if (action_state == ActionState::FAILURE) {
-        const bool result =
-            SetValue(param, {type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(old_value)});
+        const bool result = SetValue(param, {type::TypeId::INTEGER, execution::sql::Integer(old_value)});
         if (!result) {
           SETTINGS_LOG_ERROR("Failed to revert parameter \"{}\"", param_info.name_);
           throw SETTINGS_EXCEPTION("Failed to reset parameter");
@@ -128,13 +128,12 @@ void SettingsManager::SetInt64(Param param, int64_t value, common::ManagedPointe
     action_context->SetState(ActionState::FAILURE);
   } else {
     auto old_value = GetValue(param).Peek<int64_t>();
-    if (!SetValue(param, {type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(value)})) {
+    if (!SetValue(param, {type::TypeId::BIGINT, execution::sql::Integer(value)})) {
       action_context->SetState(ActionState::FAILURE);
     } else {
       ActionState action_state = InvokeCallback(param, &old_value, &value, action_context);
       if (action_state == ActionState::FAILURE) {
-        const bool result =
-            SetValue(param, {type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(old_value)});
+        const bool result = SetValue(param, {type::TypeId::BIGINT, execution::sql::Integer(old_value)});
         if (!result) {
           SETTINGS_LOG_ERROR("Failed to revert parameter \"{}\"", param_info.name_);
           throw SETTINGS_EXCEPTION("Failed to reset parameter");
@@ -163,12 +162,12 @@ void SettingsManager::SetDouble(Param param, double value, common::ManagedPointe
     action_context->SetState(ActionState::FAILURE);
   } else {
     auto old_value = GetValue(param).Peek<double>();
-    if (!SetValue(param, {type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(value)})) {
+    if (!SetValue(param, {type::TypeId::DECIMAL, execution::sql::Real(value)})) {
       action_context->SetState(ActionState::FAILURE);
     } else {
       ActionState action_state = InvokeCallback(param, &old_value, &value, action_context);
       if (action_state == ActionState::FAILURE) {
-        const bool result = SetValue(param, {type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(old_value)});
+        const bool result = SetValue(param, {type::TypeId::DECIMAL, execution::sql::Real(old_value)});
         if (!result) {
           SETTINGS_LOG_ERROR("Failed to revert parameter \"{}\"", param_info.name_);
           throw SETTINGS_EXCEPTION("Failed to reset parameter");
@@ -192,13 +191,12 @@ void SettingsManager::SetBool(Param param, bool value, common::ManagedPointer<Ac
 
   common::SharedLatch::ScopedExclusiveLatch guard(&latch_);
   auto old_value = GetValue(param).Peek<bool>();
-  if (!SetValue(param, {type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(value)})) {
+  if (!SetValue(param, {type::TypeId::BOOLEAN, execution::sql::BoolVal(value)})) {
     action_context->SetState(ActionState::FAILURE);
   } else {
     ActionState action_state = InvokeCallback(param, &old_value, &value, action_context);
     if (action_state == ActionState::FAILURE) {
-      const bool result =
-          SetValue(param, {type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(old_value)});
+      const bool result = SetValue(param, {type::TypeId::BOOLEAN, execution::sql::BoolVal(old_value)});
       if (!result) {
         SETTINGS_LOG_ERROR("Failed to revert parameter \"{}\"", param_info.name_);
         throw SETTINGS_EXCEPTION("Failed to reset parameter");
@@ -291,7 +289,7 @@ void SettingsManager::ConstructParamMap(                                        
    *     terrier::settings::Param::port,
    *     terrier::settings::ParamInfo(port, parser::ConstantValueExpression(type::TypeID::INTEGER,
    *     std::make_unique<execution::sql::Integer>(FLAGS_port)), "Terrier port (default: 15721)",
-   *     parser::ConstantValueExpression(type::TypeID::INTEGER, std::make_unique<execution::sql::Integer>(15721)),
+   *     parser::ConstantValueExpression(type::TypeID::INTEGER, execution::sql::Integer(15721)),
    *     is_mutable));
    */
 

--- a/src/settings/settings_manager.cpp
+++ b/src/settings/settings_manager.cpp
@@ -224,7 +224,7 @@ void SettingsManager::SetString(Param param, const std::string_view &value,
 
   auto string_val = execution::sql::ValueUtil::CreateStringVal(value);
 
-  if (!SetValue(param, {type::TypeId::VARCHAR, std::move(string_val.first), std::move(string_val.second)})) {
+  if (!SetValue(param, {type::TypeId::VARCHAR, string_val.first, std::move(string_val.second)})) {
     action_context->SetState(ActionState::FAILURE);
   } else {
     std::string_view new_value(value);

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -585,7 +585,7 @@ TEST_F(BinderCorrectnessTest, UpdateStatementSimpleTest) {
   EXPECT_EQ("a1", update_clause->GetColumnName());
   auto constant = update_clause->GetUpdateValue().CastManagedPointerTo<parser::ConstantValueExpression>();
   EXPECT_EQ(constant->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(constant->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 999);
+  EXPECT_EQ(constant->Peek<int64_t>(), 999);
 
   BINDER_LOG_DEBUG("Checking update condition");
   auto col_expr = update_stmt->GetUpdateCondition()->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();

--- a/test/execution/compiler_test.cpp
+++ b/test/execution/compiler_test.cpp
@@ -272,9 +272,9 @@ TEST_F(CompilerTest, SimpleSeqScanWithParamsTest) {
   MultiOutputCallback callback{std::vector<exec::OutputCallback>{store, printer}};
   auto exec_ctx = MakeExecCtx(std::move(callback), seq_scan->GetOutputSchema().Get());
   std::vector<parser::ConstantValueExpression> params;
-  params.emplace_back(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(100));
-  params.emplace_back(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(500));
-  params.emplace_back(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(3));
+  params.emplace_back(type::TypeId::INTEGER, execution::sql::Integer(100));
+  params.emplace_back(type::TypeId::INTEGER, execution::sql::Integer(500));
+  params.emplace_back(type::TypeId::INTEGER, execution::sql::Integer(3));
   exec_ctx->SetParams(common::ManagedPointer<const std::vector<parser::ConstantValueExpression>>(&params));
 
   // Run & Check
@@ -2866,8 +2866,8 @@ TEST_F(CompilerTest, InsertIntoSelectWithParamTest) {
     MultiOutputCallback callback{std::vector<exec::OutputCallback>{}};
     auto exec_ctx = MakeExecCtx(std::move(callback), insert->GetOutputSchema().Get());
     std::vector<parser::ConstantValueExpression> params;
-    params.emplace_back(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(495));
-    params.emplace_back(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(505));
+    params.emplace_back(type::TypeId::INTEGER, execution::sql::Integer(495));
+    params.emplace_back(type::TypeId::INTEGER, execution::sql::Integer(505));
     exec_ctx->SetParams(common::ManagedPointer<const std::vector<parser::ConstantValueExpression>>(&params));
     auto executable = ExecutableQuery(common::ManagedPointer(insert), common::ManagedPointer(exec_ctx));
     executable.Run(common::ManagedPointer(exec_ctx), MODE);
@@ -3083,23 +3083,23 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     // First parameter list
     auto str1_val = sql::ValueUtil::CreateStringVal(str1);
     params.emplace_back(type::TypeId::VARCHAR, std::move(str1_val.first), std::move(str1_val.second));
-    params.emplace_back(type::TypeId::DATE, std::make_unique<sql::DateVal>(date1.val_));
-    params.emplace_back(type::TypeId::DECIMAL, std::make_unique<sql::Real>(real1));
-    params.emplace_back(type::TypeId::BOOLEAN, std::make_unique<sql::BoolVal>(bool1));
-    params.emplace_back(type::TypeId::TINYINT, std::make_unique<sql::Integer>(tinyint1));
-    params.emplace_back(type::TypeId::SMALLINT, std::make_unique<sql::Integer>(smallint1));
-    params.emplace_back(type::TypeId::INTEGER, std::make_unique<sql::Integer>(int1));
-    params.emplace_back(type::TypeId::BIGINT, std::make_unique<sql::Integer>(bigint1));
+    params.emplace_back(type::TypeId::DATE, sql::DateVal(date1.val_));
+    params.emplace_back(type::TypeId::DECIMAL, sql::Real(real1));
+    params.emplace_back(type::TypeId::BOOLEAN, sql::BoolVal(bool1));
+    params.emplace_back(type::TypeId::TINYINT, sql::Integer(tinyint1));
+    params.emplace_back(type::TypeId::SMALLINT, sql::Integer(smallint1));
+    params.emplace_back(type::TypeId::INTEGER, sql::Integer(int1));
+    params.emplace_back(type::TypeId::BIGINT, sql::Integer(bigint1));
     // Second parameter list
     auto str2_val = sql::ValueUtil::CreateStringVal(str2);
     params.emplace_back(type::TypeId::VARCHAR, std::move(str2_val.first), std::move(str2_val.second));
-    params.emplace_back(type::TypeId::DATE, std::make_unique<sql::DateVal>(date2.val_));
-    params.emplace_back(type::TypeId::DECIMAL, std::make_unique<sql::Real>(real2));
-    params.emplace_back(type::TypeId::BOOLEAN, std::make_unique<sql::BoolVal>(bool2));
-    params.emplace_back(type::TypeId::TINYINT, std::make_unique<sql::Integer>(tinyint2));
-    params.emplace_back(type::TypeId::SMALLINT, std::make_unique<sql::Integer>(smallint2));
-    params.emplace_back(type::TypeId::INTEGER, std::make_unique<sql::Integer>(int2));
-    params.emplace_back(type::TypeId::BIGINT, std::make_unique<sql::Integer>(bigint2));
+    params.emplace_back(type::TypeId::DATE, sql::DateVal(date2.val_));
+    params.emplace_back(type::TypeId::DECIMAL, sql::Real(real2));
+    params.emplace_back(type::TypeId::BOOLEAN, sql::BoolVal(bool2));
+    params.emplace_back(type::TypeId::TINYINT, sql::Integer(tinyint2));
+    params.emplace_back(type::TypeId::SMALLINT, sql::Integer(smallint2));
+    params.emplace_back(type::TypeId::INTEGER, sql::Integer(int2));
+    params.emplace_back(type::TypeId::BIGINT, sql::Integer(bigint2));
     exec_ctx->SetParams(common::ManagedPointer<const std::vector<parser::ConstantValueExpression>>(&params));
     auto executable = ExecutableQuery(common::ManagedPointer(insert), common::ManagedPointer(exec_ctx));
     executable.Run(common::ManagedPointer(exec_ctx), MODE);

--- a/test/execution/compiler_test.cpp
+++ b/test/execution/compiler_test.cpp
@@ -3082,7 +3082,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     std::vector<parser::ConstantValueExpression> params;
     // First parameter list
     auto str1_val = sql::ValueUtil::CreateStringVal(str1);
-    params.emplace_back(type::TypeId::VARCHAR, std::move(str1_val.first), std::move(str1_val.second));
+    params.emplace_back(type::TypeId::VARCHAR, str1_val.first, std::move(str1_val.second));
     params.emplace_back(type::TypeId::DATE, sql::DateVal(date1.val_));
     params.emplace_back(type::TypeId::DECIMAL, sql::Real(real1));
     params.emplace_back(type::TypeId::BOOLEAN, sql::BoolVal(bool1));
@@ -3092,7 +3092,7 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     params.emplace_back(type::TypeId::BIGINT, sql::Integer(bigint1));
     // Second parameter list
     auto str2_val = sql::ValueUtil::CreateStringVal(str2);
-    params.emplace_back(type::TypeId::VARCHAR, std::move(str2_val.first), std::move(str2_val.second));
+    params.emplace_back(type::TypeId::VARCHAR, str2_val.first, std::move(str2_val.second));
     params.emplace_back(type::TypeId::DATE, sql::DateVal(date2.val_));
     params.emplace_back(type::TypeId::DECIMAL, sql::Real(real2));
     params.emplace_back(type::TypeId::BOOLEAN, sql::BoolVal(bool2));
@@ -3280,8 +3280,8 @@ TEST_F(CompilerTest, SimpleInsertWithParamsTest) {
     std::vector<parser::ConstantValueExpression> params;
     auto str1_val = sql::ValueUtil::CreateStringVal(str1);
     auto str2_val = sql::ValueUtil::CreateStringVal(str2);
-    params.emplace_back(type::TypeId::VARCHAR, std::move(str1_val.first), std::move(str1_val.second));
-    params.emplace_back(type::TypeId::VARCHAR, std::move(str2_val.first), std::move(str2_val.second));
+    params.emplace_back(type::TypeId::VARCHAR, str1_val.first, std::move(str1_val.second));
+    params.emplace_back(type::TypeId::VARCHAR, str2_val.first, std::move(str2_val.second));
     exec_ctx->SetParams(common::ManagedPointer<const std::vector<parser::ConstantValueExpression>>(&params));
     auto executable = ExecutableQuery(common::ManagedPointer(index_scan), common::ManagedPointer(exec_ctx));
     executable.Run(common::ManagedPointer(exec_ctx), MODE);

--- a/test/execution/table_vector_iterator_test.cpp
+++ b/test/execution/table_vector_iterator_test.cpp
@@ -20,7 +20,7 @@ class TableVectorIteratorTest : public SqlBasedTest {
 
  public:
   parser::ConstantValueExpression DummyExpr() {
-    return parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(0));
+    return parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(0));
   }
 
  protected:

--- a/test/include/execution/compiler/expression_util.h
+++ b/test/include/execution/compiler/expression_util.h
@@ -49,8 +49,8 @@ class ExpressionMaker {
    * Create a floating point constant expression
    */
   ManagedExpression Constant(double val) {
-    return MakeManaged(std::make_unique<parser::ConstantValueExpression>(type::TypeId::DECIMAL,
-                                                                         std::make_unique<execution::sql::Real>(val)));
+    return MakeManaged(
+        std::make_unique<parser::ConstantValueExpression>(type::TypeId::DECIMAL, execution::sql::Real(val)));
   }
 
   /**

--- a/test/include/execution/compiler/expression_util.h
+++ b/test/include/execution/compiler/expression_util.h
@@ -41,8 +41,8 @@ class ExpressionMaker {
    * Create an integer constant expression
    */
   ManagedExpression Constant(int32_t val) {
-    return MakeManaged(std::make_unique<parser::ConstantValueExpression>(
-        type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(val)));
+    return MakeManaged(
+        std::make_unique<parser::ConstantValueExpression>(type::TypeId::INTEGER, execution::sql::Integer(val)));
   }
 
   /**
@@ -58,7 +58,7 @@ class ExpressionMaker {
    */
   ManagedExpression Constant(int32_t year, uint32_t month, uint32_t day) {
     return MakeManaged(std::make_unique<parser::ConstantValueExpression>(
-        type::TypeId::DATE, std::make_unique<sql::DateVal>(sql::Date::FromYMD(year, month, day))));
+        type::TypeId::DATE, sql::DateVal(sql::Date::FromYMD(year, month, day))));
   }
 
   /**

--- a/test/include/execution/sql_test.h
+++ b/test/include/execution/sql_test.h
@@ -55,7 +55,7 @@ class SqlBasedTest : public TplTest {
   }
 
   parser::ConstantValueExpression DummyCVE() {
-    return parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(0));
+    return parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(0));
   }
 
   std::unique_ptr<terrier::catalog::CatalogAccessor> MakeAccessor() {

--- a/test/optimizer/logical_operator_test.cpp
+++ b/test/optimizer/logical_operator_test.cpp
@@ -37,8 +37,8 @@ TEST(OperatorTests, LogicalInsertTest) {
   catalog::table_oid_t table_oid(789);
   catalog::col_oid_t columns[] = {catalog::col_oid_t(1), catalog::col_oid_t(2)};
   parser::AbstractExpression *raw_values[] = {
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)),
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(9))};
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)),
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(9))};
   auto *values = new std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(
       {std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values))});
 
@@ -85,9 +85,9 @@ TEST(OperatorTests, LogicalInsertTest) {
   // NOTE: We only do this for debug builds
 #ifndef NDEBUG
   parser::AbstractExpression *bad_raw_values[] = {
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)),
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(2)),
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(3))};
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)),
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(2)),
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(3))};
   auto *bad_values = new std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>>(
       {std::vector<common::ManagedPointer<parser::AbstractExpression>>(bad_raw_values, std::end(bad_raw_values))});
   EXPECT_DEATH(LogicalInsert::Make(
@@ -167,7 +167,7 @@ TEST(OperatorTests, LogicalLimitTest) {
   size_t offset = 90;
   size_t limit = 22;
   parser::AbstractExpression *sort_expr_ori =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   auto sort_expr = common::ManagedPointer<parser::AbstractExpression>(sort_expr_ori);
   OrderByOrderingType sort_dir = OrderByOrderingType::ASC;
 
@@ -255,7 +255,7 @@ TEST(OperatorTests, LogicalUpdateTest) {
 
   std::string column = "abc";
   parser::AbstractExpression *value =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   auto update_clause =
       std::make_unique<parser::UpdateClause>(column, common::ManagedPointer<parser::AbstractExpression>(value));
   auto update_clause2 =
@@ -366,11 +366,11 @@ TEST(OperatorTests, LogicalGetTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -545,9 +545,9 @@ TEST(OperatorTests, LogicalQueryDerivedGetTest) {
   auto alias_to_expr_map_5 = std::unordered_map<std::string, common::ManagedPointer<parser::AbstractExpression>>();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   auto expr1 = common::ManagedPointer(expr_b_1);
   auto expr2 = common::ManagedPointer(expr_b_2);
 
@@ -615,11 +615,11 @@ TEST(OperatorTests, LogicalFilterTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -687,11 +687,11 @@ TEST(OperatorTests, LogicalProjectionTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -745,11 +745,11 @@ TEST(OperatorTests, LogicalDependentJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -821,11 +821,11 @@ TEST(OperatorTests, LogicalMarkJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -896,11 +896,11 @@ TEST(OperatorTests, LogicalSingleJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -972,11 +972,11 @@ TEST(OperatorTests, LogicalInnerJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -1048,11 +1048,11 @@ TEST(OperatorTests, LogicalLeftJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -1109,11 +1109,11 @@ TEST(OperatorTests, LogicalRightJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -1171,11 +1171,11 @@ TEST(OperatorTests, LogicalOuterJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -1232,11 +1232,11 @@ TEST(OperatorTests, LogicalSemiJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -1294,13 +1294,13 @@ TEST(OperatorTests, LogicalAggregateAndGroupByTest) {
 
   // ConstValueExpression subclass AbstractExpression
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
   parser::AbstractExpression *expr_b_7 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   // columns: vector of shared_ptr of AbstractExpression
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
@@ -1310,13 +1310,13 @@ TEST(OperatorTests, LogicalAggregateAndGroupByTest) {
 
   // ConstValueExpression subclass AbstractExpression
   parser::AbstractExpression *expr_b_4 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_5 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_8 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_6 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
   auto x_4 = common::ManagedPointer<parser::AbstractExpression>(expr_b_4);
   auto x_5 = common::ManagedPointer<parser::AbstractExpression>(expr_b_5);
   auto x_6 = common::ManagedPointer<parser::AbstractExpression>(expr_b_6);
@@ -1591,9 +1591,9 @@ TEST(OperatorTests, LogicalCreateIndexTest) {
 
   std::vector<common::ManagedPointer<parser::AbstractExpression>> raw_values = {
       common::ManagedPointer<parser::AbstractExpression>(
-          new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1))),
+          new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1))),
       common::ManagedPointer<parser::AbstractExpression>(
-          new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(9)))};
+          new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(9)))};
   auto raw_values_copy = raw_values;
   Operator op3 = LogicalCreateIndex::Make(catalog::namespace_oid_t(1), catalog::table_oid_t(1),
                                           parser::IndexType::BWTREE, true, "index_1", std::move(raw_values_copy))
@@ -1612,9 +1612,9 @@ TEST(OperatorTests, LogicalCreateIndexTest) {
 
   std::vector<common::ManagedPointer<parser::AbstractExpression>> raw_values_2 = {
       common::ManagedPointer<parser::AbstractExpression>(
-          new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true))),
+          new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true))),
       common::ManagedPointer<parser::AbstractExpression>(
-          new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(9)))};
+          new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(9)))};
   auto raw_values_copy3 = raw_values_2;
   Operator op10 = LogicalCreateIndex::Make(catalog::namespace_oid_t(1), catalog::table_oid_t(1),
                                            parser::IndexType::BWTREE, true, "index_1", std::move(raw_values_copy3))
@@ -1685,7 +1685,7 @@ TEST(OperatorTests, LogicalCreateTableTest) {
   auto col_def = new parser::ColumnDefinition(
       "col_1", parser::ColumnDefinition::DataType::INTEGER, true, true, true,
       common::ManagedPointer<parser::AbstractExpression>(
-          new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(9))),
+          new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(9))),
       nullptr, 4);
   Operator op1 = LogicalCreateTable::Make(catalog::namespace_oid_t(1), "Table_1",
                                           std::vector<common::ManagedPointer<parser::ColumnDefinition>>{
@@ -1831,7 +1831,7 @@ TEST(OperatorTests, LogicalCreateTriggerTest) {
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
-  auto when = new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+  auto when = new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   Operator op1 = LogicalCreateTrigger::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(1), catalog::table_oid_t(1),
                                             "Trigger_1", {}, {}, {catalog::col_oid_t(1)},
                                             common::ManagedPointer<parser::AbstractExpression>(when), 0)
@@ -1921,8 +1921,7 @@ TEST(OperatorTests, LogicalCreateTriggerTest) {
   EXPECT_FALSE(op10 == op1);
   EXPECT_NE(op1.Hash(), op10.Hash());
 
-  auto when_2 =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(2));
+  auto when_2 = new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(2));
   Operator op11 = LogicalCreateTrigger::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(1), catalog::table_oid_t(1),
                                              "Trigger_1", {}, {}, {catalog::col_oid_t(1)},
                                              common::ManagedPointer<parser::AbstractExpression>(when_2), 0)

--- a/test/optimizer/logical_operator_test.cpp
+++ b/test/optimizer/logical_operator_test.cpp
@@ -1745,7 +1745,7 @@ TEST(OperatorTests, LogicalCreateTableTest) {
   auto col_def_2 = new parser::ColumnDefinition(
       "col_1", parser::ColumnDefinition::DataType::VARCHAR, true, true, true,
       common::ManagedPointer<parser::AbstractExpression>(new parser::ConstantValueExpression(
-          type::TypeId::VARCHAR, std::move(col_def_2_string_val.first), std::move(col_def_2_string_val.second))),
+          type::TypeId::VARCHAR, col_def_2_string_val.first, std::move(col_def_2_string_val.second))),
       nullptr, 20);
   Operator op7 = LogicalCreateTable::Make(catalog::namespace_oid_t(1), "Table_2",
                                           std::vector<common::ManagedPointer<parser::ColumnDefinition>>{

--- a/test/optimizer/operator_transformer_test.cpp
+++ b/test/optimizer/operator_transformer_test.cpp
@@ -250,12 +250,12 @@ TEST_F(OperatorTransformerTest, InsertStatementSimpleTest) {
   auto insert_value_a1 =
       logical_insert->GetValues().Get()[0][0][0].CastManagedPointerTo<parser::ConstantValueExpression>();
   EXPECT_EQ(insert_value_a1->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(insert_value_a1->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 5);
+  EXPECT_EQ(insert_value_a1->Peek<int64_t>(), 5);
 
   auto insert_value_a2 =
       logical_insert->GetValues().Get()[0][0][1].CastManagedPointerTo<parser::ConstantValueExpression>();
   EXPECT_EQ(insert_value_a2->GetReturnValueType(), type::TypeId::VARCHAR);
-  EXPECT_EQ(insert_value_a2->GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView(), "MY DATA");
+  EXPECT_EQ(insert_value_a2->Peek<std::string_view>(), "MY DATA");
 }
 
 // NOLINTNEXTLINE
@@ -329,7 +329,7 @@ TEST_F(OperatorTransformerTest, UpdateStatementSimpleTest) {
   EXPECT_EQ("a1", update_clause->GetColumnName());
   auto constant = update_clause->GetUpdateValue().CastManagedPointerTo<parser::ConstantValueExpression>();
   EXPECT_EQ(constant->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(constant->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 999);
+  EXPECT_EQ(constant->Peek<int64_t>(), 999);
 
   // Test LogicalGet
   auto logical_get = operator_tree_->GetChildren()[0]->Contents()->GetContentsAs<optimizer::LogicalGet>();

--- a/test/optimizer/operator_transformer_test.cpp
+++ b/test/optimizer/operator_transformer_test.cpp
@@ -1017,7 +1017,7 @@ TEST_F(OperatorTransformerTest, CreateTableTest) {
   auto def_expr = ct->GetColumns()[3]->GetDefaultExpression();
   EXPECT_EQ(def_expr->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
   EXPECT_EQ(*(def_expr.CastManagedPointerTo<parser::ConstantValueExpression>()),
-            parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(14)));
+            parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(14)));
 
   auto chk_expr = ct->GetColumns()[3]->GetCheckExpression();
   EXPECT_EQ(chk_expr->GetExpressionType(), parser::ExpressionType::COMPARE_LESS_THAN);
@@ -1026,7 +1026,7 @@ TEST_F(OperatorTransformerTest, CreateTableTest) {
   EXPECT_EQ(chk_expr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>()->GetColumnName(), "c4");
   EXPECT_EQ(chk_expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
   EXPECT_EQ(*(chk_expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>()),
-            parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(100)));
+            parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(100)));
 
   optimizer::PlanGenerator plan_generator{};
   optimizer::PropertySet property_set{};
@@ -1060,7 +1060,7 @@ TEST_F(OperatorTransformerTest, CreateTableTest) {
   EXPECT_EQ(ctpn->GetSchema()->GetColumns()[2].AttrSize(), 4);
   EXPECT_EQ(ctpn->GetSchema()->GetColumns()[3].AttrSize(), 4);
   EXPECT_EQ(*ctpn->GetSchema()->GetColumns()[3].StoredExpression(),
-            parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(14)));
+            parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(14)));
 
   EXPECT_TRUE(ctpn->HasPrimaryKey());
   EXPECT_EQ(ctpn->GetPrimaryKey().primary_key_cols_.size(), 1);
@@ -1085,7 +1085,7 @@ TEST_F(OperatorTransformerTest, CreateTableTest) {
   EXPECT_EQ(ctpn->GetCheckConstraints()[0].constraint_name_, "con_check");
   EXPECT_EQ(ctpn->GetCheckConstraints()[0].expr_type_, parser::ExpressionType::COMPARE_LESS_THAN);
   EXPECT_EQ(ctpn->GetCheckConstraints()[0].expr_value_,
-            parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(100)));
+            parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(100)));
 }
 
 // NOLINTNEXTLINE
@@ -1374,7 +1374,7 @@ TEST_F(OperatorTransformerTest, CreateViewTest) {
   EXPECT_EQ(sc0.CastManagedPointerTo<parser::ColumnValueExpression>()->GetColumnName(), "a1");
   EXPECT_EQ(sc1->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
   EXPECT_EQ(*(sc1.CastManagedPointerTo<parser::ConstantValueExpression>()),
-            parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(4)));
+            parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(4)));
 
   optimizer::PlanGenerator plan_generator{};
   optimizer::PropertySet property_set{};
@@ -1399,7 +1399,7 @@ TEST_F(OperatorTransformerTest, CreateViewTest) {
   EXPECT_EQ(scpn0.CastManagedPointerTo<parser::ColumnValueExpression>()->GetColumnName(), "a1");
   EXPECT_EQ(scpn1->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
   EXPECT_EQ(*(scpn1.CastManagedPointerTo<parser::ConstantValueExpression>()),
-            parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(4)));
+            parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(4)));
 }
 
 // NOLINTNEXTLINE

--- a/test/optimizer/physical_operator_test.cpp
+++ b/test/optimizer/physical_operator_test.cpp
@@ -64,11 +64,11 @@ TEST(OperatorTests, SeqScanTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -168,11 +168,11 @@ TEST(OperatorTests, IndexScanTest) {
 
   // predicates
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -344,9 +344,9 @@ TEST(OperatorTests, QueryDerivedScanTest) {
   auto alias_to_expr_map_5 = std::unordered_map<std::string, common::ManagedPointer<parser::AbstractExpression>>();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   auto expr1 = common::ManagedPointer(expr_b_1);
   auto expr2 = common::ManagedPointer(expr_b_2);
 
@@ -436,8 +436,7 @@ TEST(OperatorTests, LimitTest) {
 
   size_t offset = 90;
   size_t limit = 22;
-  auto sort_expr_ori =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+  auto sort_expr_ori = new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   auto sort_expr = common::ManagedPointer<parser::AbstractExpression>(sort_expr_ori);
   OrderByOrderingType sort_dir = OrderByOrderingType::ASC;
 
@@ -485,11 +484,11 @@ TEST(OperatorTests, InnerNLJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -560,11 +559,11 @@ TEST(OperatorTests, LeftNLJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -608,11 +607,11 @@ TEST(OperatorTests, RightNLJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -656,11 +655,11 @@ TEST(OperatorTests, OuterNLJoin) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -704,11 +703,11 @@ TEST(OperatorTests, InnerHashJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -791,11 +790,11 @@ TEST(OperatorTests, LeftHashJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -839,11 +838,11 @@ TEST(OperatorTests, RightHashJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -887,11 +886,11 @@ TEST(OperatorTests, OuterHashJoinTest) {
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
   auto x_2 = common::ManagedPointer<parser::AbstractExpression>(expr_b_2);
@@ -940,8 +939,8 @@ TEST(OperatorTests, InsertTest) {
   catalog::col_oid_t columns[] = {catalog::col_oid_t(1), catalog::col_oid_t(2)};
   std::vector<catalog::index_oid_t> indexes = {catalog::index_oid_t(4), catalog::index_oid_t(5)};
   parser::AbstractExpression *raw_values[] = {
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)),
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(9))};
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)),
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(9))};
   std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> values = {
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(raw_values, std::end(raw_values))};
 
@@ -987,9 +986,9 @@ TEST(OperatorTests, InsertTest) {
   // NOTE: We only do this for debug builds
 #ifndef NDEBUG
   parser::AbstractExpression *bad_raw_values[] = {
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)),
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(2)),
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(3))};
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)),
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(2)),
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(3))};
   std::vector<std::vector<common::ManagedPointer<parser::AbstractExpression>>> bad_values = {
       std::vector<common::ManagedPointer<parser::AbstractExpression>>(bad_raw_values, std::end(bad_raw_values))};
   EXPECT_DEATH(
@@ -1163,7 +1162,7 @@ TEST(OperatorTests, UpdateTest) {
 
   std::string column = "abc";
   parser::AbstractExpression *value =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+      new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   parser::UpdateClause *raw_update_clause = new parser::UpdateClause(column, common::ManagedPointer(value));
   auto update_clause = common::ManagedPointer(raw_update_clause);
   catalog::db_oid_t database_oid(123);
@@ -1216,13 +1215,13 @@ TEST(OperatorTests, HashGroupByTest) {
 
   // ConstValueExpression subclass AbstractExpression
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
   parser::AbstractExpression *expr_b_7 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   // columns: vector of shared_ptr of AbstractExpression
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
@@ -1232,13 +1231,13 @@ TEST(OperatorTests, HashGroupByTest) {
 
   // ConstValueExpression subclass AbstractExpression
   parser::AbstractExpression *expr_b_4 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_5 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_8 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_6 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
   auto x_4 = common::ManagedPointer<parser::AbstractExpression>(expr_b_4);
   auto x_5 = common::ManagedPointer<parser::AbstractExpression>(expr_b_5);
   auto x_6 = common::ManagedPointer<parser::AbstractExpression>(expr_b_6);
@@ -1321,13 +1320,13 @@ TEST(OperatorTests, SortGroupByTest) {
 
   // ConstValueExpression subclass AbstractExpression
   parser::AbstractExpression *expr_b_1 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_2 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_3 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
   parser::AbstractExpression *expr_b_7 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
 
   // columns: vector of shared_ptr of AbstractExpression
   auto x_1 = common::ManagedPointer<parser::AbstractExpression>(expr_b_1);
@@ -1337,13 +1336,13 @@ TEST(OperatorTests, SortGroupByTest) {
 
   // ConstValueExpression subclass AbstractExpression
   parser::AbstractExpression *expr_b_4 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_5 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_8 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   parser::AbstractExpression *expr_b_6 =
-      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
+      new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
   auto x_4 = common::ManagedPointer<parser::AbstractExpression>(expr_b_4);
   auto x_5 = common::ManagedPointer<parser::AbstractExpression>(expr_b_5);
   auto x_6 = common::ManagedPointer<parser::AbstractExpression>(expr_b_6);
@@ -1614,7 +1613,7 @@ TEST(OperatorTests, CreateIndexTest) {
   auto idx_schema = std::make_unique<catalog::IndexSchema>(
       std::vector<catalog::IndexSchema::Column>{catalog::IndexSchema::Column(
           "col_1", type::TypeId::TINYINT, true,
-          parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)))},
+          parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)))},
       storage::index::IndexType::BWTREE, true, true, true, true);
 
   Operator op1 =
@@ -1629,14 +1628,14 @@ TEST(OperatorTests, CreateIndexTest) {
   auto idx_schema_dup = std::make_unique<catalog::IndexSchema>(
       std::vector<catalog::IndexSchema::Column>{catalog::IndexSchema::Column(
           "col_1", type::TypeId::TINYINT, true,
-          parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)))},
+          parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)))},
       storage::index::IndexType::BWTREE, true, true, true, true);
   EXPECT_EQ(*op1.GetContentsAs<CreateIndex>()->GetSchema(), *idx_schema_dup);
 
   auto idx_schema_2 = std::make_unique<catalog::IndexSchema>(
       std::vector<catalog::IndexSchema::Column>{catalog::IndexSchema::Column(
           "col_1", type::TypeId::TINYINT, true,
-          parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)))},
+          parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)))},
       storage::index::IndexType::BWTREE, true, true, true, true);
   Operator op2 =
       CreateIndex::Make(catalog::namespace_oid_t(1), catalog::table_oid_t(1), "index_1", std::move(idx_schema_2))
@@ -1647,7 +1646,7 @@ TEST(OperatorTests, CreateIndexTest) {
   auto idx_schema_3 = std::make_unique<catalog::IndexSchema>(
       std::vector<catalog::IndexSchema::Column>{catalog::IndexSchema::Column(
           "col_1", type::TypeId::TINYINT, true,
-          parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)))},
+          parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)))},
       storage::index::IndexType::BWTREE, true, true, true, true);
   Operator op3 =
       CreateIndex::Make(catalog::namespace_oid_t(2), catalog::table_oid_t(1), "index_1", std::move(idx_schema_3))
@@ -1658,7 +1657,7 @@ TEST(OperatorTests, CreateIndexTest) {
   auto idx_schema_4 = std::make_unique<catalog::IndexSchema>(
       std::vector<catalog::IndexSchema::Column>{catalog::IndexSchema::Column(
           "col_1", type::TypeId::TINYINT, true,
-          parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)))},
+          parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)))},
       storage::index::IndexType::BWTREE, true, true, true, true);
   Operator op4 =
       CreateIndex::Make(catalog::namespace_oid_t(1), catalog::table_oid_t(1), "index_2", std::move(idx_schema_4))
@@ -1669,7 +1668,7 @@ TEST(OperatorTests, CreateIndexTest) {
   auto idx_schema_5 = std::make_unique<catalog::IndexSchema>(
       std::vector<catalog::IndexSchema::Column>{catalog::IndexSchema::Column(
           "col_1", type::TypeId::INTEGER, true,
-          parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(1)))},
+          parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(1)))},
       storage::index::IndexType::BWTREE, true, true, true, true);
   Operator op5 =
       CreateIndex::Make(catalog::namespace_oid_t(1), catalog::table_oid_t(1), "index_1", std::move(idx_schema_5))
@@ -1681,10 +1680,10 @@ TEST(OperatorTests, CreateIndexTest) {
       std::vector<catalog::IndexSchema::Column>{
           catalog::IndexSchema::Column(
               "col_1", type::TypeId::INTEGER, true,
-              parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(1))),
+              parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(1))),
           catalog::IndexSchema::Column(
               "col_2", type::TypeId::TINYINT, true,
-              parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(1)))},
+              parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(1)))},
       storage::index::IndexType::BWTREE, true, true, true, true);
   Operator op6 =
       CreateIndex::Make(catalog::namespace_oid_t(1), catalog::table_oid_t(1), "index_1", std::move(idx_schema_6))
@@ -1713,7 +1712,7 @@ TEST(OperatorTests, CreateTableTest) {
   auto col_def = new parser::ColumnDefinition(
       "col_1", parser::ColumnDefinition::DataType::INTEGER, true, true, true,
       common::ManagedPointer<parser::AbstractExpression>(
-          new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(9))),
+          new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(9))),
       nullptr, 4);
   Operator op1 = CreateTable::Make(catalog::namespace_oid_t(1), "Table_1",
                                    std::vector<common::ManagedPointer<parser::ColumnDefinition>>{
@@ -1853,7 +1852,7 @@ TEST(OperatorTests, CreateTriggerTest) {
 
   transaction::TransactionContext *txn_context = txn_manager.BeginTransaction();
 
-  auto when = new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
+  auto when = new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
   Operator op1 =
       CreateTrigger::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(1), catalog::table_oid_t(1), "Trigger_1", {},
                           {}, {catalog::col_oid_t(1)}, common::ManagedPointer<parser::AbstractExpression>(when), 0)
@@ -1937,8 +1936,7 @@ TEST(OperatorTests, CreateTriggerTest) {
   EXPECT_FALSE(op10 == op1);
   EXPECT_NE(op1.Hash(), op10.Hash());
 
-  auto when_2 =
-      new parser::ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(2));
+  auto when_2 = new parser::ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(2));
   Operator op11 =
       CreateTrigger::Make(catalog::db_oid_t(1), catalog::namespace_oid_t(1), catalog::table_oid_t(1), "Trigger_1", {},
                           {}, {catalog::col_oid_t(1)}, common::ManagedPointer<parser::AbstractExpression>(when_2), 0)

--- a/test/optimizer/physical_operator_test.cpp
+++ b/test/optimizer/physical_operator_test.cpp
@@ -1772,7 +1772,7 @@ TEST(OperatorTests, CreateTableTest) {
   auto col_def_2 = new parser::ColumnDefinition(
       "col_1", parser::ColumnDefinition::DataType::VARCHAR, true, true, true,
       common::ManagedPointer<parser::AbstractExpression>(new parser::ConstantValueExpression(
-          type::TypeId::VARCHAR, std::move(col_def_2_string_val.first), std::move(col_def_2_string_val.second))),
+          type::TypeId::VARCHAR, col_def_2_string_val.first, std::move(col_def_2_string_val.second))),
       nullptr, 20);
   Operator op7 = CreateTable::Make(catalog::namespace_oid_t(1), "Table_2",
                                    std::vector<common::ManagedPointer<parser::ColumnDefinition>>{

--- a/test/optimizer/tpcc_plan_delivery_test.cpp
+++ b/test/optimizer/tpcc_plan_delivery_test.cpp
@@ -63,11 +63,11 @@ TEST_F(TpccPlanDeliveryTests, DeliveryDeleteNewOrder) {
     auto plll = pll->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto pllr = pll->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(plll->GetColumnOid(), schema.GetColumn("no_o_id").Oid());
-    EXPECT_EQ(pllr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+    EXPECT_EQ(pllr->Peek<int64_t>(), 1);
     auto plrl = plr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto plrr = plr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(plrl->GetColumnOid(), schema.GetColumn("no_d_id").Oid());
-    EXPECT_EQ(plrr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 2);
+    EXPECT_EQ(plrr->Peek<int64_t>(), 2);
 
     auto pred_right = scan_pred->GetChild(1).CastManagedPointerTo<parser::ComparisonExpression>();
     EXPECT_EQ(pred_right->GetChild(0)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
@@ -75,7 +75,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryDeleteNewOrder) {
     auto prl = pred_right->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto prr = pred_right->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(prl->GetColumnOid(), schema.GetColumn("no_w_id").Oid());
-    EXPECT_EQ(prr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 3);
+    EXPECT_EQ(prr->Peek<int64_t>(), 3);
 
     // IdxScan OutputSchema/ColumnIds
     auto idx_scan_schema = idx_scan->GetOutputSchema();
@@ -120,7 +120,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryUpdateCarrierId) {
     auto expr = update->GetSetClauses()[0].second;
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
     auto cve = expr.CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+    EXPECT_EQ(cve->Peek<int64_t>(), 1);
 
     // Idx Scan, full output schema
     EXPECT_EQ(update->GetChildren().size(), 1);
@@ -170,7 +170,7 @@ TEST_F(TpccPlanDeliveryTests, DeliveryUpdateDeliveryDate) {
     auto expr = update->GetSetClauses()[0].second;
     EXPECT_EQ(expr->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
     auto cve = expr.CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::TimestampVal>()->val_.ToNative(),
+    EXPECT_EQ(cve->Peek<execution::sql::Timestamp>().ToNative(),
               static_cast<uint64_t>(util::TimeConvertor::TimestampFromHMSu(2020, 1, 2, 11, 22, 33, 456000)));
 
     // Idx Scan, full output schema
@@ -263,11 +263,11 @@ TEST_F(TpccPlanDeliveryTests, DeliverySumOrderAmount) {
     auto plll = pll->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto pllr = pll->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(plll->GetColumnOid(), schema.GetColumn("ol_o_id").Oid());
-    EXPECT_EQ(pllr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+    EXPECT_EQ(pllr->Peek<int64_t>(), 1);
     auto plrl = plr->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto plrr = plr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(plrl->GetColumnOid(), schema.GetColumn("ol_d_id").Oid());
-    EXPECT_EQ(plrr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 2);
+    EXPECT_EQ(plrr->Peek<int64_t>(), 2);
 
     auto pred_right = scan_pred->GetChild(1).CastManagedPointerTo<parser::ComparisonExpression>();
     EXPECT_EQ(pred_right->GetChild(0)->GetExpressionType(), parser::ExpressionType::COLUMN_VALUE);
@@ -275,7 +275,7 @@ TEST_F(TpccPlanDeliveryTests, DeliverySumOrderAmount) {
     auto prl = pred_right->GetChild(0).CastManagedPointerTo<parser::ColumnValueExpression>();
     auto prr = pred_right->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(prl->GetColumnOid(), schema.GetColumn("ol_w_id").Oid());
-    EXPECT_EQ(prr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 3);
+    EXPECT_EQ(prr->Peek<int64_t>(), 3);
 
     // IdxScan OutputSchema
     auto idx_scan_schema = idx_scan->GetOutputSchema();
@@ -314,7 +314,7 @@ TEST_F(TpccPlanDeliveryTests, UpdateCustomBalanceDeliveryCount) {
       EXPECT_EQ(dve->GetColumnOid(), update_oids[idx]);
 
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-      EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+      EXPECT_EQ(cve->Peek<int64_t>(), 1);
     }
 
     // Idx Scan, full output schema

--- a/test/optimizer/tpcc_plan_index_scan.cpp
+++ b/test/optimizer/tpcc_plan_index_scan.cpp
@@ -48,7 +48,7 @@ TEST_F(TpccPlanIndexScanTests, SimplePredicateIndexScan) {
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(tve->GetColumnName(), "no_w_id");
     EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("no_w_id").Oid());
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+    EXPECT_EQ(cve->Peek<int64_t>(), 1);
   };
 
   std::string query = "SELECT NO_O_ID FROM \"NEW ORDER\" WHERE NO_W_ID = 1";
@@ -83,7 +83,7 @@ TEST_F(TpccPlanIndexScanTests, SimplePredicateFlippedIndexScan) {
     auto cve = scan_pred->GetChild(0).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(tve->GetColumnName(), "no_w_id");
     EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("no_w_id").Oid());
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+    EXPECT_EQ(cve->Peek<int64_t>(), 1);
   };
 
   std::string query = "SELECT NO_O_ID FROM \"NEW ORDER\" WHERE 1 < NO_W_ID";
@@ -157,7 +157,7 @@ TEST_F(TpccPlanIndexScanTests, IndexFulfillSortAndPredicate) {
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(tve->GetColumnName(), "no_w_id");
     EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("no_w_id").Oid());
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+    EXPECT_EQ(cve->Peek<int64_t>(), 1);
   };
 
   std::string query = "SELECT NO_O_ID FROM \"NEW ORDER\" WHERE NO_W_ID = 1 ORDER BY NO_W_ID";
@@ -221,7 +221,7 @@ TEST_F(TpccPlanIndexScanTests, IndexFulfillSortAndPredicateWithLimitOffset) {
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(tve->GetColumnName(), "no_w_id");
     EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("no_w_id").Oid());
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+    EXPECT_EQ(cve->Peek<int64_t>(), 1);
   };
 
   std::string query = "SELECT NO_O_ID FROM \"NEW ORDER\" WHERE NO_W_ID = 1 ORDER BY NO_W_ID LIMIT 15 OFFSET 445";

--- a/test/optimizer/tpcc_plan_neworder_test.cpp
+++ b/test/optimizer/tpcc_plan_neworder_test.cpp
@@ -58,7 +58,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateDistrict) {
     EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("d_next_o_id").Oid());
     EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
     auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+    EXPECT_EQ(cve->Peek<int64_t>(), 1);
 
     // Idx Scan, full output schema
     EXPECT_EQ(update->GetChildren().size(), 1);
@@ -138,7 +138,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
 
     {
       auto expr = update->GetSetClauses()[0].second.CastManagedPointerTo<parser::ConstantValueExpression>();
-      EXPECT_EQ(expr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+      EXPECT_EQ(expr->Peek<int64_t>(), 1);
     }
 
     {
@@ -148,7 +148,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
       EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("s_ytd").Oid());
       EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-      EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+      EXPECT_EQ(cve->Peek<int64_t>(), 1);
     }
 
     {
@@ -158,7 +158,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
       EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("s_order_cnt").Oid());
       EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-      EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+      EXPECT_EQ(cve->Peek<int64_t>(), 1);
     }
 
     {
@@ -168,7 +168,7 @@ TEST_F(TpccPlanNewOrderTests, UpdateStock) {
       EXPECT_EQ(dve->GetColumnOid(), schema.GetColumn("s_remote_cnt").Oid());
       EXPECT_EQ(expr->GetChild(1)->GetExpressionType(), parser::ExpressionType::VALUE_CONSTANT);
       auto cve = expr->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
-      EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+      EXPECT_EQ(cve->Peek<int64_t>(), 1);
     }
 
     // Idx Scan, full output schema

--- a/test/optimizer/tpcc_plan_payment_test.cpp
+++ b/test/optimizer/tpcc_plan_payment_test.cpp
@@ -167,10 +167,10 @@ TEST_F(TpccPlanPaymentTests, UpdateCustomerBalance) {
     auto set1 = update->GetSetClauses()[1].second.CastManagedPointerTo<parser::ConstantValueExpression>();
     auto set2 = update->GetSetClauses()[2].second.CastManagedPointerTo<parser::ConstantValueExpression>();
     auto set3 = update->GetSetClauses()[3].second.CastManagedPointerTo<parser::ConstantValueExpression>();
-    EXPECT_EQ(set0->GetValue().CastManagedPointerTo<execution::sql::Real>()->val_, 1);
-    EXPECT_EQ(set1->GetValue().CastManagedPointerTo<execution::sql::Real>()->val_, 2);
-    EXPECT_EQ(set2->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 3);
-    EXPECT_EQ(set3->GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView(), "4");
+    EXPECT_EQ(set0->Peek<double>(), 1);
+    EXPECT_EQ(set1->Peek<double>(), 2);
+    EXPECT_EQ(set2->Peek<int64_t>(), 3);
+    EXPECT_EQ(set3->Peek<std::string_view>(), "4");
 
     // Idx Scan, full output schema
     EXPECT_EQ(update->GetChildren().size(), 1);

--- a/test/optimizer/tpcc_plan_seq_scan.cpp
+++ b/test/optimizer/tpcc_plan_seq_scan.cpp
@@ -69,7 +69,7 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicate) {
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(tve->GetColumnName(), "o_carrier_id");
     EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("o_carrier_id").Oid());
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 5);
+    EXPECT_EQ(cve->Peek<int64_t>(), 5);
   };
 
   std::string query = "SELECT o_id from \"ORDER\" where o_carrier_id = 5";
@@ -124,7 +124,7 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateOrderBy) {
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(tve->GetColumnName(), "o_carrier_id");
     EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("o_carrier_id").Oid());
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 5);
+    EXPECT_EQ(cve->Peek<int64_t>(), 5);
   };
 
   std::string query = "SELECT o_id from \"ORDER\" where o_carrier_id = 5 ORDER BY o_ol_cnt DESC";
@@ -166,7 +166,7 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateLimit) {
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(tve->GetColumnName(), "o_carrier_id");
     EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("o_carrier_id").Oid());
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 5);
+    EXPECT_EQ(cve->Peek<int64_t>(), 5);
   };
 
   std::string query = "SELECT o_id from \"ORDER\" where o_carrier_id = 5 LIMIT 1 OFFSET 2";
@@ -229,7 +229,7 @@ TEST_F(TpccPlanSeqScanTests, SimpleSeqScanSelectWithPredicateOrderByLimit) {
     auto cve = scan_pred->GetChild(1).CastManagedPointerTo<parser::ConstantValueExpression>();
     EXPECT_EQ(tve->GetColumnName(), "o_carrier_id");
     EXPECT_EQ(tve->GetColumnOid(), schema.GetColumn("o_carrier_id").Oid());
-    EXPECT_EQ(cve->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 5);
+    EXPECT_EQ(cve->Peek<int64_t>(), 5);
   };
 
   std::string query = "SELECT o_id from \"ORDER\" where o_carrier_id = 5 ORDER BY o_ol_cnt DESC LIMIT 1 OFFSET 2";

--- a/test/optimizer/value_condition_test.cpp
+++ b/test/optimizer/value_condition_test.cpp
@@ -44,7 +44,6 @@ TEST(ValueConditionTests, GetPointerToValueTest) {
                                                                std::make_unique<execution::sql::Integer>(1));
   ValueCondition v(catalog::col_oid_t(1), "", parser::ExpressionType::INVALID, std::move(val));
 
-  EXPECT_EQ(parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(1)),
-            *v.GetPointerToValue());
+  EXPECT_EQ(parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(1)), *v.GetPointerToValue());
 }
 }  // namespace terrier::optimizer

--- a/test/optimizer/value_condition_test.cpp
+++ b/test/optimizer/value_condition_test.cpp
@@ -13,8 +13,7 @@
 namespace terrier::optimizer {
 // NOLINTNEXTLINE
 TEST(ValueConditionTests, GetColumnIDTest) {
-  auto val = std::make_unique<parser::ConstantValueExpression>(type::TypeId::INTEGER,
-                                                               std::make_unique<execution::sql::Integer>(1));
+  auto val = std::make_unique<parser::ConstantValueExpression>(type::TypeId::INTEGER, execution::sql::Integer(1));
   ValueCondition v(catalog::col_oid_t(1), "", parser::ExpressionType::INVALID, std::move(val));
 
   EXPECT_EQ(catalog::col_oid_t(1), v.GetColumnID());
@@ -22,8 +21,7 @@ TEST(ValueConditionTests, GetColumnIDTest) {
 
 // NOLINTNEXTLINE
 TEST(ValueConditionTests, GetColumnNameTest) {
-  auto val = std::make_unique<parser::ConstantValueExpression>(type::TypeId::INTEGER,
-                                                               std::make_unique<execution::sql::Integer>(1));
+  auto val = std::make_unique<parser::ConstantValueExpression>(type::TypeId::INTEGER, execution::sql::Integer(1));
   ValueCondition v(catalog::col_oid_t(1), "", parser::ExpressionType::INVALID, std::move(val));
 
   EXPECT_EQ("", v.GetColumnName());
@@ -31,8 +29,7 @@ TEST(ValueConditionTests, GetColumnNameTest) {
 
 // NOLINTNEXTLINE
 TEST(ValueConditionTests, GetTypeTest) {
-  auto val = std::make_unique<parser::ConstantValueExpression>(type::TypeId::INTEGER,
-                                                               std::make_unique<execution::sql::Integer>(1));
+  auto val = std::make_unique<parser::ConstantValueExpression>(type::TypeId::INTEGER, execution::sql::Integer(1));
   ValueCondition v(catalog::col_oid_t(1), "", parser::ExpressionType::INVALID, std::move(val));
 
   EXPECT_EQ(parser::ExpressionType::INVALID, v.GetType());
@@ -40,8 +37,7 @@ TEST(ValueConditionTests, GetTypeTest) {
 
 // NOLINTNEXTLINE
 TEST(ValueConditionTests, GetPointerToValueTest) {
-  auto val = std::make_unique<parser::ConstantValueExpression>(type::TypeId::INTEGER,
-                                                               std::make_unique<execution::sql::Integer>(1));
+  auto val = std::make_unique<parser::ConstantValueExpression>(type::TypeId::INTEGER, execution::sql::Integer(1));
   ValueCondition v(catalog::col_oid_t(1), "", parser::ExpressionType::INVALID, std::move(val));
 
   EXPECT_EQ(parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(1)), *v.GetPointerToValue());

--- a/test/parser/constant_value_expression_test.cpp
+++ b/test/parser/constant_value_expression_test.cpp
@@ -31,7 +31,7 @@ TEST_F(CVETests, BooleanTest) {
   for (uint32_t i = 0; i < num_iterations_; i++) {
     auto data = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
 
-    ConstantValueExpression value(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(data));
+    ConstantValueExpression value(type::TypeId::BOOLEAN, execution::sql::BoolVal(data));
     EXPECT_FALSE(value.GetValue()->is_null_);
     EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::BoolVal>()->val_);
 
@@ -64,7 +64,7 @@ TEST_F(CVETests, TinyIntTest) {
   for (uint32_t i = 0; i < num_iterations_; i++) {
     auto data = static_cast<int8_t>(std::uniform_int_distribution<int8_t>(INT8_MIN, INT8_MAX)(generator_));
 
-    ConstantValueExpression value(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(data));
+    ConstantValueExpression value(type::TypeId::TINYINT, execution::sql::Integer(data));
     EXPECT_FALSE(value.GetValue()->is_null_);
     EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
 
@@ -95,7 +95,7 @@ TEST_F(CVETests, SmallIntTest) {
   for (uint32_t i = 0; i < num_iterations_; i++) {
     auto data = static_cast<int16_t>(std::uniform_int_distribution<int16_t>(INT16_MIN, INT16_MAX)(generator_));
 
-    ConstantValueExpression value(type::TypeId::SMALLINT, std::make_unique<execution::sql::Integer>(data));
+    ConstantValueExpression value(type::TypeId::SMALLINT, execution::sql::Integer(data));
     EXPECT_FALSE(value.GetValue()->is_null_);
     EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
 
@@ -126,7 +126,7 @@ TEST_F(CVETests, IntegerTest) {
   for (uint32_t i = 0; i < num_iterations_; i++) {
     auto data = static_cast<int32_t>(std::uniform_int_distribution<int32_t>(INT32_MIN, INT32_MAX)(generator_));
 
-    ConstantValueExpression value(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(data));
+    ConstantValueExpression value(type::TypeId::INTEGER, execution::sql::Integer(data));
     EXPECT_FALSE(value.GetValue()->is_null_);
     EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
 
@@ -157,7 +157,7 @@ TEST_F(CVETests, BigIntTest) {
   for (uint32_t i = 0; i < num_iterations_; i++) {
     auto data = static_cast<int64_t>(std::uniform_int_distribution<int64_t>(INT64_MIN, INT64_MAX)(generator_));
 
-    ConstantValueExpression value(type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(data));
+    ConstantValueExpression value(type::TypeId::BIGINT, execution::sql::Integer(data));
     EXPECT_FALSE(value.GetValue()->is_null_);
     EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
 
@@ -188,7 +188,7 @@ TEST_F(CVETests, DecimalTest) {
   for (uint32_t i = 0; i < num_iterations_; i++) {
     auto data = std::uniform_real_distribution<double>(DBL_MIN, DBL_MAX)(generator_);
 
-    ConstantValueExpression value(type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(data));
+    ConstantValueExpression value(type::TypeId::DECIMAL, execution::sql::Real(data));
     EXPECT_FALSE(value.GetValue()->is_null_);
     EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Real>()->val_);
 
@@ -219,7 +219,7 @@ TEST_F(CVETests, TimestampTest) {
   for (uint32_t i = 0; i < num_iterations_; i++) {
     auto data = static_cast<uint64_t>(std::uniform_int_distribution<uint64_t>(0, UINT64_MAX)(generator_));
 
-    ConstantValueExpression value(type::TypeId::TIMESTAMP, std::make_unique<execution::sql::TimestampVal>(data));
+    ConstantValueExpression value(type::TypeId::TIMESTAMP, execution::sql::TimestampVal(data));
     EXPECT_FALSE(value.GetValue()->is_null_);
     EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::TimestampVal>()->val_.ToNative());
 
@@ -250,7 +250,7 @@ TEST_F(CVETests, DateTest) {
   for (uint32_t i = 0; i < num_iterations_; i++) {
     auto data = static_cast<uint32_t>(std::uniform_int_distribution<uint32_t>(0, UINT32_MAX)(generator_));
 
-    ConstantValueExpression value(type::TypeId::DATE, std::make_unique<execution::sql::DateVal>(data));
+    ConstantValueExpression value(type::TypeId::DATE, execution::sql::DateVal(data));
     EXPECT_FALSE(value.GetValue()->is_null_);
     EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::DateVal>()->val_.ToNative());
 
@@ -320,7 +320,7 @@ TEST_F(CVETests, VarCharTest) {
 TEST_F(CVETests, BooleanJsonTest) {
   auto data = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
 
-  ConstantValueExpression value(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(data));
+  ConstantValueExpression value(type::TypeId::BOOLEAN, execution::sql::BoolVal(data));
   EXPECT_FALSE(value.GetValue()->is_null_);
 
   auto json = value.ToJson();
@@ -336,7 +336,7 @@ TEST_F(CVETests, BooleanJsonTest) {
 TEST_F(CVETests, TinyIntJsonTest) {
   auto data = static_cast<int8_t>(std::uniform_int_distribution<int8_t>(INT8_MIN, INT8_MAX)(generator_));
 
-  ConstantValueExpression value(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(data));
+  ConstantValueExpression value(type::TypeId::TINYINT, execution::sql::Integer(data));
   EXPECT_FALSE(value.GetValue()->is_null_);
 
   auto json = value.ToJson();
@@ -352,7 +352,7 @@ TEST_F(CVETests, TinyIntJsonTest) {
 TEST_F(CVETests, SmallIntJsonTest) {
   auto data = static_cast<int16_t>(std::uniform_int_distribution<int16_t>(INT16_MIN, INT16_MAX)(generator_));
 
-  ConstantValueExpression value(type::TypeId::SMALLINT, std::make_unique<execution::sql::Integer>(data));
+  ConstantValueExpression value(type::TypeId::SMALLINT, execution::sql::Integer(data));
   EXPECT_FALSE(value.GetValue()->is_null_);
 
   auto json = value.ToJson();
@@ -368,7 +368,7 @@ TEST_F(CVETests, SmallIntJsonTest) {
 TEST_F(CVETests, IntegerJsonTest) {
   auto data = static_cast<int32_t>(std::uniform_int_distribution<int32_t>(INT32_MIN, INT32_MAX)(generator_));
 
-  ConstantValueExpression value(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(data));
+  ConstantValueExpression value(type::TypeId::INTEGER, execution::sql::Integer(data));
   EXPECT_FALSE(value.GetValue()->is_null_);
 
   auto json = value.ToJson();
@@ -384,7 +384,7 @@ TEST_F(CVETests, IntegerJsonTest) {
 TEST_F(CVETests, BigIntJsonTest) {
   auto data = static_cast<int64_t>(std::uniform_int_distribution<int64_t>(INT64_MIN, INT64_MAX)(generator_));
 
-  ConstantValueExpression value(type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(data));
+  ConstantValueExpression value(type::TypeId::BIGINT, execution::sql::Integer(data));
   EXPECT_FALSE(value.GetValue()->is_null_);
 
   auto json = value.ToJson();
@@ -400,7 +400,7 @@ TEST_F(CVETests, BigIntJsonTest) {
 TEST_F(CVETests, DecimalJsonTest) {
   auto data = std::uniform_real_distribution<double>(DBL_MIN, DBL_MAX)(generator_);
 
-  ConstantValueExpression value(type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(data));
+  ConstantValueExpression value(type::TypeId::DECIMAL, execution::sql::Real(data));
   EXPECT_FALSE(value.GetValue()->is_null_);
 
   auto json = value.ToJson();
@@ -416,7 +416,7 @@ TEST_F(CVETests, DecimalJsonTest) {
 TEST_F(CVETests, TimestampJsonTest) {
   auto data = static_cast<uint64_t>(std::uniform_int_distribution<uint64_t>(0, UINT64_MAX)(generator_));
 
-  ConstantValueExpression value(type::TypeId::TIMESTAMP, std::make_unique<execution::sql::TimestampVal>(data));
+  ConstantValueExpression value(type::TypeId::TIMESTAMP, execution::sql::TimestampVal(data));
   EXPECT_FALSE(value.GetValue()->is_null_);
 
   auto json = value.ToJson();
@@ -432,7 +432,7 @@ TEST_F(CVETests, TimestampJsonTest) {
 TEST_F(CVETests, DateJsonTest) {
   auto data = static_cast<uint32_t>(std::uniform_int_distribution<uint32_t>(0, UINT32_MAX)(generator_));
 
-  ConstantValueExpression value(type::TypeId::DATE, std::make_unique<execution::sql::DateVal>(data));
+  ConstantValueExpression value(type::TypeId::DATE, execution::sql::DateVal(data));
   EXPECT_FALSE(value.GetValue()->is_null_);
 
   auto json = value.ToJson();

--- a/test/parser/constant_value_expression_test.cpp
+++ b/test/parser/constant_value_expression_test.cpp
@@ -32,14 +32,13 @@ TEST_F(CVETests, BooleanTest) {
     auto data = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
 
     ConstantValueExpression value(type::TypeId::BOOLEAN, execution::sql::BoolVal(data));
-    EXPECT_FALSE(value.GetValue()->is_null_);
-    EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::BoolVal>()->val_);
+    EXPECT_FALSE(value.IsNull());
+    EXPECT_EQ(data, value.Peek<bool>());
 
     auto copy_constructed_value(value);
     EXPECT_EQ(value, copy_constructed_value);
     EXPECT_EQ(value.Hash(), copy_constructed_value.Hash());
-    ConstantValueExpression copy_assigned_value(type::TypeId::BOOLEAN,
-                                                std::make_unique<execution::sql::BoolVal>(!data));
+    ConstantValueExpression copy_assigned_value(type::TypeId::BOOLEAN, execution::sql::BoolVal(!data));
     EXPECT_NE(value, copy_assigned_value);
     EXPECT_NE(value.Hash(), copy_assigned_value.Hash());
     copy_assigned_value = value;
@@ -49,8 +48,7 @@ TEST_F(CVETests, BooleanTest) {
     auto move_constructed_value(std::move(value));
     EXPECT_EQ(copy_assigned_value, move_constructed_value);
     EXPECT_EQ(copy_assigned_value.Hash(), move_constructed_value.Hash());
-    ConstantValueExpression move_assigned_value(type::TypeId::BOOLEAN,
-                                                std::make_unique<execution::sql::BoolVal>(!data));
+    ConstantValueExpression move_assigned_value(type::TypeId::BOOLEAN, execution::sql::BoolVal(!data));
     EXPECT_NE(copy_assigned_value, move_assigned_value);
     EXPECT_NE(copy_assigned_value.Hash(), move_assigned_value.Hash());
     move_assigned_value = std::move(copy_assigned_value);
@@ -65,8 +63,8 @@ TEST_F(CVETests, TinyIntTest) {
     auto data = static_cast<int8_t>(std::uniform_int_distribution<int8_t>(INT8_MIN, INT8_MAX)(generator_));
 
     ConstantValueExpression value(type::TypeId::TINYINT, execution::sql::Integer(data));
-    EXPECT_FALSE(value.GetValue()->is_null_);
-    EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+    EXPECT_FALSE(value.IsNull());
+    EXPECT_EQ(data, value.Peek<int8_t>());
 
     auto copy_constructed_value(value);
     EXPECT_EQ(value, copy_constructed_value);
@@ -96,8 +94,8 @@ TEST_F(CVETests, SmallIntTest) {
     auto data = static_cast<int16_t>(std::uniform_int_distribution<int16_t>(INT16_MIN, INT16_MAX)(generator_));
 
     ConstantValueExpression value(type::TypeId::SMALLINT, execution::sql::Integer(data));
-    EXPECT_FALSE(value.GetValue()->is_null_);
-    EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+    EXPECT_FALSE(value.IsNull());
+    EXPECT_EQ(data, value.Peek<int16_t>());
 
     auto copy_constructed_value(value);
     EXPECT_EQ(value, copy_constructed_value);
@@ -127,8 +125,8 @@ TEST_F(CVETests, IntegerTest) {
     auto data = static_cast<int32_t>(std::uniform_int_distribution<int32_t>(INT32_MIN, INT32_MAX)(generator_));
 
     ConstantValueExpression value(type::TypeId::INTEGER, execution::sql::Integer(data));
-    EXPECT_FALSE(value.GetValue()->is_null_);
-    EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+    EXPECT_FALSE(value.IsNull());
+    EXPECT_EQ(data, value.Peek<int32_t>());
 
     auto copy_constructed_value(value);
     EXPECT_EQ(value, copy_constructed_value);
@@ -158,8 +156,8 @@ TEST_F(CVETests, BigIntTest) {
     auto data = static_cast<int64_t>(std::uniform_int_distribution<int64_t>(INT64_MIN, INT64_MAX)(generator_));
 
     ConstantValueExpression value(type::TypeId::BIGINT, execution::sql::Integer(data));
-    EXPECT_FALSE(value.GetValue()->is_null_);
-    EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+    EXPECT_FALSE(value.IsNull());
+    EXPECT_EQ(data, value.Peek<int64_t>());
 
     auto copy_constructed_value(value);
     EXPECT_EQ(value, copy_constructed_value);
@@ -189,8 +187,8 @@ TEST_F(CVETests, DecimalTest) {
     auto data = std::uniform_real_distribution<double>(DBL_MIN, DBL_MAX)(generator_);
 
     ConstantValueExpression value(type::TypeId::DECIMAL, execution::sql::Real(data));
-    EXPECT_FALSE(value.GetValue()->is_null_);
-    EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::Real>()->val_);
+    EXPECT_FALSE(value.IsNull());
+    EXPECT_EQ(data, value.Peek<double>());
 
     auto copy_constructed_value(value);
     EXPECT_EQ(value, copy_constructed_value);
@@ -220,8 +218,8 @@ TEST_F(CVETests, TimestampTest) {
     auto data = static_cast<uint64_t>(std::uniform_int_distribution<uint64_t>(0, UINT64_MAX)(generator_));
 
     ConstantValueExpression value(type::TypeId::TIMESTAMP, execution::sql::TimestampVal(data));
-    EXPECT_FALSE(value.GetValue()->is_null_);
-    EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::TimestampVal>()->val_.ToNative());
+    EXPECT_FALSE(value.IsNull());
+    EXPECT_EQ(data, value.Peek<execution::sql::Timestamp>().ToNative());
 
     auto copy_constructed_value(value);
     EXPECT_EQ(value, copy_constructed_value);
@@ -251,8 +249,8 @@ TEST_F(CVETests, DateTest) {
     auto data = static_cast<uint32_t>(std::uniform_int_distribution<uint32_t>(0, UINT32_MAX)(generator_));
 
     ConstantValueExpression value(type::TypeId::DATE, execution::sql::DateVal(data));
-    EXPECT_FALSE(value.GetValue()->is_null_);
-    EXPECT_EQ(data, value.GetValue().CastManagedPointerTo<execution::sql::DateVal>()->val_.ToNative());
+    EXPECT_FALSE(value.IsNull());
+    EXPECT_EQ(data, value.Peek<execution::sql::Timestamp>().ToNative());
 
     auto copy_constructed_value(value);
     EXPECT_EQ(value, copy_constructed_value);
@@ -287,10 +285,9 @@ TEST_F(CVETests, VarCharTest) {
 
     auto string_val = execution::sql::ValueUtil::CreateStringVal(
         common::ManagedPointer(reinterpret_cast<const char *>(data)), length);
-    ConstantValueExpression value(type::TypeId::VARCHAR, std::move(string_val.first), std::move(string_val.second));
-    EXPECT_FALSE(value.GetValue()->is_null_);
-    const std::string_view string_view =
-        value.GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView();
+    ConstantValueExpression value(type::TypeId::VARCHAR, string_val.first, std::move(string_val.second));
+    EXPECT_FALSE(value.IsNull());
+    const std::string_view string_view = value.Peek<std::string_view>();
     EXPECT_EQ(std::string_view(data, length), string_view);
     delete[] data;
 
@@ -321,7 +318,7 @@ TEST_F(CVETests, BooleanJsonTest) {
   auto data = static_cast<bool>(std::uniform_int_distribution<uint8_t>(0, 1)(generator_));
 
   ConstantValueExpression value(type::TypeId::BOOLEAN, execution::sql::BoolVal(data));
-  EXPECT_FALSE(value.GetValue()->is_null_);
+  EXPECT_FALSE(value.IsNull());
 
   auto json = value.ToJson();
   EXPECT_FALSE(json.is_null());
@@ -337,7 +334,7 @@ TEST_F(CVETests, TinyIntJsonTest) {
   auto data = static_cast<int8_t>(std::uniform_int_distribution<int8_t>(INT8_MIN, INT8_MAX)(generator_));
 
   ConstantValueExpression value(type::TypeId::TINYINT, execution::sql::Integer(data));
-  EXPECT_FALSE(value.GetValue()->is_null_);
+  EXPECT_FALSE(value.IsNull());
 
   auto json = value.ToJson();
   EXPECT_FALSE(json.is_null());
@@ -353,7 +350,7 @@ TEST_F(CVETests, SmallIntJsonTest) {
   auto data = static_cast<int16_t>(std::uniform_int_distribution<int16_t>(INT16_MIN, INT16_MAX)(generator_));
 
   ConstantValueExpression value(type::TypeId::SMALLINT, execution::sql::Integer(data));
-  EXPECT_FALSE(value.GetValue()->is_null_);
+  EXPECT_FALSE(value.IsNull());
 
   auto json = value.ToJson();
   EXPECT_FALSE(json.is_null());
@@ -369,7 +366,7 @@ TEST_F(CVETests, IntegerJsonTest) {
   auto data = static_cast<int32_t>(std::uniform_int_distribution<int32_t>(INT32_MIN, INT32_MAX)(generator_));
 
   ConstantValueExpression value(type::TypeId::INTEGER, execution::sql::Integer(data));
-  EXPECT_FALSE(value.GetValue()->is_null_);
+  EXPECT_FALSE(value.IsNull());
 
   auto json = value.ToJson();
   EXPECT_FALSE(json.is_null());
@@ -385,7 +382,7 @@ TEST_F(CVETests, BigIntJsonTest) {
   auto data = static_cast<int64_t>(std::uniform_int_distribution<int64_t>(INT64_MIN, INT64_MAX)(generator_));
 
   ConstantValueExpression value(type::TypeId::BIGINT, execution::sql::Integer(data));
-  EXPECT_FALSE(value.GetValue()->is_null_);
+  EXPECT_FALSE(value.IsNull());
 
   auto json = value.ToJson();
   EXPECT_FALSE(json.is_null());
@@ -401,7 +398,7 @@ TEST_F(CVETests, DecimalJsonTest) {
   auto data = std::uniform_real_distribution<double>(DBL_MIN, DBL_MAX)(generator_);
 
   ConstantValueExpression value(type::TypeId::DECIMAL, execution::sql::Real(data));
-  EXPECT_FALSE(value.GetValue()->is_null_);
+  EXPECT_FALSE(value.IsNull());
 
   auto json = value.ToJson();
   EXPECT_FALSE(json.is_null());
@@ -417,7 +414,7 @@ TEST_F(CVETests, TimestampJsonTest) {
   auto data = static_cast<uint64_t>(std::uniform_int_distribution<uint64_t>(0, UINT64_MAX)(generator_));
 
   ConstantValueExpression value(type::TypeId::TIMESTAMP, execution::sql::TimestampVal(data));
-  EXPECT_FALSE(value.GetValue()->is_null_);
+  EXPECT_FALSE(value.IsNull());
 
   auto json = value.ToJson();
   EXPECT_FALSE(json.is_null());
@@ -433,7 +430,7 @@ TEST_F(CVETests, DateJsonTest) {
   auto data = static_cast<uint32_t>(std::uniform_int_distribution<uint32_t>(0, UINT32_MAX)(generator_));
 
   ConstantValueExpression value(type::TypeId::DATE, execution::sql::DateVal(data));
-  EXPECT_FALSE(value.GetValue()->is_null_);
+  EXPECT_FALSE(value.IsNull());
 
   auto json = value.ToJson();
   EXPECT_FALSE(json.is_null());
@@ -454,8 +451,8 @@ TEST_F(CVETests, VarCharJsonTest) {
 
   auto string_val =
       execution::sql::ValueUtil::CreateStringVal(common::ManagedPointer(reinterpret_cast<const char *>(data)), length);
-  ConstantValueExpression value(type::TypeId::VARCHAR, std::move(string_val.first), std::move(string_val.second));
-  EXPECT_FALSE(value.GetValue()->is_null_);
+  ConstantValueExpression value(type::TypeId::VARCHAR, string_val.first, std::move(string_val.second));
+  EXPECT_FALSE(value.IsNull());
 
   auto json = value.ToJson();
   EXPECT_FALSE(json.is_null());

--- a/test/parser/constant_value_expression_test.cpp
+++ b/test/parser/constant_value_expression_test.cpp
@@ -287,7 +287,7 @@ TEST_F(CVETests, VarCharTest) {
         common::ManagedPointer(reinterpret_cast<const char *>(data)), length);
     ConstantValueExpression value(type::TypeId::VARCHAR, string_val.first, std::move(string_val.second));
     EXPECT_FALSE(value.IsNull());
-    const std::string_view string_view = value.Peek<std::string_view>();
+    const auto string_view = value.Peek<std::string_view>();
     EXPECT_EQ(std::string_view(data, length), string_view);
     delete[] data;
 

--- a/test/parser/constant_value_expression_test.cpp
+++ b/test/parser/constant_value_expression_test.cpp
@@ -250,7 +250,7 @@ TEST_F(CVETests, DateTest) {
 
     ConstantValueExpression value(type::TypeId::DATE, execution::sql::DateVal(data));
     EXPECT_FALSE(value.IsNull());
-    EXPECT_EQ(data, value.Peek<execution::sql::Timestamp>().ToNative());
+    EXPECT_EQ(data, value.Peek<execution::sql::Date>().ToNative());
 
     auto copy_constructed_value(value);
     EXPECT_EQ(value, copy_constructed_value);

--- a/test/parser/expression_test.cpp
+++ b/test/parser/expression_test.cpp
@@ -43,9 +43,9 @@ bool CompareExpressionsEqual(const std::vector<common::ManagedPointer<AbstractEx
 // NOLINTNEXTLINE
 TEST(ExpressionTests, ConstantValueExpressionTest) {
   // constant Booleans
-  auto expr_b_1 = new ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
-  auto expr_b_2 = new ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false));
-  auto expr_b_3 = new ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+  auto expr_b_1 = new ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
+  auto expr_b_2 = new ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(false));
+  auto expr_b_3 = new ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
 
   EXPECT_FALSE(*expr_b_1 == *expr_b_2);
   EXPECT_NE(expr_b_1->Hash(), expr_b_2->Hash());
@@ -63,9 +63,9 @@ TEST(ExpressionTests, ConstantValueExpressionTest) {
   delete expr_b_3;
 
   // constant tinyints
-  auto expr_ti_1 = new ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
-  auto expr_ti_2 = new ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1));
-  auto expr_ti_3 = new ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(127));
+  auto expr_ti_1 = new ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
+  auto expr_ti_2 = new ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1));
+  auto expr_ti_3 = new ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(127));
 
   EXPECT_TRUE(*expr_ti_1 == *expr_ti_2);
   EXPECT_EQ(expr_ti_1->Hash(), expr_ti_2->Hash());
@@ -73,7 +73,7 @@ TEST(ExpressionTests, ConstantValueExpressionTest) {
   EXPECT_NE(expr_ti_1->Hash(), expr_ti_3->Hash());
 
   EXPECT_EQ(expr_ti_1->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
-  EXPECT_EQ(*expr_ti_1, ConstantValueExpression(type::TypeId::TINYINT, std::make_unique<execution::sql::Integer>(1)));
+  EXPECT_EQ(*expr_ti_1, ConstantValueExpression(type::TypeId::TINYINT, execution::sql::Integer(1)));
   // There is no need to deduce the return_value_type of constant value expression
   // and calling this function essentially does nothing
   // Only test if we can call it without error.
@@ -96,10 +96,9 @@ TEST(ExpressionTests, ConstantValueExpressionTest) {
   delete expr_ti_3;
 
   // constant smallints
-  auto expr_si_1 = new ConstantValueExpression(type::TypeId::SMALLINT, std::make_unique<execution::sql::Integer>(1));
-  auto expr_si_2 = new ConstantValueExpression(type::TypeId::SMALLINT, std::make_unique<execution::sql::Integer>(1));
-  auto expr_si_3 =
-      new ConstantValueExpression(type::TypeId::SMALLINT, std::make_unique<execution::sql::Integer>(32767));
+  auto expr_si_1 = new ConstantValueExpression(type::TypeId::SMALLINT, execution::sql::Integer(1));
+  auto expr_si_2 = new ConstantValueExpression(type::TypeId::SMALLINT, execution::sql::Integer(1));
+  auto expr_si_3 = new ConstantValueExpression(type::TypeId::SMALLINT, execution::sql::Integer(32767));
 
   EXPECT_TRUE(*expr_si_1 == *expr_si_2);
   EXPECT_EQ(expr_si_1->Hash(), expr_si_2->Hash());
@@ -111,9 +110,9 @@ TEST(ExpressionTests, ConstantValueExpressionTest) {
   delete expr_si_3;
 
   // constant ints
-  auto expr_i_1 = new ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(1));
-  auto expr_i_2 = new ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(1));
-  auto expr_i_3 = new ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(32768));
+  auto expr_i_1 = new ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(1));
+  auto expr_i_2 = new ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(1));
+  auto expr_i_3 = new ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(32768));
 
   EXPECT_TRUE(*expr_i_1 == *expr_i_2);
   EXPECT_EQ(expr_i_1->Hash(), expr_i_2->Hash());
@@ -125,9 +124,9 @@ TEST(ExpressionTests, ConstantValueExpressionTest) {
   delete expr_i_3;
 
   // constant bigints
-  auto expr_bi_1 = new ConstantValueExpression(type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(1));
-  auto expr_bi_2 = new ConstantValueExpression(type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(1));
-  auto expr_bi_3 = new ConstantValueExpression(type::TypeId::BIGINT, std::make_unique<execution::sql::Integer>(32768));
+  auto expr_bi_1 = new ConstantValueExpression(type::TypeId::BIGINT, execution::sql::Integer(1));
+  auto expr_bi_2 = new ConstantValueExpression(type::TypeId::BIGINT, execution::sql::Integer(1));
+  auto expr_bi_3 = new ConstantValueExpression(type::TypeId::BIGINT, execution::sql::Integer(32768));
 
   EXPECT_TRUE(*expr_bi_1 == *expr_bi_2);
   EXPECT_EQ(expr_bi_1->Hash(), expr_bi_2->Hash());
@@ -156,12 +155,9 @@ TEST(ExpressionTests, ConstantValueExpressionTest) {
   delete expr_d_3;
 
   // constant timestamp
-  auto expr_ts_1 =
-      new ConstantValueExpression(type::TypeId::TIMESTAMP, std::make_unique<execution::sql::TimestampVal>(1));
-  auto expr_ts_2 =
-      new ConstantValueExpression(type::TypeId::TIMESTAMP, std::make_unique<execution::sql::TimestampVal>(1));
-  auto expr_ts_3 =
-      new ConstantValueExpression(type::TypeId::TIMESTAMP, std::make_unique<execution::sql::TimestampVal>(32768));
+  auto expr_ts_1 = new ConstantValueExpression(type::TypeId::TIMESTAMP, execution::sql::TimestampVal(1));
+  auto expr_ts_2 = new ConstantValueExpression(type::TypeId::TIMESTAMP, execution::sql::TimestampVal(1));
+  auto expr_ts_3 = new ConstantValueExpression(type::TypeId::TIMESTAMP, execution::sql::TimestampVal(32768));
 
   EXPECT_TRUE(*expr_ts_1 == *expr_ts_2);
   EXPECT_EQ(expr_ts_1->Hash(), expr_ts_2->Hash());
@@ -173,9 +169,9 @@ TEST(ExpressionTests, ConstantValueExpressionTest) {
   delete expr_ts_3;
 
   // constant date
-  auto expr_date_1 = new ConstantValueExpression(type::TypeId::DATE, std::make_unique<execution::sql::DateVal>(1));
-  auto expr_date_2 = new ConstantValueExpression(type::TypeId::DATE, std::make_unique<execution::sql::DateVal>(1));
-  auto expr_date_3 = new ConstantValueExpression(type::TypeId::DATE, std::make_unique<execution::sql::DateVal>(32768));
+  auto expr_date_1 = new ConstantValueExpression(type::TypeId::DATE, execution::sql::DateVal(1));
+  auto expr_date_2 = new ConstantValueExpression(type::TypeId::DATE, execution::sql::DateVal(1));
+  auto expr_date_3 = new ConstantValueExpression(type::TypeId::DATE, execution::sql::DateVal(32768));
 
   EXPECT_TRUE(*expr_date_1 == *expr_date_2);
   EXPECT_EQ(expr_date_1->Hash(), expr_date_2->Hash());
@@ -496,13 +492,12 @@ TEST(ExpressionTests, CaseExpressionTest) {
 
   // Create expression 3
   std::vector<CaseExpression::WhenClause> when_clauses_3;
-  when_clauses_3.emplace_back(
-      CaseExpression::WhenClause{std::make_unique<ConstantValueExpression>(
-                                     type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false)),
-                                 std::make_unique<StarExpression>()});
-  auto case_expr_3 = new CaseExpression(type::TypeId::BOOLEAN, std::move(when_clauses_3),
-                                        std::make_unique<ConstantValueExpression>(
-                                            type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(false)));
+  when_clauses_3.emplace_back(CaseExpression::WhenClause{
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(false)),
+      std::make_unique<StarExpression>()});
+  auto case_expr_3 = new CaseExpression(
+      type::TypeId::BOOLEAN, std::move(when_clauses_3),
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(false)));
 
   // Create expression 4
   std::vector<CaseExpression::WhenClause> when_clauses_4;
@@ -591,8 +586,7 @@ TEST(ExpressionTests, FunctionExpressionTest) {
 
   std::vector<std::unique_ptr<AbstractExpression>> children;
   auto child_expr = std::make_unique<StarExpression>();
-  auto child_expr_2 =
-      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+  auto child_expr_2 = std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   children.push_back(std::move(child_expr));
   children.push_back(std::move(child_expr_2));
   auto func_expr_5 = std::make_unique<FunctionExpression>("FullHouse", type::TypeId::VARCHAR, std::move(children));
@@ -646,13 +640,13 @@ TEST(ExpressionTests, OperatorExpressionTest) {
   EXPECT_EQ(op_expr_1->GetExpressionName(), "");
 
   std::vector<std::unique_ptr<AbstractExpression>> children;
-  children.emplace_back(std::make_unique<ConstantValueExpression>(
-      type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(static_cast<double>(1))));
+  children.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::DECIMAL, execution::sql::Real(static_cast<double>(1))));
   children.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BIGINT,
                                                                   std::make_unique<execution::sql::Integer>(32768)));
   std::vector<std::unique_ptr<AbstractExpression>> children_cp;
-  children_cp.emplace_back(std::make_unique<ConstantValueExpression>(
-      type::TypeId::DECIMAL, std::make_unique<execution::sql::Real>(static_cast<double>(1))));
+  children_cp.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::DECIMAL, execution::sql::Real(static_cast<double>(1))));
   children_cp.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BIGINT,
                                                                      std::make_unique<execution::sql::Integer>(32768)));
 
@@ -662,8 +656,7 @@ TEST(ExpressionTests, OperatorExpressionTest) {
   op_expr_2->DeriveExpressionName();
   EXPECT_EQ(op_expr_2->GetExpressionName(), "");
 
-  auto child3 =
-      std::make_unique<ConstantValueExpression>(type::TypeId::DATE, std::make_unique<execution::sql::DateVal>(1));
+  auto child3 = std::make_unique<ConstantValueExpression>(type::TypeId::DATE, execution::sql::DateVal(1));
   children_cp.push_back(std::move(child3));
   auto op_expr_3 =
       new OperatorExpression(ExpressionType::OPERATOR_CONCAT, type::TypeId::INVALID, std::move(children_cp));
@@ -964,10 +957,8 @@ TEST(ExpressionTests, DerivedValueExpressionJsonTest) {
 TEST(ExpressionTests, ComparisonExpressionJsonTest) {
   // No Generic ComparisonExpression Test needed as it is simple.
   std::vector<std::unique_ptr<AbstractExpression>> children;
-  children.emplace_back(
-      std::make_unique<ConstantValueExpression>(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(1)));
-  children.emplace_back(
-      std::make_unique<ConstantValueExpression>(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(2)));
+  children.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::INTEGER, execution::sql::Integer(1)));
+  children.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::INTEGER, execution::sql::Integer(2)));
 
   // Create expression
   auto original_expr = new ComparisonExpression(ExpressionType::COMPARE_EQUAL, std::move(children));

--- a/test/parser/expression_test.cpp
+++ b/test/parser/expression_test.cpp
@@ -192,7 +192,7 @@ TEST(ExpressionTests, ConstantValueExpressionJsonTest) {
 
   auto string_val1 = execution::sql::ValueUtil::CreateStringVal(std::string_view("ConstantValueExpressionJsonTest"));
 
-  auto original_expr = std::make_unique<ConstantValueExpression>(type::TypeId::VARCHAR, std::move(string_val1.first),
+  auto original_expr = std::make_unique<ConstantValueExpression>(type::TypeId::VARCHAR, string_val1.first,
                                                                  std::move(string_val1.second));
 
   auto copy = original_expr->Copy();
@@ -214,9 +214,8 @@ TEST(ExpressionTests, ConstantValueExpressionJsonTest) {
   EXPECT_EQ(*original_expr, *deserialized_expr);
 
   auto string_val2 = execution::sql::ValueUtil::CreateStringVal(std::string_view("ConstantValueExpressionJsonTest"));
-  EXPECT_EQ(
-      *(deserialized_expr.CastManagedPointerTo<ConstantValueExpression>()),
-      ConstantValueExpression(type::TypeId::VARCHAR, std::move(string_val2.first), std::move(string_val2.second)));
+  EXPECT_EQ(*(deserialized_expr.CastManagedPointerTo<ConstantValueExpression>()),
+            ConstantValueExpression(type::TypeId::VARCHAR, string_val2.first, std::move(string_val2.second)));
 }
 
 // NOLINTNEXTLINE

--- a/test/parser/expression_test.cpp
+++ b/test/parser/expression_test.cpp
@@ -138,12 +138,9 @@ TEST(ExpressionTests, ConstantValueExpressionTest) {
   delete expr_bi_3;
 
   // constant double/decimalGetDecimal
-  auto expr_d_1 = new ConstantValueExpression(type::TypeId::DECIMAL,
-                                              std::make_unique<execution::sql::Real>(static_cast<double>(1)));
-  auto expr_d_2 = new ConstantValueExpression(type::TypeId::DECIMAL,
-                                              std::make_unique<execution::sql::Real>(static_cast<double>(1)));
-  auto expr_d_3 = new ConstantValueExpression(type::TypeId::DECIMAL,
-                                              std::make_unique<execution::sql::Real>(static_cast<double>(32768)));
+  auto expr_d_1 = new ConstantValueExpression(type::TypeId::DECIMAL, execution::sql::Real(static_cast<double>(1)));
+  auto expr_d_2 = new ConstantValueExpression(type::TypeId::DECIMAL, execution::sql::Real(static_cast<double>(1)));
+  auto expr_d_3 = new ConstantValueExpression(type::TypeId::DECIMAL, execution::sql::Real(static_cast<double>(32768)));
 
   EXPECT_TRUE(*expr_d_1 == *expr_d_2);
   EXPECT_EQ(expr_d_1->Hash(), expr_d_2->Hash());
@@ -244,42 +241,42 @@ TEST(ExpressionTests, NullConstantValueExpressionJsonTest) {
   auto deserialized = DeserializeExpression(json);
   auto deserialized_expr = common::ManagedPointer(deserialized.result_);
   EXPECT_EQ(*original_expr, *deserialized_expr);
-  EXPECT_TRUE(deserialized_expr.CastManagedPointerTo<ConstantValueExpression>()->GetValue()->is_null_);
+  EXPECT_TRUE(deserialized_expr.CastManagedPointerTo<ConstantValueExpression>()->IsNull());
 }
 
 // NOLINTNEXTLINE
 TEST(ExpressionTests, ConjunctionExpressionTest) {
   std::vector<std::unique_ptr<AbstractExpression>> children1;
-  children1.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(true)));
-  children1.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(false)));
+  children1.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
+  children1.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(false)));
   std::vector<std::unique_ptr<AbstractExpression>> children1cp;
-  children1cp.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                     std::make_unique<execution::sql::BoolVal>(true)));
-  children1cp.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                     std::make_unique<execution::sql::BoolVal>(false)));
+  children1cp.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
+  children1cp.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(false)));
   auto c_expr_1 = new ConjunctionExpression(ExpressionType::CONJUNCTION_AND, std::move(children1));
 
   std::vector<std::unique_ptr<AbstractExpression>> children2;
-  children2.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(true)));
-  children2.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(false)));
+  children2.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
+  children2.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(false)));
   auto c_expr_2 = new ConjunctionExpression(ExpressionType::CONJUNCTION_AND, std::move(children2));
 
   std::vector<std::unique_ptr<AbstractExpression>> children3;
-  children3.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(true)));
-  children3.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(true)));
+  children3.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
+  children3.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
   auto c_expr_3 = new ConjunctionExpression(ExpressionType::CONJUNCTION_AND, std::move(children3));
 
   std::vector<std::unique_ptr<AbstractExpression>> children4;
-  children4.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(true)));
-  children4.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(false)));
+  children4.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
+  children4.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(false)));
   auto c_expr_4 = new ConjunctionExpression(ExpressionType::CONJUNCTION_OR, std::move(children4));
 
   EXPECT_TRUE(*c_expr_1 == *c_expr_2);
@@ -316,10 +313,10 @@ TEST(ExpressionTests, ConjunctionExpressionTest) {
 TEST(ExpressionTests, ConjunctionExpressionJsonTest) {
   // Create expression
   std::vector<std::unique_ptr<AbstractExpression>> children1;
-  children1.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(true)));
-  children1.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                   std::make_unique<execution::sql::BoolVal>(false)));
+  children1.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
+  children1.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(false)));
   auto c_expr_1 = new ConjunctionExpression(ExpressionType::CONJUNCTION_AND, std::move(children1));
   auto copy = c_expr_1->Copy();
   EXPECT_EQ(*c_expr_1, *copy);
@@ -374,8 +371,8 @@ TEST(ExpressionTests, AggregateExpressionTest) {
 
   // Create expression 5, field child type
   std::vector<std::unique_ptr<AbstractExpression>> children_5;
-  children_5.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                    std::make_unique<execution::sql::BoolVal>(false)));
+  children_5.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(false)));
   auto agg_expr_5 = new AggregateExpression(ExpressionType::AGGREGATE_COUNT, std::move(children_5), true);
 
   EXPECT_TRUE(*agg_expr_1 == *agg_expr_2);
@@ -405,8 +402,8 @@ TEST(ExpressionTests, AggregateExpressionTest) {
 
   // Testing DeriveReturnValueType functionality
   std::vector<std::unique_ptr<AbstractExpression>> children_6;
-  children_6.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                    std::make_unique<execution::sql::BoolVal>(true)));
+  children_6.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
   auto agg_expr_6 = new AggregateExpression(ExpressionType::AGGREGATE_MAX, std::move(children_6), true);
   agg_expr_6->DeriveReturnValueType();
 
@@ -416,8 +413,8 @@ TEST(ExpressionTests, AggregateExpressionTest) {
 
   // Testing DeriveReturnValueType functionality
   std::vector<std::unique_ptr<AbstractExpression>> children_7;
-  children_7.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                    std::make_unique<execution::sql::BoolVal>(true)));
+  children_7.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
   auto agg_expr_7 = new AggregateExpression(ExpressionType::AGGREGATE_AVG, std::move(children_7), true);
   agg_expr_7->DeriveReturnValueType();
 
@@ -427,8 +424,8 @@ TEST(ExpressionTests, AggregateExpressionTest) {
 
   // Testing DeriveReturnValueType functionality
   std::vector<std::unique_ptr<AbstractExpression>> children_8;
-  children_8.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                    std::make_unique<execution::sql::BoolVal>(true)));
+  children_8.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true)));
   auto agg_expr_8 = new AggregateExpression(ExpressionType(100), std::move(children_8), true);
   // TODO(WAN): Why is there a random NDEBUG here?
 #ifndef NDEBUG
@@ -642,13 +639,13 @@ TEST(ExpressionTests, OperatorExpressionTest) {
   std::vector<std::unique_ptr<AbstractExpression>> children;
   children.emplace_back(
       std::make_unique<ConstantValueExpression>(type::TypeId::DECIMAL, execution::sql::Real(static_cast<double>(1))));
-  children.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BIGINT,
-                                                                  std::make_unique<execution::sql::Integer>(32768)));
+  children.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BIGINT, execution::sql::Integer(32768)));
   std::vector<std::unique_ptr<AbstractExpression>> children_cp;
   children_cp.emplace_back(
       std::make_unique<ConstantValueExpression>(type::TypeId::DECIMAL, execution::sql::Real(static_cast<double>(1))));
-  children_cp.emplace_back(std::make_unique<ConstantValueExpression>(type::TypeId::BIGINT,
-                                                                     std::make_unique<execution::sql::Integer>(32768)));
+  children_cp.emplace_back(
+      std::make_unique<ConstantValueExpression>(type::TypeId::BIGINT, execution::sql::Integer(32768)));
 
   auto op_expr_2 = new OperatorExpression(ExpressionType::OPERATOR_PLUS, type::TypeId::INVALID, std::move(children));
   op_expr_2->DeriveReturnValueType();

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -199,7 +199,7 @@ TEST_F(ParserTestBase, CreateIndexTest) {
   auto ia1l = ia1->GetChild(0).CastManagedPointerTo<ColumnValueExpression>();
   EXPECT_EQ(ia1l->GetColumnName(), "o_w_id");
   auto ia1r = ia1->GetChild(1).CastManagedPointerTo<ConstantValueExpression>();
-  EXPECT_EQ(ia1r->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 2);
+  EXPECT_EQ(ia1r->Peek<int64_t>(), 2);
   auto ia2 = create_stmt->GetIndexAttributes()[1].GetExpression();
   EXPECT_EQ(ia2->GetExpressionType(), ExpressionType::OPERATOR_PLUS);
   auto ia2l = ia2->GetChild(0).CastManagedPointerTo<ColumnValueExpression>();
@@ -257,11 +257,7 @@ TEST_F(ParserTestBase, CreateViewTest) {
   EXPECT_EQ(left_child.CastManagedPointerTo<ColumnValueExpression>()->GetColumnName(), "baz");
   auto right_child = view_query->GetSelectCondition()->GetChild(1);
   EXPECT_EQ(right_child->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
-  EXPECT_EQ(right_child.CastManagedPointerTo<ConstantValueExpression>()
-                ->GetValue()
-                .CastManagedPointerTo<execution::sql::Integer>()
-                ->val_,
-            1);
+  EXPECT_EQ(right_child.CastManagedPointerTo<ConstantValueExpression>()->Peek<int64_t>(), 1);
 }
 
 // NOLINTNEXTLINE
@@ -752,7 +748,7 @@ TEST_F(ParserTestBase, OldGroupByTest) {
 
   EXPECT_EQ("id", name_exp->GetColumnName());
   EXPECT_EQ(type::TypeId::INTEGER, value_exp->GetReturnValueType());
-  EXPECT_EQ(10, value_exp->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+  EXPECT_EQ(10, value_exp->Peek<int64_t>());
 
   auto result2 = parser::PostgresParser::BuildParseTree(query);
   auto statement_2 = result2->GetStatement(0).CastManagedPointerTo<SelectStatement>();
@@ -1051,7 +1047,7 @@ TEST_F(ParserTestBase, OldColumnUpdateTest) {
     EXPECT_EQ(right_child->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
     auto right_const = right_child.CastManagedPointerTo<ConstantValueExpression>();
     EXPECT_EQ(right_const->GetReturnValueType(), type::TypeId::INTEGER);
-    EXPECT_EQ(right_const->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 2);
+    EXPECT_EQ(right_const->Peek<int64_t>(), 2);
   }
 }
 
@@ -1067,7 +1063,7 @@ TEST_F(ParserTestBase, OldExpressionUpdateTest) {
   EXPECT_EQ(upd0->GetColumnName(), "s_quantity");
   auto constant = upd0->GetUpdateValue().CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_EQ(constant->GetReturnValueType(), type::TypeId::DECIMAL);
-  ASSERT_DOUBLE_EQ(constant->GetValue().CastManagedPointerTo<execution::sql::Real>()->val_, 48.0);
+  ASSERT_DOUBLE_EQ(constant->Peek<double>(), 48.0);
 
   // Test Second Set Condition
   auto upd1 = update_stmt->GetUpdateClauses().at(1);
@@ -1078,7 +1074,7 @@ TEST_F(ParserTestBase, OldExpressionUpdateTest) {
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
   auto child2 = op_expr->GetChild(1).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_EQ(child2->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(child2->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+  EXPECT_EQ(child2->Peek<int64_t>(), 1);
 
   // Test Where clause
   auto where = update_stmt->GetUpdateCondition().CastManagedPointerTo<OperatorExpression>();
@@ -1090,7 +1086,7 @@ TEST_F(ParserTestBase, OldExpressionUpdateTest) {
   EXPECT_EQ(column->GetColumnName(), "s_i_id");
   constant = cond1->GetChild(1).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_EQ(constant->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(constant->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 68999);
+  EXPECT_EQ(constant->Peek<int64_t>(), 68999);
 
   auto cond2 = where->GetChild(1).CastManagedPointerTo<OperatorExpression>();
   EXPECT_EQ(cond2->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
@@ -1098,7 +1094,7 @@ TEST_F(ParserTestBase, OldExpressionUpdateTest) {
   EXPECT_EQ(column->GetColumnName(), "s_w_id");
   constant = cond2->GetChild(1).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_EQ(constant->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(constant->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 4);
+  EXPECT_EQ(constant->Peek<int64_t>(), 4);
 }
 
 // NOLINTNEXTLINE
@@ -1142,17 +1138,9 @@ TEST_F(ParserTestBase, OldStringUpdateTest) {
   EXPECT_EQ(child01->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
   EXPECT_EQ(child11->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
   EXPECT_EQ(child01.CastManagedPointerTo<ConstantValueExpression>()->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(child01.CastManagedPointerTo<ConstantValueExpression>()
-                ->GetValue()
-                .CastManagedPointerTo<execution::sql::Integer>()
-                ->val_,
-            2101);
+  EXPECT_EQ(child01.CastManagedPointerTo<ConstantValueExpression>()->Peek<int64_t>(), 2101);
   EXPECT_EQ(child11.CastManagedPointerTo<ConstantValueExpression>()->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(child11.CastManagedPointerTo<ConstantValueExpression>()
-                ->GetValue()
-                .CastManagedPointerTo<execution::sql::Integer>()
-                ->val_,
-            2);
+  EXPECT_EQ(child11.CastManagedPointerTo<ConstantValueExpression>()->Peek<int64_t>(), 2);
 
   // Check update clause
   auto update_clause = update->GetUpdateClauses()[0];
@@ -1160,8 +1148,7 @@ TEST_F(ParserTestBase, OldStringUpdateTest) {
   auto value = update_clause->GetUpdateValue();
   EXPECT_EQ(value->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
   auto value_expr = value.CastManagedPointerTo<ConstantValueExpression>();
-  EXPECT_EQ("2016-11-15 15:07:37",
-            value_expr->GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView());
+  EXPECT_EQ("2016-11-15 15:07:37", value_expr->Peek<std::string_view>());
   EXPECT_EQ(type::TypeId::VARCHAR, value_expr->GetReturnValueType());
 }
 
@@ -1206,12 +1193,12 @@ TEST_F(ParserTestBase, OldInsertTest) {
 
   // First item of first tuple is NULL
   auto constant = insert_stmt->GetValues()->at(0).at(0).CastManagedPointerTo<ConstantValueExpression>();
-  EXPECT_TRUE(constant->GetValue()->is_null_);
+  EXPECT_TRUE(constant->IsNull());
 
   // Second item of second tuple == 5
   constant = insert_stmt->GetValues()->at(1).at(1).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_EQ(constant->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(constant->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 5);
+  EXPECT_EQ(constant->Peek<int64_t>(), 5);
 }
 
 // NOLINTNEXTLINE
@@ -1376,10 +1363,7 @@ TEST_F(ParserTestBase, OldCreateViewTest) {
 
   auto right_child = view_query->GetSelectCondition()->GetChild(1);
   EXPECT_EQ(right_child->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
-  EXPECT_EQ("Comedy", right_child.CastManagedPointerTo<ConstantValueExpression>()
-                          ->GetValue()
-                          .CastManagedPointerTo<execution::sql::StringVal>()
-                          ->StringView());
+  EXPECT_EQ("Comedy", right_child.CastManagedPointerTo<ConstantValueExpression>()->Peek<std::string_view>());
 }
 
 // NOLINTNEXTLINE
@@ -1428,12 +1412,12 @@ TEST_F(ParserTestBase, OldConstraintTest) {
   auto child0 = default_expr->GetChild(0).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_NE(child0, nullptr);
   EXPECT_EQ(child0->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(child0->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+  EXPECT_EQ(child0->Peek<int64_t>(), 1);
 
   auto child1 = default_expr->GetChild(1).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_NE(child1, nullptr);
   EXPECT_EQ(child1->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(child1->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 2);
+  EXPECT_EQ(child1->Peek<int64_t>(), 2);
 
   // Check Second column
   column = create_stmt->GetColumns()[1];
@@ -1463,12 +1447,12 @@ TEST_F(ParserTestBase, OldConstraintTest) {
   auto plus_child2 = check_child1->GetChild(1).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_NE(plus_child2, nullptr);
   EXPECT_EQ(plus_child2->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(plus_child2->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+  EXPECT_EQ(plus_child2->Peek<int64_t>(), 1);
 
   auto check_child2 = column->GetCheckExpression()->GetChild(1).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_NE(check_child2, nullptr);
   EXPECT_EQ(check_child2->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(check_child2->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 0);
+  EXPECT_EQ(check_child2->Peek<int64_t>(), 0);
 
   // Check the foreign key constraint
   column = create_stmt->GetForeignKeys()[0];
@@ -1616,7 +1600,7 @@ TEST_F(ParserTestBase, OldFuncCallTest) {
   auto const_expr = fun_expr->GetChild(0).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_NE(const_expr, nullptr);
   EXPECT_EQ(const_expr->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(const_expr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+  EXPECT_EQ(const_expr->Peek<int64_t>(), 1);
 
   auto tv_expr = fun_expr->GetChild(1).CastManagedPointerTo<ColumnValueExpression>();
   EXPECT_NE(tv_expr, nullptr);
@@ -1644,7 +1628,7 @@ TEST_F(ParserTestBase, OldFuncCallTest) {
   const_expr = op_expr->GetChild(1).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_NE(const_expr, nullptr);
   EXPECT_EQ(const_expr->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(const_expr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 2);
+  EXPECT_EQ(const_expr->Peek<int64_t>(), 2);
 }
 
 // NOLINTNEXTLINE
@@ -1661,7 +1645,7 @@ TEST_F(ParserTestBase, OldUDFFuncCallTest) {
   auto const_expr = fun_expr->GetChild(0).CastManagedPointerTo<ConstantValueExpression>();
   EXPECT_NE(const_expr, nullptr);
   EXPECT_EQ(const_expr->GetReturnValueType(), type::TypeId::INTEGER);
-  EXPECT_EQ(const_expr->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_, 1);
+  EXPECT_EQ(const_expr->Peek<int64_t>(), 1);
 
   auto tv_expr = fun_expr->GetChild(1).CastManagedPointerTo<ColumnValueExpression>();
   EXPECT_NE(tv_expr, nullptr);
@@ -1699,7 +1683,7 @@ TEST_F(ParserTestBase, OldDateTypeTest) {
     EXPECT_EQ(type::TypeId::DATE, cast_expr->GetReturnValueType());
 
     auto const_expr = cast_expr->GetChild(0).CastManagedPointerTo<ConstantValueExpression>();
-    EXPECT_EQ("2017-01-01", const_expr->GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView());
+    EXPECT_EQ("2017-01-01", const_expr->Peek<std::string_view>());
   }
 
   {
@@ -1748,7 +1732,7 @@ TEST_F(ParserTestBase, OldTypeCastInExpressionTest) {
     EXPECT_EQ(type::TypeId::DATE, cast_expr->GetReturnValueType());
 
     auto const_expr = cast_expr->GetChild(0).CastManagedPointerTo<ConstantValueExpression>();
-    EXPECT_EQ("2018-04-04", const_expr->GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView());
+    EXPECT_EQ("2018-04-04", const_expr->Peek<std::string_view>());
   }
 
   {
@@ -1762,10 +1746,10 @@ TEST_F(ParserTestBase, OldTypeCastInExpressionTest) {
     EXPECT_EQ(type::TypeId::INTEGER, left_child->GetReturnValueType());
 
     auto value_expr = left_child->GetChild(0).CastManagedPointerTo<ConstantValueExpression>();
-    EXPECT_EQ("12345", value_expr->GetValue().CastManagedPointerTo<execution::sql::StringVal>()->StringView());
+    EXPECT_EQ("12345", value_expr->Peek<std::string_view>());
 
     auto right_child = column->GetChild(1).CastManagedPointerTo<ConstantValueExpression>();
-    EXPECT_EQ(12, right_child->GetValue().CastManagedPointerTo<execution::sql::Integer>()->val_);
+    EXPECT_EQ(12, right_child->Peek<int64_t>());
   }
 }
 

--- a/test/planner/output_schema_test.cpp
+++ b/test/planner/output_schema_test.cpp
@@ -22,8 +22,7 @@ class OutputSchemaTests : public TerrierTest {
    * @return dummy predicate
    */
   static std::unique_ptr<parser::AbstractExpression> BuildDummyPredicate() {
-    return std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                             std::make_unique<execution::sql::BoolVal>(true));
+    return std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   }
 };
 

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -266,7 +266,7 @@ TEST(PlanNodeJsonTest, CreateTablePlanNodeTest) {
 
   // CHECK CONSTRAINT
   auto get_check_info = []() {
-    parser::ConstantValueExpression val(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(1));
+    parser::ConstantValueExpression val(type::TypeId::INTEGER, execution::sql::Integer(1));
     std::vector<CheckInfo> checks;
     std::vector<std::string> cks = {"ck_a"};
     checks.emplace_back(cks, "ck_a", parser::ExpressionType::COMPARE_GREATER_THAN, std::move(val));
@@ -672,13 +672,11 @@ TEST(PlanNodeJsonTest, InsertPlanNodeJsonTest) {
   auto get_values = [&](int offset, int num_cols) {
     std::vector<common::ManagedPointer<parser::AbstractExpression>> tuple;
 
-    auto ptr =
-        new parser::ConstantValueExpression(type::TypeId::INTEGER, std::make_unique<execution::sql::Integer>(offset));
+    auto ptr = new parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(offset));
     free_exprs.push_back(ptr);
     tuple.emplace_back(ptr);
     for (; num_cols - 1 > 0; num_cols--) {
-      auto cve =
-          new parser::ConstantValueExpression(type::TypeId::BOOLEAN, std::make_unique<execution::sql::BoolVal>(true));
+      auto cve = new parser::ConstantValueExpression(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
       free_exprs.push_back(cve);
       tuple.emplace_back(cve);
     }

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -64,8 +64,7 @@ class PlanNodeJsonTest : public TerrierTest {
    * @return dummy predicate
    */
   static std::unique_ptr<parser::AbstractExpression> BuildDummyPredicate() {
-    return std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                             std::make_unique<execution::sql::BoolVal>(true));
+    return std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
   }
 };
 

--- a/test/planner/plan_node_test.cpp
+++ b/test/planner/plan_node_test.cpp
@@ -22,8 +22,7 @@ namespace terrier::planner {
 class PlanNodeTest : public TerrierTest {
  public:
   static std::unique_ptr<OutputSchema> BuildOneColumnSchema(std::string name, const type::TypeId type) {
-    auto pred = std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                  std::make_unique<execution::sql::BoolVal>(true));
+    auto pred = std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
     std::vector<OutputSchema::Column> cols;
     cols.emplace_back(OutputSchema::Column(std::move(name), type, std::move(pred)));
     return std::make_unique<OutputSchema>(std::move(cols));

--- a/test/test_util/tpch/workload.cpp
+++ b/test/test_util/tpch/workload.cpp
@@ -70,7 +70,7 @@ std::vector<parser::ConstantValueExpression> Workload::GetQueryParams(const std:
     const std::string query_val = query_name + "_p" + std::to_string(i + 1);
 
     auto string_val = execution::sql::ValueUtil::CreateStringVal(query_val);
-    params.emplace_back(type::TypeId::VARCHAR, std::move(string_val.first), std::move(string_val.second));
+    params.emplace_back(type::TypeId::VARCHAR, string_val.first, std::move(string_val.second));
   }
 
   return params;

--- a/util/execution/tpl.cpp
+++ b/util/execution/tpl.cpp
@@ -39,6 +39,7 @@
 #include "loggers/loggers_util.h"
 #include "main/db_main.h"
 #include "metrics/metrics_thread.h"
+#include "parser/expression/constant_value_expression.h"
 #include "settings/settings_manager.h"
 #include "storage/garbage_collector.h"
 #include "transaction/deferred_action_manager.h"
@@ -113,11 +114,11 @@ static void CompileAndRun(const std::string &source, const std::string &name = "
                                   common::ManagedPointer(accessor)};
   // Add dummy parameters for tests
   std::vector<parser::ConstantValueExpression> params;
-  params.emplace_back(type::TypeId::INTEGER, std::make_unique<sql::Integer>(37));
-  params.emplace_back(type::TypeId::DECIMAL, std::make_unique<sql::Real>(37.73));
-  params.emplace_back(type::TypeId::DATE, std::make_unique<sql::DateVal>(sql::Date::FromYMD(1937, 3, 7)));
+  params.emplace_back(type::TypeId::INTEGER, sql::Integer(37));
+  params.emplace_back(type::TypeId::DECIMAL, sql::Real(37.73));
+  params.emplace_back(type::TypeId::DATE, sql::DateVal(sql::Date::FromYMD(1937, 3, 7)));
   auto string_val = sql::ValueUtil::CreateStringVal(std::string_view("37 Strings"));
-  params.emplace_back(type::TypeId::VARCHAR, std::move(string_val.first), std::move(string_val.second));
+  params.emplace_back(type::TypeId::VARCHAR, string_val.first, std::move(string_val.second));
   exec_ctx.SetParams(common::ManagedPointer<const std::vector<parser::ConstantValueExpression>>(&params));
 
   // Generate test tables

--- a/util/include/execution/table_generator/sample_output.h
+++ b/util/include/execution/table_generator/sample_output.h
@@ -23,8 +23,7 @@ class SampleOutput {
    */
   void InitTestOutput() {
     // Sample output formats
-    auto pred = std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                  std::make_unique<execution::sql::BoolVal>(true));
+    auto pred = std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
     planner::OutputSchema::Column int_col{"dummy", type::TypeId::INTEGER, pred->Copy()};
     planner::OutputSchema::Column real_col{"dummy", type::TypeId::DECIMAL, pred->Copy()};
     planner::OutputSchema::Column date_col{"dummy", type::TypeId::DATE, pred->Copy()};
@@ -61,8 +60,7 @@ class SampleOutput {
 
  private:
   void InitTPCHOutput() {
-    auto pred = std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN,
-                                                                  std::make_unique<execution::sql::BoolVal>(true));
+    auto pred = std::make_unique<parser::ConstantValueExpression>(type::TypeId::BOOLEAN, execution::sql::BoolVal(true));
     planner::OutputSchema::Column int_col{"dummy", type::TypeId::INTEGER, pred->Copy()};
     planner::OutputSchema::Column real_col{"dummy", type::TypeId::DECIMAL, pred->Copy()};
     planner::OutputSchema::Column date_col{"dummy", type::TypeId::DATE, pred->Copy()};

--- a/util/include/execution/table_generator/schema_reader.h
+++ b/util/include/execution/table_generator/schema_reader.h
@@ -179,8 +179,7 @@ class SchemaReader {
   }
 
   terrier::parser::ConstantValueExpression DummyCVE() {
-    return terrier::parser::ConstantValueExpression(type::TypeId::INTEGER,
-                                                    std::make_unique<execution::sql::Integer>(0));
+    return terrier::parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(0));
   }
 
  private:

--- a/util/include/execution/table_generator/table_generator.h
+++ b/util/include/execution/table_generator/table_generator.h
@@ -296,8 +296,7 @@ class TableGenerator {
                  const catalog::Schema &table_schema);
 
   terrier::parser::ConstantValueExpression DummyCVE() {
-    return terrier::parser::ConstantValueExpression(type::TypeId::INTEGER,
-                                                    std::make_unique<execution::sql::Integer>(0));
+    return terrier::parser::ConstantValueExpression(type::TypeId::INTEGER, execution::sql::Integer(0));
   }
 };
 


### PR DESCRIPTION
Based on @pmenon's feedback.

**Major changes:**
- CVE now holds a `std::variant` to an execution engine value, rather than a `std::unique_ptr` This removes the need for a virtual destructor to clean up the value properly, which we don't want because we'd like to keep the value.h classes POD.
- Added a `Peek<>()` method to CVE to quickly extract C++ types.
- Lots of mindless signature refactors.
- Jenkinsfile from #919 that re-enables some missing checks.

This fixes an issue where we couldn't start the server when compiled with ASAN on due to a destructor mismatch on the held value.