### PR TITLE
Issue #1013: Fix Random Failure Bugs & Add More Debug Info

### DIFF
--- a/test/storage/export_table_test.cpp
+++ b/test/storage/export_table_test.cpp
@@ -83,6 +83,9 @@ struct ExportTableTest : public ::terrier::TerrierTest {
           end = true;
         }
         break;
+      case '\n':
+        end = true;
+        break;
       default:
         // Normal cases, we get a general ascii char.
         break;
@@ -90,7 +93,7 @@ struct ExportTableTest : public ::terrier::TerrierTest {
     return end;
   }
 
-  bool CheckContent(std::ifstream &csv_file, transaction::TransactionManager *txn_manager,
+  void CheckContent(std::ifstream &csv_file, transaction::TransactionManager *txn_manager,
                     const storage::BlockLayout &layout,
                     const std::unordered_map<storage::TupleSlot, storage::ProjectedRow *> &tuples,
                     const storage::DataTable &table, storage::RawBlock *block) {
@@ -117,7 +120,7 @@ struct ExportTableTest : public ::terrier::TerrierTest {
           csv_file.get(tmp_char);
           switch (tmp_char) {
             case '"':
-              // Current column is a utf-8 string delimited by "
+              // Current column is a utf-8 string delimited by " or a row with a single null value
               csv_file.seekg(1, std::ios_base::cur);
               while (!ParseNextChar(csv_file, '"', &tmp_char)) {
                 bytes.emplace_back(static_cast<byte>(tmp_char));
@@ -150,22 +153,21 @@ struct ExportTableTest : public ::terrier::TerrierTest {
           auto data = read_row->AccessWithNullCheck(j);
           if (data == nullptr) {
             // Expect null value
-            if (!bytes.empty() || integer.length() != 0) {
-              return false;
-            }
+            EXPECT_TRUE(bytes.empty() && integer.length() == 0)
+                << "Value of row " << i << " column " << j << " should be null.\n";
           } else {
             if (layout.IsVarlen(col_id)) {
               auto *varlen = reinterpret_cast<storage::VarlenEntry *>(data);
               auto content = varlen->Content();
               auto content_len = varlen->Size();
-              if (content_len != bytes.size() - 2) {
-                return false;
-              }
+              EXPECT_EQ(content_len, bytes.size() - 2)
+                  << "Value of row " << i << " column " << j << " should have length " << content_len << "\n";
+
               // the first and last element of bytes are always useless.
               for (int k = 0; k < static_cast<int>(content_len); ++k) {
-                if (bytes[k + 1] != content[k]) {
-                  return false;
-                }
+                EXPECT_EQ(bytes[k + 1], content[k])
+                    << "The " << k << "th char of row " << i << " column " << j << " should be "
+                    << static_cast<uint8_t>(content[k]) << " instead of " << static_cast<uint8_t>(bytes[k + 1]) << "\n";
               }
             } else {
               int64_t true_integer = 0;
@@ -186,9 +188,9 @@ struct ExportTableTest : public ::terrier::TerrierTest {
                 default:
                   throw NOT_IMPLEMENTED_EXCEPTION("Unsupported Attribute Size.");
               }
-              if (std::fabs(1 - (std::stof(integer) + 1e-6) / (true_integer + 1e-6)) > 1e-6) {
-                return false;
-              }
+              EXPECT_TRUE(std::fabs(1 - (std::stof(integer) + 1e-6) / (true_integer + 1e-6)) < 1e-6)
+                  << "Value of row " << i << " column " << j << " should be " << true_integer << " instead of "
+                  << integer << "\n";
             }
           }
         }
@@ -196,7 +198,6 @@ struct ExportTableTest : public ::terrier::TerrierTest {
     }
     txn_manager->Commit(txn, transaction::TransactionUtil::EmptyCallback, nullptr);
     delete[] buffer;
-    return true;
   }
 
   storage::BlockStore block_store_{5000, 5000};
@@ -213,9 +214,10 @@ TEST_F(ExportTableTest, ExportDictionaryCompressedTableTest) {
   std::ofstream outfile(PYSCRIPT_NAME, std::ios_base::out);
   outfile << PYSCRIPT;
   outfile.close();
-  generator_.seed(
+  auto seed_chosen =
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
-          .count());
+          .count();
+  generator_.seed(seed_chosen);
   storage::BlockLayout layout = StorageTestUtil::RandomLayoutWithVarlens(100, &generator_);
   storage::TupleAccessStrategy accessor(layout);
   // Technically, the block above is not "in" the table, but since we don't sequential scan that does not matter
@@ -265,10 +267,18 @@ TEST_F(ExportTableTest, ExportDictionaryCompressedTableTest) {
   EXPECT_EQ(system((std::string("python3 ") + PYSCRIPT_NAME).c_str()), 0);
 
   std::ifstream csv_file(CSV_TABLE_NAME, std::ios_base::in);
-  EXPECT_TRUE(CheckContent(csv_file, &txn_manager, layout, tuples, table, block));
+  CheckContent(csv_file, &txn_manager, layout, tuples, table, block);
   csv_file.close();
 
-  unlink(EXPORT_TABLE_NAME);
+  if (::testing::Test::HasFailure()) {
+    std::string error_csv_file_name(EXPORT_TABLE_NAME);
+    error_csv_file_name = error_csv_file_name + "_" + std::to_string(seed_chosen);
+    rename(EXPORT_TABLE_NAME, error_csv_file_name.c_str());
+    STORAGE_LOG_WARN("Error happened, see detailed exported data file {}. You may use the same seed suffix to debug.",
+                     error_csv_file_name);
+  } else {
+    unlink(EXPORT_TABLE_NAME);
+  }
   for (auto &entry : tuples) delete[] reinterpret_cast<byte *>(entry.second);  // reclaim memory used for bookkeeping
   gc.PerformGarbageCollection();
   gc.PerformGarbageCollection();  // Second call to deallocate
@@ -282,9 +292,10 @@ TEST_F(ExportTableTest, ExportVarlenTableTest) {
   std::ofstream outfile(PYSCRIPT_NAME, std::ios_base::out);
   outfile << PYSCRIPT;
   outfile.close();
-  generator_.seed(
+  auto seed_chosen =
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
-          .count());
+          .count();
+  generator_.seed(seed_chosen);
   storage::BlockLayout layout = StorageTestUtil::RandomLayoutWithVarlens(100, &generator_);
   storage::TupleAccessStrategy accessor(layout);
   // Technically, the block above is not "in" the table, but since we don't sequential scan that does not matter
@@ -334,10 +345,18 @@ TEST_F(ExportTableTest, ExportVarlenTableTest) {
   EXPECT_EQ(system((std::string("python3 ") + PYSCRIPT_NAME).c_str()), 0);
 
   std::ifstream csv_file(CSV_TABLE_NAME, std::ios_base::in);
-  EXPECT_TRUE(CheckContent(csv_file, &txn_manager, layout, tuples, table, block));
+  CheckContent(csv_file, &txn_manager, layout, tuples, table, block);
   csv_file.close();
 
-  unlink(EXPORT_TABLE_NAME);
+  if (::testing::Test::HasFailure()) {
+    std::string error_csv_file_name(EXPORT_TABLE_NAME);
+    error_csv_file_name = error_csv_file_name + "_" + std::to_string(seed_chosen);
+    rename(EXPORT_TABLE_NAME, error_csv_file_name.c_str());
+    STORAGE_LOG_WARN("Error happened, see detailed exported data file {}. You may use the same seed suffix to debug.",
+                     error_csv_file_name);
+  } else {
+    unlink(EXPORT_TABLE_NAME);
+  }
   for (auto &entry : tuples) delete[] reinterpret_cast<byte *>(entry.second);  // reclaim memory used for bookkeeping
   gc.PerformGarbageCollection();
   gc.PerformGarbageCollection();  // Second call to deallocate.


### PR DESCRIPTION
Issue #1013 raised two action items of export_table_test:

- Increase debugability;
- Fix potential bugs that caused random failures.

The first one was solved by:

1. Moving assertions into `CheckContent` so that we can distinguish different failure cases; 
2. Providing the location of mismatch data, i.e., which row and column has unexpected data; 
3. Reserving the seed and exported file if there are failures so that the failure can be reproduced.

The second item was solved by identifying a rare case where when a row only contains a single null value, it was exported as `""\n`. `\n` is its only delimiter but was not properly parsed before, so when such row was generated, the test would fail.

The new version of the test in this RB has been verified by repeating 3000 times without failures.