### PR TITLE
fix oltpbench results folder conficts

### DIFF
--- a/script/testing/oltpbench/test_oltpbench.py
+++ b/script/testing/oltpbench/test_oltpbench.py
@@ -5,6 +5,7 @@ import subprocess
 import json
 import traceback
 import shutil
+import time
 from util.constants import ErrorCode
 from util.common import run_command
 from util.test_server import TestServer
@@ -41,14 +42,10 @@ class TestOLTPBench(TestServer):
         self.xml_template = os.path.join(constants.OLTP_DIR_CONFIG,
                                          "sample_{}".format(xml_file))
 
-        # for different testing results files, please use the unified filename
-        # when there are new attributes, please update the suffix
-        self.filename_suffix = "{BENCHMARK}_w{WEIGHTS}_s{SCALEFACTOR}_t{TERMINALS}_l{LOADERTHREAD}".format(
+        # for different testing, oltpbench needs different folder to put testing results 
+        self.filename_suffix = "{BENCHMARK}_{STARTTIME}".format(
             BENCHMARK=self.benchmark,
-            WEIGHTS=self.weights.replace(",", "_"),
-            SCALEFACTOR=str(self.scalefactor),
-            TERMINALS=self.terminals,
-            LOADERTHREAD=self.loader_threads)
+            STARTTIME=time.strftime("%Y%m%d-%H%M%S"))
 
         # base directory for the result files, default is in the 'oltp_result' folder under the current directory
         self.test_result_base_dir = self.args.get("test_result_dir")


### PR DESCRIPTION
The nightly Jenkins job [failed](http://jenkins.db.cs.cmu.edu:8080/blue/organizations/jenkins/terrier-nightly/detail/terrier-nightly/29/pipeline) because there is a conflict in oltpbench results folders. For each different testing, oltpbench needs different folders to put testing results.