### PR TITLE
Abort running txn on disconnect

### DIFF
--- a/script/testing/junit/src/TrafficCopTest.java
+++ b/script/testing/junit/src/TrafficCopTest.java
@@ -37,25 +37,32 @@ public class TrafficCopTest extends TestUtility {
   @Test
   public void test_DisconnectAbort() throws SQLException {
 
+   // create another connection that will take the write lock on a tuple, forcing an about on the default connection's
+   // createStatement
    Connection second_conn = makeDefaultConnection();
    second_conn.setAutoCommit(true);
 
    Statement stmt = second_conn.createStatement();
    stmt.execute("CREATE TABLE FOO (ID INT);");
    stmt.execute("INSERT INTO FOO VALUES (1),(2),(3);");
+
+   // begin explicit txn and take the write lock on a tuple
    stmt.execute("BEGIN;");
    stmt.execute("UPDATE FOO SET ID = 4 WHERE ID = 3;");
    assertEquals(stmt.getUpdateCount(), 1);
 
    Statement second_stmt = conn.createStatement();
    try {
+      // another statement tries to update the same tuple and will fail
       second_stmt.execute("UPDATE FOO SET ID = 5 WHERE ID = 3;");
       fail();
      } catch (SQLException ex) {
       assertEquals(ex.getMessage(), "Query failed.");
      }
+   // close the second connection, forcing the explicit txn that has the write lock to abort
    second_conn.close();
 
+   // another statement can now acquire the write lock on the tuple
    Statement third_stmt = conn.createStatement();
    third_stmt.execute("UPDATE FOO SET ID = 5 WHERE ID = 3;");
    assertEquals(third_stmt.getUpdateCount(), 1);

--- a/script/testing/junit/src/TrafficCopTest.java
+++ b/script/testing/junit/src/TrafficCopTest.java
@@ -37,7 +37,7 @@ public class TrafficCopTest extends TestUtility {
   @Test
   public void test_DisconnectAbort() throws SQLException {
 
-   // create another connection that will take the write lock on a tuple, forcing an about on the default connection's
+   // create another connection that will take the write lock on a tuple, forcing an abort on the default connection's
    // createStatement
    Connection second_conn = makeDefaultConnection();
    second_conn.setAutoCommit(true);

--- a/script/testing/junit/src/TrafficCopTest.java
+++ b/script/testing/junit/src/TrafficCopTest.java
@@ -32,6 +32,38 @@ public class TrafficCopTest extends TestUtility {
  }
 
  /**
+   * DisconnectAbortTest
+   */
+  @Test
+  public void test_DisconnectAbort() throws SQLException {
+
+   Connection second_conn = makeDefaultConnection();
+   second_conn.setAutoCommit(true);
+
+   Statement stmt = second_conn.createStatement();
+   stmt.execute("CREATE TABLE FOO (ID INT);");
+   stmt.execute("INSERT INTO FOO VALUES (1),(2),(3);");
+   stmt.execute("BEGIN;");
+   stmt.execute("UPDATE FOO SET ID = 4 WHERE ID = 3;");
+   assertEquals(stmt.getUpdateCount(), 1);
+
+   Statement second_stmt = conn.createStatement();
+   try {
+      second_stmt.execute("UPDATE FOO SET ID = 5 WHERE ID = 3;");
+      fail();
+     } catch (SQLException ex) {
+      assertEquals(ex.getMessage(), "Query failed.");
+     }
+   second_conn.close();
+
+   Statement third_stmt = conn.createStatement();
+   third_stmt.execute("UPDATE FOO SET ID = 5 WHERE ID = 3;");
+   assertEquals(third_stmt.getUpdateCount(), 1);
+
+
+  }
+
+ /**
   * BadParseTest
   */
  @Test

--- a/src/network/postgres/postgres_protocol_interpreter.cpp
+++ b/src/network/postgres/postgres_protocol_interpreter.cpp
@@ -133,6 +133,13 @@ void PostgresProtocolInterpreter::Teardown(const common::ManagedPointer<ReadBuff
                                            const common::ManagedPointer<WriteQueue> out,
                                            const common::ManagedPointer<trafficcop::TrafficCop> t_cop,
                                            const common::ManagedPointer<ConnectionContext> context) {
+  // Close any open transaction
+  if (context->Transaction() != nullptr) {
+    t_cop->EndTransaction(context, QueryType::QUERY_ROLLBACK);
+    // We're about to destruct this object (probably), but reset state anyway
+    ResetTransactionState();
+  }
+
   // Drop the temp namespace (if it exists) for this connection.
 
   // It's possible that the client provided an invalid database name, in which case there's nothing to do


### PR DESCRIPTION
If the client disconnects and there is an open txn, abort it. Otherwise the system could end up in a bad state where that txn is never GC'd and version chains never get cleaned up.

**Major changes:**
- Extended `Teardown` logic in `PostgresProtocolInterpreter` to abort any running txn belonging to its `ConnectionContext`.
- JUnit test case that fails on current master to show the issue is fixed