### PR TITLE
JUnit Trace File Testing Fixes/Cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,7 +318,7 @@ pipeline {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | ./script/installation/packages.sh all'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=debug -DTERRIER_USE_ASAN=ON -DTERRIER_USE_JEMALLOC=OFF -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) terrier'
+                        sh 'cd build && cmake -DCMAKE_BUILD_TYPE=debug -DTERRIER_USE_ASAN=ON -DTERRIER_USE_JEMALLOC=OFF .. && make -j$(nproc) terrier'
                         sh 'cd build && gtimeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=debug --scale-factor=0.01 --loader-threads=4'
                         sh 'cd build && gtimeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=debug --scale-factor=0.01 --loader-threads=4'
                         sh 'cd build && gtimeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py ycsb 50,5,15,10,10,10 --build-type=debug --scale-factor=0.01 --loader-threads=4'
@@ -343,7 +343,7 @@ pipeline {
                         sh 'echo $NODE_NAME'
                         sh 'echo y | sudo ./script/installation/packages.sh all'
                         sh 'mkdir build'
-                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=debug -DTERRIER_USE_ASAN=ON -DTERRIER_USE_JEMALLOC=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
+                        sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=debug -DTERRIER_USE_ASAN=ON -DTERRIER_USE_JEMALLOC=OFF .. && make -j$(nproc) terrier'
                         sh 'cd build && timeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=debug --scale-factor=0.01 --loader-threads=4'
                         sh 'cd build && timeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=debug --scale-factor=0.01 --loader-threads=4'
                         sh 'cd build && timeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py ycsb 50,5,15,10,10,10 --build-type=debug --scale-factor=0.01 --loader-threads=4'
@@ -365,7 +365,7 @@ pipeline {
                 sh 'echo $NODE_NAME'
                 sh 'echo y | sudo ./script/installation/packages.sh all'
                 sh 'mkdir build'
-                sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON -DTERRIER_BUILD_TESTS=OFF .. && make -j$(nproc) terrier'
+                sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_USE_JEMALLOC=ON .. && make -j$(nproc) terrier'
                 sh "cd build && python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=release --query-mode=extended \
                     --loader-threads=4 --client-time=60 --terminals=8"
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,8 +98,8 @@ pipeline {
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && gtimeout 1h make unittest'
                         sh 'cd build && gtimeout 1h make check-tpl'
-                        sh 'cd build && gtimeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug'
-                        sh 'cd build && gtimeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended'
+                        sh 'cd build && gtimeout 10m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple'
+                        sh 'cd build && gtimeout 10m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended'
                     }
                     post {
                         always {
@@ -127,8 +127,8 @@ pipeline {
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended'
                     }
                     post {
                         always {
@@ -158,8 +158,8 @@ pipeline {
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF -DTERRIER_GENERATE_COVERAGE=ON .. && make -j$(nproc)'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended'
                         sh 'cd build && lcov --directory . --capture --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'/usr/*\' --output-file coverage.info'
                         sh 'cd build && lcov --remove coverage.info \'*/build/*\' --output-file coverage.info'
@@ -203,8 +203,8 @@ pipeline {
                         sh 'cd build && make check-clang-tidy'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=simple'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=debug --query-mode=extended'
                     }
                     post {
                         always {
@@ -230,8 +230,8 @@ pipeline {
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j4'
                         sh 'cd build && gtimeout 1h make unittest'
                         sh 'cd build && gtimeout 1h make check-tpl'
-                        sh 'cd build && gtimeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release'
-                        sh 'cd build && gtimeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended'
+                        sh 'cd build && gtimeout 10m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple'
+                        sh 'cd build && gtimeout 10m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended'
                     }
                     post {
                         always {
@@ -258,8 +258,8 @@ pipeline {
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended'
                     }
                     post {
                         always {
@@ -290,8 +290,8 @@ pipeline {
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DTERRIER_USE_ASAN=OFF -DTERRIER_BUILD_BENCHMARKS=OFF .. && make -j$(nproc)'
                         sh 'cd build && timeout 1h make unittest'
                         sh 'cd build && timeout 1h make check-tpl'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release'
-                        sh 'cd build && timeout 20m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=simple'
+                        sh 'cd build && timeout 10m python3 ../script/testing/junit/run_junit.py --build-type=release --query-mode=extended'
                     }
                     post {
                         always {
@@ -319,12 +319,12 @@ pipeline {
                         sh 'echo y | ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_BUILD_TYPE=debug -DTERRIER_USE_ASAN=ON -DTERRIER_USE_JEMALLOC=OFF .. && make -j$(nproc) terrier'
-                        sh 'cd build && gtimeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=debug --scale-factor=0.01 --loader-threads=4'
-                        sh 'cd build && gtimeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=debug --scale-factor=0.01 --loader-threads=4'
-                        sh 'cd build && gtimeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py ycsb 50,5,15,10,10,10 --build-type=debug --scale-factor=0.01 --loader-threads=4'
-                        sh 'cd build && gtimeout 5m python3 ../script/testing/oltpbench/run_oltpbench.py noop 100 --build-type=debug'
+                        sh 'cd build && gtimeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=debug --query-mode=simple --scale-factor=0.01 --loader-threads=4'
+                        sh 'cd build && gtimeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=debug --query-mode=simple --scale-factor=0.01 --loader-threads=4'
+                        sh 'cd build && gtimeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py ycsb 50,5,15,10,10,10 --build-type=debug --query-mode=simple --scale-factor=0.01 --loader-threads=4'
+                        sh 'cd build && gtimeout 5m python3 ../script/testing/oltpbench/run_oltpbench.py noop 100 --build-type=debug --query-mode=simple'
                         // TODO: Need to fix OLTP-Bench's TPC-C to support scalefactor correctly
-                        // sh 'cd build && gtimeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tpcc 45,43,4,4,4 --build-type=debug --scale-factor=0.01 --loader-threads=4'
+                        // sh 'cd build && gtimeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tpcc 45,43,4,4,4 --build-type=debug --query-mode=simple --scale-factor=0.01 --loader-threads=4'
                     }
                     post {
                         cleanup {
@@ -344,12 +344,12 @@ pipeline {
                         sh 'echo y | sudo ./script/installation/packages.sh all'
                         sh 'mkdir build'
                         sh 'cd build && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=debug -DTERRIER_USE_ASAN=ON -DTERRIER_USE_JEMALLOC=OFF .. && make -j$(nproc) terrier'
-                        sh 'cd build && timeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=debug --scale-factor=0.01 --loader-threads=4'
-                        sh 'cd build && timeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=debug --scale-factor=0.01 --loader-threads=4'
-                        sh 'cd build && timeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py ycsb 50,5,15,10,10,10 --build-type=debug --scale-factor=0.01 --loader-threads=4'
-                        sh 'cd build && timeout 5m python3 ../script/testing/oltpbench/run_oltpbench.py noop 100 --build-type=debug'
+                        sh 'cd build && timeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py tatp 2,35,10,35,2,14,2 --build-type=debug --query-mode=simple --scale-factor=0.01 --loader-threads=4'
+                        sh 'cd build && timeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py smallbank 15,15,15,25,15,15 --build-type=debug --query-mode=simple --scale-factor=0.01 --loader-threads=4'
+                        sh 'cd build && timeout 10m python3 ../script/testing/oltpbench/run_oltpbench.py ycsb 50,5,15,10,10,10 --build-type=debug --query-mode=simple --scale-factor=0.01 --loader-threads=4'
+                        sh 'cd build && timeout 5m python3 ../script/testing/oltpbench/run_oltpbench.py noop 100 --build-type=debug --query-mode=simple'
                         // TODO: Need to fix OLTP-Bench's TPC-C to support scalefactor correctly
-                        // sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tpcc 45,43,4,4,4 --build-type=debug --scale-factor=0.01 --loader-threads=4'
+                        // sh 'cd build && timeout 1h python3 ../script/testing/oltpbench/run_oltpbench.py tpcc 45,43,4,4,4 --build-type=debug --query-mode=simple --scale-factor=0.01 --loader-threads=4'
                     }
                     post {
                         cleanup {

--- a/script/testing/junit/build.xml
+++ b/script/testing/junit/build.xml
@@ -31,9 +31,12 @@
   <path refid="lib.classpath"/>
   <pathelement location="${out.dir}" />
 </path>
+
 <target name="test-all">
+  <antcall target="test-unit"/>
   <antcall target="test-trace"/>
 </target>
+
 <target name="generate-trace" depends="compile">
   <java classname="GenerateTrace" fork="yes">
     <classpath>
@@ -46,7 +49,13 @@
     <arg value="${db-password}"></arg>
   </java>
 </target>
+
 <target name="test-trace" depends="compile">
+  <!--
+    IMPORTANT: You have to set the NOISEPAGE_TRACE_FILE environment variable
+    with the name of the file that you want to execute. You cannot pass it in
+    through the commandline.
+  -->
   <java jar="lib/junit-platform-console-standalone-1.1.0.jar"
         dir="."
         fork="yes"
@@ -58,6 +67,7 @@
     <arg value="TracefileTest" />
   </java>
 </target>
+
 <target name="test-unit" depends="compile">
   <java jar="lib/junit-platform-console-standalone-1.1.0.jar"
         dir="."
@@ -70,14 +80,6 @@
     <arg value="TracefileTest" />
   </java>
 </target>
-<target name="test" depends="compile">
-  <junit fork="yes" haltonfailure="false" logfailedtests="true">
-    <formatter type="plain" usefile="false" />
-    <classpath refid="test.classpath" />
-    <batchtest skipNonTests="true">
-      <fileset dir="${out.dir}" includes="*.class"/>
-    </batchtest>
-  </junit>
-</target>
+
 </project>
 

--- a/script/testing/junit/constants.py
+++ b/script/testing/junit/constants.py
@@ -4,11 +4,19 @@ from util.constants import DIR_TESTING
 
 # settings of TestJUnit
 JUNIT_TEST_DIR = os.path.join(DIR_TESTING, "junit")
-JUNIT_TEST_COMMAND = "ant test-all"
 JUNIT_TEST_ERROR_MSG = "Error: failed to complete junit test"
 JUNIT_OUTPUT_FILE = "/tmp/junit_log.txt"
 
+JUNIT_TEST_CMD_ALL = "ant test-all"
+JUNIT_TEST_CMD_JUNIT = "ant test-unit"
+JUNIT_TEST_CMD_TRACE = "ant test-trace"
+
 JUNIT_OPTION_DIR = os.path.join(JUNIT_TEST_DIR, "out")
 JUNIT_OPTION_XML = os.path.join(JUNIT_OPTION_DIR, "options.xml")
+
+TESTFILES_REPO = 'noisepage-testfiles'
+TESTFILES_REPO_URL = "https://github.com/cmu-db/%s.git" % (TESTFILES_REPO)
+TESTFILES_REPO_TRACE_DIR = "sql_trace"
+TESTFILES_PREFIX = "_output.test"
 
 DEFAULT_PREPARE_THRESHOLD = 5

--- a/script/testing/junit/constants.py
+++ b/script/testing/junit/constants.py
@@ -16,7 +16,7 @@ JUNIT_OPTION_XML = os.path.join(JUNIT_OPTION_DIR, "options.xml")
 
 TESTFILES_REPO = 'noisepage-testfiles'
 TESTFILES_REPO_URL = "https://github.com/cmu-db/%s.git" % (TESTFILES_REPO)
-TESTFILES_REPO_TRACE_DIR = "sql_trace"
-TESTFILES_PREFIX = "_output.test"
+TESTFILES_REPO_TRACE_DIR = "sql"
+TESTFILES_PREFIX = ".test"
 
 DEFAULT_PREPARE_THRESHOLD = 5

--- a/script/testing/junit/run_junit.py
+++ b/script/testing/junit/run_junit.py
@@ -1,11 +1,17 @@
+#!/usr/bin/env python3
+
 import os
 import sys
 import argparse
 import traceback
 import git
+import glob
 from git import Repo
+
 base_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, base_path)
+
+from junit import constants
 from junit.test_junit import TestJUnit
 
 def is_git_repo(path):
@@ -16,11 +22,11 @@ def is_git_repo(path):
         return False
 
 def download_git_repo():
-    noise_path = os.getcwd()+"/noisepage-testfiles"
-    if not os.path.isdir(noise_path):
-        os.mkdir(noise_path)
-    if not is_git_repo(noise_path):
-        repo = Repo.clone_from("https://github.com/cmu-db/noisepage-testfiles.git", noise_path)
+    trace_path = os.path.join(os.getcwd(), constants.TESTFILES_REPO)
+    if not os.path.isdir(trace_path):
+        os.mkdir(trace_path)
+    if not is_git_repo(trace_path):
+        repo = Repo.clone_from(constants.TESTFILES_REPO_URL, trace_path)
 
 if __name__ == "__main__":
 
@@ -41,40 +47,64 @@ if __name__ == "__main__":
                          type=int,
                          help="Threshold under the 'extened' query mode")
 
-    download_git_repo()
     args = vars(aparser.parse_args())
+    
+    
+    # HACK: We manually download the Git repo for the testfiles.
+    # This needs to be switched to using true Git submodules
+    download_git_repo()
+    
+    all_exit_codes = []
+    
+    # Step 1: Run the regular JUnit tests. 
     exit_code = 0
-    code = []
     try:
-        unit_command = TestJUnit(args)
-        unit_command.test_command = "ant test-unit"
-        exit_code = unit_command.run()
+        runner = TestJUnit(args)
+        runner.test_command = constants.JUNIT_TEST_CMD_JUNIT
+        exit_code = runner.run()
     except:
-        print("Exception trying to run test-unit")
+        print("Exception trying to run '%s'" % constants.JUNIT_TEST_CMD_JUNIT)
+        print("================ Python Error Output ==================")
+        traceback.print_exc(file=sys.stdout)
         exit_code = 1
-    code.append(exit_code)
-    noise_trace_dir = os.getcwd() + "/noisepage-testfiles/sql_trace/"
+    finally:
+        all_exit_codes.append(exit_code)
+    
+        
+    # Step 2: Run the trace test for each file that we find
+    # Each directory represents another set of SQL traces to test.
+    noise_trace_dir = os.path.join(os.getcwd(), constants.TESTFILES_REPO, constants.TESTFILES_REPO_TRACE_DIR)
     for test_type in os.listdir(noise_trace_dir):
-        type_dir = noise_trace_dir + test_type
-        if os.path.isdir(type_dir):
-            for file in os.listdir(type_dir):
-                if "output" in file:
-                    path = type_dir + "/" + file
-                    os.environ["path"] = path
-                    try:
-                        print(os.environ["path"])
-                        junit = TestJUnit(args)
-                        exit_code = junit.run()
-                        code.append(exit_code)
+        type_dir = os.path.join(noise_trace_dir, test_type)
+        if not os.path.isdir(type_dir): continue
 
-                    except:
-                        print("Exception trying to run junit tests")
-                        print("================ Python Error Output ==================")
-                        traceback.print_exc(file=sys.stdout)
-                        exit_code = 1
-                    print("="*80)
+        # Look for all of the .test files in the each directory
+        for file in glob.glob(os.path.join(type_dir, "*" + constants.TESTFILES_PREFIX)):
+            os.environ["NOISEPAGE_TRACE_FILE"] = os.path.join(type_dir, file)
+            print(os.environ["NOISEPAGE_TRACE_FILE"])
+            
+            exit_code = 0
+            try:
+                runner = TestJUnit(args)
+                runner.test_command = constants.JUNIT_TEST_CMD_TRACE
+                exit_code = runner.run()
+            except KeyboardInterrupt:
+                exit_code = 1
+                raise
+            except:
+                print("Exception trying to run '%s'" % constants.JUNIT_TEST_CMD_TRACE)
+                print("================ Python Error Output ==================")
+                traceback.print_exc(file=sys.stdout)
+                exit_code = 1
+            finally:
+                all_exit_codes.append(exit_code)
+            print("="*80)
+        ## FOR (files)
+    ## FOR (dirs)
+    
+    # Compute final exit code. If any test failed, then the entire program has to fail
     final_code = 0
-    for c in code:
+    for c in all_exit_codes:
         final_code = final_code or c
-    print("Final exit code: " + str(final_code))
     sys.exit(final_code)
+# MAIN

--- a/script/testing/junit/src/TracefileTest.java
+++ b/script/testing/junit/src/TracefileTest.java
@@ -33,7 +33,10 @@ public class TracefileTest {
     public void setUp() throws FileNotFoundException, SQLException {
         System.out.println("Working Directory = " + System.getProperty("user.dir"));
         conn = TestUtility.makeDefaultConnection();
-        String path = System.getenv("path");
+        String path = System.getenv("NOISEPAGE_TRACE_FILE");
+        if (path == null || path.isEmpty()) {
+            throw new RuntimeException("No 'trace-path' environment variable was specified");
+        }
         System.out.println("File name: " + path);
         file = new File(path);
         mog = new MogSqlite(file);

--- a/script/testing/junit/test_junit.py
+++ b/script/testing/junit/test_junit.py
@@ -10,7 +10,7 @@ class TestJUnit(TestServer):
     """
     def __init__(self, args):
         TestServer.__init__(self, args)
-        self.test_command = constants.JUNIT_TEST_COMMAND
+        self.test_command = constants.JUNIT_TEST_CMD_ALL
         self.test_command_cwd = constants.JUNIT_TEST_DIR
         self.test_error_msg = constants.JUNIT_TEST_ERROR_MSG
         self.test_output_file = self.args.get("test_output_file")

--- a/script/testing/util/constants.py
+++ b/script/testing/util/constants.py
@@ -18,9 +18,9 @@ DEFAULT_TEST_OUTPUT_FILE = "/tmp/terrier_test_{}.log".format(
     datetime.utcnow().isoformat(sep="-", timespec="seconds").replace(":", "-"))
 
 # Number of seconds to wait after starting the DBMS before trying to connect
-DB_START_WAIT = 2 # seconds
+DB_START_WAIT = 1 # seconds
 # Number of times we will try to start the DBMS and connect to it
-DB_START_ATTEMPTS = 3
+DB_START_ATTEMPTS = 2
 # For each start attempt, the number of times we will attempt to connect to the DBMS
 DB_CONNECT_ATTEMPTS = 50
 # How long to wait before each connection attempt

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -9,6 +9,8 @@
 #include "common/action_context.h"
 #include "common/managed_pointer.h"
 #include "metrics/metrics_thread.h"
+#include "network/postgres/postgres_command_factory.h"
+#include "network/postgres/postgres_protocol_interpreter.h"
 #include "network/terrier_server.h"
 #include "optimizer/statistics/stats_storage.h"
 #include "settings/settings_manager.h"

--- a/src/include/network/connection_handle.h
+++ b/src/include/network/connection_handle.h
@@ -25,10 +25,9 @@
 #include "network/connection_handler_task.h"
 #include "network/network_io_wrapper.h"
 #include "network/network_types.h"
-#include "network/postgres/postgres_command_factory.h"
-#include "network/postgres/postgres_protocol_interpreter.h"
 #include "network/protocol_interpreter.h"
 #include "traffic_cop/traffic_cop.h"
+
 namespace terrier::network {
 
 /**

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -10,6 +10,7 @@
 #include "common/settings.h"
 #include "gtest/gtest.h"
 #include "network/connection_handle_factory.h"
+#include "network/postgres/postgres_protocol_interpreter.h"
 #include "network/terrier_server.h"
 #include "spdlog/spdlog.h"
 #include "storage/garbage_collector.h"


### PR DESCRIPTION
This PR is focused on fixing up the junit tracefile testing code. I am going to rename the files in [noisepage-testfiles](https://github.com/cmu-db/noisepage-testfiles), but I want to make sure that this works first.

* Cleaned up tracefile testing Python code
* Moved Postgres-specific code out of ConnectionHandle
* Simplify Jenkinsfile and make sure we only build the server binary for end-to-end tests

When the build passes, I will rename the files in the separate repo and then push a commit.

https://youtu.be/GMMpzTw7WDA