### PR TITLE
Adding support for NOT expression

### DIFF
--- a/src/execution/sema/sema_expr.cpp
+++ b/src/execution/sema/sema_expr.cpp
@@ -269,7 +269,7 @@ void Sema::VisitUnaryOpExpr(ast::UnaryOpExpr *node) {
 
   switch (node->Op()) {
     case parsing::Token::Type::BANG: {
-      if (!expr_type->IsBoolType()) {
+      if (!expr_type->IsBoolType() && !expr_type->IsSqlBooleanType()) {
         GetErrorReporter()->Report(node->Position(), ErrorMessages::kInvalidOperation, node->Op(), expr_type);
         return;
       }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -405,9 +405,17 @@ void BytecodeGenerator::VisitArithmeticUnaryExpr(ast::UnaryOpExpr *op) {
 
 void BytecodeGenerator::VisitLogicalNotExpr(ast::UnaryOpExpr *op) {
   LocalVar dest = ExecutionResult()->GetOrCreateDestination(op->GetType());
-  LocalVar input = VisitExpressionForRValue(op->Expression());
-  Emitter()->EmitUnaryOp(Bytecode::Not, dest, input);
-  ExecutionResult()->SetDestination(dest.ValueOf());
+  LocalVar input;
+  if (op->GetType()->IsBoolType()) {
+    input = VisitExpressionForRValue(op->Expression());
+    Emitter()->EmitUnaryOp(Bytecode::Not, dest, input);
+    ExecutionResult()->SetDestination(dest.ValueOf());
+  }
+  else if (op->GetType()->IsSqlBooleanType()) {
+    input = VisitExpressionForLValue(op->Expression());
+    Emitter()->EmitUnaryOp(Bytecode::NotSql, dest, input);
+    ExecutionResult()->SetDestination(dest);
+  }
 }
 
 void BytecodeGenerator::VisitUnaryOpExpr(ast::UnaryOpExpr *node) {

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -410,8 +410,7 @@ void BytecodeGenerator::VisitLogicalNotExpr(ast::UnaryOpExpr *op) {
     input = VisitExpressionForRValue(op->Expression());
     Emitter()->EmitUnaryOp(Bytecode::Not, dest, input);
     ExecutionResult()->SetDestination(dest.ValueOf());
-  }
-  else if (op->GetType()->IsSqlBooleanType()) {
+  } else if (op->GetType()->IsSqlBooleanType()) {
     input = VisitExpressionForLValue(op->Expression());
     Emitter()->EmitUnaryOp(Bytecode::NotSql, dest, input);
     ExecutionResult()->SetDestination(dest);

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -328,6 +328,13 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {
     DISPATCH_NEXT();
   }
 
+  OP(NotSql) : {
+    auto *dest = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());
+    auto *input = frame->LocalAt<sql::BoolVal *>(READ_LOCAL_ID());
+    OpNotSql(dest, input);
+    DISPATCH_NEXT();
+  }
+
   // -------------------------------------------------------
   // Jumps
   // -------------------------------------------------------

--- a/src/include/execution/ast/type.h
+++ b/src/include/execution/ast/type.h
@@ -276,7 +276,6 @@ class Type : public util::RegionObject {
    */
   bool IsSqlValueType() const;
 
-
   /**
    * Checks whether this is a sql boolean type
    * @return true iff this is a sql boolean type

--- a/src/include/execution/ast/type.h
+++ b/src/include/execution/ast/type.h
@@ -276,6 +276,13 @@ class Type : public util::RegionObject {
    */
   bool IsSqlValueType() const;
 
+
+  /**
+   * Checks whether this is a sql boolean type
+   * @return true iff this is a sql boolean type
+   */
+  bool IsSqlBooleanType() const;
+
   /**
    * Checks whether this is a sql aggregator type
    * @return true iff this is a sql aggregator type.
@@ -763,6 +770,8 @@ inline bool Type::IsSqlValueType() const {
   }
   return false;
 }
+
+inline bool Type::IsSqlBooleanType() const { return IsSpecificBuiltin(BuiltinType::Boolean); }
 
 inline bool Type::IsSqlAggregatorType() const {
   if (auto *builtin_type = SafeAs<BuiltinType>()) {

--- a/src/include/execution/sql/functions/comparison_functions.h
+++ b/src/include/execution/sql/functions/comparison_functions.h
@@ -216,6 +216,14 @@ class EXPORT ComparisonFunctions {
     return int32_t(len1) - int32_t(len2);
   }
 
+  /**
+   * Logical negation for SQL booleans
+   */
+  static void NotBoolVal(terrier::execution::sql::BoolVal *result, terrier::execution::sql::BoolVal *input) {
+    *result = terrier::execution::sql::BoolVal(!input->val_);
+    result->is_null_ = input->is_null_;
+  }
+
  private:
   /**
    * Compare two strings. Returns

--- a/src/include/execution/sql/functions/comparison_functions.h
+++ b/src/include/execution/sql/functions/comparison_functions.h
@@ -219,9 +219,9 @@ class EXPORT ComparisonFunctions {
   /**
    * Logical negation for SQL booleans
    */
-  static void NotBoolVal(terrier::execution::sql::BoolVal *result, terrier::execution::sql::BoolVal *input) {
-    *result = terrier::execution::sql::BoolVal(!input->val_);
-    result->is_null_ = input->is_null_;
+  static void NotBoolVal(BoolVal *result, const BoolVal &input) {
+    result->is_null_ = input.is_null_;
+    result->val_ = !input.val_;
   }
 
  private:

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -67,15 +67,13 @@ ALL_TYPES(COMPARISONS);
 
 VM_OP_HOT void OpNot(bool *const result, const bool input) { *result = !input; }
 
-VM_OP_HOT void OpNotSql(terrier::execution::sql::BoolVal* result,
-                        terrier::execution::sql::BoolVal* input) {
+VM_OP_HOT void OpNotSql(terrier::execution::sql::BoolVal *result, terrier::execution::sql::BoolVal *input) {
   if (input->is_null_) {
     *result = terrier::execution::sql::BoolVal::Null();
   } else {
     *result = terrier::execution::sql::BoolVal(!input->val_);
   }
 }
-
 
 // ---------------------------------------------------------
 // Primitive arithmetic

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -67,8 +67,8 @@ ALL_TYPES(COMPARISONS);
 
 VM_OP_HOT void OpNot(bool *const result, const bool input) { *result = !input; }
 
-VM_OP_HOT void OpNotSql(terrier::execution::sql::BoolVal *result, terrier::execution::sql::BoolVal *input) {
-  terrier::execution::sql::ComparisonFunctions::NotBoolVal(result, input);
+VM_OP_HOT void OpNotSql(terrier::execution::sql::BoolVal *const result, terrier::execution::sql::BoolVal *const input) {
+  terrier::execution::sql::ComparisonFunctions::NotBoolVal(result, *input);
 }
 
 // ---------------------------------------------------------

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -68,11 +68,7 @@ ALL_TYPES(COMPARISONS);
 VM_OP_HOT void OpNot(bool *const result, const bool input) { *result = !input; }
 
 VM_OP_HOT void OpNotSql(terrier::execution::sql::BoolVal *result, terrier::execution::sql::BoolVal *input) {
-  if (input->is_null_) {
-    *result = terrier::execution::sql::BoolVal::Null();
-  } else {
-    *result = terrier::execution::sql::BoolVal(!input->val_);
-  }
+  terrier::execution::sql::ComparisonFunctions::NotBoolVal(result, input);
 }
 
 // ---------------------------------------------------------

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -67,6 +67,16 @@ ALL_TYPES(COMPARISONS);
 
 VM_OP_HOT void OpNot(bool *const result, const bool input) { *result = !input; }
 
+VM_OP_HOT void OpNotSql(terrier::execution::sql::BoolVal* result,
+                        terrier::execution::sql::BoolVal* input) {
+  if (input->is_null_) {
+    *result = terrier::execution::sql::BoolVal::Null();
+  } else {
+    *result = terrier::execution::sql::BoolVal(!input->val_);
+  }
+}
+
+
 // ---------------------------------------------------------
 // Primitive arithmetic
 // ---------------------------------------------------------

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -67,7 +67,7 @@ ALL_TYPES(COMPARISONS);
 
 VM_OP_HOT void OpNot(bool *const result, const bool input) { *result = !input; }
 
-VM_OP_HOT void OpNotSql(terrier::execution::sql::BoolVal *const result, terrier::execution::sql::BoolVal *const input) {
+VM_OP_HOT void OpNotSql(terrier::execution::sql::BoolVal *const result, const terrier::execution::sql::BoolVal *input) {
   terrier::execution::sql::ComparisonFunctions::NotBoolVal(result, *input);
 }
 

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -66,6 +66,7 @@ namespace terrier::execution::vm {
   CREATE_FOR_ALL_TYPES(F, NotEqual, OperandType::Local, OperandType::Local, OperandType::Local)                       \
   /* Boolean complement */                                                                                            \
   F(Not, OperandType::Local, OperandType::Local)                                                                      \
+  F(NotSql, OperandType::Local, OperandType::Local)                                                                   \
                                                                                                                       \
   /* Branching */                                                                                                     \
   F(Jump, OperandType::JumpOffset)                                                                                    \


### PR DESCRIPTION
The NOT expression did not work in terrier, because the operator only accepted primitive booleans. These changes overload the NOT operator to also accept SQL booleans, which fixes the issue. 