### PR TITLE
Hackathon log2

### DIFF
--- a/script/testing/junit/traces/functions.test
+++ b/script/testing/junit/traces/functions.test
@@ -41,12 +41,12 @@ SELECT tan(double_val) AS result FROM functions1 WHERE is_null = 1
 1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
 
 query I nosort
-SELECT log2(double_val) AS result FROM data WHERE is_null = 0
+SELECT log2(double_val) AS result FROM functions1 WHERE is_null = 0
 ----
 1 values hashing to 79fbd1dc909b6c5a233897815e27b6c9
 
 query I nosort
-SELECT log2(double_val) AS result FROM data WHERE is_null = 1
+SELECT log2(double_val) AS result FROM functions1 WHERE is_null = 1
 ----
 1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
 

--- a/script/testing/junit/traces/functions.test
+++ b/script/testing/junit/traces/functions.test
@@ -41,6 +41,16 @@ SELECT tan(double_val) AS result FROM functions1 WHERE is_null = 1
 1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
 
 query I nosort
+SELECT log2(double_val) AS result FROM data WHERE is_null = 0
+----
+1 values hashing to 79fbd1dc909b6c5a233897815e27b6c9
+
+query I nosort
+SELECT log2(double_val) AS result FROM data WHERE is_null = 1
+----
+1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
+
+query I nosort
 SELECT lower(str_a_val) AS result FROM functions1 WHERE is_null = 0
 ----
 1 values hashing to 5ab557c937e38f15291c04b7e99544ad

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1778,6 +1778,9 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   // cot
   BOOTSTRAP_TRIG_FN("cot", postgres::COT_PRO_OID, execution::ast::Builtin::Cot)
 
+  // log2
+  BOOTSTRAP_TRIG_FN("log2", postgres::LOG2_PRO_OID, execution::ast::Builtin::Log2)
+
 #undef BOOTSTRAP_TRIG_FN
 
   auto str_type = GetTypeOidForType(type::TypeId::VARCHAR);
@@ -1848,6 +1851,10 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
 
   // cot
   BOOTSTRAP_TRIG_FN("cot", postgres::COT_PRO_OID, execution::ast::Builtin::Cot)
+
+  // log2
+  BOOTSTRAP_TRIG_FN("log2", postgres::LOG2_PRO_OID, execution::ast::Builtin::Log2)
+
 #undef BOOTSTRAP_TRIG_FN
 
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -1468,7 +1468,8 @@ void Sema::CheckMathTrigCall(ast::CallExpr *call, ast::Builtin builtin) {
     case ast::Builtin::Tan:
     case ast::Builtin::ACos:
     case ast::Builtin::ASin:
-    case ast::Builtin::ATan: {
+    case ast::Builtin::ATan:
+    case ast::Builtin::Log2: {
       if (!CheckArgCount(call, 1)) {
         return;
       }
@@ -2827,7 +2828,8 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     case ast::Builtin::Cos:
     case ast::Builtin::Cot:
     case ast::Builtin::Sin:
-    case ast::Builtin::Tan: {
+    case ast::Builtin::Tan:
+    case ast::Builtin::Log2: {
       CheckMathTrigCall(call, builtin);
       break;
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1654,6 +1654,10 @@ void BytecodeGenerator::VisitBuiltinTrigCall(ast::CallExpr *call, ast::Builtin b
       GetEmitter()->Emit(Bytecode::Tan, dest, src);
       break;
     }
+    case ast::Builtin::Log2: {
+      Emitter()->Emit(Bytecode::Log2, dest, src);
+      break;
+    }
     default: {
       UNREACHABLE("Impossible trigonometric bytecode");
     }
@@ -2358,6 +2362,10 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     case ast::Builtin::Cot:
     case ast::Builtin::Sin:
     case ast::Builtin::Tan: {
+      VisitBuiltinTrigCall(call, builtin);
+      break;
+    }
+    case ast::Builtin::Log2: {
       VisitBuiltinTrigCall(call, builtin);
       break;
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1655,7 +1655,7 @@ void BytecodeGenerator::VisitBuiltinTrigCall(ast::CallExpr *call, ast::Builtin b
       break;
     }
     case ast::Builtin::Log2: {
-      Emitter()->Emit(Bytecode::Log2, dest, src);
+      GetEmitter()->Emit(Bytecode::Log2, dest, src);
       break;
     }
     default: {

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -73,6 +73,7 @@ constexpr proc_oid_t TAN_PRO_OID = proc_oid_t(90);
 constexpr proc_oid_t COT_PRO_OID = proc_oid_t(91);
 constexpr proc_oid_t LOWER_PRO_OID = proc_oid_t(92);
 constexpr proc_oid_t UPPER_PRO_OID = proc_oid_t(93);
+constexpr proc_oid_t LOG2_PRO_OID = proc_oid_t(133);
 constexpr proc_oid_t VERSION_PRO_OID = proc_oid_t(150);
 
 constexpr proc_oid_t NP_RUNNERS_EMIT_INT_PRO_OID = proc_oid_t(94);

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -264,6 +264,7 @@ namespace terrier::execution::ast {
   F(Cot, cot)                                                           \
   F(Sin, sin)                                                           \
   F(Tan, tan)                                                           \
+  F(Log2, log2)                                                         \
                                                                         \
   /* Generic */                                                         \
   F(SizeOf, sizeOf)                                                     \


### PR DESCRIPTION
This PR was created by cherry picking this commit: https://github.com/apavlo/terrier/commit/5fdc3d8fcb4a2607df2fa0bcd52fa5c00fccdfd0 and applying some manual updates.

The original PR can be found here: https://github.com/apavlo/terrier/pull/5

Works towards resolving #1001 

A couple of notes about this PR:
- This will likely have some minor merge conflicts with https://github.com/cmu-db/terrier/pull/1078, I will resolve as we merge
- As far as I can tell postgres doesn't have a `log2` function, the closest I could find was `log(base, x)`
- Because of some precision issues the results of the test trace from terrier is off by one in the least significant digit from the results from postgres