### PR TITLE
Fix AdaptiveCheckTest in sql_filter_manager_test.cpp

### DIFF
--- a/test/execution/sql_filter_manager_test.cpp
+++ b/test/execution/sql_filter_manager_test.cpp
@@ -135,30 +135,25 @@ TEST_F(FilterManagerTest, MixedTaatVaatFilterTest) {
 }
 
 // NOLINTNEXTLINE
-#if __APPLE__
-TEST_F(FilterManagerTest, DISABLED_AdaptiveCheckTest) {
-  // TODO(WAN): For some reason, the adaptivity fails for AppleClang-1001.0.46.4 sometimes.
-#else
 TEST_F(FilterManagerTest, AdaptiveCheckTest) {
-#endif
   auto exec_ctx = MakeExecCtx();
   uint32_t iter = 0;
 
-  // Create a filter that implements: colA < 500 AND colB < 9
+  // Create a filter that implements: colA < 500 AND colB < 7
   FilterManager filter(exec_ctx->GetExecutionSettings(), true, &iter);
   filter.StartNewClause();
   filter.InsertClauseTerms(
       {[](auto exec_ctx, auto vp, auto tids, auto ctx) {
          auto *r = reinterpret_cast<uint32_t *>(ctx);
-         if (*r < 100) std::this_thread::sleep_for(1us);  // Fake a sleep.
+         if (*r < 1000) std::this_thread::sleep_for(250us);  // Fake a sleep.
          const auto val = GenericValue::CreateInteger(500);
          VectorFilterExecutor::SelectLessThanVal(
              reinterpret_cast<exec::ExecutionContext *>(exec_ctx)->GetExecutionSettings(), vp, Col::A, val, tids);
        },
        [](auto exec_ctx, auto vp, auto tids, auto ctx) {
          auto *r = reinterpret_cast<uint32_t *>(ctx);
-         if (*r > 100) std::this_thread::sleep_for(1us);  // Fake a sleep.
-         const auto val = GenericValue::CreateInteger(9);
+         if (*r >= 1000) std::this_thread::sleep_for(250us);  // Fake a sleep.
+         const auto val = GenericValue::CreateInteger(7);
          VectorFilterExecutor::SelectLessThanVal(
              reinterpret_cast<exec::ExecutionContext *>(exec_ctx)->GetExecutionSettings(), vp, Col::B, val, tids);
        }});
@@ -171,7 +166,7 @@ TEST_F(FilterManagerTest, AdaptiveCheckTest) {
   VectorOps::Generate(vp.GetColumn(Col::B), 0, 1);
 
   for (uint32_t run = 0; run < 2; run++) {
-    for (uint32_t i = 0; i < 100; i++, iter++) {
+    for (uint32_t i = 0; i < 1000; i++, iter++) {
       // Remove any lingering filter.
       vp.Reset(common::Constants::K_DEFAULT_VECTOR_SIZE);
       // Create an iterator and filter it.


### PR DESCRIPTION
Noise is apparently massive in some situations, which can cause spurious test failures. As a result, we disable this test on Apple machines and get false positives on others. However, steps can be taken to decrease the noise and increase the signal for this test, such that false positives are exceedingly unlikely.

To do so, this commit increases the average number of samples taken and dramatically increasing the overhead of the "slow" filters, respectively. For added effect, we exaggerate selectivity differences as well. This is mostly apparent in execution traces.


This _should_ (we have to wait for Jenkins results) fix the test failures noted by Wan, which would allow this test to be ran on Apple machines. It would also fix some spurious test failures that I've encountered.