### PR TITLE
Fix FindClangTools.cmake

### DIFF
--- a/cmake_modules/FindClangTools.cmake
+++ b/cmake_modules/FindClangTools.cmake
@@ -41,6 +41,7 @@ endif()
 if (CLANG_TOOLS_VERSION)
   find_program(CLANG_TIDY_BIN
       NAMES clang-tidy-${CLANG_TOOLS_VERSION}
+      clang-tidy
       PATHS
       ${ClangTools_PATH}
       $ENV{CLANG_TOOLS_PATH}
@@ -97,6 +98,7 @@ endif()
 if (CLANG_TOOLS_VERSION)
   find_program(CLANG_FORMAT_BIN
       NAMES clang-format-${CLANG_TOOLS_VERSION}
+      clang-format
       PATHS
       ${ClangTools_PATH}
       $ENV{CLANG_TOOLS_PATH}


### PR DESCRIPTION
A long-standing pet peeve of mine is that FindClangTools.cmake isn't particularly portable. This can lead to clang tools not being found on certain configurations. This PR aims to fix that.

From #1067.