### PR TITLE
Address check-clang-tidy issues on master

### DIFF
--- a/benchmark/runner/mini_runners.cpp
+++ b/benchmark/runner/mini_runners.cpp
@@ -1062,9 +1062,9 @@ void NetworkQueriesOutputRunners(pqxx::work *txn) {
 
           if (col > 1) {
             query_ss << ",";
-            for (int i = 1; i < col; i++) {
+            for (int j = 1; j < col; j++) {
               query_ss << "nprunnersdummy" << type_s << "()";
-              if (i != col - 1) {
+              if (j != col - 1) {
                 query_ss << ",";
               }
             }
@@ -1074,9 +1074,9 @@ void NetworkQueriesOutputRunners(pqxx::work *txn) {
           pqxx::result r{txn->exec(query_ss.str())};
 
           // Get all the results
-          for (const auto &row : r) {
-            for (auto i = 0; i < col; i++) {
-              null << row[i];
+          for (const auto &result_row : r) {
+            for (auto j = 0; j < col; j++) {
+              null << result_row[j];
             }
           }
         }
@@ -2182,31 +2182,32 @@ int main(int argc, char **argv) {
 
   for (int i = 0; i < argc; i++) {
     for (auto *arg : args) {
-      if (strstr(argv[i], arg->match) != nullptr) {
-        arg->found = true;
-        arg->value = strstr(argv[i], "=") + 1;
-        arg->intValue = atoi(arg->value);
+      if (strstr(argv[i], arg->match_) != nullptr) {
+        arg->found_ = true;
+        arg->value_ = strstr(argv[i], "=") + 1;
+        arg->int_value_ = atoi(arg->value_);
       }
     }
   }
 
-  if (port_info.found) terrier::runner::port = port_info.intValue;
-  if (skip_large_rows_runs_info.found) terrier::runner::skip_large_rows_runs = true;
-  if (warm_num_info.found) terrier::runner::warmup_iterations_num = warm_num_info.intValue;
-  if (rerun_info.found) terrier::runner::rerun_iterations = rerun_info.intValue;
-  if (updel_info.found) terrier::runner::updel_limit = updel_info.intValue;
-  if (warm_limit_info.found) terrier::runner::warmup_rows_limit = warm_limit_info.intValue;
+  if (port_info.found_) terrier::runner::port = port_info.int_value_;
+  if (skip_large_rows_runs_info.found_) terrier::runner::skip_large_rows_runs = true;
+  if (warm_num_info.found_) terrier::runner::warmup_iterations_num = warm_num_info.int_value_;
+  if (rerun_info.found_) terrier::runner::rerun_iterations = rerun_info.int_value_;
+  if (updel_info.found_) terrier::runner::updel_limit = updel_info.int_value_;
+  if (warm_limit_info.found_) terrier::runner::warmup_rows_limit = warm_limit_info.int_value_;
 
   terrier::LoggersUtil::Initialize();
   SETTINGS_LOG_INFO("Starting mini-runners with this parameter set:");
-  SETTINGS_LOG_INFO("Port ({}): {}", port_info.match, terrier::runner::port);
-  SETTINGS_LOG_INFO("Skip Large Rows ({}): {}", skip_large_rows_runs_info.match, terrier::runner::skip_large_rows_runs);
-  SETTINGS_LOG_INFO("Warmup Iterations ({}): {}", warm_num_info.match, terrier::runner::warmup_iterations_num);
-  SETTINGS_LOG_INFO("Rerun Iterations ({}): {}", rerun_info.match, terrier::runner::rerun_iterations);
-  SETTINGS_LOG_INFO("Update/Delete Index Limit ({}): {}", updel_info.match, terrier::runner::updel_limit);
-  SETTINGS_LOG_INFO("Warmup Rows Limit ({}): {}", warm_limit_info.match, terrier::runner::warmup_rows_limit);
-  SETTINGS_LOG_INFO("Filter ({}): {}", filter_info.match, filter_info.value);
-  SETTINGS_LOG_INFO("Compiled ({}): {}", compiled_info.match, compiled_info.found);
+  SETTINGS_LOG_INFO("Port ({}): {}", port_info.match_, terrier::runner::port);
+  SETTINGS_LOG_INFO("Skip Large Rows ({}): {}", skip_large_rows_runs_info.match_,
+                    terrier::runner::skip_large_rows_runs);
+  SETTINGS_LOG_INFO("Warmup Iterations ({}): {}", warm_num_info.match_, terrier::runner::warmup_iterations_num);
+  SETTINGS_LOG_INFO("Rerun Iterations ({}): {}", rerun_info.match_, terrier::runner::rerun_iterations);
+  SETTINGS_LOG_INFO("Update/Delete Index Limit ({}): {}", updel_info.match_, terrier::runner::updel_limit);
+  SETTINGS_LOG_INFO("Warmup Rows Limit ({}): {}", warm_limit_info.match_, terrier::runner::warmup_rows_limit);
+  SETTINGS_LOG_INFO("Filter ({}): {}", filter_info.match_, filter_info.value_);
+  SETTINGS_LOG_INFO("Compiled ({}): {}", compiled_info.match_, compiled_info.found_);
 
   // Benchmark Config Environment Variables
   // Check whether we are being passed environment variables to override configuration parameter
@@ -2219,8 +2220,8 @@ int main(int argc, char **argv) {
 
   terrier::runner::InitializeRunnersState();
 
-  if (filter_info.found) {
-    if (compiled_info.found) {
+  if (filter_info.found_) {
+    if (compiled_info.found_) {
       terrier::runner::MiniRunners::mode = terrier::execution::vm::ExecutionMode::Compiled;
     }
 

--- a/test/execution/parsing_scanner_test.cpp
+++ b/test/execution/parsing_scanner_test.cpp
@@ -73,7 +73,7 @@ void CheckEquality(uint32_t test_idx, const std::vector<Token::Type> &expected,
 void RunTests(const std::vector<TestCase> &tests) {
   for (unsigned test_idx = 0; test_idx < tests.size(); test_idx++) {
     const auto &test = tests[test_idx];
-    Scanner scanner(test.source.data(), test.source.length());
+    Scanner scanner(test.source_.data(), test.source_.length());
 
     std::vector<Token::Type> actual;
 
@@ -81,13 +81,13 @@ void RunTests(const std::vector<TestCase> &tests) {
     for (auto token = scanner.Next(); token != Token::Type::EOS; token = scanner.Next(), token_idx++) {
       actual.push_back(token);
 
-      if (test.check != nullptr) {
-        test.check(&scanner, token_idx);
+      if (test.check_ != nullptr) {
+        test.check_(&scanner, token_idx);
       }
     }
 
     // Expect final sizes should be the same
-    CheckEquality(test_idx, test.expected_tokens, actual);
+    CheckEquality(test_idx, test.expected_tokens_, actual);
   }
 }
 

--- a/test/execution/parsing_scanner_test.cpp
+++ b/test/execution/parsing_scanner_test.cpp
@@ -51,9 +51,9 @@ TEST_F(ScannerTest, SimpleSourceTest) {
 namespace {
 
 struct TestCase {
-  const std::string source;
-  std::vector<Token::Type> expected_tokens;
-  std::function<void(Scanner *scanner, uint32_t token_idx)> check;
+  const std::string source_;
+  std::vector<Token::Type> expected_tokens_;
+  std::function<void(Scanner *scanner, uint32_t token_idx)> check_;
 };
 
 }  // namespace

--- a/test/execution/sql_sorter_test.cpp
+++ b/test/execution/sql_sorter_test.cpp
@@ -161,7 +161,7 @@ struct TestTuple {
   uint32_t key_;
   uint32_t data_[N];
 
-  int32_t Compare(const TestTuple<N> &other) const { return key - other.key; }
+  int32_t Compare(const TestTuple<N> &other) const { return key_ - other.key_; }
 };
 
 // Generic function to perform a parallel sort. The input parameter indicates the sizes of each
@@ -199,7 +199,7 @@ void TestParallelSort(exec::ExecutionContext *exec_ctx, const std::vector<uint32
     auto *sorter = container.AccessCurrentThreadStateAs<Sorter>();
     for (uint32_t i = 0; i < sorter_sizes[tid]; i++) {
       auto *elem = reinterpret_cast<TestTuple<N> *>(sorter->AllocInputTuple());
-      elem->key = mt() % 3333;
+      elem->key_ = mt() % 3333;
     }
   });
 

--- a/test/execution/sql_sorter_test.cpp
+++ b/test/execution/sql_sorter_test.cpp
@@ -158,8 +158,8 @@ TEST_F(SorterTest, TopKTest) {
 
 template <uint32_t N>
 struct TestTuple {
-  uint32_t key;
-  uint32_t data[N];
+  uint32_t key_;
+  uint32_t data_[N];
 
   int32_t Compare(const TestTuple<N> &other) const { return key - other.key; }
 };

--- a/test/execution/sql_thread_state_container_test.cpp
+++ b/test/execution/sql_thread_state_container_test.cpp
@@ -46,17 +46,17 @@ TEST_F(ThreadStateContainerTest, ComplexObjectContainerTest) {
       [](UNUSED_ATTRIBUTE auto *_, auto *s) {
         // Set some stuff to indicate object is initialized
         auto obj = new (s) Object();
-        obj->x = 10;
-        obj->initialized = true;
+        obj->x_ = 10;
+        obj->initialized_ = true;
       },
       nullptr, nullptr);
   ForceCreationOfThreadStates(&container, 4);
 
   // Check
   container.ForEach<Object>([](Object *obj) {
-    EXPECT_EQ(10u, obj->x);
-    EXPECT_EQ(nullptr, obj->next);
-    EXPECT_EQ(true, obj->initialized);
+    EXPECT_EQ(10u, obj->x_);
+    EXPECT_EQ(nullptr, obj->next_);
+    EXPECT_EQ(true, obj->initialized_);
   });
   EXECUTION_LOG_TRACE("{} thread states", container.GetThreadStateCount());
 }

--- a/test/execution/sql_thread_state_container_test.cpp
+++ b/test/execution/sql_thread_state_container_test.cpp
@@ -31,11 +31,11 @@ TEST_F(ThreadStateContainerTest, EmptyStateTest) {
 // NOLINTNEXTLINE
 TEST_F(ThreadStateContainerTest, ComplexObjectContainerTest) {
   struct Object {
-    uint64_t x{0};
-    uint32_t arr[10] = {0};
-    uint32_t arr_2[2] = {44, 23};
-    Object *next{nullptr};
-    bool initialized{false};
+    uint64_t x_{0};
+    uint32_t arr_[10] = {0};
+    uint32_t arr_2_[2] = {44, 23};
+    Object *next_{nullptr};
+    bool initialized_{false};
   };
 
   MemoryPool memory(nullptr);

--- a/test/execution/util_chunked_vector_test.cpp
+++ b/test/execution/util_chunked_vector_test.cpp
@@ -147,7 +147,7 @@ class Simple {
 
   ~Simple() { count--; }
 
-  uint32_t id() const noexcept { return id_; }
+  uint32_t Id() const noexcept { return id_; }
 
  private:
   uint32_t id_;

--- a/test/execution/util_chunked_vector_test.cpp
+++ b/test/execution/util_chunked_vector_test.cpp
@@ -164,9 +164,9 @@ TEST_F(ChunkedVectorTest, ClearTest) {
   v.emplace_back(3);
 
   EXPECT_EQ(3u, v.size());
-  EXPECT_EQ(1u, v[0].id());
-  EXPECT_EQ(2u, v[1].id());
-  EXPECT_EQ(3u, v[2].id());
+  EXPECT_EQ(1u, v[0].Id());
+  EXPECT_EQ(2u, v[1].Id());
+  EXPECT_EQ(3u, v[2].Id());
 
   v.clear();
 
@@ -177,9 +177,9 @@ TEST_F(ChunkedVectorTest, ClearTest) {
   v.emplace_back(12);
 
   EXPECT_EQ(3u, v.size());
-  EXPECT_EQ(10u, v[0].id());
-  EXPECT_EQ(11u, v[1].id());
-  EXPECT_EQ(12u, v[2].id());
+  EXPECT_EQ(10u, v[0].Id());
+  EXPECT_EQ(11u, v[1].Id());
+  EXPECT_EQ(12u, v[2].Id());
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
Ran check-clang-tidy with the flag to apply fixes in the background while working on other stuff. Diff looks reasonable.

Fix #1119.