### PR TITLE
Explicit instantiation of spdlog template functions

### DIFF
--- a/src/include/loggers/loggers_util.h
+++ b/src/include/loggers/loggers_util.h
@@ -21,6 +21,7 @@ using stdout_sink_mt = stdout_sink<details::console_stdout, details::console_mut
 
 extern std::shared_ptr<spdlog::sinks::stdout_sink_mt> default_sink;  // NOLINT
 
+/// @cond DOXYGEN_IGNORE
 extern template void spdlog::logger::trace<std::string>(const std::string &);
 extern template void spdlog::logger::debug<std::string>(const std::string &);
 extern template void spdlog::logger::info<std::string>(const std::string &);
@@ -38,6 +39,7 @@ extern template void spdlog::logger::debug<std::string_view>(const std::string_v
 extern template void spdlog::logger::info<std::string_view>(const std::string_view &);
 extern template void spdlog::logger::warn<std::string_view>(const std::string_view &);
 extern template void spdlog::logger::error<std::string_view>(const std::string_view &);
+/// @endcond
 
 namespace terrier {
 

--- a/src/include/loggers/loggers_util.h
+++ b/src/include/loggers/loggers_util.h
@@ -2,15 +2,42 @@
 
 #include <memory>
 
+#include "spdlog/logger.h"
+
 // flush the debug logs, every <n> seconds
 #define DEBUG_LOG_FLUSH_INTERVAL 3
 
-#include "spdlog/fmt/ostr.h"
-#include "spdlog/sinks/basic_file_sink.h"
-#include "spdlog/sinks/stdout_sinks.h"
-#include "spdlog/spdlog.h"
+namespace spdlog::details {
+struct console_stdout;
+struct console_mutex;
+}  // namespace spdlog::details
+
+namespace spdlog::sinks {
+template <typename TargetStream, typename ConsoleMutex>
+class stdout_sink;
+
+using stdout_sink_mt = stdout_sink<details::console_stdout, details::console_mutex>;
+}  // namespace spdlog::sinks
 
 extern std::shared_ptr<spdlog::sinks::stdout_sink_mt> default_sink;  // NOLINT
+
+extern template void spdlog::logger::trace<std::string>(const std::string &);
+extern template void spdlog::logger::debug<std::string>(const std::string &);
+extern template void spdlog::logger::info<std::string>(const std::string &);
+extern template void spdlog::logger::warn<std::string>(const std::string &);
+extern template void spdlog::logger::error<std::string>(const std::string &);
+
+extern template void spdlog::logger::trace<>(const char *fmt);
+extern template void spdlog::logger::debug<>(const char *fmt);
+extern template void spdlog::logger::info<>(const char *fmt);
+extern template void spdlog::logger::warn<>(const char *fmt);
+extern template void spdlog::logger::error<>(const char *fmt);
+
+extern template void spdlog::logger::trace<std::string_view>(const std::string_view &);
+extern template void spdlog::logger::debug<std::string_view>(const std::string_view &);
+extern template void spdlog::logger::info<std::string_view>(const std::string_view &);
+extern template void spdlog::logger::warn<std::string_view>(const std::string_view &);
+extern template void spdlog::logger::error<std::string_view>(const std::string_view &);
 
 namespace terrier {
 

--- a/src/include/loggers/loggers_util.h
+++ b/src/include/loggers/loggers_util.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <string_view>
 
 #include "spdlog/logger.h"
 

--- a/src/include/network/terrier_server.h
+++ b/src/include/network/terrier_server.h
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #include <sys/file.h>
 
+#include <condition_variable>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>

--- a/src/include/network/terrier_server.h
+++ b/src/include/network/terrier_server.h
@@ -9,7 +9,7 @@
 #include <pthread.h>
 #include <sys/file.h>
 
-#include <condition_variable>
+#include <condition_variable>  // NOLINT
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>

--- a/src/include/optimizer/binding.h
+++ b/src/include/optimizer/binding.h
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "loggers/optimizer_logger.h"
-
 #include "optimizer/group.h"
 #include "optimizer/memo.h"
 #include "optimizer/operator_node.h"
@@ -74,7 +73,7 @@ class GroupBindingIterator : public BindingIterator {
         num_group_items_(target_group_->GetLogicalExpressions().size()),
         current_item_index_(0),
         txn_(txn) {
-    OPTIMIZER_LOG_TRACE("Attempting to bind on group {0}", id);
+    OPTIMIZER_LOG_TRACE("Attempting to bind on group " + std::to_string(!id));
   }
 
   /**

--- a/src/include/storage/write_ahead_log/disk_log_consumer_task.h
+++ b/src/include/storage/write_ahead_log/disk_log_consumer_task.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <condition_variable>  // NOLINT
 #include <utility>
 #include <vector>
+
 #include "common/container/concurrent_blocking_queue.h"
 #include "common/container/concurrent_queue.h"
 #include "common/dedicated_thread_task.h"

--- a/src/include/storage/write_ahead_log/log_serializer_task.h
+++ b/src/include/storage/write_ahead_log/log_serializer_task.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <condition_variable>  // NOLINT
 #include <queue>
 #include <unordered_map>
 #include <utility>

--- a/src/loggers/binder_logger.cpp
+++ b/src/loggers/binder_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::binder {
 
 std::shared_ptr<spdlog::logger> binder_logger = nullptr;  // NOLINT

--- a/src/loggers/catalog_logger.cpp
+++ b/src/loggers/catalog_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::catalog {
 
 std::shared_ptr<spdlog::logger> catalog_logger = nullptr;  // NOLINT

--- a/src/loggers/common_logger.cpp
+++ b/src/loggers/common_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::common {
 
 std::shared_ptr<spdlog::logger> common_logger = nullptr;  // NOLINT

--- a/src/loggers/execution_logger.cpp
+++ b/src/loggers/execution_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::execution {
 
 std::shared_ptr<spdlog::logger> execution_logger = nullptr;  // NOLINT

--- a/src/loggers/index_logger.cpp
+++ b/src/loggers/index_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::storage {
 
 std::shared_ptr<spdlog::logger> index_logger = nullptr;  // NOLINT

--- a/src/loggers/loggers_util.cpp
+++ b/src/loggers/loggers_util.cpp
@@ -14,6 +14,8 @@
 #include "loggers/settings_logger.h"
 #include "loggers/storage_logger.h"
 #include "loggers/transaction_logger.h"
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
 
 std::shared_ptr<spdlog::sinks::stdout_sink_mt> default_sink = nullptr;  // NOLINT
 
@@ -53,3 +55,21 @@ void LoggersUtil::ShutDown() {
   }
 }
 }  // namespace terrier
+
+template void spdlog::logger::trace<std::string>(const std::string &);
+template void spdlog::logger::debug<std::string>(const std::string &);
+template void spdlog::logger::info<std::string>(const std::string &);
+template void spdlog::logger::warn<std::string>(const std::string &);
+template void spdlog::logger::error<std::string>(const std::string &);
+
+template void spdlog::logger::trace<>(const char *fmt);
+template void spdlog::logger::debug<>(const char *fmt);
+template void spdlog::logger::info<>(const char *fmt);
+template void spdlog::logger::warn<>(const char *fmt);
+template void spdlog::logger::error<>(const char *fmt);
+
+template void spdlog::logger::trace<std::string_view>(const std::string_view &);
+template void spdlog::logger::debug<std::string_view>(const std::string_view &);
+template void spdlog::logger::info<std::string_view>(const std::string_view &);
+template void spdlog::logger::warn<std::string_view>(const std::string_view &);
+template void spdlog::logger::error<std::string_view>(const std::string_view &);

--- a/src/loggers/metrics_logger.cpp
+++ b/src/loggers/metrics_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::metrics {
 
 std::shared_ptr<spdlog::logger> metrics_logger = nullptr;  // NOLINT

--- a/src/loggers/network_logger.cpp
+++ b/src/loggers/network_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::network {
 
 std::shared_ptr<spdlog::logger> network_logger = nullptr;  // NOLINT

--- a/src/loggers/optimizer_logger.cpp
+++ b/src/loggers/optimizer_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::optimizer {
 
 std::shared_ptr<spdlog::logger> optimizer_logger = nullptr;  // NOLINT

--- a/src/loggers/parser_logger.cpp
+++ b/src/loggers/parser_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::parser {
 
 std::shared_ptr<spdlog::logger> parser_logger = nullptr;  // NOLINT

--- a/src/loggers/settings_logger.cpp
+++ b/src/loggers/settings_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::settings {
 
 std::shared_ptr<spdlog::logger> settings_logger = nullptr;  // NOLINT

--- a/src/loggers/storage_logger.cpp
+++ b/src/loggers/storage_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::storage {
 
 std::shared_ptr<spdlog::logger> storage_logger = nullptr;  // NOLINT

--- a/src/loggers/transaction_logger.cpp
+++ b/src/loggers/transaction_logger.cpp
@@ -2,6 +2,9 @@
 
 #include <memory>
 
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+
 namespace terrier::transaction {
 
 std::shared_ptr<spdlog::logger> transaction_logger = nullptr;  // NOLINT

--- a/src/optimizer/binding.cpp
+++ b/src/optimizer/binding.cpp
@@ -69,8 +69,9 @@ GroupExprBindingIterator::GroupExprBindingIterator(const Memo &memo, GroupExpres
     return;
   }
 
-  OPTIMIZER_LOG_TRACE("Attempting to bind on group {0} with expression of type {1}, children size {2}",
-                      gexpr->GetGroupID(), gexpr->Contents()->GetName().c_str(), child_groups.size())
+  OPTIMIZER_LOG_TRACE("Attempting to bind on group " + std::to_string(!gexpr->GetGroupID()) +
+                      " with expression of type " + gexpr->Contents()->GetName() + ", children size " +
+                      std::to_string(child_groups.size()))
 
   // Find all bindings for children
   children_bindings_.resize(child_groups.size());

--- a/src/optimizer/group.cpp
+++ b/src/optimizer/group.cpp
@@ -1,4 +1,5 @@
 #include "optimizer/group.h"
+
 #include "loggers/optimizer_logger.h"
 
 namespace terrier::optimizer {
@@ -38,8 +39,8 @@ void Group::AddExpression(GroupExpression *expr, bool enforced) {
 }
 
 bool Group::SetExpressionCost(GroupExpression *expr, double cost, PropertySet *properties) {
-  OPTIMIZER_LOG_TRACE("Adding expression cost on group {0} with op {1}", expr->GetGroupID(),
-                      expr->Contents()->GetName().c_str())
+  OPTIMIZER_LOG_TRACE("Adding expression cost on group " + std::to_string(!expr->GetGroupID()) + " with op {1}" +
+                      expr->Contents()->GetName())
 
   auto it = lowest_cost_expressions_.find(properties);
   if (it == lowest_cost_expressions_.end()) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -69,8 +69,8 @@ std::unique_ptr<planner::AbstractPlanNode> Optimizer::ChooseBestPlan(
   Group *group = context_->GetMemo().GetGroupByID(id);
   auto gexpr = group->GetBestExpression(required_props);
 
-  OPTIMIZER_LOG_TRACE("Choosing best plan for group {0} with op {1}", gexpr->GetGroupID(),
-                      gexpr->Contents()->GetName().c_str());
+  OPTIMIZER_LOG_TRACE("Choosing best plan for group " + std::to_string(!gexpr->GetGroupID()) + " with op " +
+                      gexpr->Contents()->GetName());
 
   std::vector<group_id_t> child_groups = gexpr->GetChildGroupIDs();
 
@@ -110,7 +110,7 @@ std::unique_ptr<planner::AbstractPlanNode> Optimizer::ChooseBestPlan(
   PlanGenerator generator;
   auto plan = generator.ConvertOpNode(txn, accessor, op, required_props, required_cols, output_cols,
                                       std::move(children_plans), std::move(children_expr_map));
-  OPTIMIZER_LOG_TRACE("Finish Choosing best plan for group {0}", id);
+  OPTIMIZER_LOG_TRACE("Finish Choosing best plan for group " + std::to_string(!id));
 
   delete op;
   return plan;

--- a/src/optimizer/optimizer_task.cpp
+++ b/src/optimizer/optimizer_task.cpp
@@ -1,3 +1,5 @@
+#include "optimizer/optimizer_task.h"
+
 #include <algorithm>
 #include <functional>
 #include <memory>
@@ -7,7 +9,6 @@
 #include "optimizer/binding.h"
 #include "optimizer/child_property_deriver.h"
 #include "optimizer/optimizer_context.h"
-#include "optimizer/optimizer_task.h"
 #include "optimizer/property_enforcer.h"
 #include "optimizer/statistics/child_stats_deriver.h"
 #include "optimizer/statistics/stats_calculator.h"
@@ -49,7 +50,7 @@ RuleSet &OptimizerTask::GetRuleSet() const { return context_->GetOptimizerContex
 // OptimizeGroup
 //===--------------------------------------------------------------------===//
 void OptimizeGroup::Execute() {
-  OPTIMIZER_LOG_TRACE("OptimizeGroup::Execute() group {0}", group_->GetID());
+  OPTIMIZER_LOG_TRACE("OptimizeGroup::Execute() group " + std::to_string(!group_->GetID()));
   if (group_->GetCostLB() > context_->GetCostUpperBound() ||                    // Cost LB > Cost UB
       group_->GetBestExpression(context_->GetRequiredProperties()) != nullptr)  // Has optimized given the context
     return;
@@ -203,7 +204,7 @@ void DeriveStats::Execute() {
   auto children_required_stats =
       deriver.DeriveInputStats(gexpr_, required_cols_, &context_->GetOptimizerContext()->GetMemo());
   bool derive_children = false;
-  OPTIMIZER_LOG_TRACE("DeriveStats::Execute() group {0}", gexpr_->GetGroupID());
+  OPTIMIZER_LOG_TRACE("DeriveStats::Execute() group " + std::to_string(!gexpr_->GetGroupID()));
 
   // If we haven't got enough stats to compute the current stats, derive them
   // from the child first

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -11,6 +11,7 @@
 #include "gtest/gtest.h"
 #include "network/connection_handle_factory.h"
 #include "network/terrier_server.h"
+#include "spdlog/spdlog.h"
 #include "storage/garbage_collector.h"
 #include "test_util/manual_packet_util.h"
 #include "test_util/test_harness.h"

--- a/test/optimizer/top_k_elements_test.cpp
+++ b/test/optimizer/top_k_elements_test.cpp
@@ -138,7 +138,7 @@ TEST_F(TopKElementsTests, SortedKeyTest) {
     // guarantee that the keys we shove in will have the exact amount
     // that we originally set them to.
 
-    OPTIMIZER_LOG_TRACE("Top-" + std::to_string(i) + ": " + key + " <-> " + expected_key);
+    OPTIMIZER_LOG_TRACE("Top-" + std::to_string(i) += ": " + key + " <-> " += expected_key);
     // EXPECT_EQ(key, expected_key) << "Iteration #" << i;
     i++;
   }

--- a/test/optimizer/top_k_elements_test.cpp
+++ b/test/optimizer/top_k_elements_test.cpp
@@ -1,3 +1,5 @@
+#include "optimizer/statistics/top_k_elements.h"
+
 #include <stack>
 #include <string>
 #include <unordered_map>
@@ -6,8 +8,6 @@
 #include "gtest/gtest.h"
 #include "loggers/optimizer_logger.h"
 #include "optimizer/statistics/count_min_sketch.h"
-#include "optimizer/statistics/top_k_elements.h"
-
 #include "test_util/test_harness.h"
 
 namespace terrier::optimizer {
@@ -45,7 +45,10 @@ TEST_F(TopKElementsTests, SimpleIncrementTest) {
   top_k.Increment(5, 15);
   EXPECT_EQ(top_k.GetSize(), 5);
 
-  OPTIMIZER_LOG_TRACE(top_k);
+  std::ostringstream stream;
+  stream << top_k;
+
+  OPTIMIZER_LOG_TRACE(stream.str());
 }
 
 // Check that if incrementally increase the count of a key that
@@ -134,7 +137,8 @@ TEST_F(TopKElementsTests, SortedKeyTest) {
     // TODO(pavlo): This text case is in correct because we can't
     // guarantee that the keys we shove in will have the exact amount
     // that we originally set them to.
-    OPTIMIZER_LOG_TRACE("Top-{0}: {1} <-> {2}", i, key, expected_key);
+
+    OPTIMIZER_LOG_TRACE("Top-" + std::to_string(i) + ": " + key + " <-> " + expected_key);
     // EXPECT_EQ(key, expected_key) << "Iteration #" << i;
     i++;
   }

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -17,6 +17,7 @@
 #include "parser/pg_trigger.h"
 #include "parser/postgresparser.h"
 #include "parser/statements.h"
+#include "spdlog/spdlog.h"
 #include "test_util/test_harness.h"
 
 namespace terrier::parser {


### PR DESCRIPTION
Mostly for @abalakumar083 to run his compilation time analysis on. If it seems to actually trim down the time spent in template instantiation, we may merge it. The win wasn't huge for me locally:

**Master:**
```
make -j12  2376.07s user 143.76s system 1019% cpu 4:07.27 total
```

**This PR:**
```
make -j12  2285.42s user 135.46s system 1026% cpu 3:55.78 total
```