### PR TITLE
Avoid AppleClang on ASAN debug builds for macOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,6 +89,8 @@ pipeline {
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
                         LLVM_DIR="/usr/local/Cellar/llvm@8/8.0.1_1"
+                        CXX="/usr/local/Cellar/llvm@8/8.0.1_1/bin/clang++"
+                        CC="/usr/local/Cellar/llvm@8/8.0.1_1/bin/clang"
                     }
                     steps {
                         sh 'echo $NODE_NAME'
@@ -313,6 +315,8 @@ pipeline {
                     environment {
                         ASAN_OPTIONS="detect_container_overflow=0"
                         LLVM_DIR="/usr/local/Cellar/llvm@8/8.0.1_1"
+                        CXX="/usr/local/Cellar/llvm@8/8.0.1_1/bin/clang++"
+                        CC="/usr/local/Cellar/llvm@8/8.0.1_1/bin/clang"
                     }
                     steps {
                         sh 'echo $NODE_NAME'


### PR DESCRIPTION
Depending on how ccache is set up, this could be useless. This is just here for discussion and testing. Based on discussion with Matt on Slack (in #general, dated 07-24-2020) this may be able to serve as a temporary fix for the issues seen in #1029. 