### PR TITLE
Hackathon string1

### DIFF
--- a/script/testing/junit/traces/functions.test
+++ b/script/testing/junit/traces/functions.test
@@ -71,6 +71,16 @@ SELECT tanh(double_val) AS result FROM functions1 WHERE is_null = 1
 1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
 
 query I nosort
+SELECT exp(double_val) AS result FROM functions1 WHERE is_null = 0
+----
+1 values hashing to 73eeec3b16d21b9f2c49fc66bb912349
+
+query I nosort
+SELECT exp(double_val) AS result FROM functions1 WHERE is_null = 1
+----
+1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
+
+query I nosort
 SELECT lower(str_a_val) AS result FROM functions1 WHERE is_null = 0
 ----
 1 values hashing to 5ab557c937e38f15291c04b7e99544ad
@@ -87,6 +97,36 @@ SELECT position('C' in str_a_val) AS result FROM functions1 WHERE is_null = 0
 
 query I nosort
 SELECT position('C' in str_a_val) AS result FROM functions1 WHERE is_null = 1
+----
+1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
+
+query I nosort
+SELECT ascii(str_a_val) AS result FROM functions1 WHERE is_null = 0
+----
+1 values hashing to 767abe6119a018446bcd7627ff8a4f2d
+
+query I nosort
+SELECT ascii(str_a_val) AS result FROM functions1 WHERE is_null = 1
+----
+1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
+
+query I nosort
+SELECT chr(int_val) AS result FROM functions1 WHERE is_null = 0
+----
+1 values hashing to d9bed3b7e151f11b8fdadf75f1db96d9
+
+query I nosort
+SELECT chr(int_val) AS result FROM functions1 WHERE is_null = 1
+----
+1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
+
+query I nosort
+SELECT char_length(str_a_val) AS result FROM functions1 WHERE is_null = 0
+----
+1 values hashing to 9ae0ea9e3c9c6e1b9b6252c8395efdc1
+
+query I nosort
+SELECT char_length(str_a_val) AS result FROM functions1 WHERE is_null = 1
 ----
 1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
 

--- a/script/testing/junit/traces/functions.test
+++ b/script/testing/junit/traces/functions.test
@@ -50,5 +50,15 @@ SELECT lower(str_a_val) AS result FROM functions1 WHERE is_null = 1
 ----
 1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
 
+query I nosort
+SELECT position('C' in str_a_val) AS result FROM functions1 WHERE is_null = 0
+----
+1 values hashing to 6d7fce9fee471194aa8b5b6e47267f03
+
+query I nosort
+SELECT position('C' in str_a_val) AS result FROM functions1 WHERE is_null = 1
+----
+1 values hashing to 68b329da9893e34099c7d8ad5cb9c940
+
 statement ok
 DROP TABLE functions1

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1814,6 +1814,10 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   CreateProcedure(txn, postgres::NP_RUNNERS_DUMMY_REAL_PRO_OID, "nprunnersdummyreal", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {}, {}, {}, {}, real_type, "", false);
 
+    // ascii
+  CreateProcedure(txn, postgres::ASCII_PRO_OID, "ascii", postgres::INTERNAL_LANGUAGE_OID,
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, int_type, "", true);
+
   // lower
   CreateProcedure(txn, postgres::LOWER_PRO_OID, "lower", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, str_type, "", true);
@@ -1879,6 +1883,13 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   BOOTSTRAP_TRIG_FN("cot", postgres::COT_PRO_OID, execution::ast::Builtin::Cot)
 #undef BOOTSTRAP_TRIG_FN
 
+  // ascii
+  func_context = new execution::functions::FunctionContext("ascii", type::TypeId::INTEGER, {type::TypeId::VARCHAR},
+                                                           execution::ast::Builtin::ASCII, true);
+  SetProcCtxPtr(txn, postgres::ASCII_PRO_OID, func_context);
+  txn->RegisterAbortAction([=]() { delete func_context; });
+
+  // lower
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::Lower, true);
   SetProcCtxPtr(txn, postgres::LOWER_PRO_OID, func_context);

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1813,6 +1813,11 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {}, {}, {}, {}, str_type, "", false);
   // TODO(tanujnay112): no op codes for lower and upper yet
 
+  // position
+  CreateProcedure(txn, postgres::POSITION_PRO_OID, "position", postgres::INTERNAL_LANGUAGE_OID,
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str1", "str2"}, {str_type, str_type},
+                  {str_type, str_type}, {}, int_type, "", true);
+
   BootstrapProcContexts(txn);
 }
 
@@ -1853,6 +1858,12 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   func_context = new execution::functions::FunctionContext("lower", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::Lower, true);
   SetProcCtxPtr(txn, postgres::LOWER_PRO_OID, func_context);
+
+  func_context = new execution::functions::FunctionContext("position", type::TypeId::INTEGER,
+                                                           {type::TypeId::VARCHAR, type::TypeId::VARCHAR},
+                                                           execution::ast::Builtin::Position, true);
+  SetProcCtxPtr(txn, postgres::POSITION_PRO_OID, func_context);
+
   txn->RegisterAbortAction([=]() { delete func_context; });
 
   func_context = new execution::functions::FunctionContext("version", type::TypeId::VARCHAR, {},

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1821,7 +1821,6 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   CreateProcedure(txn, postgres::ASCII_PRO_OID, "ascii", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, int_type, "", true);
 
-  auto int_type = GetTypeOidForType(type::TypeId::INTEGER);
   // Chr
   CreateProcedure(txn, postgres::CHR_PRO_OID, "chr", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"num"}, {int_type}, {int_type}, {}, str_type, "", true);

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1859,6 +1859,8 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
                                                            execution::ast::Builtin::Lower, true);
   SetProcCtxPtr(txn, postgres::LOWER_PRO_OID, func_context);
 
