### PR TITLE
Increase microbenchmark lax_tolerance from 30 to 50.

### DIFF
--- a/script/micro_bench/run_micro_bench.py
+++ b/script/micro_bench/run_micro_bench.py
@@ -108,7 +108,7 @@ class Config(object):
         self.benchmarks = BENCHMARKS_TO_RUN
 
         # if fewer than min_ref_values are available
-        self.lax_tolerance = 30
+        self.lax_tolerance = 50
 
         # minimum run time for the benchmark, seconds
         self.min_time = 10


### PR DESCRIPTION
Suggested by @apavlo. The microbenchmarks are noisy and we end up merging a lot of stuff that fails that stage. Does anyone have objections?