### PR TITLE
fix "module 'oltpbench.constants' has no attribute 'ErrorCode'"

### DIFF
--- a/script/testing/oltpbench/test_oltpbench.py
+++ b/script/testing/oltpbench/test_oltpbench.py
@@ -170,7 +170,7 @@ class TestOLTPBench(TestServer):
             for test in unexpected_result.keys():
                 if (unexpected_result[test] != 0):
                     print(str(unexpected_result))
-                    sys.exit(constants.ErrorCode.ERROR)
+                    sys.exit(ErrorCode.ERROR)
         else:
             print(str(unexpected_result))
-            sys.exit(constants.ErrorCode.ERROR)
+            sys.exit(ErrorCode.ERROR)


### PR DESCRIPTION
This error happens when: "run_oltpbench.py ycsb 50,5,15,10,10,10 --build-type=release --loader-threads=4 --terminals=4"
![image](https://user-images.githubusercontent.com/996019/85047009-41131300-b15f-11ea-8afa-71873bc2c3f1.png)

