### PR TITLE
Relax asserts in MetricsStore

### DIFF
--- a/src/include/loggers/metrics_logger.h
+++ b/src/include/loggers/metrics_logger.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+
+#include "loggers/loggers_util.h"
+
+namespace terrier::metrics {
+extern std::shared_ptr<spdlog::logger> metrics_logger;  // NOLINT
+
+void InitMetricsLogger();
+}  // namespace terrier::metrics
+
+#define METRICS_LOG_TRACE(...) ::terrier::metrics::metrics_logger->trace(__VA_ARGS__);
+
+#define METRICS_LOG_DEBUG(...) ::terrier::metrics::metrics_logger->debug(__VA_ARGS__);
+
+#define METRICS_LOG_INFO(...) ::terrier::metrics::metrics_logger->info(__VA_ARGS__);
+
+#define METRICS_LOG_WARN(...) ::terrier::metrics::metrics_logger->warn(__VA_ARGS__);
+
+#define METRICS_LOG_ERROR(...) ::terrier::metrics::metrics_logger->error(__VA_ARGS__);

--- a/src/include/metrics/metrics_store.h
+++ b/src/include/metrics/metrics_store.h
@@ -9,6 +9,7 @@
 #include "catalog/catalog_defs.h"
 #include "common/managed_pointer.h"
 #include "execution/exec_defs.h"
+#include "loggers/metrics_logger.h"
 #include "metrics/abstract_metric.h"
 #include "metrics/abstract_raw_data.h"
 #include "metrics/execution_metric.h"
