### PR TITLE
Hook up per-component metrics settings to DBMain's Builder

### DIFF
--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -285,23 +285,18 @@ class DBMain {
         metrics_manager = std::make_unique<metrics::MetricsManager>();
         if (use_settings_manager_) {
           if (settings_manager->GetBool(settings::Param::metrics_logging)) {
-            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
             metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING, 0);
           }
           if (settings_manager->GetBool(settings::Param::metrics_transaction)) {
-            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
             metrics_manager->EnableMetric(metrics::MetricsComponent::TRANSACTION, 0);
           }
           if (settings_manager->GetBool(settings::Param::metrics_gc)) {
-            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
             metrics_manager->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
           }
           if (settings_manager->GetBool(settings::Param::metrics_execution)) {
-            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
             metrics_manager->EnableMetric(metrics::MetricsComponent::EXECUTION, 0);
           }
           if (settings_manager->GetBool(settings::Param::metrics_pipeline)) {
-            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
             metrics_manager->EnableMetric(metrics::MetricsComponent::EXECUTION_PIPELINE, 0);
           }
         }

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -281,7 +281,31 @@ class DBMain {
           use_settings_manager_ ? BootstrapSettingsManager(common::ManagedPointer(db_main)) : DISABLED;
 
       std::unique_ptr<metrics::MetricsManager> metrics_manager = DISABLED;
-      if (use_metrics_) metrics_manager = std::make_unique<metrics::MetricsManager>();
+      if (use_metrics_) {
+        metrics_manager = std::make_unique<metrics::MetricsManager>();
+        if (use_settings_manager_) {
+          if (settings_manager->GetBool(settings::Param::metrics_logging)) {
+            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
+            metrics_manager->EnableMetric(metrics::MetricsComponent::LOGGING, 0);
+          }
+          if (settings_manager->GetBool(settings::Param::metrics_transaction)) {
+            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
+            metrics_manager->EnableMetric(metrics::MetricsComponent::TRANSACTION, 0);
+          }
+          if (settings_manager->GetBool(settings::Param::metrics_gc)) {
+            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
+            metrics_manager->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
+          }
+          if (settings_manager->GetBool(settings::Param::metrics_execution)) {
+            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
+            metrics_manager->EnableMetric(metrics::MetricsComponent::EXECUTION, 0);
+          }
+          if (settings_manager->GetBool(settings::Param::metrics_pipeline)) {
+            auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(0));
+            metrics_manager->EnableMetric(metrics::MetricsComponent::EXECUTION_PIPELINE, 0);
+          }
+        }
+      }
 
       std::unique_ptr<metrics::MetricsThread> metrics_thread = DISABLED;
       if (use_metrics_thread_) {

--- a/src/include/settings/settings_callbacks.h
+++ b/src/include/settings/settings_callbacks.h
@@ -105,6 +105,26 @@ class Callbacks {
    * @param db_main pointer to db_main
    * @param action_context pointer to the action context for this settings change
    */
+  static void MetricsGC(void *old_value, void *new_value, DBMain *db_main,
+                              common::ManagedPointer<common::ActionContext> action_context);
+
+  /**
+   * Enable or disable metrics collection for ExecutionEngine pipeline
+   * @param old_value old settings value
+   * @param new_value new settings value
+   * @param db_main pointer to db_main
+   * @param action_context pointer to the action context for this settings change
+   */
+  static void MetricsExecution(void *old_value, void *new_value, DBMain *db_main,
+                              common::ManagedPointer<common::ActionContext> action_context);
+
+  /**
+   * Enable or disable metrics collection for ExecutionEngine pipeline
+   * @param old_value old settings value
+   * @param new_value new settings value
+   * @param db_main pointer to db_main
+   * @param action_context pointer to the action context for this settings change
+   */
   static void MetricsPipeline(void *old_value, void *new_value, DBMain *db_main,
                               common::ManagedPointer<common::ActionContext> action_context);
 };

--- a/src/include/settings/settings_callbacks.h
+++ b/src/include/settings/settings_callbacks.h
@@ -99,24 +99,24 @@ class Callbacks {
                                  common::ManagedPointer<common::ActionContext> action_context);
 
   /**
-   * Enable or disable metrics collection for ExecutionEngine pipeline
+   * Enable or disable metrics collection for GarbageCollector component
    * @param old_value old settings value
    * @param new_value new settings value
    * @param db_main pointer to db_main
    * @param action_context pointer to the action context for this settings change
    */
   static void MetricsGC(void *old_value, void *new_value, DBMain *db_main,
-                              common::ManagedPointer<common::ActionContext> action_context);
+                        common::ManagedPointer<common::ActionContext> action_context);
 
   /**
-   * Enable or disable metrics collection for ExecutionEngine pipeline
+   * Enable or disable metrics collection for Execution component
    * @param old_value old settings value
    * @param new_value new settings value
    * @param db_main pointer to db_main
    * @param action_context pointer to the action context for this settings change
    */
   static void MetricsExecution(void *old_value, void *new_value, DBMain *db_main,
-                              common::ManagedPointer<common::ActionContext> action_context);
+                               common::ManagedPointer<common::ActionContext> action_context);
 
   /**
    * Enable or disable metrics collection for ExecutionEngine pipeline

--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -179,6 +179,22 @@ SETTING_bool(
 )
 
 SETTING_bool(
+    metrics_gc,
+    "Metrics collection for the GarbageCollector component (default: false).",
+    false,
+    true,
+    terrier::settings::Callbacks::MetricsGC
+)
+
+SETTING_bool(
+    metrics_execution,
+    "Metrics collection for the Execution component (default: false).",
+    false,
+    true,
+    terrier::settings::Callbacks::MetricsExecution
+)
+
+SETTING_bool(
     metrics_pipeline,
     "Metrics collection for the ExecutionEngine pipelines (default: false).",
     false,

--- a/src/settings/settings_callbacks.cpp
+++ b/src/settings/settings_callbacks.cpp
@@ -82,6 +82,28 @@ void Callbacks::MetricsTransaction(void *const old_value, void *const new_value,
   action_context->SetState(common::ActionState::SUCCESS);
 }
 
+void Callbacks::MetricsGC(void *const old_value, void *const new_value, DBMain *const db_main,
+                          common::ManagedPointer<common::ActionContext> action_context) {
+  action_context->SetState(common::ActionState::IN_PROGRESS);
+  bool new_status = *static_cast<bool *>(new_value);
+  if (new_status)
+    db_main->GetMetricsManager()->EnableMetric(metrics::MetricsComponent::GARBAGECOLLECTION, 0);
+  else
+    db_main->GetMetricsManager()->DisableMetric(metrics::MetricsComponent::GARBAGECOLLECTION);
+  action_context->SetState(common::ActionState::SUCCESS);
+}
+
+void Callbacks::MetricsExecution(void *const old_value, void *const new_value, DBMain *const db_main,
+                                 common::ManagedPointer<common::ActionContext> action_context) {
+  action_context->SetState(common::ActionState::IN_PROGRESS);
+  bool new_status = *static_cast<bool *>(new_value);
+  if (new_status)
+    db_main->GetMetricsManager()->EnableMetric(metrics::MetricsComponent::EXECUTION, 0);
+  else
+    db_main->GetMetricsManager()->DisableMetric(metrics::MetricsComponent::EXECUTION);
+  action_context->SetState(common::ActionState::SUCCESS);
+}
+
 void Callbacks::MetricsPipeline(void *const old_value, void *const new_value, DBMain *const db_main,
                                 common::ManagedPointer<common::ActionContext> action_context) {
   action_context->SetState(common::ActionState::IN_PROGRESS);

--- a/test/metrics/metrics_test.cpp
+++ b/test/metrics/metrics_test.cpp
@@ -198,4 +198,74 @@ TEST_F(MetricsTests, TransactionCSVTest) {
 
   metrics_manager_->UnregisterThread();
 }
+
+/**
+ *  Testing that we can enable and disable per-component metrics
+ *
+ */
+// NOLINTNEXTLINE
+TEST_F(MetricsTests, ToggleSettings) {
+  // metrics_logging
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::LOGGING));
+  auto action_context = std::make_unique<common::ActionContext>(common::action_id_t(1));
+  const auto callback = +[](common::ManagedPointer<common::ActionContext> action_context) -> void {
+    action_context->SetState(common::ActionState::SUCCESS);
+  };
+  settings_manager_->SetBool(settings::Param::metrics_logging, true, common::ManagedPointer(action_context), callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_TRUE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::LOGGING));
+  action_context = std::make_unique<common::ActionContext>(common::action_id_t(2));
+  settings_manager_->SetBool(settings::Param::metrics_logging, false, common::ManagedPointer(action_context), callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::LOGGING));
+
+  // metrics_transaction
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::TRANSACTION));
+  action_context = std::make_unique<common::ActionContext>(common::action_id_t(3));
+  settings_manager_->SetBool(settings::Param::metrics_transaction, true, common::ManagedPointer(action_context),
+                             callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_TRUE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::TRANSACTION));
+  action_context = std::make_unique<common::ActionContext>(common::action_id_t(4));
+  settings_manager_->SetBool(settings::Param::metrics_transaction, false, common::ManagedPointer(action_context),
+                             callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::TRANSACTION));
+
+  // metrics_gc
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::GARBAGECOLLECTION));
+  action_context = std::make_unique<common::ActionContext>(common::action_id_t(5));
+  settings_manager_->SetBool(settings::Param::metrics_gc, true, common::ManagedPointer(action_context), callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_TRUE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::GARBAGECOLLECTION));
+  action_context = std::make_unique<common::ActionContext>(common::action_id_t(6));
+  settings_manager_->SetBool(settings::Param::metrics_gc, false, common::ManagedPointer(action_context), callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::GARBAGECOLLECTION));
+
+  // metrics_execution
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::EXECUTION));
+  action_context = std::make_unique<common::ActionContext>(common::action_id_t(7));
+  settings_manager_->SetBool(settings::Param::metrics_execution, true, common::ManagedPointer(action_context),
+                             callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_TRUE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::EXECUTION));
+  action_context = std::make_unique<common::ActionContext>(common::action_id_t(8));
+  settings_manager_->SetBool(settings::Param::metrics_execution, false, common::ManagedPointer(action_context),
+                             callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::EXECUTION));
+
+  // metrics_pipeline
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::EXECUTION_PIPELINE));
+  action_context = std::make_unique<common::ActionContext>(common::action_id_t(9));
+  settings_manager_->SetBool(settings::Param::metrics_pipeline, true, common::ManagedPointer(action_context), callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_TRUE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::EXECUTION_PIPELINE));
+  action_context = std::make_unique<common::ActionContext>(common::action_id_t(10));
+  settings_manager_->SetBool(settings::Param::metrics_pipeline, false, common::ManagedPointer(action_context),
+                             callback);
+  EXPECT_EQ(action_context->GetState(), common::ActionState::SUCCESS);
+  EXPECT_FALSE(metrics_manager_->ComponentEnabled(metrics::MetricsComponent::EXECUTION_PIPELINE));
+}
 }  // namespace terrier::metrics


### PR DESCRIPTION
We have settings to toggle per-component metrics at runtime, but I never hooked them up to DBMain's builder to enable them if they were turned on at the command line at server launch. This fixes that problem.