### PR TITLE
Fix nightly build timer

### DIFF
--- a/Jenkinsfile-nightly
+++ b/Jenkinsfile-nightly
@@ -15,7 +15,6 @@ pipeline {
     stages {
         stage('Performance') {
             agent { label 'benchmark' }
-            when { branch 'master' } 
             steps {
                 loop_terminals_run_oltp(OLTP_TERMINALS)
             }
@@ -28,7 +27,6 @@ pipeline {
 
         stage('Microbenchmark') {
             agent { label 'benchmark' }
-            when { branch 'master' }
             steps {
                 sh 'echo $NODE_NAME'
                 sh 'echo y | sudo ./script/installation/packages.sh all'


### PR DESCRIPTION
The [nightly builds](http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/terrier-nightly/detail/terrier-nightly/10/pipeline/) skipped Performance and Microbenchmark stages. Because the `branch` condition only works on a multibranch Pipeline. We configured the branch as `*/master` on the webpage so we don't need it in the Jenkinsfile