### PR TITLE
Fix CREATE INDEX creation of PR

### DIFF
--- a/script/testing/junit/traces/create_index.test
+++ b/script/testing/junit/traces/create_index.test
@@ -1,0 +1,59 @@
+statement ok
+CREATE TABLE t (a INT, b INT, c INT);
+
+statement ok
+INSERT INTO t VALUES (1, 2, 3);
+
+statement ok
+INSERT INTO t VALUES (4, 5, 6);
+
+statement ok
+INSERT INTO t VALUES (7, 8, 9);
+
+statement ok
+
+
+statement ok
+CREATE INDEX idxa ON t (a);
+
+statement ok
+CREATE INDEX idxb ON t (b);
+
+statement ok
+CREATE INDEX idxc ON t (c);
+
+statement ok
+
+
+# Obviously, we assume the following are index scans.
+# If they are not, this test is moot.
+# When we support `EXPLAIN`, then we can just do that.
+statement ok
+
+
+query III nosort
+SELECT * from t WHERE a = 1;
+----
+3 values hashing to c0710d6b4f15dfa88f600b0e6b624077
+
+query III nosort
+SELECT * from t WHERE b = 5;
+----
+3 values hashing to 47d69c01abdea0f776cbc9e788b5186f
+
+query III nosort
+SELECT * from t WHERE c = 9;
+----
+3 values hashing to a873cf97b7aacbd83abb3d4ccbc36fa3
+
+statement ok
+
+
+statement ok
+CREATE INDEX idxcomb ON t (c, b, a);
+
+query III nosort
+SELECT * from t WHERE a = 4 and b = 5 and c = 6;
+----
+3 values hashing to 47d69c01abdea0f776cbc9e788b5186f
+


### PR DESCRIPTION
Since there isn't a corresponding issue, the bug (with repro) is as follows:
From this commit: efcb7e6311c784500cba3b9baa8d2c9fdf11f503

```
psql (10.14 (Ubuntu 10.14-0ubuntu0.18.04.1), server 9.5devel)
Type "help" for help.

terrier=# create table t (a INT, b INT, c INT);
CREATE TABLE
terrier=# insert into t values (1, 2, 3);
INSERT 0 1
terrier=# create index idx on t (c);
CREATE INDEX
terrier=# select * from t where c = 3;
 a | b | c 
---+---+---
(0 rows)

terrier=# create index idx_a on t (a);
CREATE INDEX
terrier=# select * from t where a = 1;
 a | b | c 
---+---+---
 1 | 2 | 3
(1 row)

terrier=# select * from t where c = 3;
 a | b | c 
---+---+---
(0 rows)
```

The fix corrects the offset passed to `VPIGet` when fetching a column value that is needed when constructing the PR in preparation for inserting into the index. The fix still maintains the base column assumption (that also exists inside the optimizer's index selection logic).