### PR TITLE
compiled_query_execution command line arg

### DIFF
--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -618,8 +618,8 @@ class DBMain {
      * @param value use component
      * @return self reference for chaining
      */
-    Builder &SetExecutionMode(const execution::vm::ExecutionMode execution_mode) {
-      execution_mode_ = execution_mode;
+    Builder &SetExecutionMode(const execution::vm::ExecutionMode value) {
+      execution_mode_ = value;
       return *this;
     }
 

--- a/src/include/main/db_main.h
+++ b/src/include/main/db_main.h
@@ -351,7 +351,7 @@ class DBMain {
         TERRIER_ASSERT(use_execution_ && execution_layer != DISABLED, "TrafficCopLayer needs ExecutionLayer.");
         traffic_cop = std::make_unique<trafficcop::TrafficCop>(
             txn_layer->GetTransactionManager(), catalog_layer->GetCatalog(), DISABLED,
-            common::ManagedPointer(stats_storage), optimizer_timeout_, use_query_cache_);
+            common::ManagedPointer(stats_storage), optimizer_timeout_, use_query_cache_, execution_mode_);
       }
 
       std::unique_ptr<NetworkLayer> network_layer = DISABLED;
@@ -614,6 +614,15 @@ class DBMain {
       return *this;
     }
 
+    /**
+     * @param value use component
+     * @return self reference for chaining
+     */
+    Builder &SetExecutionMode(const execution::vm::ExecutionMode execution_mode) {
+      execution_mode_ = execution_mode;
+      return *this;
+    }
+
    private:
     std::unordered_map<settings::Param, settings::ParamInfo> param_map_;
 
@@ -651,6 +660,7 @@ class DBMain {
     bool use_traffic_cop_ = false;
     uint64_t optimizer_timeout_ = 5000;
     bool use_query_cache_ = true;
+    execution::vm::ExecutionMode execution_mode_ = execution::vm::ExecutionMode::Interpret;
     uint16_t network_port_ = 15721;
     uint16_t connection_thread_count_ = 4;
     bool use_network_ = false;
@@ -691,6 +701,10 @@ class DBMain {
           static_cast<uint16_t>(settings_manager->GetInt(settings::Param::connection_thread_count));
       optimizer_timeout_ = static_cast<uint64_t>(settings_manager->GetInt(settings::Param::task_execution_timeout));
       use_query_cache_ = settings_manager->GetBool(settings::Param::use_query_cache);
+
+      execution_mode_ = settings_manager->GetBool(settings::Param::compiled_query_execution)
+                            ? execution::vm::ExecutionMode::Compiled
+                            : execution::vm::ExecutionMode::Interpret;
 
       metrics_pipeline_ = settings_manager->GetBool(settings::Param::metrics_pipeline);
       metrics_transaction_ = settings_manager->GetBool(settings::Param::metrics_transaction);

--- a/src/include/settings/settings_defs.h
+++ b/src/include/settings/settings_defs.h
@@ -225,3 +225,11 @@ SETTING_bool(
     false,
     terrier::settings::Callbacks::NoOp
 )
+
+SETTING_bool(
+    compiled_query_execution,
+    "Compile queries to native machine code using LLVM, rather than relying on TPL interpretation (default: false).",
+    false,
+    false,
+    terrier::settings::Callbacks::NoOp
+)

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -7,6 +7,7 @@
 
 #include "catalog/catalog_defs.h"
 #include "common/managed_pointer.h"
+#include "execution/vm/vm_defs.h"
 #include "network/network_defs.h"
 #include "traffic_cop/traffic_cop_defs.h"
 
@@ -66,18 +67,20 @@ class TrafficCop {
    * @param stats_storage for optimizer calls
    * @param optimizer_timeout for optimizer calls
    * @param use_query_cache whether to cache physical plans and generated code for Extended Query protocol
+   * @param execution_mode how to run executable queries after code generation
    */
   TrafficCop(common::ManagedPointer<transaction::TransactionManager> txn_manager,
              common::ManagedPointer<catalog::Catalog> catalog,
              common::ManagedPointer<storage::ReplicationLogProvider> replication_log_provider,
              common::ManagedPointer<optimizer::StatsStorage> stats_storage, uint64_t optimizer_timeout,
-             bool use_query_cache)
+             bool use_query_cache, const execution::vm::ExecutionMode execution_mode)
       : txn_manager_(txn_manager),
         catalog_(catalog),
         replication_log_provider_(replication_log_provider),
         stats_storage_(stats_storage),
         optimizer_timeout_(optimizer_timeout),
-        use_query_cache_(use_query_cache) {}
+        use_query_cache_(use_query_cache),
+        execution_mode_(execution_mode) {}
 
   virtual ~TrafficCop() = default;
 
@@ -221,7 +224,8 @@ class TrafficCop {
   common::ManagedPointer<storage::ReplicationLogProvider> replication_log_provider_;
   common::ManagedPointer<optimizer::StatsStorage> stats_storage_;
   uint64_t optimizer_timeout_;
-  bool use_query_cache_;
+  const bool use_query_cache_;
+  const execution::vm::ExecutionMode execution_mode_;
 };
 
 }  // namespace terrier::trafficcop

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -357,7 +357,7 @@ TrafficCopResult TrafficCop::RunExecutableQuery(const common::ManagedPointer<net
 
   const auto exec_query = portal->GetStatement()->GetExecutableQuery();
 
-  exec_query->Run(common::ManagedPointer(exec_ctx), execution::vm::ExecutionMode::Interpret);
+  exec_query->Run(common::ManagedPointer(exec_ctx), execution_mode_);
 
   if (connection_ctx->TransactionState() == network::NetworkTransactionStateType::BLOCK) {
     // Execution didn't set us to FAIL state, go ahead and return command complete

--- a/test/network/network_test.cpp
+++ b/test/network/network_test.cpp
@@ -71,7 +71,7 @@ class NetworkTests : public TerrierTest {
                                     common::ManagedPointer(gc_));
 
     tcop_ = new trafficcop::TrafficCop(common::ManagedPointer(txn_manager_), common::ManagedPointer(catalog_), DISABLED,
-                                       DISABLED, 0, false);
+                                       DISABLED, 0, false, execution::vm::ExecutionMode::Interpret);
 
     auto txn = txn_manager_->BeginTransaction();
     catalog_->CreateDatabase(common::ManagedPointer(txn), catalog::DEFAULT_DATABASE, true);


### PR DESCRIPTION
Add `compiled_query_execution` boolean arg to enable LLVM compilation instead of TPL interpretation. Default is to interpret. Currently doesn't allow for enabling adaptive mode since that doesn't work anyway on short queries due to object life cycle issues.