### PR TITLE
Move index wrapper definitions to cpp files

### DIFF
--- a/src/include/storage/index/bwtree_index.h
+++ b/src/include/storage/index/bwtree_index.h
@@ -5,27 +5,25 @@
 #include <utility>
 #include <vector>
 
+#include "common/managed_pointer.h"
 #include "storage/index/index.h"
 #include "storage/index/index_defs.h"
-#include "transaction/deferred_action_manager.h"
-#include "transaction/transaction_context.h"
-#include "transaction/transaction_manager.h"
+
+namespace terrier::transaction {
+class TransactionContext;
+}
+
+namespace third_party::bwtree {
+template <typename KeyType, typename ValueType, typename KeyComparator, typename KeyEqualityChecker,
+          typename KeyHashFunc, typename ValueEqualityChecker, typename ValueHashFunc>
+class BwTree;
+}
 
 namespace terrier::storage::index {
 template <uint8_t KeySize>
 class CompactIntsKey;
 template <uint16_t KeySize>
 class GenericKey;
-}  // namespace terrier::storage::index
-
-namespace third_party::bwtree {
-template <typename KeyType, typename ValueType, typename KeyComparator = std::less<KeyType>,
-          typename KeyEqualityChecker = std::equal_to<KeyType>, typename KeyHashFunc = std::hash<KeyType>,
-          typename ValueEqualityChecker = std::equal_to<ValueType>, typename ValueHashFunc = std::hash<ValueType>>
-class BwTree;
-}
-
-namespace terrier::storage::index {
 
 /**
  * Wrapper around Ziqi's OpenBwTree.
@@ -38,7 +36,9 @@ class BwTreeIndex final : public Index {
  private:
   explicit BwTreeIndex(IndexMetadata metadata);
 
-  const std::unique_ptr<third_party::bwtree::BwTree<KeyType, TupleSlot>> bwtree_;
+  const std::unique_ptr<third_party::bwtree::BwTree<KeyType, TupleSlot, std::less<KeyType>, std::equal_to<KeyType>,
+                                                    std::hash<KeyType>, std::equal_to<TupleSlot>, std::hash<TupleSlot>>>
+      bwtree_;
 
  public:
   IndexType Type() const final { return IndexType::BWTREE; }

--- a/src/include/storage/index/bwtree_index.h
+++ b/src/include/storage/index/bwtree_index.h
@@ -13,7 +13,7 @@ namespace terrier::transaction {
 class TransactionContext;
 }
 
-namespace third_party::bwtree {
+namespace third_party::bwtree {  // NOLINT: check censored doesn't like this namespace name
 template <typename KeyType, typename ValueType, typename KeyComparator, typename KeyEqualityChecker,
           typename KeyHashFunc, typename ValueEqualityChecker, typename ValueHashFunc>
 class BwTree;

--- a/src/include/storage/index/bwtree_index.h
+++ b/src/include/storage/index/bwtree_index.h
@@ -5,7 +5,6 @@
 #include <utility>
 #include <vector>
 
-#include "bwtree/bwtree.h"
 #include "storage/index/index.h"
 #include "storage/index/index_defs.h"
 #include "transaction/deferred_action_manager.h"
@@ -17,6 +16,16 @@ template <uint8_t KeySize>
 class CompactIntsKey;
 template <uint16_t KeySize>
 class GenericKey;
+}  // namespace terrier::storage::index
+
+namespace third_party::bwtree {
+template <typename KeyType, typename ValueType, typename KeyComparator = std::less<KeyType>,
+          typename KeyEqualityChecker = std::equal_to<KeyType>, typename KeyHashFunc = std::hash<KeyType>,
+          typename ValueEqualityChecker = std::equal_to<ValueType>, typename ValueHashFunc = std::hash<ValueType>>
+class BwTree;
+}
+
+namespace terrier::storage::index {
 
 /**
  * Wrapper around Ziqi's OpenBwTree.
@@ -27,189 +36,36 @@ class BwTreeIndex final : public Index {
   friend class IndexBuilder;
 
  private:
-  explicit BwTreeIndex(IndexMetadata metadata)
-      : Index(std::move(metadata)), bwtree_{new third_party::bwtree::BwTree<KeyType, TupleSlot>{false}} {}
+  explicit BwTreeIndex(IndexMetadata metadata);
 
   const std::unique_ptr<third_party::bwtree::BwTree<KeyType, TupleSlot>> bwtree_;
 
  public:
   IndexType Type() const final { return IndexType::BWTREE; }
 
-  void PerformGarbageCollection() final { bwtree_->PerformGarbageCollection(); };
+  void PerformGarbageCollection() final;
 
-  bool Insert(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
-              const TupleSlot location) final {
-    TERRIER_ASSERT(!(metadata_.GetSchema().Unique()),
-                   "This Insert is designed for secondary indexes with no uniqueness constraints.");
-    KeyType index_key;
-    index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
-    const bool result = bwtree_->Insert(index_key, location, false);
+  bool Insert(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+              TupleSlot location) final;
 
-    TERRIER_ASSERT(
-        result,
-        "non-unique index shouldn't fail to insert. If it did, something went wrong deep inside the BwTree itself.");
-    // Register an abort action with the txn context in case of rollback
-    txn->RegisterAbortAction([=]() {
-      const bool UNUSED_ATTRIBUTE result = bwtree_->Delete(index_key, location);
-      TERRIER_ASSERT(result, "Delete on the index failed.");
-    });
-    return result;
-  }
+  bool InsertUnique(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+                    TupleSlot location) final;
 
-  bool InsertUnique(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
-                    const TupleSlot location) final {
-    TERRIER_ASSERT(metadata_.GetSchema().Unique(), "This Insert is designed for indexes with uniqueness constraints.");
-    KeyType index_key;
-    index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
-    bool predicate_satisfied = false;
-
-    // The predicate checks if any matching keys have write-write conflicts or are still visible to the calling txn.
-    auto predicate = [txn](const TupleSlot slot) -> bool {
-      const auto *const data_table = slot.GetBlock()->data_table_;
-      const auto has_conflict = data_table->HasConflict(*txn, slot);
-      const auto is_visible = data_table->IsVisible(*txn, slot);
-      return has_conflict || is_visible;
-    };
-
-    const bool result = bwtree_->ConditionalInsert(index_key, location, predicate, &predicate_satisfied);
-
-    TERRIER_ASSERT(predicate_satisfied != result, "If predicate is not satisfied then insertion should succeed.");
-
-    if (result) {
-      // Register an abort action with the txn context in case of rollback
-      txn->RegisterAbortAction([=]() {
-        const bool UNUSED_ATTRIBUTE result = bwtree_->Delete(index_key, location);
-        TERRIER_ASSERT(result, "Delete on the index failed.");
-      });
-    } else {
-      // Presumably you've already made modifications to a DataTable (the source of the TupleSlot argument to this
-      // function) however, the index found a constraint violation and cannot allow that operation to succeed. For MVCC
-      // correctness, this txn must now abort for the GC to clean up the version chain in the DataTable correctly.
-      txn->SetMustAbort();
-    }
-
-    return result;
-  }
-
-  void Delete(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
-              const TupleSlot location) final {
-    KeyType index_key;
-    index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
-
-    TERRIER_ASSERT(!(location.GetBlock()->data_table_->HasConflict(*txn, location)) &&
-                       !(location.GetBlock()->data_table_->IsVisible(*txn, location)),
-                   "Called index delete on a TupleSlot that has a conflict with this txn or is still visible.");
-
-    // Register a deferred action for the GC with txn manager. See base function comment.
-    txn->RegisterCommitAction([=](transaction::DeferredActionManager *deferred_action_manager) {
-      deferred_action_manager->RegisterDeferredAction([=]() {
-        const bool UNUSED_ATTRIBUTE result = bwtree_->Delete(index_key, location);
-        TERRIER_ASSERT(result, "Deferred delete on the index failed.");
-      });
-    });
-  }
+  void Delete(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+              TupleSlot location) final;
 
   void ScanKey(const transaction::TransactionContext &txn, const ProjectedRow &key,
-               std::vector<TupleSlot> *value_list) final {
-    TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
-
-    std::vector<TupleSlot> results;
-
-    // Build search key
-    KeyType index_key;
-    index_key.SetFromProjectedRow(key, metadata_, metadata_.GetSchema().GetColumns().size());
-
-    // Perform lookup in BwTree
-    bwtree_->GetValue(index_key, results);
-
-    // Avoid resizing our value_list, even if it means over-provisioning
-    value_list->reserve(results.size());
-
-    // Perform visibility check on result
-    for (const auto &result : results) {
-      if (IsVisible(txn, result)) value_list->emplace_back(result);
-    }
-
-    TERRIER_ASSERT(!(metadata_.GetSchema().Unique()) || (metadata_.GetSchema().Unique() && value_list->size() <= 1),
-                   "Invalid number of results for unique index.");
-  }
+               std::vector<TupleSlot> *value_list) final;
 
   void ScanAscending(const transaction::TransactionContext &txn, ScanType scan_type, uint32_t num_attrs,
                      ProjectedRow *low_key, ProjectedRow *high_key, uint32_t limit,
-                     std::vector<TupleSlot> *value_list) final {
-    TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
-    TERRIER_ASSERT(scan_type == ScanType::Closed || scan_type == ScanType::OpenLow || scan_type == ScanType::OpenHigh ||
-                       scan_type == ScanType::OpenBoth,
-                   "Invalid scan_type passed into BwTreeIndex::Scan");
-
-    bool low_key_exists = (scan_type == ScanType::Closed || scan_type == ScanType::OpenHigh);
-    bool high_key_exists = (scan_type == ScanType::Closed || scan_type == ScanType::OpenLow);
-
-    // Build search keys
-    KeyType index_low_key, index_high_key;
-    if (low_key_exists) index_low_key.SetFromProjectedRow(*low_key, metadata_, num_attrs);
-    if (high_key_exists) index_high_key.SetFromProjectedRow(*high_key, metadata_, num_attrs);
-
-    // Perform lookup in BwTree
-    auto scan_itr = low_key_exists ? bwtree_->Begin(index_low_key) : bwtree_->Begin();
-
-    // Limit of 0 indicates "no limit"
-    while ((limit == 0 || value_list->size() < limit) && !scan_itr.IsEnd() &&
-           (!high_key_exists || scan_itr->first.PartialLessThan(index_high_key, &metadata_, num_attrs))) {
-      // Perform visibility check on result
-      if (IsVisible(txn, scan_itr->second)) value_list->emplace_back(scan_itr->second);
-      scan_itr++;
-    }
-  }
+                     std::vector<TupleSlot> *value_list) final;
 
   void ScanDescending(const transaction::TransactionContext &txn, const ProjectedRow &low_key,
-                      const ProjectedRow &high_key, std::vector<TupleSlot> *value_list) final {
-    TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
-
-    // Build search keys
-    KeyType index_low_key, index_high_key;
-    index_low_key.SetFromProjectedRow(low_key, metadata_, metadata_.GetSchema().GetColumns().size());
-    index_high_key.SetFromProjectedRow(high_key, metadata_, metadata_.GetSchema().GetColumns().size());
-
-    // Perform lookup in BwTree
-    auto scan_itr = bwtree_->Begin(index_high_key);
-    // Back up one element if we didn't match the high key
-    // This currently uses the BwTree's decrement operator on the iterator, which is not guaranteed to be
-    // constant time. In some cases it may be faster to do an ascending scan and then reverse the result vector. It
-    // depends on the visibility selectivity and final result set size. We can change the implementation in the future
-    // if it proves to be a problem.
-    if (scan_itr.IsEnd() || bwtree_->KeyCmpGreater(scan_itr->first, index_high_key)) scan_itr--;
-
-    while (!scan_itr.IsREnd() && (bwtree_->KeyCmpGreaterEqual(scan_itr->first, index_low_key))) {
-      // Perform visibility check on result
-      if (IsVisible(txn, scan_itr->second)) value_list->emplace_back(scan_itr->second);
-      scan_itr--;
-    }
-  }
+                      const ProjectedRow &high_key, std::vector<TupleSlot> *value_list) final;
 
   void ScanLimitDescending(const transaction::TransactionContext &txn, const ProjectedRow &low_key,
-                           const ProjectedRow &high_key, std::vector<TupleSlot> *value_list,
-                           const uint32_t limit) final {
-    TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
-    TERRIER_ASSERT(limit > 0, "Limit must be greater than 0.");
-
-    // Build search keys
-    KeyType index_low_key, index_high_key;
-    index_low_key.SetFromProjectedRow(low_key, metadata_, metadata_.GetSchema().GetColumns().size());
-    index_high_key.SetFromProjectedRow(high_key, metadata_, metadata_.GetSchema().GetColumns().size());
-
-    // Perform lookup in BwTree
-    auto scan_itr = bwtree_->Begin(index_high_key);
-    // Back up one element if we didn't match the high key, see comment on line 152.
-    if (scan_itr.IsEnd() || bwtree_->KeyCmpGreater(scan_itr->first, index_high_key)) scan_itr--;
-
-    while (value_list->size() < limit && !scan_itr.IsREnd() &&
-           (bwtree_->KeyCmpGreaterEqual(scan_itr->first, index_low_key))) {
-      // Perform visibility check on result
-      if (IsVisible(txn, scan_itr->second)) value_list->emplace_back(scan_itr->second);
-      scan_itr--;
-    }
-  }
+                           const ProjectedRow &high_key, std::vector<TupleSlot> *value_list, uint32_t limit) final;
 };
 
 extern template class BwTreeIndex<CompactIntsKey<8>>;

--- a/src/include/storage/index/bwtree_index.h
+++ b/src/include/storage/index/bwtree_index.h
@@ -36,8 +36,10 @@ class BwTreeIndex final : public Index {
  private:
   explicit BwTreeIndex(IndexMetadata metadata);
 
-  const std::unique_ptr<third_party::bwtree::BwTree<KeyType, TupleSlot, std::less<KeyType>, std::equal_to<KeyType>,
-                                                    std::hash<KeyType>, std::equal_to<TupleSlot>, std::hash<TupleSlot>>>
+  const std::unique_ptr<third_party::bwtree::BwTree<
+      KeyType, TupleSlot, std::less<KeyType>,  // NOLINT transparent functors can't figure out template
+      std::equal_to<KeyType>,                  // NOLINT transparent functors can't figure out template
+      std::hash<KeyType>, std::equal_to<TupleSlot>, std::hash<TupleSlot>>>
       bwtree_;
 
  public:

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -49,7 +49,8 @@ class HashIndex final : public Index {
   explicit HashIndex(IndexMetadata metadata);
 
   const std::unique_ptr<
-      cuckoohash_map<KeyType, ValueType, std::hash<KeyType>, std::equal_to<KeyType>,
+      cuckoohash_map<KeyType, ValueType, std::hash<KeyType>,
+                     std::equal_to<KeyType>,  // NOLINT transparent functors can't figure out template
                      std::allocator<std::pair<const KeyType, ValueType>>, LIBCUCKOO_DEFAULT_SLOT_PER_BUCKET>>
       hash_map_;
 

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <functional>
 #include <memory>
 #include <unordered_set>
@@ -8,13 +7,17 @@
 #include <variant>  // NOLINT (Matt): lint thinks this C++17 header is a C header because it only knows C++11
 #include <vector>
 
-#include "libcuckoo/cuckoohash_map.hh"
+#include "common/managed_pointer.h"
+#include "libcuckoo/cuckoohash_config.hh"
 #include "storage/index/index.h"
 #include "storage/index/index_defs.h"
-#include "transaction/deferred_action_manager.h"
-#include "transaction/transaction_context.h"
-#include "transaction/transaction_manager.h"
-#include "xxHash/xxh3.h"
+
+namespace terrier::transaction {
+class TransactionContext;
+}
+
+template <class Key, class T, class Hash, class KeyEqual, class Allocator, std::size_t SLOT_PER_BUCKET>
+class cuckoohash_map;
 
 namespace terrier::storage::index {
 
@@ -22,10 +25,6 @@ template <uint16_t KeySize>
 class HashKey;
 template <uint16_t KeySize>
 class GenericKey;
-
-// TODO(Matt): unclear at the moment if we would want this to be tunable via the SettingsManager. Alternatively, it
-// might be something that is a per-index hint based on the table size (cardinality?), rather than a global setting
-constexpr uint16_t INITIAL_CUCKOOHASH_MAP_SIZE = 256;
 
 /**
  * Wrapper around libcuckoo's hash map. The MVCC is logic is similar to our reference index (BwTreeIndex). Much of the
@@ -39,237 +38,35 @@ class HashIndex final : public Index {
   friend class IndexBuilder;
 
  private:
-  struct TupleSlotHash {
-    std::size_t operator()(const TupleSlot &slot) const {
-      return XXH3_64bits(reinterpret_cast<const void *>(&slot), sizeof(TupleSlot));
-    }
-  };
+  // TODO(Matt): unclear at the moment if we would want this to be tunable via the SettingsManager. Alternatively, it
+  // might be something that is a per-index hint based on the table size (cardinality?), rather than a global setting
+  static constexpr uint16_t INITIAL_CUCKOOHASH_MAP_SIZE = 256;
+  struct TupleSlotHash;
 
   using ValueMap = std::unordered_set<TupleSlot, TupleSlotHash>;
   using ValueType = std::variant<TupleSlot, ValueMap>;
 
-  explicit HashIndex(IndexMetadata metadata)
-      : Index(std::move(metadata)), hash_map_{new cuckoohash_map<KeyType, ValueType>(INITIAL_CUCKOOHASH_MAP_SIZE)} {}
+  explicit HashIndex(IndexMetadata metadata);
 
-  const std::unique_ptr<cuckoohash_map<KeyType, ValueType>> hash_map_;
-
-  /**
-   * The lambda below is used for aborted inserts as well as committed deletes to perform the erase logic. Macros are
-   * ugly but you can't define a macro that captures location outside of the scope of that variable
-   */
-#define ERASE_KEY_ACTION                                                                                               \
-  [=]() {                                                                                                              \
-    /* See the underlying container's API for more details, but the lambda below is invoked when the key is found. */  \
-    auto key_found_fn = [location](ValueType &value) -> bool {                                                         \
-      if (std::holds_alternative<TupleSlot>(value)) {                                                                  \
-        /* It's just a TupleSlot, functor should return true for cuckoohash_map's uprase_fn to erase key/value pair */ \
-        return true;                                                                                                   \
-      }                                                                                                                \
-      auto &value_map = std::get<ValueMap>(value);                                                                     \
-      if (value_map.size() == 2) {                                                                                     \
-        /* functor should replace the ValueMap with a TupleSlot for the other location */                              \
-        for (const auto i : value_map) {                                                                               \
-          if (i != location) {                                                                                         \
-            value = i; /* Assigning TupleSlot type will change the std::variant to TupleSlot and free the ValueMap */  \
-            TERRIER_ASSERT(std::holds_alternative<TupleSlot>(value), "value should now be a TupleSlot.");              \
-            return false; /* Return false so cuckoohash_map's uprase_fn doesn't erase key/value pair */                \
-          }                                                                                                            \
-        }                                                                                                              \
-      }                                                                                                                \
-      /* ValueMap contains more than 2 elements, erase location from the ValueMap */                                   \
-      const auto UNUSED_ATTRIBUTE erase_result = value_map.erase(location);                                            \
-      TERRIER_ASSERT(erase_result == 1, "Erasing from the ValueMap should not fail.");                                 \
-      TERRIER_ASSERT(value_map.size() > 1, "ValueMap should not have fewer than 2 elements.");                         \
-      return false; /* Return false so cuckoohash_map's uprase_fn doesn't erase key/value pair */                      \
-    };                                                                                                                 \
-    const bool UNUSED_ATTRIBUTE uprase_result = hash_map_->uprase_fn(index_key, key_found_fn);                         \
-    TERRIER_ASSERT(!uprase_result, "This operation should NOT insert a new key into the cuckoohash_map.");             \
-  }
+  const std::unique_ptr<
+      cuckoohash_map<KeyType, ValueType, std::hash<KeyType>, std::equal_to<KeyType>,
+                     std::allocator<std::pair<const KeyType, ValueType>>, LIBCUCKOO_DEFAULT_SLOT_PER_BUCKET>>
+      hash_map_;
 
  public:
   IndexType Type() const final { return IndexType::HASHMAP; }
 
-  bool Insert(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
-              const TupleSlot location) final {
-    TERRIER_ASSERT(!(metadata_.GetSchema().Unique()),
-                   "This Insert is designed for secondary indexes with no uniqueness constraints.");
-    KeyType index_key;
-    index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
+  bool Insert(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+              TupleSlot location) final;
 
-    bool UNUSED_ATTRIBUTE insert_result = false;
+  bool InsertUnique(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+                    TupleSlot location) final;
 
-    /**
-     * See the underlying container's API for more details, but the lambda below is invoked when the key is found.
-     *
-     * Captures:
-     * location the TupleSlot (value) being added to index
-     * insert_result captured by reference so it can be updated in outer scope. true if insert succeeded
-     *
-     * Args:
-     * value the current value for this key value (found by underlying containiner on lookup, then passed to
-     * key_found_fn)
-     *
-     * return true if cuckoohash_map's uprase_fn should delete the key/value pair. For inserts we always return false.
-     */
-    auto key_found_fn = [location, &insert_result](ValueType &value) -> bool {
-      if (std::holds_alternative<TupleSlot>(value)) {
-        // replace the TupleSlot with a ValueMap containing both the old and new inserted value
-        const auto existing_location = std::get<TupleSlot>(value);
-        value = ValueMap({{location}, {existing_location}}, 2);
-        insert_result = true;
-      } else {
-        // insert the location to the cuckoohash_map
-        auto &value_map = std::get<ValueMap>(value);
-        insert_result = value_map.emplace(location).second;
-      }
-      return false;
-    };
-
-    const bool UNUSED_ATTRIBUTE uprase_result = hash_map_->uprase_fn(index_key, key_found_fn, location);
-
-    TERRIER_ASSERT(insert_result != uprase_result,
-                   "Either a new key was inserted (uprase_result), or the value already existed and a new value was "
-                   "inserted (insert_result).");
-
-    // Register an abort action with the txn context in case of rollback
-    txn->RegisterAbortAction(ERASE_KEY_ACTION);
-
-    return true;
-  }
-
-  bool InsertUnique(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
-                    const TupleSlot location) final {
-    TERRIER_ASSERT(metadata_.GetSchema().Unique(), "This Insert is designed for indexes with uniqueness constraints.");
-    KeyType index_key;
-    index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
-    bool predicate_satisfied = false;
-
-    // The predicate checks if any matching keys have write-write conflicts or are still visible to the calling txn.
-    auto predicate = [txn](const TupleSlot slot) -> bool {
-      const auto *const data_table = slot.GetBlock()->data_table_;
-      const auto has_conflict = data_table->HasConflict(*txn, slot);
-      const auto is_visible = data_table->IsVisible(*txn, slot);
-      return has_conflict || is_visible;
-    };
-
-    bool UNUSED_ATTRIBUTE insert_result = false;
-
-    /**
-     * See the underlying container's API for more details, but the lambda below is invoked when the key is found.
-     *
-     * Captures:
-     * location the TupleSlot (value) being added to index
-     * insert_result captured by reference so it can be updated in outer scope. true if insert succeeded
-     * predicate_satisfied captured by reference so it can be updated in outer scope. true if uniqueness
-     * predicate was satisfied (i.e. there's a conflict with the insert)
-     * predicate std::function to evaluate for key uniqueness
-     *
-     * Args:
-     * value the current value for this key value (found by underlying containiner on lookup, then passed to
-     * key_found_fn)
-     *
-     * return true if cuckoohash_map's uprase_fn should delete the key/value pair. For inserts we always return false.
-     */
-    auto key_found_fn = [location, &insert_result, &predicate_satisfied, predicate](ValueType &value) -> bool {
-      if (std::holds_alternative<TupleSlot>(value)) {
-        const auto existing_location = std::get<TupleSlot>(value);
-        predicate_satisfied = predicate(existing_location);
-        if (!predicate_satisfied) {
-          // replace the TupleSlot with a ValueMap containing both the old and new inserted value
-          value = ValueMap({{location}, {existing_location}}, 2);
-          insert_result = true;
-        }
-      } else {
-        auto &value_map = std::get<ValueMap>(value);
-
-        predicate_satisfied = std::any_of(value_map.cbegin(), value_map.cend(), predicate);
-
-        if (!predicate_satisfied) {
-          // insert the location to the cuckoohash_map
-          insert_result = value_map.emplace(location).second;
-          TERRIER_ASSERT(insert_result,
-                         " index shouldn't fail to insert after predicate check. If it did, something went wrong deep "
-                         "inside the hash map itself.");
-        }
-      }
-      return false;
-    };
-
-    const bool UNUSED_ATTRIBUTE uprase_result = hash_map_->uprase_fn(index_key, key_found_fn, location);
-    const bool UNUSED_ATTRIBUTE overall_result = insert_result || uprase_result;
-
-    TERRIER_ASSERT(predicate_satisfied != overall_result,
-                   "Cant have satisfied the predicate and also succeeded to insert.");
-    TERRIER_ASSERT(predicate_satisfied || (insert_result != uprase_result),
-                   "Either a new key was inserted (uprase_result), or the value already existed and a new value was "
-                   "inserted (insert_result).");
-
-    if (overall_result) {
-      txn->RegisterAbortAction(ERASE_KEY_ACTION);
-    } else {
-      // Presumably you've already made modifications to a DataTable (the source of the TupleSlot argument to this
-      // function) however, the index found a constraint violation and cannot allow that operation to succeed. For MVCC
-      // correctness, this txn must now abort for the GC to clean up the version chain in the DataTable correctly.
-      txn->SetMustAbort();
-    }
-
-    return overall_result;
-  }
-
-  void Delete(const common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
-              const TupleSlot location) final {
-    KeyType index_key;
-    index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
-
-    TERRIER_ASSERT(!(location.GetBlock()->data_table_->HasConflict(*txn, location)) &&
-                       !(location.GetBlock()->data_table_->IsVisible(*txn, location)),
-                   "Called index delete on a TupleSlot that has a conflict with this txn or is still visible.");
-
-    // Register a deferred action for the GC with txn manager. See base function comment.
-    txn->RegisterCommitAction([=](transaction::DeferredActionManager *deferred_action_manager) {
-      deferred_action_manager->RegisterDeferredAction(ERASE_KEY_ACTION);
-    });
-  }
+  void Delete(common::ManagedPointer<transaction::TransactionContext> txn, const ProjectedRow &tuple,
+              TupleSlot location) final;
 
   void ScanKey(const transaction::TransactionContext &txn, const ProjectedRow &key,
-               std::vector<TupleSlot> *value_list) final {
-    TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
-
-    // Build search key
-    KeyType index_key;
-    index_key.SetFromProjectedRow(key, metadata_, metadata_.GetSchema().GetColumns().size());
-
-    /**
-     * See the underlying container's API for more details, but the lambda below is invoked when the key is found.
-     *
-     * Captures:
-     * value_list pointer to the vector to be populated with result values
-     * txn reference to the calling txn in order to do visibility checks
-     *
-     * Args:
-     * value the current value for this key value (found by underlying containiner on lookup, then passed to
-     * key_found_fn)
-     */
-    auto key_found_fn = [value_list, &txn](const ValueType &value) -> void {
-      if (std::holds_alternative<TupleSlot>(value)) {
-        const auto existing_location = std::get<TupleSlot>(value);
-        if (IsVisible(txn, existing_location)) value_list->emplace_back(existing_location);
-      } else {
-        const auto &value_map = std::get<ValueMap>(value);
-
-        for (const auto i : value_map) {
-          if (IsVisible(txn, i)) value_list->emplace_back(i);
-        }
-      }
-    };
-
-    const bool UNUSED_ATTRIBUTE find_result = hash_map_->find_fn(index_key, key_found_fn);
-
-    TERRIER_ASSERT(!(metadata_.GetSchema().Unique()) || (metadata_.GetSchema().Unique() && value_list->size() <= 1),
-                   "Invalid number of results for unique index.");
-  }
-
-#undef ERASE_KEY_ACTION
+               std::vector<TupleSlot> *value_list) final;
 };
 
 extern template class HashIndex<HashKey<8>>;

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "catalog/catalog_defs.h"
+#include "common/managed_pointer.h"
 #include "common/performance_counter.h"
 #include "storage/data_table.h"
 #include "storage/index/index_defs.h"