+  txn->RegisterAbortAction([=]() { delete func_context; });
+
   func_context = new execution::functions::FunctionContext("position", type::TypeId::INTEGER,
                                                            {type::TypeId::VARCHAR, type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::Position, true);

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1821,12 +1821,13 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   CreateProcedure(txn, postgres::ASCII_PRO_OID, "ascii", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, int_type, "", true);
 
+  auto int_type = GetTypeOidForType(type::TypeId::INTEGER);
   // Chr
   CreateProcedure(txn, postgres::CHR_PRO_OID, "chr", postgres::INTERNAL_LANGUAGE_OID,
-                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"num"}, {dec_type}, {dec_type}, {}, str_type, "", true);
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"num"}, {int_type}, {int_type}, {}, str_type, "", true);
   // CharLength
   CreateProcedure(txn, postgres::CHARLENGTH_PRO_OID, "char_length", postgres::INTERNAL_LANGUAGE_OID,
-                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, dec_type, "", true);
+                  postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, int_type, "", true);
 
   // lower
   CreateProcedure(txn, postgres::LOWER_PRO_OID, "lower", postgres::INTERNAL_LANGUAGE_OID,
@@ -1911,12 +1912,12 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
 
   txn->RegisterAbortAction([=]() { delete func_context; });
 
-  func_context = new execution::functions::FunctionContext("chr", type::TypeId::INTEGER, {type::TypeId::INTEGER},
+  func_context = new execution::functions::FunctionContext("chr", type::TypeId::VARCHAR, {type::TypeId::INTEGER},
                                                            execution::ast::Builtin::Chr, true);
   SetProcCtxPtr(txn, postgres::CHR_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 
-  func_context = new execution::functions::FunctionContext("char_length", type::TypeId::VARCHAR, {type::TypeId::VARCHAR},
+  func_context = new execution::functions::FunctionContext("char_length", type::TypeId::INTEGER, {type::TypeId::VARCHAR},
                                                            execution::ast::Builtin::CharLength, true);
   SetProcCtxPtr(txn, postgres::CHARLENGTH_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1817,7 +1817,7 @@ void DatabaseCatalog::BootstrapProcs(const common::ManagedPointer<transaction::T
   CreateProcedure(txn, postgres::NP_RUNNERS_DUMMY_REAL_PRO_OID, "nprunnersdummyreal", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {}, {}, {}, {}, real_type, "", false);
 
-    // ascii
+  // ascii
   CreateProcedure(txn, postgres::ASCII_PRO_OID, "ascii", postgres::INTERNAL_LANGUAGE_OID,
                   postgres::NAMESPACE_DEFAULT_NAMESPACE_OID, {"str"}, {str_type}, {str_type}, {}, int_type, "", true);
 
@@ -1916,8 +1916,8 @@ void DatabaseCatalog::BootstrapProcContexts(const common::ManagedPointer<transac
   SetProcCtxPtr(txn, postgres::CHR_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 
-  func_context = new execution::functions::FunctionContext("char_length", type::TypeId::INTEGER, {type::TypeId::VARCHAR},
-                                                           execution::ast::Builtin::CharLength, true);
+  func_context = new execution::functions::FunctionContext(
+      "char_length", type::TypeId::INTEGER, {type::TypeId::VARCHAR}, execution::ast::Builtin::CharLength, true);
   SetProcCtxPtr(txn, postgres::CHARLENGTH_PRO_OID, func_context);
   txn->RegisterAbortAction([=]() { delete func_context; });
 

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2390,6 +2390,33 @@ void Sema::CheckBuiltinParamCall(ast::CallExpr *call, ast::Builtin builtin) {
 void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
   ast::BuiltinType::Kind sql_type;
   switch (builtin) {
+    case ast::Builtin::ASCII: {
+      // check to make sure this function has two arguments
+      if (!CheckArgCount(call, 2)) {
+        return;
+      }
+
+      // checking to see if the first argument is an execution context
+      auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
+      if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
+        ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
+        return;
+      }
+
+      // checking to see if the second argument is a string
+      auto *resolved_type = Resolve(call->Arguments()[1]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+        ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
+        return;
+      }
+
+      // this function returns an Integer (an ASCII value)
+      sql_type = ast::BuiltinType::Integer;
+      break;
+    }
     case ast::Builtin::Lower: {
       // check to make sure this function has two arguments
       if (!CheckArgCount(call, 2)) {
@@ -2907,6 +2934,7 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
       CheckBuiltinParamCall(call, builtin);
       break;
     }
+    case ast::Builtin::ASCII:
     case ast::Builtin::Lower:
     case ast::Builtin::Version: {
       CheckBuiltinStringCall(call, builtin);

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2425,7 +2425,6 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
 
       // this function returns a string
       sql_type = ast::BuiltinType::StringVal;
-      call->SetType(ast::BuiltinType::Get(GetContext(), sql_type));
       break;
 
     }
@@ -2455,7 +2454,6 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
 
       // this function returns a string
       sql_type = ast::BuiltinType::Integer;
-      call->SetType(ast::BuiltinType::Get(GetContext(), sql_type));
       break;
     }
     case ast::Builtin::ASCII: {
@@ -2510,7 +2508,6 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
 
       // this function returns a string
       sql_type = ast::BuiltinType::StringVal;
-      call->SetType(ast::BuiltinType::Get(GetContext(), sql_type));
       break;
     }
     case ast::Builtin::Version: {
@@ -2570,7 +2567,7 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
     default:
       UNREACHABLE("Unimplemented string call!!");
   }
-
+  call->SetType(ast::BuiltinType::Get(GetContext(), sql_type));
 }
 
 void Sema::CheckBuiltinTestCatalogLookup(ast::CallExpr *call) {

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -1467,7 +1467,16 @@ void Sema::CheckMathTrigCall(ast::CallExpr *call, ast::Builtin builtin) {
       }
       break;
     }
-    case ast::Builtin::Exp:
+    case ast::Builtin::Exp: {
+      if (!CheckArgCount(call, 2)) {
+        return;
+      }
+      if (!call_args[1]->GetType()->IsSpecificBuiltin(real_kind)) {
+        ReportIncorrectCallArg(call, 0, GetBuiltinType(real_kind));
+        return;
+      }
+      break;
+    }
     case ast::Builtin::Cos:
     case ast::Builtin::Cot:
     case ast::Builtin::Sin:

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2426,6 +2426,43 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
       sql_type = ast::BuiltinType::StringVal;
       break;
     }
+    case ast::Builtin::Position: {
+      // check to make sure this function has three arguments
+      if (!CheckArgCount(call, 3)) {
+        return;
+      }
+
+      // checking to see if the first argument is an execution context
+      auto exec_ctx_kind = ast::BuiltinType::ExecutionContext;
+      if (!IsPointerToSpecificBuiltin(call->Arguments()[0]->GetType(), exec_ctx_kind)) {
+        ReportIncorrectCallArg(call, 0, GetBuiltinType(exec_ctx_kind)->PointerTo());
+        return;
+      }
+
+      // checking to see if the second argument is a string
+      auto *resolved_type = Resolve(call->Arguments()[1]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+        ReportIncorrectCallArg(call, 1, ast::StringType::Get(GetContext()));
+        return;
+      }
+
+      // checking to see if the third argument is a string
+      resolved_type = Resolve(call->Arguments()[2]);
+      if (resolved_type == nullptr) {
+        return;
+      }
+      if (!resolved_type->IsSpecificBuiltin(ast::BuiltinType::StringVal)) {
+        ReportIncorrectCallArg(call, 2, ast::StringType::Get(GetContext()));
+        return;
+      }
+
+      // this function returns a string
+      sql_type = ast::BuiltinType::Integer;
+      break;
+    }
     default:
       UNREACHABLE("Unimplemented string call!!");
   }
@@ -2861,6 +2898,10 @@ void Sema::CheckBuiltinCall(ast::CallExpr *call) {
     }
     case ast::Builtin::Lower:
     case ast::Builtin::Version: {
+      CheckBuiltinStringCall(call, builtin);
+      break;
+    }
+    case ast::Builtin::Position: {
       CheckBuiltinStringCall(call, builtin);
       break;
     }

--- a/src/execution/sema/sema_builtin.cpp
+++ b/src/execution/sema/sema_builtin.cpp
@@ -2402,7 +2402,7 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
   switch (builtin) {
     case ast::Builtin::Chr: {
       // check to make sure this function has two arguments
-      if(!CheckArgCount(call, 2)) {
+      if (!CheckArgCount(call, 2)) {
         return;
       }
 
@@ -2426,12 +2426,11 @@ void Sema::CheckBuiltinStringCall(ast::CallExpr *call, ast::Builtin builtin) {
       // this function returns a string
       sql_type = ast::BuiltinType::StringVal;
       break;
-
     }
 
     case ast::Builtin::CharLength: {
       // check to make sure this function has two arguments
-      if(!CheckArgCount(call, 2)) {
+      if (!CheckArgCount(call, 2)) {
         return;
       }
 

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -386,7 +386,7 @@ void StringFunctions::Position(exec::ExecutionContext *ctx, Integer *pos, const 
                   search_sub_str_view.end(), [](char ch1, char ch2) { return std::toupper(ch1) == std::toupper(ch2); });
   auto found = (it - search_str_view.begin());
 
-  if (found == search_str_view.length()) {
+  if (static_cast<size_t>(found) == search_str_view.length()) {
     *pos = Integer(0);
   } else {
     *pos = Integer(found + 1);

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -410,7 +410,7 @@ void StringFunctions::ASCII(exec::ExecutionContext *ctx, Integer *result, const 
 
 void StringFunctions::Chr(exec::ExecutionContext *ctx, StringVal *result, const Integer &code) {
   uint64_t num = static_cast<uint64_t>(code.val_);
-  if (num == 0) {
+  if (num == 0 || num > 0x10FFFF) {
     // FIXME: this should properly throw a function error
     *result = StringVal::Null();
   } else {

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -408,4 +408,12 @@ void StringFunctions::ASCII(exec::ExecutionContext *ctx, Integer *result, const 
   *result = Integer(static_cast<int>(str_view.front()));
 }
 
+void StringFunctions::Chr(exec::ExecutionContext *ctx, StringVal *result, const Integer &code) {
+  if (code >= 0 && code <= 127) {
+    *result = StringVal(&static_cast<char>(code.val_), 1);
+  } else {
+    *result = StringVal::Null();
+  }
+}
+
 }  // namespace terrier::execution::sql

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -409,7 +409,7 @@ void StringFunctions::ASCII(exec::ExecutionContext *ctx, Integer *result, const 
 }
 
 void StringFunctions::Chr(exec::ExecutionContext *ctx, StringVal *result, const Integer &code) {
-  uint64_t num = static_cast<uint64_t>(code.val_);
+  auto num = static_cast<uint64_t>(code.val_);
   if (num == 0 || num > 0x10FFFF) {
     // FIXME: this should properly throw a function error
     *result = StringVal::Null();
@@ -418,8 +418,7 @@ void StringFunctions::Chr(exec::ExecutionContext *ctx, StringVal *result, const 
       char res[1];
       res[0] = static_cast<char>(0x7f & num);
       *result = StringVal(res, 1);
-    }
-    else if (num <= 0x7ff) {
+    } else if (num <= 0x7ff) {
       char res[2];
       res[0] = static_cast<char>(0xc0 | ((num >> 6) & 0x1f));
       res[1] = static_cast<char>(0x80 | (num & 0x3f));

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -404,8 +404,8 @@ void StringFunctions::ASCII(exec::ExecutionContext *ctx, Integer *result, const 
     return;
   }
 
-  auto *str_content = str.Content();
-  *result = Integer(int(str_content[0]));
+  auto str_view = str.StringView();
+  *result = Integer(static_cast<int>(str_view.front()));
 }
 
 }  // namespace terrier::execution::sql

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -399,7 +399,7 @@ void StringFunctions::ASCII(exec::ExecutionContext *ctx, Integer *result, const 
     return;
   }
 
-  if (str.len_ == 0) {
+  if (str.GetLength() == 0) {
     *result = Integer(0);
     return;
   }

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -370,4 +370,26 @@ void StringFunctions::Like(BoolVal *result, UNUSED_ATTRIBUTE exec::ExecutionCont
   result->val_ = sql::Like{}(string.val_, pattern.val_);  // NOLINT
 }
 
+void StringFunctions::Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str,
+                               const StringVal &search_sub_str) {
+  if (search_str.is_null_ || search_sub_str.is_null_) {
+    *pos = Integer::Null();
+    return;
+  }
+
+  auto search_str_view = search_str.StringView();
+  auto search_sub_str_view = search_sub_str.StringView();
+
+  // Postgres performs a case insensitive search for Position()
+  auto it =
+      std::search(search_str_view.begin(), search_str_view.end(), search_sub_str_view.begin(),
+                  search_sub_str_view.end(), [](char ch1, char ch2) { return std::toupper(ch1) == std::toupper(ch2); });
+  auto found = (it - search_str_view.begin());
+
+  if (found == search_str_view.length()) {
+    *pos = Integer(0);
+  } else {
+    *pos = Integer(found + 1);
+  }
+}
 }  // namespace terrier::execution::sql

--- a/src/execution/sql/functions/string_functions.cpp
+++ b/src/execution/sql/functions/string_functions.cpp
@@ -392,4 +392,20 @@ void StringFunctions::Position(exec::ExecutionContext *ctx, Integer *pos, const 
     *pos = Integer(found + 1);
   }
 }
+
+void StringFunctions::ASCII(exec::ExecutionContext *ctx, Integer *result, const StringVal &str) {
+  if (str.is_null_) {
+    *result = Integer::Null();
+    return;
+  }
+
+  if (str.len_ == 0) {
+    *result = Integer(0);
+    return;
+  }
+
+  auto *str_content = str.Content();
+  *result = Integer(int(str_content[0]));
+}
+
 }  // namespace terrier::execution::sql

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2109,7 +2109,8 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
   LocalVar ret = GetExecutionResult()->GetOrCreateDestination(call->GetType());
   switch (builtin) {
     case ast::Builtin::ASCII: {
-      Emitter()->Emit(Bytecode::ASCII, exec_ctx, ret, input_string);
+      LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
+      GetEmitter()->Emit(Bytecode::ASCII, exec_ctx, ret, input_string);
       break;
     }
     case ast::Builtin::Lower: {

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1671,7 +1671,7 @@ void BytecodeGenerator::VisitBuiltinTrigCall(ast::CallExpr *call, ast::Builtin b
     }
     case ast::Builtin::Exp: {
       src = VisitExpressionForRValue(call->Arguments()[1]);
-      Emitter()->Emit(Bytecode::Exp, dest, src);
+      GetEmitter()->Emit(Bytecode::Exp, dest, src);
       break;
     }
     default: {
@@ -2115,11 +2115,13 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
   switch (builtin) {
     case ast::Builtin::Chr: {
       // input_string here is a integer type number
-      Emitter()->Emit(Bytecode::Chr, exec_ctx, ret, input_string);
+      LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
+      GetEmitter()->Emit(Bytecode::Chr, exec_ctx, ret, input_string);
       break;
     }
     case ast::Builtin::CharLength: {
-      Emitter()->Emit(Bytecode::CharLength, exec_ctx, ret, input_string);
+      LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
+      GetEmitter()->Emit(Bytecode::CharLength, exec_ctx, ret, input_string);
       break;
     }
     case ast::Builtin::ASCII: {

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2108,6 +2108,10 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
   LocalVar exec_ctx = VisitExpressionForRValue(call->Arguments()[0]);
   LocalVar ret = GetExecutionResult()->GetOrCreateDestination(call->GetType());
   switch (builtin) {
+    case ast::Builtin::ASCII: {
+      Emitter()->Emit(Bytecode::ASCII, exec_ctx, ret, input_string);
+      break;
+    }
     case ast::Builtin::Lower: {
       LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
       GetEmitter()->Emit(Bytecode::Lower, ret, exec_ctx, input_string);
@@ -2470,6 +2474,7 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
       VisitBuiltinParamCall(call, builtin);
       break;
     }
+    case ast::Builtin::ASCII:
     case ast::Builtin::Lower:
     case ast::Builtin::Version:
     case ast::Builtin::Position: {

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2103,8 +2103,9 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
       break;
     }
     case ast::Builtin::Position: {
+      LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
       LocalVar sub_string = VisitExpressionForRValue(call->Arguments()[2]);
-      Emitter()->Emit(Bytecode::Position, exec_ctx, ret, input_string, sub_string);
+      GetEmitter()->Emit(Bytecode::Position, exec_ctx, ret, input_string, sub_string);
       break;
     }
     default:

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2102,6 +2102,11 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
       GetEmitter()->Emit(Bytecode::Version, ret, exec_ctx);
       break;
     }
+    case ast::Builtin::Position: {
+      LocalVar sub_string = VisitExpressionForRValue(call->Arguments()[2]);
+      Emitter()->Emit(Bytecode::Position, exec_ctx, ret, input_string, sub_string);
+      break;
+    }
     default:
       UNREACHABLE("Unimplemented string function!");
   }
@@ -2447,7 +2452,8 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
       break;
     }
     case ast::Builtin::Lower:
-    case ast::Builtin::Version: {
+    case ast::Builtin::Version:
+    case ast::Builtin::Position: {
       VisitBuiltinStringCall(call, builtin);
       break;
     }

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -2108,6 +2108,15 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
   LocalVar exec_ctx = VisitExpressionForRValue(call->Arguments()[0]);
   LocalVar ret = GetExecutionResult()->GetOrCreateDestination(call->GetType());
   switch (builtin) {
+    case ast::Builtin::Chr: {
+      // input_string here is a integer type number
+      Emitter()->Emit(Bytecode::Chr, exec_ctx, ret, input_string);
+      break;
+    }
+    case ast::Builtin::CharLength: {
+      Emitter()->Emit(Bytecode::Chr, exec_ctx, ret, input_string);
+      break;
+    }
     case ast::Builtin::ASCII: {
       LocalVar input_string = VisitExpressionForRValue(call->Arguments()[1]);
       GetEmitter()->Emit(Bytecode::ASCII, exec_ctx, ret, input_string);
@@ -2376,6 +2385,7 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
     case ast::Builtin::IndexIteratorGetSlot:
       VisitBuiltinIndexIteratorCall(call, builtin);
       break;
+    case ast::Builtin::Exp:
     case ast::Builtin::ACos:
     case ast::Builtin::ASin:
     case ast::Builtin::ATan:
@@ -2475,6 +2485,8 @@ void BytecodeGenerator::VisitBuiltinCallExpr(ast::CallExpr *call) {
       VisitBuiltinParamCall(call, builtin);
       break;
     }
+    case ast::Builtin::Chr:
+    case ast::Builtin::CharLength:
     case ast::Builtin::ASCII:
     case ast::Builtin::Lower:
     case ast::Builtin::Version:

--- a/src/execution/vm/bytecode_generator.cpp
+++ b/src/execution/vm/bytecode_generator.cpp
@@ -1669,6 +1669,11 @@ void BytecodeGenerator::VisitBuiltinTrigCall(ast::CallExpr *call, ast::Builtin b
       GetEmitter()->Emit(Bytecode::Tan, dest, src);
       break;
     }
+    case ast::Builtin::Exp: {
+      src = VisitExpressionForRValue(call->Arguments()[1]);
+      Emitter()->Emit(Bytecode::Exp, dest, src);
+      break;
+    }
     default: {
       UNREACHABLE("Impossible trigonometric bytecode");
     }
@@ -2114,7 +2119,7 @@ void BytecodeGenerator::VisitBuiltinStringCall(ast::CallExpr *call, ast::Builtin
       break;
     }
     case ast::Builtin::CharLength: {
-      Emitter()->Emit(Bytecode::Chr, exec_ctx, ret, input_string);
+      Emitter()->Emit(Bytecode::CharLength, exec_ctx, ret, input_string);
       break;
     }
     case ast::Builtin::ASCII: {

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -2060,6 +2060,20 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {  // NOLINT
   // -------------------------------------------------------
   // String functions
   // -------------------------------------------------------
+  OP(Chr) : {
+    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+    auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
+    auto *input = frame->LocalAt<const sql::Integer *>(READ_LOCAL_ID());
+    OpChr(exec_ctx, result, input);
+    DISPATCH_NEXT();
+  }
+  OP(CharLength) : {
+    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+    auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());
+    auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    OpCharLength(exec_ctx, result, input);
+    DISPATCH_NEXT();
+  }
   OP(ASCII) : {
     auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
     auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -2060,6 +2060,13 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {  // NOLINT
   // -------------------------------------------------------
   // String functions
   // -------------------------------------------------------
+  OP(ASCII) : {
+    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+    auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());
+    auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    OpASCII(exec_ctx, result, input);
+    DISPATCH_NEXT();
+  }
 
   OP(Concat) : {
     auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -2103,6 +2103,15 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {  // NOLINT
     DISPATCH_NEXT();
   }
 
+  OP(Position) : {
+    auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
+    auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());
+    auto *search_str = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    auto *search_sub_str = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
+    OpPosition(exec_ctx, result, search_str, search_sub_str);
+    DISPATCH_NEXT();
+  }
+
   OP(LPad) : {
     auto *result = frame->LocalAt<sql::StringVal *>(READ_LOCAL_ID());
     auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());

--- a/src/execution/vm/vm.cpp
+++ b/src/execution/vm/vm.cpp
@@ -2071,7 +2071,7 @@ void VM::Interpret(const uint8_t *ip, Frame *frame) {  // NOLINT
     auto *exec_ctx = frame->LocalAt<exec::ExecutionContext *>(READ_LOCAL_ID());
     auto *result = frame->LocalAt<sql::Integer *>(READ_LOCAL_ID());
     auto *input = frame->LocalAt<const sql::StringVal *>(READ_LOCAL_ID());
-    OpCharLength(exec_ctx, result, input);
+    OpCharLength(result, exec_ctx, input);
     DISPATCH_NEXT();
   }
   OP(ASCII) : {

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -67,6 +67,7 @@ constexpr proc_oid_t ASIN_PRO_OID = proc_oid_t(86);
 constexpr proc_oid_t ATAN_PRO_OID = proc_oid_t(87);
 constexpr proc_oid_t COS_PRO_OID = proc_oid_t(88);
 constexpr proc_oid_t SIN_PRO_OID = proc_oid_t(89);
+constexpr proc_oid_t EXP_PRO_OID = proc_oid_t(135);
 
 // TODO(tanujnay112) This overflows into the next internal oid range and will continue to do so
 constexpr proc_oid_t TAN_PRO_OID = proc_oid_t(90);
@@ -78,6 +79,8 @@ constexpr proc_oid_t COSH_PRO_OID = proc_oid_t(127);
 constexpr proc_oid_t SINH_PRO_OID = proc_oid_t(128);
 constexpr proc_oid_t TANH_PRO_OID = proc_oid_t(129);
 constexpr proc_oid_t VERSION_PRO_OID = proc_oid_t(150);
+constexpr proc_oid_t CHR_PRO_OID = proc_oid_t(106);
+constexpr proc_oid_t CHARLENGTH_PRO_OID = proc_oid_t(112);
 
 constexpr proc_oid_t NP_RUNNERS_EMIT_INT_PRO_OID = proc_oid_t(94);
 constexpr proc_oid_t NP_RUNNERS_EMIT_REAL_PRO_OID = proc_oid_t(95);

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -80,4 +80,6 @@ constexpr proc_oid_t NP_RUNNERS_EMIT_REAL_PRO_OID = proc_oid_t(95);
 constexpr proc_oid_t NP_RUNNERS_DUMMY_INT_PRO_OID = proc_oid_t(96);
 constexpr proc_oid_t NP_RUNNERS_DUMMY_REAL_PRO_OID = proc_oid_t(97);
 
+constexpr proc_oid_t POSITION_PRO_OID = proc_oid_t(105);
+
 }  // namespace terrier::catalog::postgres

--- a/src/include/catalog/postgres/pg_proc.h
+++ b/src/include/catalog/postgres/pg_proc.h
@@ -73,6 +73,7 @@ constexpr proc_oid_t TAN_PRO_OID = proc_oid_t(90);
 constexpr proc_oid_t COT_PRO_OID = proc_oid_t(91);
 constexpr proc_oid_t LOWER_PRO_OID = proc_oid_t(92);
 constexpr proc_oid_t UPPER_PRO_OID = proc_oid_t(93);
+constexpr proc_oid_t ASCII_PRO_OID = proc_oid_t(100);
 constexpr proc_oid_t COSH_PRO_OID = proc_oid_t(127);
 constexpr proc_oid_t SINH_PRO_OID = proc_oid_t(128);
 constexpr proc_oid_t TANH_PRO_OID = proc_oid_t(129);

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -268,6 +268,9 @@ namespace terrier::execution::ast {
   F(Sin, sin)                                                           \
   F(Tan, tan)                                                           \
                                                                         \
+  /* EXP */                                                             \
+  F(Exp, exp)                                                           \
+                                                                        \
   /* Generic */                                                         \
   F(SizeOf, sizeOf)                                                     \
   F(OffsetOf, offsetOf)                                                 \
@@ -290,6 +293,10 @@ namespace terrier::execution::ast {
   F(Version, version)                                                   \
   F(Position, position)                                                 \
   F(ASCII, ascii)                                                       \
+                                                                        \
+  /* Char function */                                                   \
+  F(Chr, chr)                                                           \
+  F(CharLength, charLength)                                             \
                                                                         \
   /* Mini runners functions */                                          \
   F(NpRunnersEmitInt, NpRunnersEmitInt)                                 \

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -285,6 +285,7 @@ namespace terrier::execution::ast {
   /* String functions */                                                \
   F(Lower, lower)                                                       \
   F(Version, version)                                                   \
+  F(Position, position)                                                 \
                                                                         \
   /* Mini runners functions */                                          \
   F(NpRunnersEmitInt, NpRunnersEmitInt)                                 \

--- a/src/include/execution/ast/builtins.h
+++ b/src/include/execution/ast/builtins.h
@@ -289,6 +289,7 @@ namespace terrier::execution::ast {
   F(Lower, lower)                                                       \
   F(Version, version)                                                   \
   F(Position, position)                                                 \
+  F(ASCII, ascii)                                                       \
                                                                         \
   /* Mini runners functions */                                          \
   F(NpRunnersEmitInt, NpRunnersEmitInt)                                 \

--- a/src/include/execution/sql/functions/string_functions.h
+++ b/src/include/execution/sql/functions/string_functions.h
@@ -103,5 +103,4 @@ class StringFunctions {
   static void Chr(exec::ExecutionContext *ctx, StringVal *result, const Integer &code);
 
 };
-
 }  // namespace terrier::execution::sql

--- a/src/include/execution/sql/functions/string_functions.h
+++ b/src/include/execution/sql/functions/string_functions.h
@@ -101,6 +101,5 @@ class StringFunctions {
 
   /** Compute CHR(code). */
   static void Chr(exec::ExecutionContext *ctx, StringVal *result, const Integer &code);
-
 };
 }  // namespace terrier::execution::sql

--- a/src/include/execution/sql/functions/string_functions.h
+++ b/src/include/execution/sql/functions/string_functions.h
@@ -98,6 +98,10 @@ class StringFunctions {
   /** Compute POSITION(search_str, search_sub_str). */
   static void Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str,
                        const StringVal &search_sub_str);
+
+  /** Compute CHR(code). */
+  static void Chr(exec::ExecutionContext *ctx, StringVal *result, const Integer &code);
+
 };
 
 }  // namespace terrier::execution::sql

--- a/src/include/execution/sql/functions/string_functions.h
+++ b/src/include/execution/sql/functions/string_functions.h
@@ -91,6 +91,10 @@ class StringFunctions {
 
   /** Compute LIKE(string, pattern). */
   static void Like(BoolVal *result, exec::ExecutionContext *ctx, const StringVal &string, const StringVal &pattern);
+
+  /** Compute POSITION(search_str, search_sub_str). */
+  static void Position(exec::ExecutionContext *ctx, Integer *pos, const StringVal &search_str,
+                       const StringVal &search_sub_str);
 };
 
 }  // namespace terrier::execution::sql

--- a/src/include/execution/sql/functions/string_functions.h
+++ b/src/include/execution/sql/functions/string_functions.h
@@ -21,6 +21,9 @@ class StringFunctions {
   /** This class cannot be copied or moved. */
   DISALLOW_COPY_AND_MOVE(StringFunctions);
 
+  /** Compute ASCII(str). */
+  static void ASCII(exec::ExecutionContext *ctx, Integer *result, const StringVal &str);
+
   /** Compute LENGTH(str). */
   static void CharLength(Integer *result, exec::ExecutionContext *ctx, const StringVal &str) {
     Length(result, ctx, str);

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1466,6 +1466,11 @@ VM_OP_WARM void OpNpRunnersDummyReal(UNUSED_ATTRIBUTE terrier::execution::exec::
 // String functions
 // ---------------------------------------------------------
 
+VM_OP_WARM void OpASCII(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::Integer *result,
+                        const terrier::execution::sql::StringVal *str) {
+  terrier::execution::sql::StringFunctions::ASCII(ctx, result, *str);
+}
+
 VM_OP_WARM void OpCharLength(terrier::execution::sql::Integer *result, terrier::execution::exec::ExecutionContext *ctx,
                              const terrier::execution::sql::StringVal *str) {
   terrier::execution::sql::StringFunctions::CharLength(result, ctx, *str);

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1496,6 +1496,12 @@ VM_OP_WARM void OpLower(terrier::execution::sql::StringVal *result, terrier::exe
   terrier::execution::sql::StringFunctions::Lower(result, ctx, *str);
 }
 
+VM_OP_WARM void OpPosition(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::Integer *result,
+                           const terrier::execution::sql::StringVal *search_str,
+                           const terrier::execution::sql::StringVal *search_sub_str) {
+  terrier::execution::sql::StringFunctions::Position(ctx, result, *search_str, *search_sub_str);
+}
+
 VM_OP_WARM void OpLPad(terrier::execution::sql::StringVal *result, terrier::execution::exec::ExecutionContext *ctx,
                        const terrier::execution::sql::StringVal *str, const terrier::execution::sql::Integer *len,
                        const terrier::execution::sql::StringVal *pad) {

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1466,7 +1466,7 @@ VM_OP_WARM void OpNpRunnersDummyReal(UNUSED_ATTRIBUTE terrier::execution::exec::
 // String functions
 // ---------------------------------------------------------
 VM_OP_WARM void OpChr(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
-                             const terrier::execution::sql::Integer *n) {
+                      const terrier::execution::sql::Integer *n) {
   terrier::execution::sql::StringFunctions::Chr(ctx, result, *n);
 }
 

--- a/src/include/execution/vm/bytecode_handlers.h
+++ b/src/include/execution/vm/bytecode_handlers.h
@@ -1465,6 +1465,10 @@ VM_OP_WARM void OpNpRunnersDummyReal(UNUSED_ATTRIBUTE terrier::execution::exec::
 // ---------------------------------------------------------
 // String functions
 // ---------------------------------------------------------
+VM_OP_WARM void OpChr(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::StringVal *result,
+                             const terrier::execution::sql::Integer *n) {
+  terrier::execution::sql::StringFunctions::Chr(ctx, result, *n);
+}
 
 VM_OP_WARM void OpASCII(terrier::execution::exec::ExecutionContext *ctx, terrier::execution::sql::Integer *result,
                         const terrier::execution::sql::StringVal *str) {

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -582,6 +582,7 @@ namespace terrier::execution::vm {
   F(Substring, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)    \
   F(Trim, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
   F(Upper, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
+  F(Position, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                         \
                                                                                                                       \
   /* Date Functions */                                                                                                \
   F(ExtractYear, OperandType::Local, OperandType::Local)                                                              \

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -564,7 +564,6 @@ namespace terrier::execution::vm {
   F(RoundUpTo, OperandType::Local, OperandType::Local, OperandType::Local)                                            \
   F(Log, OperandType::Local, OperandType::Local, OperandType::Local)                                                  \
   F(Pow, OperandType::Local, OperandType::Local, OperandType::Local)                                                  \
-  F(Exp, OperandType::Local, OperandType::Local)                                                                      \
                                                                                                                       \
   /* String functions */                                                                                              \
   F(Chr, OperandType::Local, OperandType::Local, OperandType::Local)                                                  \

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -566,6 +566,7 @@ namespace terrier::execution::vm {
   F(Pow, OperandType::Local, OperandType::Local, OperandType::Local)                                                  \
                                                                                                                       \
   /* String functions */                                                                                              \
+  F(ASCII, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(Concat, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                           \
   F(Left, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \
   F(Length, OperandType::Local, OperandType::Local, OperandType::Local)                                               \

--- a/src/include/execution/vm/bytecodes.h
+++ b/src/include/execution/vm/bytecodes.h
@@ -564,8 +564,11 @@ namespace terrier::execution::vm {
   F(RoundUpTo, OperandType::Local, OperandType::Local, OperandType::Local)                                            \
   F(Log, OperandType::Local, OperandType::Local, OperandType::Local)                                                  \
   F(Pow, OperandType::Local, OperandType::Local, OperandType::Local)                                                  \
+  F(Exp, OperandType::Local, OperandType::Local)                                                                      \
                                                                                                                       \
   /* String functions */                                                                                              \
+  F(Chr, OperandType::Local, OperandType::Local, OperandType::Local)                                                  \
+  F(CharLength, OperandType::Local, OperandType::Local, OperandType::Local)                                           \
   F(ASCII, OperandType::Local, OperandType::Local, OperandType::Local)                                                \
   F(Concat, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                           \
   F(Left, OperandType::Local, OperandType::Local, OperandType::Local, OperandType::Local)                             \

--- a/test/execution/sql_functions_string_functions_test.cpp
+++ b/test/execution/sql_functions_string_functions_test.cpp
@@ -592,42 +592,42 @@ TEST_F(StringFunctionsTests, ASCII) {
 
 // NOLINTNEXTLINE
 TEST_F(StringFunctionsTests, Chr) {
-// Nulls
-{
-auto result = StringVal("");
-StringFunctions::Chr(Ctx(), &result, Integer(0));
-EXPECT_TRUE(result.is_null_);
-}
+  // Nulls
+  {
+    auto result = StringVal("");
+    StringFunctions::Chr(Ctx(), &result, Integer(0));
+    EXPECT_TRUE(result.is_null_);
+  }
 
-// Simple ascii
-auto result = StringVal("");
-StringFunctions::Chr(Ctx(), &result, Integer(65));
-EXPECT_TRUE(StringVal("A", 1) == result);
+  // Simple ascii
+  auto result = StringVal("");
+  StringFunctions::Chr(Ctx(), &result, Integer(65));
+  EXPECT_TRUE(StringVal("A", 1) == result);
 
-// More than ascii 127
-result = StringVal("");
-StringFunctions::Chr(Ctx(), &result, Integer(352));
-EXPECT_TRUE(StringVal("Š", 2) == result);
+  // More than ascii 127
+  result = StringVal("");
+  StringFunctions::Chr(Ctx(), &result, Integer(352));
+  EXPECT_TRUE(StringVal("Š", 2) == result);
 }
 
 // NOLINTNEXTLINE
 TEST_F(StringFunctionsTests, CharLength) {
-// Nulls
-{
-auto result = Integer(0);
-StringFunctions::CharLength(Ctx(), &result, StringVal::Null());
-EXPECT_TRUE(result.is_null_);
-}
+  // Nulls
+  {
+    auto result = Integer(0);
+    StringFunctions::CharLength(&result, Ctx(), StringVal::Null());
+    EXPECT_TRUE(result.is_null_);
+  }
 
-// Simple char
-auto result = Integer(0);
-StringFunctions::CharLength(Ctx(), &result, StringVal("H"));
-EXPECT_TRUE(1 == result.val_);
+  // Simple char
+  auto result = Integer(0);
+  StringFunctions::CharLength(&result, Ctx(), StringVal("H"));
+  EXPECT_EQ(1, result.val_);
 
-// Simple nulti char
-result = Integer(0);
-StringFunctions::CharLength(Ctx(), &result, StringVal("Has a beg"));
-EXPECT_TRUE(9 == result.val_);
+  // Simple nulti char
+  result = Integer(0);
+  StringFunctions::CharLength(&result, Ctx(), StringVal("Has a beg"));
+  EXPECT_EQ(9, result.val_);
 }
 
 }  // namespace terrier::execution::sql::test

--- a/test/execution/sql_functions_string_functions_test.cpp
+++ b/test/execution/sql_functions_string_functions_test.cpp
@@ -590,4 +590,44 @@ TEST_F(StringFunctionsTests, ASCII) {
   }
 }
 
+// NOLINTNEXTLINE
+TEST_F(StringFunctionsTests, Chr) {
+// Nulls
+{
+auto result = StringVal("");
+StringFunctions::Chr(Ctx(), &result, Integer(0));
+EXPECT_TRUE(result.is_null_);
+}
+
+// Simple ascii
+auto result = StringVal("");
+StringFunctions::Chr(Ctx(), &result, Integer(65));
+EXPECT_TRUE(StringVal("A", 1) == result);
+
+// More than ascii 127
+result = StringVal("");
+StringFunctions::Chr(Ctx(), &result, Integer(352));
+EXPECT_TRUE(StringVal("Š", 2) == result);
+}
+
+// NOLINTNEXTLINE
+TEST_F(StringFunctionsTests, CharLength) {
+// Nulls
+{
+auto result = Integer(0);
+StringFunctions::CharLength(Ctx(), &result, StringVal::Null());
+EXPECT_TRUE(result.is_null_);
+}
+
+// Simple char
+auto result = Integer(0);
+StringFunctions::CharLength(Ctx(), &result, StringVal("H"));
+EXPECT_TRUE(1 == result.val_);
+
+// Simple nulti char
+result = Integer(0);
+StringFunctions::CharLength(Ctx(), &result, StringVal("Has a beg"));
+EXPECT_TRUE(9 == result.val_);
+}
+
 }  // namespace terrier::execution::sql::test

--- a/test/execution/sql_functions_string_functions_test.cpp
+++ b/test/execution/sql_functions_string_functions_test.cpp
@@ -540,4 +540,54 @@ TEST_F(StringFunctionsTests, Trim) {
   EXPECT_TRUE(StringVal("test") == result);
 }
 
+// NOLINTNEXTLINE
+TEST_F(StringFunctionsTests, ASCII) {
+  // Null StringVal returns a null integer
+  {
+    auto x = StringVal::Null();
+    auto result = Integer(-1);
+
+    StringFunctions::ASCII(Ctx(), &result, x);
+    EXPECT_TRUE(result.is_null_);
+  }
+
+  // Empty string returns a null integer
+  {
+    auto x = StringVal("");
+    auto result = Integer(-1);
+
+    StringFunctions::ASCII(Ctx(), &result, x);
+    EXPECT_FALSE(result.is_null_);
+    EXPECT_EQ(0, result.val_);
+  }
+
+  // Single lowercase character string (ex: "a") returns ASCII value of the lowercase character (ex: 97)
+  {
+    auto x = StringVal("a");
+    auto result = Integer(-1);
+    StringFunctions::ASCII(Ctx(), &result, x);
+    EXPECT_FALSE(result.is_null_);
+    EXPECT_EQ(97, result.val_);
+  }
+
+  // String starting with a space (ex: " a") returns ASCII value of space (ex: 32)
+  {
+    auto x = StringVal(" a");
+    auto result = Integer(-1);
+    StringFunctions::ASCII(Ctx(), &result, x);
+    EXPECT_FALSE(result.is_null_);
+    EXPECT_EQ(32, result.val_);
+  }
+
+  // String starting with an uppercase character, more than 1 in length (ex: "ALPHA") returns value of the ASCII
+  // value of the first uppercase character (ex: 65)
+  {
+    auto x = StringVal("ALPHA");
+    auto result = Integer(-1);
+    StringFunctions::ASCII(Ctx(), &result, x);
+    EXPECT_FALSE(result.is_null_);
+    EXPECT_EQ(65, result.val_);
+  }
+}
+
 }  // namespace terrier::execution::sql::test


### PR DESCRIPTION
This PR implements the following built-in string (and one math) functions

- position
- ascii
- exp
- chr 
- char_length

I accomplished this by cherry picking the following commits and applying some manual updates:
- position:
  - apavlo@5da6124
  - apavlo@55a2a10
- ascii:
  - https://github.com/apavlo/terrier/pull/8/commits/b38d0cbb7d9394f059e67762a4113c39b100a3d4
  - https://github.com/apavlo/terrier/pull/8/commits/89024ece2e54f4b4a130f16ef0f80abb78db133a
- exp, chr, char_length:
  - https://github.com/apavlo/terrier/pull/11/commits/1ac9c06ab79d21a29daca60bb4e82c1084e2ad48
  - https://github.com/apavlo/terrier/pull/11/commits/10f0a84b52a1aa628eb52a72cf479479254ededf
  - https://github.com/apavlo/terrier/pull/11/commits/e34bf3dd7789e2751d959b20c47d36985a47f602
  - https://github.com/apavlo/terrier/pull/11/commits/f0cda0678289b85844aea912a5acfcf24b69a7fb
  - https://github.com/apavlo/terrier/pull/11/commits/934f0068ecc841a59511f46e17d1547d01ec04ac
  - https://github.com/apavlo/terrier/pull/11/commits/9acb3462ea6d74a8fd285edd1c36e79961bfeaf9
  - https://github.com/apavlo/terrier/pull/11/commits/470eb9450b397e3ceb3348eefacfe3a82e065a8c

The original PRs can be found here:
- position: apavlo#7
- ascii: https://github.com/apavlo/terrier/pull/8
- exp, chr, char_length: https://github.com/apavlo/terrier/pull/11

Works towards resolving #1001

A couple of notes about this PR:

- @vilas897 @abhijithanilkumar @arvindsaik I slightly messed up the cherry picking of position and I became the git author of 5da6124, though you're still mentioned in the commit message. If you'd like I can rebase and change the author back to you all.
- Because of some precision limitations the results of the test traces for exp from terrier is different from the results from postgres