### PR TITLE
Re-enable Microbenchmark Regression Checks

### DIFF
--- a/script/micro_bench/run_micro_bench.py
+++ b/script/micro_bench/run_micro_bench.py
@@ -116,7 +116,7 @@ class Config(object):
         # of sources. Stop if the history requirements are met.
         self.ref_data_sources = [
             {"project" : "terrier-nightly",
-             "min_build" : 363,
+             "min_build" : None, # 363,
             },
         ]
         return
@@ -329,6 +329,8 @@ class Build(object):
         # turn them into Artifact objects
         self.artifact_list = []
         for item in artifacts_lod:
+            # Make sure the filename ends with "_benchmark.json"
+            if not item["fileName"].endswith("_benchmark.json"): continue
             self.artifact_list.append(Artifact(build_url, item))
         return self.artifact_list
 

--- a/script/micro_bench/run_micro_bench.py
+++ b/script/micro_bench/run_micro_bench.py
@@ -50,7 +50,7 @@ JENKINS_URL = "http://jenkins.db.cs.cmu.edu:8080"
 LOCAL_REPO_DIR = os.path.realpath("local")
 
 # How many historical values are "required" before enforcing the threshold check
-MIN_REF_VALUES = 30
+MIN_REF_VALUES = 20
 
 # Default failure threshold
 # The regression threshold determines how much the benchmark is allowed to get


### PR DESCRIPTION
We moved the testing team's new nightly job on Jenkins to replace the old 'terrier-nightly'. This reset the build number. This caused a problem in the microbenchmark script because Pervaze had set it to ignore any data **before** 363. I also had to modify the code to ignore any artifact file that is not from the microbenchmarks (e.g., OLTP-Bench files). This fixes #1033.

https://youtu.be/FfIj2VOfg8s