### PR TITLE
Clean up optimizer includes a bit

### DIFF
--- a/src/include/optimizer/cost_model/trivial_cost_model.h
+++ b/src/include/optimizer/cost_model/trivial_cost_model.h
@@ -1,12 +1,9 @@
 #pragma once
 
+#include "common/macros.h"
 #include "optimizer/cost_model/abstract_cost_model.h"
-#include "optimizer/group_expression.h"
-#include "optimizer/physical_operators.h"
-#include "transaction/transaction_context.h"
 
-namespace terrier {
-namespace optimizer {
+namespace terrier::optimizer {
 
 class Memo;
 class GroupExpression;
@@ -43,14 +40,7 @@ class TrivialCostModel : public AbstractCostModel {
    * @param gexpr GroupExpression to calculate cost for
    */
   double CalculateCost(transaction::TransactionContext *txn, catalog::CatalogAccessor *accessor, Memo *memo,
-                       GroupExpression *gexpr) override {
-    gexpr_ = gexpr;
-    memo_ = memo;
-    txn_ = txn;
-    accessor_ = accessor;
-    gexpr_->Contents()->Accept(common::ManagedPointer<OperatorVisitor>(this));
-    return output_cost_;
-  };
+                       GroupExpression *gexpr) override;
 
   /**
    * Visit a SeqScan operator
@@ -62,12 +52,7 @@ class TrivialCostModel : public AbstractCostModel {
    * Visit a IndexScan operator
    * @param op operator
    */
-  void Visit(const IndexScan *op) override {
-    // Get the table schema
-    // This heuristic is not really good --- it merely picks the index based on
-    // how many of those index's keys are set (op->GetBounds())
-    output_cost_ = SCAN_COST - op->GetBounds().size();
-  }
+  void Visit(const IndexScan *op) override;
 
   /**
    * Visit a QueryDerivedScan operator
@@ -91,12 +76,7 @@ class TrivialCostModel : public AbstractCostModel {
    * Visit a InnerIndexJoin operator
    * @param op operator
    */
-  void Visit(const InnerIndexJoin *op) override {
-    // Get the table schema
-    // This heuristic is not really good --- it merely picks the index based on
-    // how many of those index's keys are set (op->GetBounds())
-    output_cost_ = NLJOIN_COST - op->GetJoinKeys().size();
-  }
+  void Visit(const InnerIndexJoin *op) override;
 
   /**
    * Visit a InnerNLJoin operator
@@ -215,5 +195,4 @@ class TrivialCostModel : public AbstractCostModel {
   double output_cost_ = 0;
 };
 
-}  // namespace optimizer
-}  // namespace terrier
+}  // namespace terrier::optimizer

--- a/src/include/optimizer/input_column_deriver.h
+++ b/src/include/optimizer/input_column_deriver.h
@@ -9,12 +9,17 @@
 #include "optimizer/operator_visitor.h"
 #include "transaction/transaction_context.h"
 
+namespace planner {
+enum class AggregateStrategyType;
+}
+
 namespace terrier::optimizer {
 
 class PropertySet;
 class GroupExpression;
 class OperatorNode;
 class Memo;
+class BaseOperatorNodeContents;
 
 /**
  * InputColumnDeriver generate input and output columns based on the required columns,

--- a/src/include/optimizer/logical_operators.h
+++ b/src/include/optimizer/logical_operators.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// THIS HEADER IS HUGE! DO NOT INCLUDE IT IN OTHER HEADERS!
+
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/include/optimizer/operator_visitor.h
+++ b/src/include/optimizer/operator_visitor.h
@@ -1,9 +1,80 @@
 #pragma once
 
-#include "optimizer/logical_operators.h"
-#include "optimizer/physical_operators.h"
-
 namespace terrier::optimizer {
+
+class LeafOperator;
+class TableFreeScan;
+class SeqScan;
+class IndexScan;
+class ExternalFileScan;
+class QueryDerivedScan;
+class OrderBy;
+class Limit;
+class InnerIndexJoin;
+class InnerNLJoin;
+class LeftNLJoin;
+class RightNLJoin;
+class OuterNLJoin;
+class InnerHashJoin;
+class LeftHashJoin;
+class RightHashJoin;
+class OuterHashJoin;
+class Insert;
+class InsertSelect;
+class Delete;
+class Update;
+class HashGroupBy;
+class SortGroupBy;
+class Aggregate;
+class ExportExternalFile;
+class CreateDatabase;
+class CreateFunction;
+class CreateIndex;
+class CreateTable;
+class CreateNamespace;
+class CreateTrigger;
+class CreateView;
+class DropDatabase;
+class DropTable;
+class DropIndex;
+class DropNamespace;
+class DropTrigger;
+class DropView;
+class Analyze;
+class LogicalGet;
+class LogicalExternalFileGet;
+class LogicalQueryDerivedGet;
+class LogicalFilter;
+class LogicalProjection;
+class LogicalMarkJoin;
+class LogicalSingleJoin;
+class LogicalDependentJoin;
+class LogicalInnerJoin;
+class LogicalLeftJoin;
+class LogicalRightJoin;
+class LogicalOuterJoin;
+class LogicalSemiJoin;
+class LogicalAggregateAndGroupBy;
+class LogicalInsert;
+class LogicalInsertSelect;
+class LogicalDelete;
+class LogicalUpdate;
+class LogicalLimit;
+class LogicalExportExternalFile;
+class LogicalCreateDatabase;
+class LogicalCreateFunction;
+class LogicalCreateIndex;
+class LogicalCreateTable;
+class LogicalCreateNamespace;
+class LogicalCreateTrigger;
+class LogicalCreateView;
+class LogicalDropDatabase;
+class LogicalDropTable;
+class LogicalDropIndex;
+class LogicalDropNamespace;
+class LogicalDropTrigger;
+class LogicalDropView;
+class LogicalAnalyze;
 
 /**
  * Utility class for visitor pattern

--- a/src/include/optimizer/optimizer_context.h
+++ b/src/include/optimizer/optimizer_context.h
@@ -140,31 +140,7 @@ class OptimizerContext {
    * @param node AbstractOptimizerNode to convert
    * @returns GroupExpression representing AbstractOptimizerNode
    */
-  GroupExpression *MakeGroupExpression(common::ManagedPointer<AbstractOptimizerNode> node) {
-    std::vector<group_id_t> child_groups;
-    for (auto &child : node->GetChildren()) {
-      if (child->Contents()->GetOpType() == OpType::LEAF) {
-        // Special case for LEAF
-        const auto leaf = child->Contents()->GetContentsAs<LeafOperator>();
-        auto child_group = leaf->GetOriginGroup();
-        child_groups.push_back(child_group);
-      } else {
-        // Create a GroupExpression for the child
-        auto gexpr = MakeGroupExpression(child);
-
-        // Insert into the memo (this allows for duplicate detection)
-        auto mexpr = memo_.InsertExpression(gexpr, false);
-        if (mexpr == nullptr) {
-          // Delete if need to (see InsertExpression spec)
-          child_groups.push_back(gexpr->GetGroupID());
-          delete gexpr;
-        } else {
-          child_groups.push_back(mexpr->GetGroupID());
-        }
-      }
-    }
-    return new GroupExpression(node->Contents(), std::move(child_groups));
-  }
+  GroupExpression *MakeGroupExpression(common::ManagedPointer<AbstractOptimizerNode> node);
 
   /**
    * A group contains all logical/physically equivalent AbstractOptimizerNodes.

--- a/src/include/optimizer/physical_operators.h
+++ b/src/include/optimizer/physical_operators.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// THIS HEADER IS HUGE! DO NOT INCLUDE IT IN OTHER HEADERS!
+
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/include/optimizer/plan_generator.h
+++ b/src/include/optimizer/plan_generator.h
@@ -34,6 +34,10 @@ namespace transaction {
 class TransactionContext;
 }  // namespace transaction
 
+namespace planner {
+enum class AggregateStrategyType;
+}
+
 namespace optimizer {
 
 class PropertySet;

--- a/src/optimizer/binding.cpp
+++ b/src/optimizer/binding.cpp
@@ -1,10 +1,11 @@
+#include "optimizer/binding.h"
+
 #include <memory>
 #include <utility>
 #include <vector>
 
-#include "optimizer/binding.h"
-
 #include "loggers/optimizer_logger.h"
+#include "optimizer/logical_operators.h"
 #include "optimizer/operator_visitor.h"
 #include "optimizer/optimizer.h"
 

--- a/src/optimizer/child_property_deriver.cpp
+++ b/src/optimizer/child_property_deriver.cpp
@@ -1,13 +1,15 @@
+#include "optimizer/child_property_deriver.h"
+
 #include <utility>
 #include <vector>
 
 #include "catalog/catalog_accessor.h"
 #include "catalog/index_schema.h"
 #include "common/managed_pointer.h"
-#include "optimizer/child_property_deriver.h"
 #include "optimizer/group_expression.h"
 #include "optimizer/index_util.h"
 #include "optimizer/memo.h"
+#include "optimizer/physical_operators.h"
 #include "optimizer/properties.h"
 #include "optimizer/property_set.h"
 #include "parser/expression_util.h"

--- a/src/optimizer/cost_model/trivial_cost_model.cpp
+++ b/src/optimizer/cost_model/trivial_cost_model.cpp
@@ -13,7 +13,7 @@ double TrivialCostModel::CalculateCost(transaction::TransactionContext *txn, cat
   accessor_ = accessor;
   gexpr_->Contents()->Accept(common::ManagedPointer<OperatorVisitor>(this));
   return output_cost_;
-};
+}
 
 void TrivialCostModel::Visit(const IndexScan *op) {
   // Get the table schema

--- a/src/optimizer/cost_model/trivial_cost_model.cpp
+++ b/src/optimizer/cost_model/trivial_cost_model.cpp
@@ -1,0 +1,32 @@
+#include "optimizer/cost_model/trivial_cost_model.h"
+
+#include "optimizer/group_expression.h"
+#include "optimizer/physical_operators.h"
+
+namespace terrier::optimizer {
+
+double TrivialCostModel::CalculateCost(transaction::TransactionContext *txn, catalog::CatalogAccessor *accessor,
+                                       Memo *memo, GroupExpression *gexpr) {
+  gexpr_ = gexpr;
+  memo_ = memo;
+  txn_ = txn;
+  accessor_ = accessor;
+  gexpr_->Contents()->Accept(common::ManagedPointer<OperatorVisitor>(this));
+  return output_cost_;
+};
+
+void TrivialCostModel::Visit(const IndexScan *op) {
+  // Get the table schema
+  // This heuristic is not really good --- it merely picks the index based on
+  // how many of those index's keys are set (op->GetBounds())
+  output_cost_ = SCAN_COST - op->GetBounds().size();
+}
+
+void TrivialCostModel::Visit(const InnerIndexJoin *op) {
+  // Get the table schema
+  // This heuristic is not really good --- it merely picks the index based on
+  // how many of those index's keys are set (op->GetBounds())
+  output_cost_ = NLJOIN_COST - op->GetJoinKeys().size();
+}
+
+}  // namespace terrier::optimizer

--- a/src/optimizer/optimizer_context.cpp
+++ b/src/optimizer/optimizer_context.cpp
@@ -1,0 +1,33 @@
+#include "optimizer/optimizer_context.h"
+
+#include "optimizer/logical_operators.h"
+
+namespace terrier::optimizer {
+
+GroupExpression *OptimizerContext::MakeGroupExpression(common::ManagedPointer<AbstractOptimizerNode> node) {
+  std::vector<group_id_t> child_groups;
+  for (auto &child : node->GetChildren()) {
+    if (child->Contents()->GetOpType() == OpType::LEAF) {
+      // Special case for LEAF
+      const auto leaf = child->Contents()->GetContentsAs<LeafOperator>();
+      auto child_group = leaf->GetOriginGroup();
+      child_groups.push_back(child_group);
+    } else {
+      // Create a GroupExpression for the child
+      auto gexpr = MakeGroupExpression(child);
+
+      // Insert into the memo (this allows for duplicate detection)
+      auto mexpr = memo_.InsertExpression(gexpr, false);
+      if (mexpr == nullptr) {
+        // Delete if need to (see InsertExpression spec)
+        child_groups.push_back(gexpr->GetGroupID());
+        delete gexpr;
+      } else {
+        child_groups.push_back(mexpr->GetGroupID());
+      }
+    }
+  }
+  return new GroupExpression(node->Contents(), std::move(child_groups));
+}
+
+}  // namespace terrier::optimizer

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -12,6 +12,7 @@
 #include "execution/sql/value.h"
 #include "optimizer/abstract_optimizer_node.h"
 #include "optimizer/operator_node.h"
+#include "optimizer/physical_operators.h"
 #include "optimizer/properties.h"
 #include "optimizer/property_set.h"
 #include "optimizer/util.h"

--- a/src/optimizer/rules/implementation_rules.cpp
+++ b/src/optimizer/rules/implementation_rules.cpp
@@ -11,6 +11,7 @@
 #include "loggers/optimizer_logger.h"
 #include "optimizer/group_expression.h"
 #include "optimizer/index_util.h"
+#include "optimizer/logical_operators.h"
 #include "optimizer/optimizer_context.h"
 #include "optimizer/optimizer_defs.h"
 #include "optimizer/physical_operators.h"

--- a/src/optimizer/rules/rewrite_rules.cpp
+++ b/src/optimizer/rules/rewrite_rules.cpp
@@ -1,3 +1,5 @@
+#include "optimizer/rules/rewrite_rules.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -9,11 +11,11 @@
 #include "loggers/optimizer_logger.h"
 #include "optimizer/group_expression.h"
 #include "optimizer/index_util.h"
+#include "optimizer/logical_operators.h"
 #include "optimizer/optimizer_context.h"
 #include "optimizer/optimizer_defs.h"
 #include "optimizer/physical_operators.h"
 #include "optimizer/properties.h"
-#include "optimizer/rules/rewrite_rules.h"
 #include "optimizer/util.h"
 #include "parser/expression_util.h"
 

--- a/src/optimizer/rules/transformation_rules.cpp
+++ b/src/optimizer/rules/transformation_rules.cpp
@@ -1,3 +1,5 @@
+#include "optimizer/rules/transformation_rules.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -9,11 +11,11 @@
 #include "loggers/optimizer_logger.h"
 #include "optimizer/group_expression.h"
 #include "optimizer/index_util.h"
+#include "optimizer/logical_operators.h"
 #include "optimizer/optimizer_context.h"
 #include "optimizer/optimizer_defs.h"
 #include "optimizer/physical_operators.h"
 #include "optimizer/properties.h"
-#include "optimizer/rules/transformation_rules.h"
 #include "optimizer/util.h"
 #include "parser/expression_util.h"
 

--- a/src/optimizer/rules/unnesting_rules.cpp
+++ b/src/optimizer/rules/unnesting_rules.cpp
@@ -1,3 +1,5 @@
+#include "optimizer/rules/unnesting_rules.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -9,11 +11,11 @@
 #include "loggers/optimizer_logger.h"
 #include "optimizer/group_expression.h"
 #include "optimizer/index_util.h"
+#include "optimizer/logical_operators.h"
 #include "optimizer/optimizer_context.h"
 #include "optimizer/optimizer_defs.h"
 #include "optimizer/physical_operators.h"
 #include "optimizer/properties.h"
-#include "optimizer/rules/unnesting_rules.h"
 #include "optimizer/util.h"
 #include "parser/expression_util.h"
 

--- a/src/optimizer/statistics/child_stats_deriver.cpp
+++ b/src/optimizer/statistics/child_stats_deriver.cpp
@@ -1,3 +1,5 @@
+#include "optimizer/statistics/child_stats_deriver.h"
+
 #include <algorithm>
 #include <memory>
 #include <string>
@@ -5,8 +7,7 @@
 #include <utility>
 #include <vector>
 
-#include "optimizer/statistics/child_stats_deriver.h"
-
+#include "optimizer/logical_operators.h"
 #include "optimizer/memo.h"
 #include "parser/expression/column_value_expression.h"
 #include "parser/expression_util.h"

--- a/src/optimizer/statistics/stats_calculator.cpp
+++ b/src/optimizer/statistics/stats_calculator.cpp
@@ -9,8 +9,10 @@
 #include <vector>
 
 #include "catalog/catalog_accessor.h"
+#include "optimizer/logical_operators.h"
 #include "optimizer/memo.h"
 #include "optimizer/optimizer_context.h"
+#include "optimizer/physical_operators.h"
 #include "optimizer/statistics/column_stats.h"
 #include "optimizer/statistics/selectivity.h"
 #include "optimizer/statistics/stats_storage.h"

--- a/test/optimizer/operator_transformer_test.cpp
+++ b/test/optimizer/operator_transformer_test.cpp
@@ -17,6 +17,7 @@
 #include "optimizer/operator_node.h"
 #include "optimizer/optimization_context.h"
 #include "optimizer/optimizer_context.h"
+#include "optimizer/physical_operators.h"
 #include "optimizer/plan_generator.h"
 #include "optimizer/query_to_operator_transformer.h"
 #include "optimizer/rules/implementation_rules.h"

--- a/test/optimizer/optimizer_context_test.cpp
+++ b/test/optimizer/optimizer_context_test.cpp
@@ -1,19 +1,21 @@
+#include "optimizer/optimizer_context.h"
+
 #include <memory>
 #include <stack>
 #include <utility>
 #include <vector>
 
 #include "optimizer/binding.h"
-#include "optimizer/optimizer_context.h"
+#include "optimizer/logical_operators.h"
 #include "optimizer/optimizer_defs.h"
 #include "optimizer/optimizer_task.h"
 #include "optimizer/optimizer_task_pool.h"
 #include "optimizer/pattern.h"
+#include "optimizer/physical_operators.h"
+#include "test_util/test_harness.h"
 #include "transaction/deferred_action_manager.h"
 #include "transaction/timestamp_manager.h"
 #include "transaction/transaction_manager.h"
-
-#include "test_util/test_harness.h"
 
 namespace terrier::optimizer {
 


### PR DESCRIPTION
logical_operators.h and physical_operators.h are both over 2000 lines, included in operator_visitor.h, which in turn is included in a bunch of other headers so it propagates. This PR makes it so only the translation units that need them include those files.