### PR TITLE
Handle Execution Exceptions

### DIFF
--- a/src/execution/compiler/executable_query.cpp
+++ b/src/execution/compiler/executable_query.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include "brain/operating_unit.h"
+#include "common/error/error_code.h"
 #include "common/error/exception.h"
 #include "execution/ast/ast_dump.h"
 #include "execution/ast/context.h"
@@ -37,14 +38,16 @@ void ExecutableQuery::Fragment::Run(byte query_state[], vm::ExecutionMode mode) 
   for (const auto &func_name : functions_) {
     Function func;
     if (!module_->GetFunction(func_name, mode, &func)) {
-      throw EXECUTION_EXCEPTION(fmt::format("Could not find function '{}' in query fragment.", func_name));
+      throw EXECUTION_EXCEPTION(fmt::format("Could not find function '{}' in query fragment.", func_name),
+                                common::ErrorCode::ERRCODE_INTERNAL_ERROR);
     }
     try {
       func(query_state);
     } catch (const AbortException &e) {
       for (const auto &teardown_name : teardown_fn_) {
         if (!module_->GetFunction(teardown_name, mode, &func)) {
-          throw EXECUTION_EXCEPTION(fmt::format("Could not find teardown function '{}' in query fragment.", func_name));
+          throw EXECUTION_EXCEPTION(fmt::format("Could not find teardown function '{}' in query fragment.", func_name),
+                                    common::ErrorCode::ERRCODE_INTERNAL_ERROR);
         }
         func(query_state);
       }

--- a/src/execution/compiler/operator/csv_scan_translator.cpp
+++ b/src/execution/compiler/operator/csv_scan_translator.cpp
@@ -85,7 +85,8 @@ ast::Expr *CSVScanTranslator::GetTableColumn(catalog::col_oid_t col_oid) const {
   const auto output_schema = GetPlan().GetOutputSchema();
   if (col_oid.UnderlyingValue() > output_schema->NumColumns()) {
     throw EXECUTION_EXCEPTION(
-        fmt::format("Codegen: out-of-bounds CSV column access @ idx={}", col_oid.UnderlyingValue()));
+        fmt::format("Codegen: out-of-bounds CSV column access @ idx={}", col_oid.UnderlyingValue()),
+        common::ErrorCode::ERRCODE_DATA_EXCEPTION);
   }
 
   // Return the field converted to the appropriate type.

--- a/src/execution/compiler/operator/operator_translator.cpp
+++ b/src/execution/compiler/operator/operator_translator.cpp
@@ -25,9 +25,10 @@ ast::Expr *OperatorTranslator::GetOutput(WorkContext *context, uint32_t attr_idx
   // Check valid output column.
   const auto output_schema = plan_.GetOutputSchema();
   if (attr_idx >= output_schema->NumColumns()) {
-    throw EXECUTION_EXCEPTION(fmt::format("Codegen: Cannot read column {} from '{}' with output schema {}", attr_idx,
-                                          planner::PlanNodeTypeToString(plan_.GetPlanNodeType()),
-                                          output_schema->ToJson().dump()));
+    throw EXECUTION_EXCEPTION(
+        fmt::format("Codegen: Cannot read column {} from '{}' with output schema {}", attr_idx,
+                    planner::PlanNodeTypeToString(plan_.GetPlanNodeType()), output_schema->ToJson().dump()),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 
   const auto output_expression = output_schema->GetColumn(attr_idx).GetExpr();
@@ -38,7 +39,8 @@ ast::Expr *OperatorTranslator::GetChildOutput(WorkContext *context, uint32_t chi
   // Check valid child.
   if (child_idx >= plan_.GetChildrenSize()) {
     throw EXECUTION_EXCEPTION(fmt::format("Codegen: Plan type '{}' does not have child at index {}",
-                                          planner::PlanNodeTypeToString(plan_.GetPlanNodeType()), child_idx));
+                                          planner::PlanNodeTypeToString(plan_.GetPlanNodeType()), child_idx),
+                              common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 
   // Check valid output column from child.

--- a/src/execution/compiler/operator/seq_scan_translator.cpp
+++ b/src/execution/compiler/operator/seq_scan_translator.cpp
@@ -338,7 +338,8 @@ uint32_t SeqScanTranslator::GetColOidIndex(catalog::col_oid_t col_oid) const {
       return i;
     }
   }
-  throw EXECUTION_EXCEPTION(fmt::format("Seq scan translator: col OID {} not found.", col_oid.UnderlyingValue()));
+  throw EXECUTION_EXCEPTION(fmt::format("Seq scan translator: col OID {} not found.", col_oid.UnderlyingValue()),
+                            common::ErrorCode::ERRCODE_INTERNAL_ERROR);
 }
 
 std::vector<catalog::col_oid_t> SeqScanTranslator::MakeInputOids(const catalog::Schema &schema,

--- a/src/execution/sql/sql.cpp
+++ b/src/execution/sql/sql.cpp
@@ -32,7 +32,8 @@ SqlTypeId GetSqlTypeFromInternalType(TypeId type) {
     case TypeId::Varbinary:
       return SqlTypeId::Varchar;
     default:
-      throw EXECUTION_EXCEPTION(fmt::format("Not a SQL type, {}.", TypeIdToString(type)));
+      throw EXECUTION_EXCEPTION(fmt::format("Not a SQL type, {}.", TypeIdToString(type)),
+                                common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/execution/sql/vector_operations/arithmetic.cpp
+++ b/src/execution/sql/vector_operations/arithmetic.cpp
@@ -32,17 +32,20 @@ void CheckBinaryOperation(const Vector &left, const Vector &right, Vector *resul
   if (left.GetTypeId() != right.GetTypeId()) {
     throw EXECUTION_EXCEPTION(
         fmt::format("Left and right vector types to binary operation must be the same, left {} right {}",
-                    TypeIdToString(left.GetTypeId()), TypeIdToString(right.GetTypeId())));
+                    TypeIdToString(left.GetTypeId()), TypeIdToString(right.GetTypeId())),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
   if (left.GetTypeId() != result->GetTypeId()) {
     throw EXECUTION_EXCEPTION(
         fmt::format("Result type of binary operation must be the same as input type, input {} result {}.",
-                    TypeIdToString(left.GetTypeId()), TypeIdToString(result->GetTypeId())));
+                    TypeIdToString(left.GetTypeId()), TypeIdToString(result->GetTypeId())),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
   if (!left.IsConstant() && !right.IsConstant() && left.GetCount() != right.GetCount()) {
     throw EXECUTION_EXCEPTION(
         fmt::format("Left and right input vectors to binary operation must have the same size, left {} right {}.",
-                    left.GetCount(), right.GetCount()));
+                    left.GetCount(), right.GetCount()),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 
@@ -153,7 +156,8 @@ void DivModOperation(const Vector &left, const Vector &right, Vector *result) {
       break;
     default:
       throw EXECUTION_EXCEPTION(
-          fmt::format("Invalid type for arithmetic operation, {}.", TypeIdToString(left.GetTypeId())));
+          fmt::format("Invalid type for arithmetic operation, {}.", TypeIdToString(left.GetTypeId())),
+          common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 
@@ -195,7 +199,8 @@ void BinaryArithmeticOperation(const exec::ExecutionSettings &exec_settings, con
       break;
     default:
       throw EXECUTION_EXCEPTION(
-          fmt::format("Invalid type for arithmetic operation, {}.", TypeIdToString(left.GetTypeId())));
+          fmt::format("Invalid type for arithmetic operation, {}.", TypeIdToString(left.GetTypeId())),
+          common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/execution/sql/vector_operations/fill.cpp
+++ b/src/execution/sql/vector_operations/fill.cpp
@@ -11,7 +11,8 @@ namespace {
 void CheckFillArguments(const Vector &input, const GenericValue &value) {
   if (input.GetTypeId() != value.GetTypeId()) {
     throw EXECUTION_EXCEPTION(fmt::format("Invalid types for fill, input {} value {}.",
-                                          TypeIdToString(input.GetTypeId()), TypeIdToString(value.GetTypeId())));
+                                          TypeIdToString(input.GetTypeId()), TypeIdToString(value.GetTypeId())),
+                              common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 
@@ -70,8 +71,8 @@ void VectorOps::Fill(Vector *vector, const GenericValue &value) {
       TemplatedFillOperation(vector, vector->varlen_heap_.AddVarlen(value.str_value_));
       break;
     default:
-      throw EXECUTION_EXCEPTION(
-          fmt::format("Vector of type {} cannot be filled.", TypeIdToString(vector->GetTypeId())));
+      throw EXECUTION_EXCEPTION(fmt::format("Vector of type {} cannot be filled.", TypeIdToString(vector->GetTypeId())),
+                                common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/execution/sql/vector_operations/gather.cpp
+++ b/src/execution/sql/vector_operations/gather.cpp
@@ -9,7 +9,8 @@ namespace {
 void CheckGatherArguments(const Vector &pointers, UNUSED_ATTRIBUTE Vector *result) {
   if (pointers.GetTypeId() != TypeId::Pointer) {
     throw EXECUTION_EXCEPTION(
-        fmt::format("Gather only works on pointer inputs, input type {}.", TypeIdToString(pointers.GetTypeId())));
+        fmt::format("Gather only works on pointer inputs, input type {}.", TypeIdToString(pointers.GetTypeId())),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/execution/sql/vector_operations/gather_select.cpp
+++ b/src/execution/sql/vector_operations/gather_select.cpp
@@ -35,16 +35,20 @@ void CheckGatherAndSelect(const Vector &input, const Vector &pointers, UNUSED_AT
                           TupleIdList *result) {
   if (pointers.GetTypeId() != TypeId::Pointer) {
     throw EXECUTION_EXCEPTION(
-        fmt::format("Pointers vector must be TypeId::Pointer, but is type {}.", TypeIdToString(pointers.GetTypeId())));
+        fmt::format("Pointers vector must be TypeId::Pointer, but is type {}.", TypeIdToString(pointers.GetTypeId())),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
   if (input.GetSize() != pointers.GetSize()) {
     throw EXECUTION_EXCEPTION(
-        fmt::format("Input vectors have mismatched shapes, {} vs {}.", input.GetSize(), pointers.GetSize()));
+        fmt::format("Input vectors have mismatched shapes, {} vs {}.", input.GetSize(), pointers.GetSize()),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
   if (result->GetCapacity() != input.GetSize()) {
-    throw EXECUTION_EXCEPTION(fmt::format(
-        "Result list not large enough to store all TIDs in input vector, input size {} results capacity {}.",
-        input.GetSize(), result->GetCapacity()));
+    throw EXECUTION_EXCEPTION(
+        fmt::format(
+            "Result list not large enough to store all TIDs in input vector, input size {} results capacity {}.",
+            input.GetSize(), result->GetCapacity()),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/execution/sql/vector_operations/generate.cpp
+++ b/src/execution/sql/vector_operations/generate.cpp
@@ -9,7 +9,8 @@ namespace {
 void CheckGenerateArguments(const Vector &input) {
   if (!IsTypeNumeric(input.GetTypeId())) {
     throw EXECUTION_EXCEPTION(fmt::format("Sequence generation only allowed on numeric vectors, vector of type {}.",
-                                          TypeIdToString(input.GetTypeId())));
+                                          TypeIdToString(input.GetTypeId())),
+                              common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/execution/sql/vector_operations/hash.cpp
+++ b/src/execution/sql/vector_operations/hash.cpp
@@ -10,7 +10,8 @@ namespace {
 void CheckHashArguments(const Vector &input, Vector *result) {
   if (result->GetTypeId() != TypeId::Hash) {
     throw EXECUTION_EXCEPTION(
-        fmt::format("Output of Hash() operation must be hash, but is type {}.", TypeIdToString(result->GetTypeId())));
+        fmt::format("Output of Hash() operation must be hash, but is type {}.", TypeIdToString(result->GetTypeId())),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/execution/sql/vector_operations/inplace_arithmetic.cpp
+++ b/src/execution/sql/vector_operations/inplace_arithmetic.cpp
@@ -55,7 +55,8 @@ void VectorOps::AddInPlace(const exec::ExecutionSettings &exec_settings, Vector 
       break;
     default:
       throw EXECUTION_EXCEPTION(
-          fmt::format("Invalid type for in-place arithmetic operation, type {}.", TypeIdToString(left->GetTypeId())));
+          fmt::format("Invalid type for in-place arithmetic operation, type {}.", TypeIdToString(left->GetTypeId())),
+          common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/execution/sql/vector_operations/inplace_bitwise.cpp
+++ b/src/execution/sql/vector_operations/inplace_bitwise.cpp
@@ -49,7 +49,8 @@ void VectorOps::BitwiseAndInPlace(const exec::ExecutionSettings &exec_settings, 
       break;
     default:
       throw EXECUTION_EXCEPTION(
-          fmt::format("Invalid type for in-place bitwise operation, type {}.", TypeIdToString(left->GetTypeId())));
+          fmt::format("Invalid type for in-place bitwise operation, type {}.", TypeIdToString(left->GetTypeId())),
+          common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/execution/sql/vector_operations/like.cpp
+++ b/src/execution/sql/vector_operations/like.cpp
@@ -45,7 +45,8 @@ template <typename Op>
 void TemplatedLikeOperation(const Vector &a, const Vector &b, TupleIdList *tid_list) {
   if (a.GetTypeId() != TypeId::Varchar || b.GetTypeId() != TypeId::Varchar) {
     throw EXECUTION_EXCEPTION(fmt::format("Inputs to (NOT) LIKE must be VARCHAR, left {} right {}.",
-                                          TypeIdToString(a.GetTypeId()), TypeIdToString(b.GetTypeId())));
+                                          TypeIdToString(a.GetTypeId()), TypeIdToString(b.GetTypeId())),
+                              common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 
   if (b.IsConstant()) {

--- a/src/execution/sql/vector_operations/select.cpp
+++ b/src/execution/sql/vector_operations/select.cpp
@@ -46,23 +46,27 @@ struct IsSafeForFullCompute<T, std::enable_if_t<std::is_fundamental_v<T> || std:
 void CheckSelection(const Vector &left, const Vector &right, TupleIdList *result) {
   if (left.GetTypeId() != right.GetTypeId()) {
     throw EXECUTION_EXCEPTION(fmt::format("Input vector types must match for selections, left {} right {}.",
-                                          TypeIdToString(left.GetTypeId()), TypeIdToString(right.GetTypeId())));
+                                          TypeIdToString(left.GetTypeId()), TypeIdToString(right.GetTypeId())),
+                              common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
   if (!left.IsConstant() && !right.IsConstant()) {
     if (left.GetSize() != right.GetSize()) {
       throw EXECUTION_EXCEPTION(
           fmt::format("Left and right vectors to comparison have different sizes, left {} right {}.", left.GetSize(),
-                      right.GetSize()));
+                      right.GetSize()),
+          common::ErrorCode::ERRCODE_INTERNAL_ERROR);
     }
     if (left.GetCount() != right.GetCount()) {
       throw EXECUTION_EXCEPTION(
           fmt::format("Left and right vectors to comparison have different counts, left {} right {}.", left.GetCount(),
-                      right.GetCount()));
+                      right.GetCount()),
+          common::ErrorCode::ERRCODE_INTERNAL_ERROR);
     }
     if (result->GetCapacity() != left.GetSize()) {
       throw EXECUTION_EXCEPTION(
           fmt::format("Result list not large enough to store all TIDs in input vector, result {} input {}.",
-                      result->GetCapacity(), left.GetSize()));
+                      result->GetCapacity(), left.GetSize()),
+          common::ErrorCode::ERRCODE_INTERNAL_ERROR);
     }
   }
 }

--- a/src/include/common/error/exception.h
+++ b/src/include/common/error/exception.h
@@ -22,8 +22,8 @@ namespace terrier {
 #define NETWORK_PROCESS_EXCEPTION(msg) NetworkProcessException(msg, __FILE__, __LINE__)
 #define OPTIMIZER_EXCEPTION(msg) OptimizerException(msg, __FILE__, __LINE__)
 #define SYNTAX_EXCEPTION(msg) SyntaxException(msg, __FILE__, __LINE__)
-#define EXECUTION_EXCEPTION(msg) ExecutionException(msg, __FILE__, __LINE__)
 #define ABORT_EXCEPTION(msg) AbortException(msg, __FILE__, __LINE__)
+#define EXECUTION_EXCEPTION(msg, code) ExecutionException(msg, __FILE__, __LINE__, (code))
 #define BINDER_EXCEPTION(msg, code) BinderException(msg, __FILE__, __LINE__, (code))
 #define SETTINGS_EXCEPTION(msg, code) SettingsException(msg, __FILE__, __LINE__, (code))
 
@@ -155,8 +155,8 @@ DEFINE_EXCEPTION(NetworkProcessException, ExceptionType::NETWORK);
 DEFINE_EXCEPTION(OptimizerException, ExceptionType::OPTIMIZER);
 DEFINE_EXCEPTION(ConversionException, ExceptionType::CONVERSION);
 DEFINE_EXCEPTION(SyntaxException, ExceptionType::SYNTAX);
-DEFINE_EXCEPTION(ExecutionException, ExceptionType::EXECUTION);
 DEFINE_EXCEPTION(AbortException, ExceptionType::EXECUTION);
+DEFINE_EXCEPTION_WITH_ERRCODE(ExecutionException, ExceptionType::EXECUTION);
 DEFINE_EXCEPTION_WITH_ERRCODE(BinderException, ExceptionType::BINDER);
 DEFINE_EXCEPTION_WITH_ERRCODE(SettingsException, ExceptionType::SETTINGS);
 

--- a/src/include/execution/sql/operators/cast_operators.h
+++ b/src/include/execution/sql/operators/cast_operators.h
@@ -46,7 +46,8 @@ struct EXPORT Cast {
     if (!TryCast<InType, OutType>{}(input, &result)) {
       throw EXECUTION_EXCEPTION(
           fmt::format("Type {} cannot be cast because the value is out of range for the target type {}.",
-                      TypeIdToString(GetTypeId<InType>()), TypeIdToString(GetTypeId<OutType>())));
+                      TypeIdToString(GetTypeId<InType>()), TypeIdToString(GetTypeId<OutType>())),
+          common::ErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE);
     }
     return result;  // NOLINT
   }

--- a/src/include/execution/sql/vector_operations/inplace_operation_executor.h
+++ b/src/include/execution/sql/vector_operations/inplace_operation_executor.h
@@ -22,12 +22,14 @@ inline void CheckInplaceOperation(const Vector *result, const Vector &input) {
   if (result->GetTypeId() != input.GetTypeId()) {
     throw EXECUTION_EXCEPTION(
         fmt::format("Left and right vector types to inplace operation must be the same, left {} right {}.",
-                    TypeIdToString(result->GetTypeId()), TypeIdToString(input.GetTypeId())));
+                    TypeIdToString(result->GetTypeId()), TypeIdToString(input.GetTypeId())),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
   if (!input.IsConstant() && result->GetCount() != input.GetCount()) {
     throw EXECUTION_EXCEPTION(
         fmt::format("Left and right input vectors to binary operation must have the same size, left {} right {}.",
-                    result->GetCount(), input.GetCount()));
+                    result->GetCount(), input.GetCount()),
+        common::ErrorCode::ERRCODE_INTERNAL_ERROR);
   }
 }
 

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -391,7 +391,17 @@ TrafficCopResult TrafficCop::RunExecutableQuery(const common::ManagedPointer<net
 
   const auto exec_query = portal->GetStatement()->GetExecutableQuery();
 
-  exec_query->Run(common::ManagedPointer(exec_ctx), execution_mode_);
+  try {
+    exec_query->Run(common::ManagedPointer(exec_ctx), execution_mode_);
+  } catch (ExecutionException &e) {
+    /*
+     * An ExecutionException is thrown in the case of some failure caused by a software bug or caused by some data
+     * exception. In either case we abort the current transaction and return an error to the client.
+     */
+    connection_ctx->Transaction()->SetMustAbort();
+    auto error = common::ErrorData(common::ErrorSeverity::ERROR, e.what(), e.code_);
+    return {ResultType::ERROR, error};
+  }
 
   if (connection_ctx->TransactionState() == network::NetworkTransactionStateType::BLOCK) {
     // Execution didn't set us to FAIL state, go ahead and return command complete

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -398,8 +398,11 @@ TrafficCopResult TrafficCop::RunExecutableQuery(const common::ManagedPointer<net
      * An ExecutionException is thrown in the case of some failure caused by a software bug or caused by some data
      * exception. In either case we abort the current transaction and return an error to the client.
      */
+    // TODO(Matt): evict this plan from the statement cache when the functionality is available
     connection_ctx->Transaction()->SetMustAbort();
     auto error = common::ErrorData(common::ErrorSeverity::ERROR, e.what(), e.code_);
+    error.AddField(common::ErrorField::LINE, std::to_string(e.GetLine()));
+    error.AddField(common::ErrorField::FILE, e.GetFile());
     return {ResultType::ERROR, error};
   }
 


### PR DESCRIPTION
Currently there are various places where ExecutionException can be
thrown from, mostly only reachable through software bugs. Before
this commit they will be fatal and cause the DB to crash.

This commit now handles ExecutionExceptions byt causing the
transaction to abort, and returning an error message to the user.