### PR TITLE
Create a new stage in the pipeline that runs OLTPbench on TPCC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -375,5 +375,25 @@ pipeline {
                 }
             }
         }
+
+        stage('Performance') {
+            agent { label 'benchmark' }
+            steps {
+                sh 'echo $NODE_NAME'
+                sh 'echo y | sudo ./script/installation/packages.sh'
+                sh 'sudo apt-get -y install ccache'
+                sh 'mkdir build'
+                sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) all'
+                sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=release --loader-threads=4'
+                sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=release --loader-threads=4'
+                sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tpcc 45,43,4,4,4 --build-type=release --loader-threads=4'
+                sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py noop 100 --build-type=release'
+            }
+            post {
+                cleanup {
+                    deleteDir()
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Add a new stage in Jenkinsfile. It will run OLTPBench on the same machine as microbenchmark tests.  So that we could analyze the trends in performance for NoisePage.