### PR TITLE
Fix concat operator

### DIFF
--- a/src/execution/ast/ast_dump.cpp
+++ b/src/execution/ast/ast_dump.cpp
@@ -275,6 +275,13 @@ void AstDumperImpl::VisitBinaryOpExpr(BinaryOpExpr *node) {
   DumpExpr(node->Right());
 }
 
+void AstDumperImpl::VisitStringBinaryOpExpr(StringBinaryOpExpr *node) {
+  DumpExpressionCommon(node);
+  DumpToken(node->Op());
+  DumpExpr(node->Left());
+  DumpExpr(node->Right());
+}
+
 void AstDumperImpl::VisitComparisonOpExpr(ComparisonOpExpr *node) {
   DumpExpressionCommon(node);
   DumpToken(node->Op());

--- a/src/execution/ast/ast_pretty_print.cpp
+++ b/src/execution/ast/ast_pretty_print.cpp
@@ -197,6 +197,12 @@ void AstPrettyPrintImpl::VisitBinaryOpExpr(BinaryOpExpr *node) {
   Visit(node->Right());
 }
 
+void AstPrettyPrintImpl::VisitStringBinaryOpExpr(StringBinaryOpExpr *node) {
+  Visit(node->Left());
+  os_ << " " << parsing::Token::GetString(node->Op()) << " ";
+  Visit(node->Right());
+}
+
 void AstPrettyPrintImpl::VisitMapTypeRepr(MapTypeRepr *node) {
   os_ << "map[";
   Visit(node->KeyType());

--- a/src/execution/compiler/codegen.cpp
+++ b/src/execution/compiler/codegen.cpp
@@ -277,6 +277,12 @@ ast::Expr *CodeGen::BinaryOp(parsing::Token::Type op, ast::Expr *left, ast::Expr
   return context_->GetNodeFactory()->NewBinaryOpExpr(position_, op, left, right);
 }
 
+ast::Expr *CodeGen::StringBinaryOp(parsing::Token::Type op, ast::Expr *left, ast::Expr *right,
+                                   ast::Expr *exec_ctx) const {
+  TERRIER_ASSERT(parsing::Token::IsStringBinaryOp(op), "Provided operation isn't string binary");
+  return context_->GetNodeFactory()->NewStringBinaryOpExpr(position_, op, left, right, exec_ctx);
+}
+
 ast::Expr *CodeGen::Compare(parsing::Token::Type op, ast::Expr *left, ast::Expr *right) const {
   return context_->GetNodeFactory()->NewComparisonOpExpr(position_, op, left, right);
 }

--- a/src/execution/compiler/compilation_context.cpp
+++ b/src/execution/compiler/compilation_context.cpp
@@ -21,6 +21,7 @@
 #include "execution/compiler/expression/null_check_translator.h"
 #include "execution/compiler/expression/param_value_translator.h"
 #include "execution/compiler/expression/star_translator.h"
+#include "execution/compiler/expression/string_operator_translator.h"
 #include "execution/compiler/expression/unary_translator.h"
 #include "execution/compiler/function_builder.h"
 #include "execution/compiler/operator/csv_scan_translator.h"
@@ -333,6 +334,11 @@ void CompilationContext::Prepare(const parser::AbstractExpression &expression) {
     case parser::ExpressionType::OPERATOR_IS_NOT_NULL: {
       const auto &operator_expr = dynamic_cast<const parser::OperatorExpression &>(expression);
       translator = std::make_unique<NullCheckTranslator>(operator_expr, this);
+      break;
+    }
+    case parser::ExpressionType::OPERATOR_CONCAT: {
+      const auto &operator_expr = dynamic_cast<const parser::OperatorExpression &>(expression);
+      translator = std::make_unique<StringOperatorTranslator>(operator_expr, this);
       break;
     }
     case parser::ExpressionType::VALUE_CONSTANT: {

--- a/src/execution/compiler/expression/string_operator_translator.cpp
+++ b/src/execution/compiler/expression/string_operator_translator.cpp
@@ -1,0 +1,35 @@
+#include "execution/compiler/expression/string_operator_translator.h"
+
+#include "common/error/exception.h"
+#include "execution/compiler/codegen.h"
+#include "execution/compiler/compilation_context.h"
+#include "execution/compiler/work_context.h"
+#include "parser/expression/operator_expression.h"
+#include "spdlog/fmt/fmt.h"
+
+namespace terrier::execution::compiler {
+
+StringOperatorTranslator::StringOperatorTranslator(const parser::OperatorExpression &expr,
+                                                   CompilationContext *compilation_context)
+    : ExpressionTranslator(expr, compilation_context) {
+  // Prepare the left and right expression subtrees for translation.
+  compilation_context->Prepare(*expr.GetChild(0));
+  compilation_context->Prepare(*expr.GetChild(1));
+}
+
+ast::Expr *StringOperatorTranslator::DeriveValue(WorkContext *ctx, const ColumnValueProvider *provider) const {
+  auto *codegen = GetCodeGen();
+  auto left_val = ctx->DeriveValue(*GetExpression().GetChild(0), provider);
+  auto right_val = ctx->DeriveValue(*GetExpression().GetChild(1), provider);
+
+  switch (auto expr_type = GetExpression().GetExpressionType(); expr_type) {
+    case parser::ExpressionType::OPERATOR_CONCAT:
+      return codegen->StringBinaryOp(parsing::Token::Type::CONCAT, left_val, right_val, GetExecutionContextPtr());
+    default: {
+      throw NOT_IMPLEMENTED_EXCEPTION(
+          fmt::format("Translation of string operator type {}", parser::ExpressionTypeToString(expr_type, true)));
+    }
+  }
+}
+
+}  // namespace terrier::execution::compiler

--- a/src/execution/parsing/parser.cpp
+++ b/src/execution/parsing/parser.cpp
@@ -390,6 +390,9 @@ ast::Expr *Parser::ParseBinaryOpExpr(uint32_t min_prec) {
       const SourcePosition &position = scanner_->CurrentPosition();
       ast::Expr *right = ParseBinaryOpExpr(prec);
 
+      // TODO(jkosh44): To properly parse string binary ops we would need to also check Token::IsStringBinaryOp(op)
+      // and then set left = node_factory_->NewStringBinaryOpExpr(position, op, left, right, exec_ctx). However
+      // I can't figure out how to get exec_ctx here.
       if (Token::IsCompareOp(op)) {
         left = node_factory_->NewComparisonOpExpr(position, op, left, right);
       } else {

--- a/src/execution/parsing/scanner.cpp
+++ b/src/execution/parsing/scanner.cpp
@@ -95,7 +95,11 @@ void Scanner::Scan() {
       }
       case '|': {
         Advance();
-        type = Token::Type::BIT_OR;
+        if (Matches('|')) {
+          type = Token::Type::CONCAT;
+        } else {
+          type = Token::Type::BIT_OR;
+        }
         break;
       }
       case '^': {

--- a/src/execution/sema/sema_checking.cpp
+++ b/src/execution/sema/sema_checking.cpp
@@ -136,6 +136,17 @@ Sema::CheckResult Sema::CheckArithmeticOperands(parsing::Token::Type op, const S
   return {nullptr, left, right};
 }
 
+Sema::CheckResult Sema::CheckStringOperands(parsing::Token::Type op, const SourcePosition &pos, ast::Expr *left,
+                                            ast::Expr *right, ast::Expr *exec_ctx) {
+  // If neither inputs are string, fail early
+  if (!left->GetType()->IsSqlStringType() || !right->GetType()->IsSqlStringType()) {
+    GetErrorReporter()->Report(pos, ErrorMessages::kIllegalTypesForBinary, op, left->GetType(), right->GetType());
+    return {nullptr, left, right};
+  }
+
+  return {left->GetType(), left, right};
+}
+
 Sema::CheckResult Sema::CheckSqlComparisonOperands(parsing::Token::Type op, const SourcePosition &pos, ast::Expr *left,
                                                    ast::Expr *right) {
   TERRIER_ASSERT(left->GetType()->IsSqlValueType() || right->GetType()->IsSqlValueType(),

--- a/src/execution/sema/sema_expr.cpp
+++ b/src/execution/sema/sema_expr.cpp
@@ -47,6 +47,31 @@ void Sema::VisitBinaryOpExpr(ast::BinaryOpExpr *node) {
   }
 }
 
+void Sema::VisitStringBinaryOpExpr(ast::StringBinaryOpExpr *node) {
+  ast::Type *left_type = Resolve(node->Left());
+  ast::Type *right_type = Resolve(node->Right());
+  ast::Type *exec_ctx_type = Resolve(node->ExecutionContext());
+
+  if (left_type == nullptr || right_type == nullptr || exec_ctx_type == nullptr) {
+    // Some error occurred
+    return;
+  }
+
+  switch (node->Op()) {
+    case parsing::Token::Type::CONCAT: {
+      auto [result_type, left, right] =
+          CheckStringOperands(node->Op(), node->Position(), node->Left(), node->Right(), node->ExecutionContext());
+      node->SetType(result_type);
+      if (node->Left() != left) node->SetLeft(left);
+      if (node->Right() != right) node->SetRight(right);
+      break;
+    }
+    default: {
+      EXECUTION_LOG_ERROR("{} is not a binary operation!", parsing::Token::GetString(node->Op()));
+    }
+  }
+}
+
 void Sema::VisitComparisonOpExpr(ast::ComparisonOpExpr *node) {
   ast::Type *left_type = Resolve(node->Left());
   ast::Type *right_type = Resolve(node->Right());

--- a/src/execution/vm/bytecode_emitter.cpp
+++ b/src/execution/vm/bytecode_emitter.cpp
@@ -43,6 +43,11 @@ void BytecodeEmitter::EmitBinaryOp(Bytecode bytecode, LocalVar dest, LocalVar lh
   EmitAll(bytecode, dest, lhs, rhs);
 }
 
+void BytecodeEmitter::EmitStringBinaryOp(Bytecode bytecode, LocalVar dest, LocalVar exec_ctx, LocalVar lhs,
+                                         LocalVar rhs) {
+  EmitAll(bytecode, dest, exec_ctx, lhs, rhs);
+}
+
 void BytecodeEmitter::EmitLea(LocalVar dest, LocalVar src, uint32_t offset) {
   EmitAll(Bytecode::Lea, dest, src, offset);
 }

--- a/src/include/execution/ast/ast.h
+++ b/src/include/execution/ast/ast.h
@@ -60,6 +60,7 @@ namespace ast {
 #define EXPRESSION_NODES(T)             \
   T(BadExpr)                            \
   T(BinaryOpExpr)                       \
+  T(StringBinaryOpExpr)                 \
   T(CallExpr)                           \
   T(ComparisonOpExpr)                   \
   T(FunctionLitExpr)                    \
@@ -1037,6 +1038,77 @@ class BinaryOpExpr : public Expr {
   parsing::Token::Type op_;
   Expr *left_;
   Expr *right_;
+};
+
+/**
+ * A Stringbinary expression with non-null left and right children, an operator, and a reference to the execution
+ * context.
+ */
+class StringBinaryOpExpr : public Expr {
+ public:
+  /**
+   * Constructor
+   * @param pos source position
+   * @param op binary operator
+   * @param left lhs
+   * @param right rhs
+   * @param exec_ctx execution context
+   */
+  StringBinaryOpExpr(const SourcePosition &pos, parsing::Token::Type op, Expr *left, Expr *right, Expr *exec_ctx)
+      : Expr(Kind::StringBinaryOpExpr, pos), op_(op), left_(left), right_(right), exec_ctx_(exec_ctx) {}
+
+  /**
+   * @return The parsing token representing the kind of binary operation. +, -, etc.
+   */
+  parsing::Token::Type Op() const { return op_; }
+
+  /**
+   * @return The left input to the binary expression.
+   */
+  Expr *Left() const { return left_; }
+
+  /**
+   * @return The right input to the binary expression.
+   */
+  Expr *Right() const { return right_; }
+
+  /**
+   * Is the given node a binary expression? Needed as part of the custom AST RTTI infrastructure.
+   * @param node The node to check.
+   * @return True if the node is a binary expression; false otherwise.
+   */
+  static bool classof(const AstNode *node) {  // NOLINT
+    return node->GetKind() == Kind::StringBinaryOpExpr;
+  }
+
+  /**
+   * @return The Execution Context
+   */
+  Expr *ExecutionContext() const { return exec_ctx_; }
+
+ private:
+  friend class sema::Sema;
+
+  void SetLeft(Expr *left) {
+    TERRIER_ASSERT(left != nullptr, "Left cannot be null!");
+    left_ = left;
+  }
+
+  void SetRight(Expr *right) {
+    TERRIER_ASSERT(right != nullptr, "Right cannot be null!");
+    right_ = right;
+  }
+
+  void SetExecCtx(Expr *exec_ctx) {
+    TERRIER_ASSERT(exec_ctx != nullptr, "Execution Context cannot be null!");
+    exec_ctx_ = exec_ctx;
+  }
+
+ private:
+  parsing::Token::Type op_;
+  Expr *left_;
+  Expr *right_;
+  Expr *exec_ctx_;
 };
 
 /**

--- a/src/include/execution/ast/ast_node_factory.h
+++ b/src/include/execution/ast/ast_node_factory.h
@@ -159,6 +159,19 @@ class AstNodeFactory {
 
   /**
    * @param pos source position
+   * @param op binary operator
+   * @param left lhs of the operator
+   * @param right rhs of the operator
+   * @param exec_ctx the execution context that we are running with
+   * @return created StringBinaryOpExpr node
+   */
+  StringBinaryOpExpr *NewStringBinaryOpExpr(const SourcePosition &pos, parsing::Token::Type op, Expr *left, Expr *right,
+                                            Expr *exec_ctx) {
+    return new (region_) StringBinaryOpExpr(pos, op, left, right, exec_ctx);
+  }
+
+  /**
+   * @param pos source position
    * @param op comparision operator
    * @param left lhs of the operator
    * @param right rhs of the operator

--- a/src/include/execution/ast/ast_traversal_visitor.h
+++ b/src/include/execution/ast/ast_traversal_visitor.h
@@ -226,6 +226,13 @@ inline void AstTraversalVisitor<Subclass>::VisitBinaryOpExpr(BinaryOpExpr *node)
 }
 
 template <typename Subclass>
+inline void AstTraversalVisitor<Subclass>::VisitStringBinaryOpExpr(StringBinaryOpExpr *node) {
+  PROCESS_NODE(node);
+  RECURSE(Visit(node->Left()));
+  RECURSE(Visit(node->Right()));
+}
+
+template <typename Subclass>
 inline void AstTraversalVisitor<Subclass>::VisitMapTypeRepr(MapTypeRepr *node) {
   PROCESS_NODE(node);
   RECURSE(Visit(node->KeyType()));

--- a/src/include/execution/ast/type.h
+++ b/src/include/execution/ast/type.h
@@ -281,6 +281,11 @@ class Type : public util::RegionObject {
   bool IsSqlBooleanType() const;
 
   /**
+   * @return True if this is a builtin SQL String type; false otherwise.
+   */
+  bool IsSqlStringType() const;
+
+  /**
    * @return True if this is a builtin SQL aggregate type; false otherwise.
    */
   bool IsSqlAggregatorType() const;
@@ -763,6 +768,8 @@ inline bool Type::IsSqlValueType() const {
 }
 
 inline bool Type::IsSqlBooleanType() const { return IsSpecificBuiltin(BuiltinType::Boolean); }
+
+inline bool Type::IsSqlStringType() const { return IsSpecificBuiltin(BuiltinType::StringVal); }
 
 inline bool Type::IsSqlAggregatorType() const {
   if (auto *builtin_type = SafeAs<BuiltinType>()) {

--- a/src/include/execution/compiler/codegen.h
+++ b/src/include/execution/compiler/codegen.h
@@ -356,6 +356,18 @@ class CodeGen {
   [[nodiscard]] ast::Expr *BinaryOp(parsing::Token::Type op, ast::Expr *left, ast::Expr *right) const;
 
   /**
+   * Generate a string binary operation of the provided operation type (<b>op</b>) between the
+   * provided left and right operands, returning its result.
+   * @param op The binary operation.
+   * @param left The left input.
+   * @param right The right input.
+   * @param exec_ctx The execution context that we are running with.
+   * @return The result of the binary operation.
+   */
+  [[nodiscard]] ast::Expr *StringBinaryOp(parsing::Token::Type op, ast::Expr *left, ast::Expr *right,
+                                          ast::Expr *exec_ctx) const;
+
+  /**
    * Generate a comparison operation of the provided type between the provided left and right
    * operands, returning its result.
    * @param op The binary operation.

--- a/src/include/execution/compiler/expression/string_operator_translator.h
+++ b/src/include/execution/compiler/expression/string_operator_translator.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "execution/compiler/expression/expression_translator.h"
+
+namespace terrier::parser {
+class OperatorExpression;
+}  // namespace terrier::parser
+
+namespace terrier::execution::compiler {
+
+/**
+ * A translator for string operator expressions.
+ */
+class StringOperatorTranslator : public ExpressionTranslator {
+ public:
+  /**
+   * Create a translator for the given string operator expression.
+   * @param expr The expression to translate.
+   * @param compilation_context The context in which translation occurs.
+   */
+  StringOperatorTranslator(const parser::OperatorExpression &expr, CompilationContext *compilation_context);
+
+  /**
+   * Derive the value of the expression.
+   * @param ctx The context containing collected subexpressions.
+   * @param provider A provider for specific column values.
+   * @return The value of the expression.
+   */
+  ast::Expr *DeriveValue(WorkContext *ctx, const ColumnValueProvider *provider) const override;
+};
+
+}  // namespace terrier::execution::compiler

--- a/src/include/execution/parsing/token.h
+++ b/src/include/execution/parsing/token.h
@@ -41,6 +41,7 @@ namespace terrier::execution::parsing {
   T(STAR, "*", 10)                                 \
   T(SLASH, "/", 10)                                \
   T(PERCENT, "%", 10)                              \
+  T(CONCAT, "||", 11)                              \
                                                    \
   /* Comparison operators, sorted by precedence */ \
   T(BANG_EQUAL, "!=", 5)                           \
@@ -129,6 +130,11 @@ class Token {
     return (static_cast<uint8_t>(Type::COMMA) <= static_cast<uint8_t>(op) &&
             static_cast<uint8_t>(op) <= static_cast<uint8_t>(Type::PERCENT));
   }
+
+  /**
+   * @return True if the given operator represents a binary operation; false otherwise.
+   */
+  static bool IsStringBinaryOp(Type op) { return Type::CONCAT == op; }
 
   /**
    * @return True if the given token represents a comparison operator; false otherwise.

--- a/src/include/execution/sema/sema.h
+++ b/src/include/execution/sema/sema.h
@@ -100,6 +100,10 @@ class Sema : public ast::AstVisitor<Sema> {
   CheckResult CheckArithmeticOperands(parsing::Token::Type op, const SourcePosition &pos, ast::Expr *left,
                                       ast::Expr *right);
 
+  // Check operands to an string operation: ||, etc.
+  CheckResult CheckStringOperands(parsing::Token::Type op, const SourcePosition &pos, ast::Expr *left, ast::Expr *right,
+                                  ast::Expr *exec_ctx);
+
   CheckResult CheckComparisonOperands(parsing::Token::Type op, const SourcePosition &pos, ast::Expr *left,
                                       ast::Expr *right);
 

--- a/src/include/execution/vm/bytecode_emitter.h
+++ b/src/include/execution/vm/bytecode_emitter.h
@@ -193,6 +193,16 @@ class BytecodeEmitter {
    */
   void EmitBinaryOp(Bytecode bytecode, LocalVar dest, LocalVar lhs, LocalVar rhs);
 
+  /**
+   * Emit binary operator code
+   * @param bytecode bytecode of the binary operation
+   * @param dest destination variable
+   * @param lhs lhs of the operator
+   * @param rhs rhs of the operator
+   * @param exec_ctx execution context of the operator
+   */
+  void EmitStringBinaryOp(Bytecode bytecode, LocalVar dest, LocalVar exec_ctx, LocalVar lhs, LocalVar rhs);
+
   // -------------------------------------------------------
   // Generic emissions
   // -------------------------------------------------------

--- a/src/include/parser/expression_util.h
+++ b/src/include/parser/expression_util.h
@@ -146,7 +146,6 @@ class ExpressionUtil {
       case ExpressionType::OPERATOR_MINUS:
       case ExpressionType::OPERATOR_MULTIPLY:
       case ExpressionType::OPERATOR_DIVIDE:
-      case ExpressionType::OPERATOR_CONCAT:
       case ExpressionType::OPERATOR_MOD:
         return true;
       default:

--- a/src/parser/expression/operator_expression.cpp
+++ b/src/parser/expression/operator_expression.cpp
@@ -33,7 +33,11 @@ void OperatorExpression::DeriveReturnValueType() {
     return t1->GetReturnValueType() < t2->GetReturnValueType();
   });
   const auto &type = (*max_type_child)->GetReturnValueType();
-  TERRIER_ASSERT(type <= type::TypeId::DECIMAL, "Invalid operand type in Operator Expression.");
+  if (this->GetExpressionType() == ExpressionType::OPERATOR_CONCAT) {
+    TERRIER_ASSERT(type == type::TypeId::VARCHAR, "Invalid operand type in Operator Expression.");
+  } else {
+    TERRIER_ASSERT(type <= type::TypeId::DECIMAL, "Invalid operand type in Operator Expression.");
+  }
   this->SetReturnValueType(type);
 }
 

--- a/test/execution/ast_dump_test.cpp
+++ b/test/execution/ast_dump_test.cpp
@@ -60,6 +60,7 @@ class ExtractKindNames : public AstTraversalVisitor<ExtractKindNames<FindInfinit
   EXTRACT_KINDNAME_METHOD(ForStmt);
   EXTRACT_KINDNAME_METHOD(ForInStmt);
   EXTRACT_KINDNAME_METHOD(BinaryOpExpr);
+  EXTRACT_KINDNAME_METHOD(StringBinaryOpExpr);
   EXTRACT_KINDNAME_METHOD(LitExpr);
   EXTRACT_KINDNAME_METHOD(StructTypeRepr);
   EXTRACT_KINDNAME_METHOD(PointerTypeRepr);

--- a/test/execution/ast_test.cpp
+++ b/test/execution/ast_test.cpp
@@ -61,6 +61,7 @@ TEST_F(AstTest, HierarchyTest) {
   {
     AstNode *all_exprs[] = {
         factory.NewBinaryOpExpr(EmptyPos(), parsing::Token::Type::PLUS, nullptr, nullptr),
+        factory.NewStringBinaryOpExpr(EmptyPos(), parsing::Token::Type::CONCAT, nullptr, nullptr, nullptr),
         factory.NewCallExpr(factory.NewNilLiteral(EmptyPos()), util::RegionVector<Expr *>(Region())),
         factory.NewFunctionLitExpr(
             factory.NewFunctionType(EmptyPos(), util::RegionVector<FieldDecl *>(Region()), nullptr), nullptr),


### PR DESCRIPTION
The sql parser was correctly parsing "||" as CONCAT but there was
no tpl parsing, tpl ast generation, semantic checking, or
bytecode generation for concat. This commit adds tpl ast
generation, semantic checking, and bytecode generation. tpl
parsing still isn't working properly. We reuse the concat
built-in bytecode handling as the underlying implementation.

Originally CONCAT was being treated as a normal BinaryOpExpr,
however CONCAT needs access to the Execution Context in order
to allocate space for a new string. Normal BinaryOpExpr don't
have a reference to the execution context. Therefore we needed
to create a new type of expression, StringBinaryOpExpr, which
has a reference to the execution context.

StringBinaryOpExpr was made to be generalized for use with  any
string binary operation. Some other options would have been:
- Add a reference to the Execution Context to BinaryOpExpr.
However this is probably wasteful since the majority of binary
operations do not need a reference to the Execution Context.
- Create a specific operation for CONCAT.
- Generalize further and make some StringOpExpr, that instead
of having a left and right expression, has a vector of
expressions. This would allow it to be reused on string
operations that need a reference to the Execution Context and
have any amount of arguments.

Many elements were inspired by/taken out of the following PR:
https://github.com/cmu-db/terrier/pull/839/files

Fixes: #804

Co-authored-by: VenkatDatta <nhvenkatdatta@gmail.com>