### PR TITLE
macOS: Only use the LLVM-bundled clang for code generation

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -21,7 +21,13 @@ configure_file(
 # Find CLANG
 set(SUPPORTED_CLANGS "clang++-8" "clang++")
 
-find_program(CLANG NAMES ${SUPPORTED_CLANGS})
+# On macOS, the clang++ we want is not the clang++ in PATH. On Linux, it is.
+if (APPLE)
+    set(CLANG "${LLVM_TOOLS_BINARY_DIR}/clang++")
+else ()
+    find_program(CLANG NAMES ${SUPPORTED_CLANGS})
+endif ()
+
 if (NOT EXISTS ${CLANG})
     message(FATAL_ERROR "Unable to locate clang++.")
 else ()


### PR DESCRIPTION
This fix is included in #1017/#1026 but the scope continues to grow and I'd like this simple fix in. This resolves the error seen on latest AppleClang:
```
Reading input 'bytecode_handlers_ir.bc' ...
Parsing into LLVM Module ...
Error parsing bytecode handler bitcode file: Unknown attribute kind (60) (Producer: 'APPLE_1_1103.0.32.62_0' Reader: 'LLVM 8.0.1')
```
We only want to use the LLVM-bundled clang for code generation.