### PR TITLE
ensure the match is not empty before assigning ref_cycles_us_

### DIFF
--- a/src/execution/util/cpu_info.cpp
+++ b/src/execution/util/cpu_info.cpp
@@ -109,8 +109,10 @@ void CpuInfo::InitCpuInfo() {
       std::regex cpu_freq_regex("\\s[\\d.]+GHz");
       std::cmatch m;
       std::regex_search(model_name_.c_str(), m, cpu_freq_regex);
-      double base_cpu_ghz = std::stod(m[0].str());
-      ref_cycles_us_ = static_cast<uint64_t>(base_cpu_ghz * 1000);
+      if (!m.empty()) {
+        double base_cpu_ghz = std::stod(m[0].str());
+        ref_cycles_us_ = static_cast<uint64_t>(base_cpu_ghz * 1000);
+      }
     } else if (name.startswith("cpu MHz")) {
       double cpu_mhz;
       value.getAsDouble(cpu_mhz);


### PR DESCRIPTION
Doing a quick trial on AMD Epyc, I encountered a bug in `InitCpuInfo()`.  It currently relies on regex matching "GHz" in `/proc/cpuinfo` to set the base frequency and works correctly on model names like:
```model name      : Intel(R) Xeon(R) CPU E5-2620 v3 @ 2.40GHz```

On AMD Epyc, no clock speed is presented:
```model name      : AMD EPYC 7452 32-Core Processor```

This results in `stod()` being called on an empty `cmatch` and causing crashes like the following:
```
crd@epyc:/mnt/terrier/build$ gdb ./debug/terrier
GNU gdb (Ubuntu 8.1-0ubuntu3.2) 8.1.0.20180409-git
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./debug/terrier...done.
(gdb) r
Starting program: /mnt/terrier/build/debug/terrier
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff24ff700 (LWP 7845)]
[New Thread 0x7ffff1cfe700 (LWP 7846)]
[New Thread 0x7ffff10bf700 (LWP 7847)]
[New Thread 0x7ffff08be700 (LWP 7848)]
[New Thread 0x7fff6eeab700 (LWP 7849)]
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stod

Thread 1 "terrier" received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
51      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff5230801 in __GI_abort () at abort.c:79
#2  0x00007ffff5c23957 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff5c29ae6 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff5c29b21 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007ffff5c29d54 in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007ffff5c257eb in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x0000555555ffd834 in __gnu_cxx::__stoa<double, double, char> (
    __convf=0x7ffff5235ff0 <__GI_strtod>, __name=0x555557c80c40 "stod", __str=0x7fffffffd160 "",
    __idx=0x0) at /usr/include/c++/7/ext/string_conversions.h:83
#8  0x0000555555ffc936 in std::__cxx11::stod (__str="", __idx=0x0)
    at /usr/include/c++/7/bits/basic_string.h:6402
#9  0x00005555562d64a3 in terrier::execution::CpuInfo::InitCpuInfo (
    this=0x555558f35e60 <terrier::execution::CpuInfo::Instance()::instance>)
    at /mnt/terrier/src/execution/util/cpu_info.cpp:112
#10 0x00005555562d57d9 in terrier::execution::CpuInfo::CpuInfo (
    this=0x555558f35e60 <terrier::execution::CpuInfo::Instance()::instance>)
    at /mnt/terrier/src/execution/util/cpu_info.cpp:73
#11 0x0000555555f9a047 in terrier::execution::CpuInfo::Instance ()
    at /mnt/terrier/src/include/execution/util/cpu_info.h:52
#12 0x0000555555f9a8ec in terrier::execution::ExecutionUtil::InitTPL ()
    at /mnt/terrier/src/include/execution/execution_util.h:21
#13 0x0000555555f98f55 in terrier::DBMain::ExecutionLayer::ExecutionLayer (this=0x602000017530)
    at /mnt/terrier/src/main/db_main.cpp:34
#14 0x0000555555dff046 in std::make_unique<terrier::DBMain::ExecutionLayer> ()
    at /usr/include/c++/7/bits/unique_ptr.h:821
#15 0x0000555555df1a74 in terrier::DBMain::Builder::Build (this=0x7fffffffe350)
    at /mnt/terrier/src/include/main/db_main.h:341
#16 0x0000555555de68bb in main (argc=1, argv=0x7fffffffe568)
    at /mnt/terrier/src/main/terrier.cpp:85
```

I looked briefly to see if there was a more general, reliable way to get this base clock information but it appears that there is not one, even in this age...
