### PR TITLE
Reduce a normal debug logging event from WARN to TRACE

### DIFF
--- a/src/include/parser/expression_util.h
+++ b/src/include/parser/expression_util.h
@@ -368,8 +368,7 @@ class ExpressionUtil {
       //
       // However, there are other cases where EvaluateExpression will result in an unbound
       // ColumnValueExpression particularly when dealing with InnerIndexJoin.
-      OPTIMIZER_LOG_WARN("EvaluateExpression resulted in an unbound ColumnValueExpression");
-      // TERRIER_ASSERT(0, "EvaluateExpression resulted in an unbound ColumnValueExpression");
+      OPTIMIZER_LOG_TRACE("EvaluateExpression resulted in an unbound ColumnValueExpression");
     } else if (IsAggregateExpression(expr->GetExpressionType())) {
       /*
       TODO(wz2, [ExecutionEngine]): If value_idx is somehow needed during aggregation, reviist this


### PR DESCRIPTION
Per @17zhangw when I asked why this warning was now showing up in TPC-C and TATP:
```
The warnings start showing up since it executes an IndexNLJoin for TPCC stock level. This isn’t really a “true error” per se — just that ExpressionUtil::EvaluateExpression is set up to always expect a ColumnValueExpression to be replaced by a DerivedValueExpression (which is not the case for an IndexNLJoin).
In the case that the query doesn’t contain an IndexNLJoin, then the “unbound ColumnValueExpression” is a sign of the optimizer breaking since some predicate/key is using a base column at a non-scan node.
```