@@ -40,7 +41,10 @@ class MetricsStore {
    */
   void RecordSerializerData(const uint64_t num_bytes, const uint64_t num_records,
                             const common::ResourceTracker::Metrics &resource_metrics) {
-    TERRIER_ASSERT(ComponentEnabled(MetricsComponent::LOGGING), "LoggingMetric not enabled.");
+    if (!ComponentEnabled(MetricsComponent::LOGGING))
+      METRICS_LOG_WARN(
+          "RecordSerializerData() called without logging metrics enabled. Was it recently disabled and the component "
+          "is just lagging?");
     TERRIER_ASSERT(logging_metric_ != nullptr, "LoggingMetric not allocated. Check MetricsStore constructor.");
     logging_metric_->RecordSerializerData(num_bytes, num_records, resource_metrics);
   }
@@ -53,7 +57,10 @@ class MetricsStore {
    */
   void RecordConsumerData(const uint64_t num_bytes, const uint64_t num_records,
                           const common::ResourceTracker::Metrics &resource_metrics) {
-    TERRIER_ASSERT(ComponentEnabled(MetricsComponent::LOGGING), "LoggingMetric not enabled.");
+    if (!ComponentEnabled(MetricsComponent::LOGGING))
+      METRICS_LOG_WARN(
+          "RecordConsumerData() called without logging metrics enabled. Was it recently disabled and the component is "
+          "just lagging?");
     TERRIER_ASSERT(logging_metric_ != nullptr, "LoggingMetric not allocated. Check MetricsStore constructor.");
     logging_metric_->RecordConsumerData(num_bytes, num_records, resource_metrics);
   }
@@ -64,7 +71,10 @@ class MetricsStore {
    * @param resource_metrics second entry of metrics datapoint
    */
   void RecordDeallocateData(const uint64_t num_processed, const common::ResourceTracker::Metrics &resource_metrics) {
-    TERRIER_ASSERT(ComponentEnabled(MetricsComponent::GARBAGECOLLECTION), "GarbageCollectionMetric not enabled.");
+    if (!ComponentEnabled(MetricsComponent::GARBAGECOLLECTION))
+      METRICS_LOG_WARN(
+          "RecordDeallocateData() called without GC metrics enabled. Was it recently disabled and the component is "
+          "just lagging?");
     TERRIER_ASSERT(gc_metric_ != nullptr, "GarbageCollectionMetric not allocated. Check MetricsStore constructor.");
     gc_metric_->RecordDeallocateData(num_processed, resource_metrics);
   }
@@ -78,7 +88,10 @@ class MetricsStore {
    */
   void RecordUnlinkData(const uint64_t num_processed, const uint64_t num_buffers, const uint64_t num_readonly,
                         const common::ResourceTracker::Metrics &resource_metrics) {
-    TERRIER_ASSERT(ComponentEnabled(MetricsComponent::GARBAGECOLLECTION), "GarbageCollectionMetric not enabled.");
+    if (!ComponentEnabled(MetricsComponent::GARBAGECOLLECTION))
+      METRICS_LOG_WARN(
+          "RecordUnlinkData() called without GC metrics enabled. Was it recently disabled and the component is just "
+          "lagging?");
     TERRIER_ASSERT(gc_metric_ != nullptr, "GarbageCollectionMetric not allocated. Check MetricsStore constructor.");
     gc_metric_->RecordUnlinkData(num_processed, num_buffers, num_readonly, resource_metrics);
   }
@@ -88,7 +101,10 @@ class MetricsStore {
    * @param resource_metrics first entry of txn datapoint
    */
   void RecordBeginData(const common::ResourceTracker::Metrics &resource_metrics) {
-    TERRIER_ASSERT(ComponentEnabled(MetricsComponent::TRANSACTION), "TransactionMetric not enabled.");
+    if (!ComponentEnabled(MetricsComponent::TRANSACTION))
+      METRICS_LOG_WARN(
+          "RecordBeginData() called without transaction metrics enabled. Was it recently disabled and the component is "
+          "just lagging?");
     TERRIER_ASSERT(txn_metric_ != nullptr, "TransactionMetric not allocated. Check MetricsStore constructor.");
     txn_metric_->RecordBeginData(resource_metrics);
   }
@@ -99,7 +115,10 @@ class MetricsStore {
    * @param resource_metrics second entry of txn datapoint
    */
   void RecordCommitData(const uint64_t is_readonly, const common::ResourceTracker::Metrics &resource_metrics) {
-    TERRIER_ASSERT(ComponentEnabled(MetricsComponent::TRANSACTION), "TransactionMetric not enabled.");
+    if (!ComponentEnabled(MetricsComponent::TRANSACTION))
+      METRICS_LOG_WARN(
+          "RecordCommitData() called without transaction metrics enabled. Was it recently disabled and the component "
+          "is just lagging?");
     TERRIER_ASSERT(txn_metric_ != nullptr, "TransactionMetric not allocated. Check MetricsStore constructor.");
     txn_metric_->RecordCommitData(is_readonly, resource_metrics);
   }
@@ -113,7 +132,8 @@ class MetricsStore {
    */
   void RecordExecutionData(const char *feature, uint32_t len, uint8_t execution_mode,
                            const common::ResourceTracker::Metrics &resource_metrics) {
-    TERRIER_ASSERT(ComponentEnabled(MetricsComponent::EXECUTION), "ExecutionMetric not enabled.");
+    if (!ComponentEnabled(MetricsComponent::EXECUTION))
+      METRICS_LOG_WARN("RecordExecutionData() called without execution metrics enabled.");
     TERRIER_ASSERT(execution_metric_ != nullptr, "ExecutionMetric not allocated. Check MetricsStore constructor.");
     execution_metric_->RecordExecutionData(feature, len, execution_mode, resource_metrics);
   }
@@ -129,7 +149,8 @@ class MetricsStore {
   void RecordPipelineData(execution::query_id_t query_id, execution::pipeline_id_t pipeline_id, uint8_t execution_mode,
                           std::vector<brain::ExecutionOperatingUnitFeature> &&features,
                           const common::ResourceTracker::Metrics &resource_metrics) {
-    TERRIER_ASSERT(ComponentEnabled(MetricsComponent::EXECUTION_PIPELINE), "PipelineMMetric not enabled.");
+    if (!ComponentEnabled(MetricsComponent::EXECUTION_PIPELINE))
+      METRICS_LOG_WARN("RecordPipelineData() called without pipepline metrics enabled.");
     TERRIER_ASSERT(pipeline_metric_ != nullptr, "PipelineMetric not allocated. Check MetricsStore constructor.");
     pipeline_metric_->RecordPipelineData(query_id, pipeline_id, execution_mode, std::move(features), resource_metrics);
   }

--- a/src/loggers/loggers_util.cpp
+++ b/src/loggers/loggers_util.cpp
@@ -8,6 +8,7 @@
 #include "loggers/common_logger.h"
 #include "loggers/execution_logger.h"
 #include "loggers/index_logger.h"
+#include "loggers/metrics_logger.h"
 #include "loggers/network_logger.h"
 #include "loggers/optimizer_logger.h"
 #include "loggers/parser_logger.h"
@@ -29,11 +30,12 @@ void LoggersUtil::Initialize() {
     catalog::InitCatalogLogger();
     common::InitCommonLogger();
     execution::InitExecutionLogger();
-    storage::InitIndexLogger();
+    metrics::InitMetricsLogger();
     network::InitNetworkLogger();
     optimizer::InitOptimizerLogger();
     parser::InitParserLogger();
     settings::InitSettingsLogger();
+    storage::InitIndexLogger();
     storage::InitStorageLogger();
     transaction::InitTransactionLogger();
 

--- a/src/loggers/metrics_logger.cpp
+++ b/src/loggers/metrics_logger.cpp
@@ -1,0 +1,16 @@
+#include "loggers/metrics_logger.h"
+
+#include <memory>
+
+namespace terrier::metrics {
+
+std::shared_ptr<spdlog::logger> metrics_logger = nullptr;  // NOLINT
+
+void InitMetricsLogger() {
+  if (metrics_logger == nullptr) {
+    metrics_logger = std::make_shared<spdlog::logger>("metrics_logger", ::default_sink);  // NOLINT
+    spdlog::register_logger(metrics_logger);
+  }
+}
+
+}  // namespace terrier::metrics

--- a/src/storage/write_ahead_log/disk_log_consumer_task.cpp
+++ b/src/storage/write_ahead_log/disk_log_consumer_task.cpp
@@ -1,4 +1,5 @@
 #include "storage/write_ahead_log/disk_log_consumer_task.h"
+
 #include "common/resource_tracker.h"
 #include "common/scoped_timer.h"
 #include "common/thread_context.h"
@@ -57,15 +58,6 @@ void DiskLogConsumerTask::DiskLogConsumerTaskLoop() {
   // input for this operating unit
   uint64_t num_bytes = 0, num_buffers = 0;
 
-  bool logging_metrics_enabled =
-      common::thread_context.metrics_store_ != nullptr &&
-      common::thread_context.metrics_store_->ComponentToRecord(metrics::MetricsComponent::LOGGING);
-
-  if (logging_metrics_enabled) {
-    // start the operating unit resource tracker
-    common::thread_context.resource_tracker_.Start();
-  }
-
   // Keeps track of how much data we've written to the log file since the last persist
   current_data_written_ = 0;
   // Initialize sleep period
@@ -77,6 +69,15 @@ void DiskLogConsumerTask::DiskLogConsumerTaskLoop() {
   // Disk log consumer task thread spins in this loop. When notified or periodically, we wake up and process serialized
   // buffers
   do {
+    const bool logging_metrics_enabled =
+        common::thread_context.metrics_store_ != nullptr &&
+        common::thread_context.metrics_store_->ComponentToRecord(metrics::MetricsComponent::LOGGING);
+
+    if (logging_metrics_enabled) {
+      // start the operating unit resource tracker
+      common::thread_context.resource_tracker_.Start();
+    }
+
     curr_sleep = next_sleep;
     {
       // Wait until we are told to flush buffers
@@ -125,8 +126,6 @@ void DiskLogConsumerTask::DiskLogConsumerTaskLoop() {
         common::thread_context.metrics_store_->RecordConsumerData(num_bytes, num_buffers, resource_metrics);
       }
       num_bytes = num_buffers = 0;
-      // start the operating unit resource tracker
-      common::thread_context.resource_tracker_.Start();
     }
   } while (run_task_);
   // Be extra sure we processed everything

--- a/src/storage/write_ahead_log/log_serializer_task.cpp
+++ b/src/storage/write_ahead_log/log_serializer_task.cpp
@@ -42,7 +42,7 @@ void LogSerializerTask::LogSerializerTaskLoop() {
 
 bool LogSerializerTask::Process() {
   uint64_t num_bytes = 0, num_records = 0;
-  bool logging_metrics_enabled =
+  const bool logging_metrics_enabled =
       common::thread_context.metrics_store_ != nullptr &&
       common::thread_context.metrics_store_->ComponentToRecord(metrics::MetricsComponent::LOGGING);
   if (logging_metrics_enabled) {

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -12,7 +12,7 @@ TransactionContext *TransactionManager::BeginTransaction() {
   timestamp_t start_time;
   TransactionContext *result;
 
-  bool txn_metrics_enabled =
+  const bool txn_metrics_enabled =
       common::thread_context.metrics_store_ != nullptr &&
       common::thread_context.metrics_store_->ComponentToRecord(metrics::MetricsComponent::TRANSACTION);
 
@@ -78,7 +78,7 @@ timestamp_t TransactionManager::UpdatingCommitCriticalSection(TransactionContext
 timestamp_t TransactionManager::Commit(TransactionContext *const txn, transaction::callback_fn callback,
                                        void *callback_arg) {
   timestamp_t result;
-  bool txn_metrics_enabled =
+  const bool txn_metrics_enabled =
       common::thread_context.metrics_store_ != nullptr &&
       common::thread_context.metrics_store_->ComponentToRecord(metrics::MetricsComponent::TRANSACTION);
 


### PR DESCRIPTION
There's a race condition between disabling a component's metrics and the component potentially still wanting to record one of its data points. We had asserts that would trip occasionally in this event (see [this recent Jenkins run](http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/terrier/detail/master/593/tests/)). This relaxes the assert to just use the (new) `MetricsLogger` to print out a warning message.