### PR TITLE
Fix package versions.

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -106,12 +106,12 @@ install_linux() {
       ant
    #install libpqxx-6.2 manually
    apt-get -y install wget
-   wget http://mirrors.kernel.org/ubuntu/pool/universe/libp/libpqxx/libpqxx-dev_6.2.4-4_amd64.deb
-   wget http://mirrors.kernel.org/ubuntu/pool/universe/libp/libpqxx/libpqxx-6.2_6.2.4-4_amd64.deb
-   dpkg -i libpqxx-6.2_6.2.4-4_amd64.deb
-   dpkg -i libpqxx-dev_6.2.4-4_amd64.deb
-   rm libpqxx-6.2_6.2.4-4_amd64.deb
-   rm libpqxx-dev_6.2.4-4_amd64.deb
+   wget http://mirrors.kernel.org/ubuntu/pool/universe/libp/libpqxx/libpqxx-dev_6.2.5-1_amd64.deb
+   wget http://mirrors.kernel.org/ubuntu/pool/universe/libp/libpqxx/libpqxx-6.2_6.2.5-1_amd64.deb
+   dpkg -i libpqxx-dev_6.2.5-1_amd64.deb
+   dpkg -i libpqxx-6.2_6.2.5-1_amd64.deb
+   rm libpqxx-dev_6.2.5-1_amd64.deb
+   rm libpqxx-6.2_6.2.5-1_amd64.deb
 }
 
 main "$@"


### PR DESCRIPTION
Debian packages libpqxx-dev_6.2.4-4_amd64.deb and libpqxx-6.2_6.2.4-4_amd64.deb no longer exist. The update packages are libpqxx-dev_6.2.5-1_amd64.deb and libpqxx-6.2_6.2.5-1_amd64.deb. 

Changes are tested on Ubuntu 18.04.