--- a/src/storage/block_compactor.cpp
+++ b/src/storage/block_compactor.cpp
@@ -6,9 +6,8 @@
 #include <utility>
 #include <vector>
 
-#include "storage/index/bwtree_index.h"
-#include "storage/index/index_defs.h"
 #include "storage/sql_table.h"
+#include "transaction/deferred_action_manager.h"
 #include "transaction/transaction_util.h"
 
 namespace terrier::storage {

--- a/src/storage/index/bwtree_index.cpp
+++ b/src/storage/index/bwtree_index.cpp
@@ -3,6 +3,8 @@
 #include "bwtree/bwtree.h"
 #include "storage/index/compact_ints_key.h"
 #include "storage/index/generic_key.h"
+#include "transaction/deferred_action_manager.h"
+#include "transaction/transaction_context.h"
 
 namespace terrier::storage::index {
 

--- a/src/storage/index/bwtree_index.cpp
+++ b/src/storage/index/bwtree_index.cpp
@@ -1,8 +1,201 @@
 #include "storage/index/bwtree_index.h"
+
+#include "bwtree/bwtree.h"
 #include "storage/index/compact_ints_key.h"
 #include "storage/index/generic_key.h"
 
 namespace terrier::storage::index {
+
+template <typename KeyType>
+BwTreeIndex<KeyType>::BwTreeIndex(IndexMetadata metadata)
+    : Index(std::move(metadata)), bwtree_{new third_party::bwtree::BwTree<KeyType, TupleSlot>{false}} {}
+
+template <typename KeyType>
+void BwTreeIndex<KeyType>::PerformGarbageCollection() {
+  bwtree_->PerformGarbageCollection();
+}
+
+template <typename KeyType>
+bool BwTreeIndex<KeyType>::Insert(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                  const ProjectedRow &tuple, const TupleSlot location) {
+  TERRIER_ASSERT(!(metadata_.GetSchema().Unique()),
+                 "This Insert is designed for secondary indexes with no uniqueness constraints.");
+  KeyType index_key;
+  index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
+  const bool result = bwtree_->Insert(index_key, location, false);
+
+  TERRIER_ASSERT(
+      result,
+      "non-unique index shouldn't fail to insert. If it did, something went wrong deep inside the BwTree itself.");
+  // Register an abort action with the txn context in case of rollback
+  txn->RegisterAbortAction([=]() {
+    const bool UNUSED_ATTRIBUTE result = bwtree_->Delete(index_key, location);
+    TERRIER_ASSERT(result, "Delete on the index failed.");
+  });
+  return result;
+}
+
+template <typename KeyType>
+bool BwTreeIndex<KeyType>::InsertUnique(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                        const ProjectedRow &tuple, const TupleSlot location) {
+  TERRIER_ASSERT(metadata_.GetSchema().Unique(), "This Insert is designed for indexes with uniqueness constraints.");
+  KeyType index_key;
+  index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
+  bool predicate_satisfied = false;
+
+  // The predicate checks if any matching keys have write-write conflicts or are still visible to the calling txn.
+  auto predicate = [txn](const TupleSlot slot) -> bool {
+    const auto *const data_table = slot.GetBlock()->data_table_;
+    const auto has_conflict = data_table->HasConflict(*txn, slot);
+    const auto is_visible = data_table->IsVisible(*txn, slot);
+    return has_conflict || is_visible;
+  };
+
+  const bool result = bwtree_->ConditionalInsert(index_key, location, predicate, &predicate_satisfied);
+
+  TERRIER_ASSERT(predicate_satisfied != result, "If predicate is not satisfied then insertion should succeed.");
+
+  if (result) {
+    // Register an abort action with the txn context in case of rollback
+    txn->RegisterAbortAction([=]() {
+      const bool UNUSED_ATTRIBUTE result = bwtree_->Delete(index_key, location);
+      TERRIER_ASSERT(result, "Delete on the index failed.");
+    });
+  } else {
+    // Presumably you've already made modifications to a DataTable (the source of the TupleSlot argument to this
+    // function) however, the index found a constraint violation and cannot allow that operation to succeed. For MVCC
+    // correctness, this txn must now abort for the GC to clean up the version chain in the DataTable correctly.
+    txn->SetMustAbort();
+  }
+
+  return result;
+}
+
+template <typename KeyType>
+void BwTreeIndex<KeyType>::Delete(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                  const ProjectedRow &tuple, const TupleSlot location) {
+  KeyType index_key;
+  index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
+
+  TERRIER_ASSERT(!(location.GetBlock()->data_table_->HasConflict(*txn, location)) &&
+                     !(location.GetBlock()->data_table_->IsVisible(*txn, location)),
+                 "Called index delete on a TupleSlot that has a conflict with this txn or is still visible.");
+
+  // Register a deferred action for the GC with txn manager. See base function comment.
+  txn->RegisterCommitAction([=](transaction::DeferredActionManager *deferred_action_manager) {
+    deferred_action_manager->RegisterDeferredAction([=]() {
+      const bool UNUSED_ATTRIBUTE result = bwtree_->Delete(index_key, location);
+      TERRIER_ASSERT(result, "Deferred delete on the index failed.");
+    });
+  });
+}
+
+template <typename KeyType>
+void BwTreeIndex<KeyType>::ScanKey(const transaction::TransactionContext &txn, const ProjectedRow &key,
+                                   std::vector<TupleSlot> *value_list) {
+  TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
+
+  std::vector<TupleSlot> results;
+
+  // Build search key
+  KeyType index_key;
+  index_key.SetFromProjectedRow(key, metadata_, metadata_.GetSchema().GetColumns().size());
+
+  // Perform lookup in BwTree
+  bwtree_->GetValue(index_key, results);
+
+  // Avoid resizing our value_list, even if it means over-provisioning
+  value_list->reserve(results.size());
+
+  // Perform visibility check on result
+  for (const auto &result : results) {
+    if (IsVisible(txn, result)) value_list->emplace_back(result);
+  }
+
+  TERRIER_ASSERT(!(metadata_.GetSchema().Unique()) || (metadata_.GetSchema().Unique() && value_list->size() <= 1),
+                 "Invalid number of results for unique index.");
+}
+
+template <typename KeyType>
+void BwTreeIndex<KeyType>::ScanAscending(const transaction::TransactionContext &txn, ScanType scan_type,
+                                         uint32_t num_attrs, ProjectedRow *low_key, ProjectedRow *high_key,
+                                         uint32_t limit, std::vector<TupleSlot> *value_list) {
+  TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
+  TERRIER_ASSERT(scan_type == ScanType::Closed || scan_type == ScanType::OpenLow || scan_type == ScanType::OpenHigh ||
+                     scan_type == ScanType::OpenBoth,
+                 "Invalid scan_type passed into BwTreeIndex::Scan");
+
+  bool low_key_exists = (scan_type == ScanType::Closed || scan_type == ScanType::OpenHigh);
+  bool high_key_exists = (scan_type == ScanType::Closed || scan_type == ScanType::OpenLow);
+
+  // Build search keys
+  KeyType index_low_key, index_high_key;
+  if (low_key_exists) index_low_key.SetFromProjectedRow(*low_key, metadata_, num_attrs);
+  if (high_key_exists) index_high_key.SetFromProjectedRow(*high_key, metadata_, num_attrs);
+
+  // Perform lookup in BwTree
+  auto scan_itr = low_key_exists ? bwtree_->Begin(index_low_key) : bwtree_->Begin();
+
+  // Limit of 0 indicates "no limit"
+  while ((limit == 0 || value_list->size() < limit) && !scan_itr.IsEnd() &&
+         (!high_key_exists || scan_itr->first.PartialLessThan(index_high_key, &metadata_, num_attrs))) {
+    // Perform visibility check on result
+    if (IsVisible(txn, scan_itr->second)) value_list->emplace_back(scan_itr->second);
+    scan_itr++;
+  }
+}
+
+template <typename KeyType>
+void BwTreeIndex<KeyType>::BwTreeIndex::ScanDescending(const transaction::TransactionContext &txn,
+                                                       const ProjectedRow &low_key, const ProjectedRow &high_key,
+                                                       std::vector<TupleSlot> *value_list) {
+  TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
+
+  // Build search keys
+  KeyType index_low_key, index_high_key;
+  index_low_key.SetFromProjectedRow(low_key, metadata_, metadata_.GetSchema().GetColumns().size());
+  index_high_key.SetFromProjectedRow(high_key, metadata_, metadata_.GetSchema().GetColumns().size());
+
+  // Perform lookup in BwTree
+  auto scan_itr = bwtree_->Begin(index_high_key);
+  // Back up one element if we didn't match the high key
+  // This currently uses the BwTree's decrement operator on the iterator, which is not guaranteed to be
+  // constant time. In some cases it may be faster to do an ascending scan and then reverse the result vector. It
+  // depends on the visibility selectivity and final result set size. We can change the implementation in the future
+  // if it proves to be a problem.
+  if (scan_itr.IsEnd() || bwtree_->KeyCmpGreater(scan_itr->first, index_high_key)) scan_itr--;
+
+  while (!scan_itr.IsREnd() && (bwtree_->KeyCmpGreaterEqual(scan_itr->first, index_low_key))) {
+    // Perform visibility check on result
+    if (IsVisible(txn, scan_itr->second)) value_list->emplace_back(scan_itr->second);
+    scan_itr--;
+  }
+}
+
+template <typename KeyType>
+void BwTreeIndex<KeyType>::ScanLimitDescending(const transaction::TransactionContext &txn, const ProjectedRow &low_key,
+                                               const ProjectedRow &high_key, std::vector<TupleSlot> *value_list,
+                                               const uint32_t limit) {
+  TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
+  TERRIER_ASSERT(limit > 0, "Limit must be greater than 0.");
+
+  // Build search keys
+  KeyType index_low_key, index_high_key;
+  index_low_key.SetFromProjectedRow(low_key, metadata_, metadata_.GetSchema().GetColumns().size());
+  index_high_key.SetFromProjectedRow(high_key, metadata_, metadata_.GetSchema().GetColumns().size());
+
+  // Perform lookup in BwTree
+  auto scan_itr = bwtree_->Begin(index_high_key);
+  // Back up one element if we didn't match the high key, see comment on line 152.
+  if (scan_itr.IsEnd() || bwtree_->KeyCmpGreater(scan_itr->first, index_high_key)) scan_itr--;
+
+  while (value_list->size() < limit && !scan_itr.IsREnd() &&
+         (bwtree_->KeyCmpGreaterEqual(scan_itr->first, index_low_key))) {
+    // Perform visibility check on result
+    if (IsVisible(txn, scan_itr->second)) value_list->emplace_back(scan_itr->second);
+    scan_itr--;
+  }
+}
 
 template class BwTreeIndex<CompactIntsKey<8>>;
 template class BwTreeIndex<CompactIntsKey<16>>;

--- a/src/storage/index/bwtree_index.cpp
+++ b/src/storage/index/bwtree_index.cpp
@@ -10,7 +10,7 @@ namespace terrier::storage::index {
 
 template <typename KeyType>
 BwTreeIndex<KeyType>::BwTreeIndex(IndexMetadata metadata)
-    : Index(std::move(metadata)), bwtree_{new third_party::bwtree::BwTree<KeyType, TupleSlot>{false}} {}
+    : Index(std::move(metadata)), bwtree_(std::make_unique<third_party::bwtree::BwTree<KeyType, TupleSlot>>(false)) {}
 
 template <typename KeyType>
 void BwTreeIndex<KeyType>::PerformGarbageCollection() {

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -19,10 +19,7 @@ struct HashIndex<KeyType>::TupleSlotHash {
 template <typename KeyType>
 HashIndex<KeyType>::HashIndex(IndexMetadata metadata)
     : Index(std::move(metadata)),
-      hash_map_(std::make_unique<
-                cuckoohash_map<KeyType, ValueType, std::hash<KeyType>, std::equal_to<KeyType>,
-                               std::allocator<std::pair<const KeyType, ValueType>>, LIBCUCKOO_DEFAULT_SLOT_PER_BUCKET>>(
-          INITIAL_CUCKOOHASH_MAP_SIZE)) {}
+      hash_map_(std::make_unique<cuckoohash_map<KeyType, ValueType>>(INITIAL_CUCKOOHASH_MAP_SIZE)) {}
 
 /**
  * The lambda below is used for aborted inserts as well as committed deletes to perform the erase logic. Macros are

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -1,8 +1,244 @@
 #include "storage/index/hash_index.h"
+
+#include "libcuckoo/cuckoohash_map.hh"
 #include "storage/index/generic_key.h"
 #include "storage/index/hash_key.h"
+#include "transaction/deferred_action_manager.h"
+#include "transaction/transaction_context.h"
+#include "xxHash/xxh3.h"
 
 namespace terrier::storage::index {
+
+template <typename KeyType>
+struct HashIndex<KeyType>::TupleSlotHash {
+  std::size_t operator()(const TupleSlot &slot) const {
+    return XXH3_64bits(reinterpret_cast<const void *>(&slot), sizeof(TupleSlot));
+  }
+};
+
+template <typename KeyType>
+HashIndex<KeyType>::HashIndex(IndexMetadata metadata)
+    : Index(std::move(metadata)),
+      hash_map_(std::make_unique<
+                cuckoohash_map<KeyType, ValueType, std::hash<KeyType>, std::equal_to<KeyType>,
+                               std::allocator<std::pair<const KeyType, ValueType>>, LIBCUCKOO_DEFAULT_SLOT_PER_BUCKET>>(
+          INITIAL_CUCKOOHASH_MAP_SIZE)) {}
+
+/**
+ * The lambda below is used for aborted inserts as well as committed deletes to perform the erase logic. Macros are
+ * ugly but you can't define a macro that captures location outside of the scope of that variable
+ */
+#define ERASE_KEY_ACTION                                                                                               \
+  [=]() {                                                                                                              \
+    /* See the underlying container's API for more details, but the lambda below is invoked when the key is found. */  \
+    auto key_found_fn = [location](ValueType &value) -> bool {                                                         \
+      if (std::holds_alternative<TupleSlot>(value)) {                                                                  \
+        /* It's just a TupleSlot, functor should return true for cuckoohash_map's uprase_fn to erase key/value pair */ \
+        return true;                                                                                                   \
+      }                                                                                                                \
+      auto &value_map = std::get<ValueMap>(value);                                                                     \
+      if (value_map.size() == 2) {                                                                                     \
+        /* functor should replace the ValueMap with a TupleSlot for the other location */                              \
+        for (const auto i : value_map) {                                                                               \
+          if (i != location) {                                                                                         \
+            value = i; /* Assigning TupleSlot type will change the std::variant to TupleSlot and free the ValueMap */  \
+            TERRIER_ASSERT(std::holds_alternative<TupleSlot>(value), "value should now be a TupleSlot.");              \
+            return false; /* Return false so cuckoohash_map's uprase_fn doesn't erase key/value pair */                \
+          }                                                                                                            \
+        }                                                                                                              \
+      }                                                                                                                \
+      /* ValueMap contains more than 2 elements, erase location from the ValueMap */                                   \
+      const auto UNUSED_ATTRIBUTE erase_result = value_map.erase(location);                                            \
+      TERRIER_ASSERT(erase_result == 1, "Erasing from the ValueMap should not fail.");                                 \
+      TERRIER_ASSERT(value_map.size() > 1, "ValueMap should not have fewer than 2 elements.");                         \
+      return false; /* Return false so cuckoohash_map's uprase_fn doesn't erase key/value pair */                      \
+    };                                                                                                                 \
+    const bool UNUSED_ATTRIBUTE uprase_result = hash_map_->uprase_fn(index_key, key_found_fn);                         \
+    TERRIER_ASSERT(!uprase_result, "This operation should NOT insert a new key into the cuckoohash_map.");             \
+  }
+
+template <typename KeyType>
+bool HashIndex<KeyType>::Insert(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                const ProjectedRow &tuple, const TupleSlot location) {
+  TERRIER_ASSERT(!(metadata_.GetSchema().Unique()),
+                 "This Insert is designed for secondary indexes with no uniqueness constraints.");
+  KeyType index_key;
+  index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
+
+  bool UNUSED_ATTRIBUTE insert_result = false;
+
+  /**
+   * See the underlying container's API for more details, but the lambda below is invoked when the key is found.
+   *
+   * Captures:
+   * location the TupleSlot (value) being added to index
+   * insert_result captured by reference so it can be updated in outer scope. true if insert succeeded
+   *
+   * Args:
+   * value the current value for this key value (found by underlying containiner on lookup, then passed to
+   * key_found_fn)
+   *
+   * return true if cuckoohash_map's uprase_fn should delete the key/value pair. For inserts we always return false.
+   */
+  auto key_found_fn = [location, &insert_result](ValueType &value) -> bool {
+    if (std::holds_alternative<TupleSlot>(value)) {
+      // replace the TupleSlot with a ValueMap containing both the old and new inserted value
+      const auto existing_location = std::get<TupleSlot>(value);
+      value = ValueMap({{location}, {existing_location}}, 2);
+      insert_result = true;
+    } else {
+      // insert the location to the cuckoohash_map
+      auto &value_map = std::get<ValueMap>(value);
+      insert_result = value_map.emplace(location).second;
+    }
+    return false;
+  };
+
+  const bool UNUSED_ATTRIBUTE uprase_result = hash_map_->uprase_fn(index_key, key_found_fn, location);
+
+  TERRIER_ASSERT(insert_result != uprase_result,
+                 "Either a new key was inserted (uprase_result), or the value already existed and a new value was "
+                 "inserted (insert_result).");
+
+  // Register an abort action with the txn context in case of rollback
+  txn->RegisterAbortAction(ERASE_KEY_ACTION);
+
+  return true;
+}
+template <typename KeyType>
+bool HashIndex<KeyType>::InsertUnique(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                      const ProjectedRow &tuple, const TupleSlot location) {
+  TERRIER_ASSERT(metadata_.GetSchema().Unique(), "This Insert is designed for indexes with uniqueness constraints.");
+  KeyType index_key;
+  index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
+  bool predicate_satisfied = false;
+
+  // The predicate checks if any matching keys have write-write conflicts or are still visible to the calling txn.
+  auto predicate = [txn](const TupleSlot slot) -> bool {
+    const auto *const data_table = slot.GetBlock()->data_table_;
+    const auto has_conflict = data_table->HasConflict(*txn, slot);
+    const auto is_visible = data_table->IsVisible(*txn, slot);
+    return has_conflict || is_visible;
+  };
+
+  bool UNUSED_ATTRIBUTE insert_result = false;
+
+  /**
+   * See the underlying container's API for more details, but the lambda below is invoked when the key is found.
+   *
+   * Captures:
+   * location the TupleSlot (value) being added to index
+   * insert_result captured by reference so it can be updated in outer scope. true if insert succeeded
+   * predicate_satisfied captured by reference so it can be updated in outer scope. true if uniqueness
+   * predicate was satisfied (i.e. there's a conflict with the insert)
+   * predicate std::function to evaluate for key uniqueness
+   *
+   * Args:
+   * value the current value for this key value (found by underlying containiner on lookup, then passed to
+   * key_found_fn)
+   *
+   * return true if cuckoohash_map's uprase_fn should delete the key/value pair. For inserts we always return false.
+   */
+  auto key_found_fn = [location, &insert_result, &predicate_satisfied, predicate](ValueType &value) -> bool {
+    if (std::holds_alternative<TupleSlot>(value)) {
+      const auto existing_location = std::get<TupleSlot>(value);
+      predicate_satisfied = predicate(existing_location);
+      if (!predicate_satisfied) {
+        // replace the TupleSlot with a ValueMap containing both the old and new inserted value
+        value = ValueMap({{location}, {existing_location}}, 2);
+        insert_result = true;
+      }
+    } else {
+      auto &value_map = std::get<ValueMap>(value);
+
+      predicate_satisfied = std::any_of(value_map.cbegin(), value_map.cend(), predicate);
+
+      if (!predicate_satisfied) {
+        // insert the location to the cuckoohash_map
+        insert_result = value_map.emplace(location).second;
+        TERRIER_ASSERT(insert_result,
+                       " index shouldn't fail to insert after predicate check. If it did, something went wrong deep "
+                       "inside the hash map itself.");
+      }
+    }
+    return false;
+  };
+
+  const bool UNUSED_ATTRIBUTE uprase_result = hash_map_->uprase_fn(index_key, key_found_fn, location);
+  const bool UNUSED_ATTRIBUTE overall_result = insert_result || uprase_result;
+
+  TERRIER_ASSERT(predicate_satisfied != overall_result,
+                 "Cant have satisfied the predicate and also succeeded to insert.");
+  TERRIER_ASSERT(predicate_satisfied || (insert_result != uprase_result),
+                 "Either a new key was inserted (uprase_result), or the value already existed and a new value was "
+                 "inserted (insert_result).");
+
+  if (overall_result) {
+    txn->RegisterAbortAction(ERASE_KEY_ACTION);
+  } else {
+    // Presumably you've already made modifications to a DataTable (the source of the TupleSlot argument to this
+    // function) however, the index found a constraint violation and cannot allow that operation to succeed. For MVCC
+    // correctness, this txn must now abort for the GC to clean up the version chain in the DataTable correctly.
+    txn->SetMustAbort();
+  }
+
+  return overall_result;
+}
+template <typename KeyType>
+void HashIndex<KeyType>::Delete(const common::ManagedPointer<transaction::TransactionContext> txn,
+                                const ProjectedRow &tuple, const TupleSlot location) {
+  KeyType index_key;
+  index_key.SetFromProjectedRow(tuple, metadata_, metadata_.GetSchema().GetColumns().size());
+
+  TERRIER_ASSERT(!(location.GetBlock()->data_table_->HasConflict(*txn, location)) &&
+                     !(location.GetBlock()->data_table_->IsVisible(*txn, location)),
+                 "Called index delete on a TupleSlot that has a conflict with this txn or is still visible.");
+
+  // Register a deferred action for the GC with txn manager. See base function comment.
+  txn->RegisterCommitAction([=](transaction::DeferredActionManager *deferred_action_manager) {
+    deferred_action_manager->RegisterDeferredAction(ERASE_KEY_ACTION);
+  });
+}
+template <typename KeyType>
+void HashIndex<KeyType>::ScanKey(const transaction::TransactionContext &txn, const ProjectedRow &key,
+                                 std::vector<TupleSlot> *value_list) {
+  TERRIER_ASSERT(value_list->empty(), "Result set should begin empty.");
+
+  // Build search key
+  KeyType index_key;
+  index_key.SetFromProjectedRow(key, metadata_, metadata_.GetSchema().GetColumns().size());
+
+  /**
+   * See the underlying container's API for more details, but the lambda below is invoked when the key is found.
+   *
+   * Captures:
+   * value_list pointer to the vector to be populated with result values
+   * txn reference to the calling txn in order to do visibility checks
+   *
+   * Args:
+   * value the current value for this key value (found by underlying containiner on lookup, then passed to
+   * key_found_fn)
+   */
+  auto key_found_fn = [value_list, &txn](const ValueType &value) -> void {
+    if (std::holds_alternative<TupleSlot>(value)) {
+      const auto existing_location = std::get<TupleSlot>(value);
+      if (IsVisible(txn, existing_location)) value_list->emplace_back(existing_location);
+    } else {
+      const auto &value_map = std::get<ValueMap>(value);
+
+      for (const auto i : value_map) {
+        if (IsVisible(txn, i)) value_list->emplace_back(i);
+      }
+    }
+  };
+
+  const bool UNUSED_ATTRIBUTE find_result = hash_map_->find_fn(index_key, key_found_fn);
+
+  TERRIER_ASSERT(!(metadata_.GetSchema().Unique()) || (metadata_.GetSchema().Unique() && value_list->size() <= 1),
+                 "Invalid number of results for unique index.");
+}
+
+#undef ERASE_KEY_ACTION
 
 template class HashIndex<HashKey<8>>;
 template class HashIndex<HashKey<16>>;

--- a/src/storage/recovery/recovery_manager.cpp
+++ b/src/storage/recovery/recovery_manager.cpp
@@ -19,6 +19,8 @@
 #include "common/dedicated_thread_registry.h"
 #include "storage/index/index_builder.h"
 #include "storage/write_ahead_log/log_io.h"
+#include "transaction/deferred_action_manager.h"
+#include "transaction/transaction_manager.h"
 
 namespace terrier::storage {
 

--- a/third_party/bwtree/bwtree.h
+++ b/third_party/bwtree/bwtree.h
@@ -526,9 +526,9 @@ class BwTreeBase {
  * be set as the standard operator in C++ (i.e. the operator for primitive types
  * AND/OR overloaded operators for derived types)
  */
-template <typename KeyType, typename ValueType, typename KeyComparator = std::less<KeyType>,
-          typename KeyEqualityChecker = std::equal_to<KeyType>, typename KeyHashFunc = std::hash<KeyType>,
-          typename ValueEqualityChecker = std::equal_to<ValueType>, typename ValueHashFunc = std::hash<ValueType>>
+template <typename KeyType, typename ValueType, typename KeyComparator,
+          typename KeyEqualityChecker, typename KeyHashFunc,
+          typename ValueEqualityChecker, typename ValueHashFunc>
 class BwTree : public BwTreeBase {
  public:
   class EpochManager;

--- a/third_party/bwtree/bwtree.h
+++ b/third_party/bwtree/bwtree.h
@@ -526,9 +526,9 @@ class BwTreeBase {
  * be set as the standard operator in C++ (i.e. the operator for primitive types
  * AND/OR overloaded operators for derived types)
  */
-template <typename KeyType, typename ValueType, typename KeyComparator,
-          typename KeyEqualityChecker, typename KeyHashFunc,
-          typename ValueEqualityChecker, typename ValueHashFunc>
+template <typename KeyType, typename ValueType, typename KeyComparator = std::less<KeyType>,
+          typename KeyEqualityChecker = std::equal_to<KeyType>, typename KeyHashFunc = std::hash<KeyType>,
+          typename ValueEqualityChecker = std::equal_to<ValueType>, typename ValueHashFunc = std::hash<ValueType>>
 class BwTree : public BwTreeBase {
  public:
   class EpochManager;


### PR DESCRIPTION
This gets the third party bwtree.h and cuckoohash_map.hh headers out of our header files and not getting parsed and clang-tidy'd again all over the codebase,