### PR TITLE
Performance Fix - Use col_ids during codegen of Index scan

### DIFF
--- a/src/execution/compiler/operator/index_scan_translator.cpp
+++ b/src/execution/compiler/operator/index_scan_translator.cpp
@@ -20,12 +20,13 @@ IndexScanTranslator::IndexScanTranslator(const planner::IndexScanPlanNode &plan,
                                          CompilationContext *compilation_context, Pipeline *pipeline)
     : OperatorTranslator(plan, compilation_context, pipeline, brain::ExecutionOperatingUnitType::IDX_SCAN),
       input_oids_(plan.GetColumnOids()),
+      col_ids_array_(GetCodeGen()->GetCatalogAccessor()->GetTable(plan.GetTableOid())->ColIdsForOids(input_oids_)),
       table_schema_(GetCodeGen()->GetCatalogAccessor()->GetSchema(plan.GetTableOid())),
       table_pm_(GetCodeGen()->GetCatalogAccessor()->GetTable(plan.GetTableOid())->ProjectionMapForOids(input_oids_)),
       index_schema_(GetCodeGen()->GetCatalogAccessor()->GetIndexSchema(plan.GetIndexOid())),
       index_pm_(GetCodeGen()->GetCatalogAccessor()->GetIndex(plan.GetIndexOid())->GetKeyOidToOffsetMap()),
       index_iter_(GetCodeGen()->MakeFreshIdentifier("index_iter")),
-      col_oids_(GetCodeGen()->MakeFreshIdentifier("col_oids")),
+      col_ids_(GetCodeGen()->MakeFreshIdentifier("col_ids")),
       index_pr_(GetCodeGen()->MakeFreshIdentifier("index_pr")),
       lo_index_pr_(GetCodeGen()->MakeFreshIdentifier("lo_index_pr")),
       hi_index_pr_(GetCodeGen()->MakeFreshIdentifier("hi_index_pr")),
@@ -51,11 +52,11 @@ IndexScanTranslator::IndexScanTranslator(const planner::IndexScanPlanNode &plan,
 
 void IndexScanTranslator::PerformPipelineWork(WorkContext *context, FunctionBuilder *function) const {
   const auto &op = GetPlanAs<planner::IndexScanPlanNode>();
-  // var col_oids: [num_cols]uint32
-  // col_oids[i] = ...
-  SetOids(function);
+  // var col_ids: [num_cols]uint32
+  // col_ids[i] = ...
+  SetIds(function);
   // var index_iter : IndexIterator
-  // @indexIteratorInit(&index_iter, queryState.execCtx, num_attrs, table_oid, index_oid, col_oids)
+  // @indexIteratorInit(&index_iter, queryState.execCtx, num_attrs, table_oid, index_oid, col_ids)
   DeclareIterator(function);
   // Either:
   // (A) var index_pr = @indexIteratorGetPR(&index_iter)
@@ -111,15 +112,15 @@ ast::Expr *IndexScanTranslator::GetTableColumn(catalog::col_oid_t col_oid) const
   return GetCodeGen()->PRGet(GetCodeGen()->MakeExpr(table_pr_), type, nullable, attr_idx);
 }
 
-void IndexScanTranslator::SetOids(FunctionBuilder *builder) const {
-  // var col_oids: [num_cols]uint32
-  ast::Expr *arr_type = GetCodeGen()->ArrayType(input_oids_.size(), ast::BuiltinType::Kind::Uint32);
-  builder->Append(GetCodeGen()->DeclareVar(col_oids_, arr_type, nullptr));
+void IndexScanTranslator::SetIds(FunctionBuilder *builder) const {
+  // var col_ids: [num_cols]uint32
+  ast::Expr *arr_type = GetCodeGen()->ArrayType(col_ids_array_.size(), ast::BuiltinType::Kind::Uint32);
+  builder->Append(GetCodeGen()->DeclareVar(col_ids_, arr_type, nullptr));
 
   for (uint16_t i = 0; i < input_oids_.size(); i++) {
-    // col_oids[i] = col_oid
-    ast::Expr *lhs = GetCodeGen()->ArrayAccess(col_oids_, i);
-    ast::Expr *rhs = GetCodeGen()->Const32(input_oids_[i].UnderlyingValue());
+    // col_ids[i] = col_id
+    ast::Expr *lhs = GetCodeGen()->ArrayAccess(col_ids_, i);
+    ast::Expr *rhs = GetCodeGen()->Const32(col_ids_array_[i].UnderlyingValue());
     builder->Append(GetCodeGen()->Assign(lhs, rhs));
   }
 }
@@ -128,7 +129,7 @@ void IndexScanTranslator::DeclareIterator(FunctionBuilder *builder) const {
   // var index_iter : IndexIterator
   ast::Expr *iter_type = GetCodeGen()->BuiltinType(ast::BuiltinType::IndexIterator);
   builder->Append(GetCodeGen()->DeclareVar(index_iter_, iter_type, nullptr));
-  // @indexIteratorInit(&index_iter, queryState.execCtx, num_attrs, table_oid, index_oid, col_oids)
+  // @indexIteratorInit(&index_iter, queryState.execCtx, num_attrs, table_oid, index_oid, col_ids)
   uint32_t num_attrs = 0;
   const auto &op = GetPlanAs<planner::IndexScanPlanNode>();
   if (op.GetScanType() == planner::IndexScanType::Exact) {
@@ -139,7 +140,7 @@ void IndexScanTranslator::DeclareIterator(FunctionBuilder *builder) const {
 
   ast::Expr *init_call = GetCodeGen()->IndexIteratorInit(
       index_iter_, GetCompilationContext()->GetExecutionContextPtrFromQueryState(), num_attrs,
-      op.GetTableOid().UnderlyingValue(), op.GetIndexOid().UnderlyingValue(), col_oids_);
+      op.GetTableOid().UnderlyingValue(), op.GetIndexOid().UnderlyingValue(), col_ids_);
   builder->Append(GetCodeGen()->MakeStmt(init_call));
 }
 

--- a/src/execution/sql/index_iterator.cpp
+++ b/src/execution/sql/index_iterator.cpp
@@ -7,18 +7,18 @@
 namespace terrier::execution::sql {
 
 IndexIterator::IndexIterator(exec::ExecutionContext *exec_ctx, uint32_t num_attrs, uint32_t table_oid,
-                             uint32_t index_oid, uint32_t *col_oids, uint32_t num_oids)
+                             uint32_t index_oid, uint32_t *col_ids, uint32_t num_ids)
     : exec_ctx_(exec_ctx),
       num_attrs_(num_attrs),
-      col_oids_(col_oids, col_oids + num_oids),
+      col_ids_(col_ids, col_ids + num_ids),
       index_(exec_ctx_->GetAccessor()->GetIndex(catalog::index_oid_t(index_oid))),
       table_(exec_ctx_->GetAccessor()->GetTable(catalog::table_oid_t(table_oid))) {}
 
 void IndexIterator::Init() {
   // Initialize projected rows for the index and the table
-  TERRIER_ASSERT(!col_oids_.empty(), "There must be at least one col oid!");
+  TERRIER_ASSERT(!col_ids_.empty(), "There must be at least one col oid!");
   // Table's PR
-  auto table_pri = table_->InitializerForProjectedRow(col_oids_);
+  auto table_pri = table_->InitializerForProjectedRow(col_ids_);
   table_buffer_ = exec_ctx_->GetMemoryPool()->AllocateAligned(table_pri.ProjectedRowSize(), alignof(uint64_t), false);
   table_pr_ = table_pri.InitializeRow(table_buffer_);
 

--- a/src/include/execution/compiler/operator/index_join_translator.h
+++ b/src/include/execution/compiler/operator/index_join_translator.h
@@ -59,7 +59,7 @@ class IndexJoinTranslator : public OperatorTranslator, public PipelineDriver {
 
  private:
   void DeclareIterator(FunctionBuilder *builder) const;
-  void SetOids(FunctionBuilder *builder) const;
+  void SetIds(FunctionBuilder *builder) const;
   void FillKey(WorkContext *context, FunctionBuilder *builder, ast::Identifier pr,
                const std::unordered_map<catalog::indexkeycol_oid_t, planner::IndexExpression> &index_exprs) const;
   void FreeIterator(FunctionBuilder *builder) const;
@@ -69,6 +69,7 @@ class IndexJoinTranslator : public OperatorTranslator, public PipelineDriver {
 
  private:
   std::vector<catalog::col_oid_t> input_oids_;
+  std::vector<storage::col_id_t> col_ids_array_;
   const catalog::Schema &table_schema_;
   storage::ProjectionMap table_pm_;
   const catalog::IndexSchema &index_schema_;
@@ -76,7 +77,7 @@ class IndexJoinTranslator : public OperatorTranslator, public PipelineDriver {
 
   // Structs and local variables
   ast::Identifier index_iter_;
-  ast::Identifier col_oids_;
+  ast::Identifier col_ids_;
   ast::Identifier lo_index_pr_;
   ast::Identifier hi_index_pr_;
   ast::Identifier table_pr_;

--- a/src/include/execution/compiler/operator/index_scan_translator.h
+++ b/src/include/execution/compiler/operator/index_scan_translator.h
@@ -59,7 +59,7 @@ class IndexScanTranslator : public OperatorTranslator, public PipelineDriver {
 
  private:
   void DeclareIterator(FunctionBuilder *builder) const;
-  void SetOids(FunctionBuilder *builder) const;
+  void SetIds(FunctionBuilder *builder) const;
   void FillKey(WorkContext *context, FunctionBuilder *builder, ast::Identifier pr,
                const std::unordered_map<catalog::indexkeycol_oid_t, planner::IndexExpression> &index_exprs) const;
   void FreeIterator(FunctionBuilder *builder) const;
@@ -69,6 +69,7 @@ class IndexScanTranslator : public OperatorTranslator, public PipelineDriver {
 
  private:
   std::vector<catalog::col_oid_t> input_oids_;
+  std::vector<storage::col_id_t> col_ids_array_;
   const catalog::Schema &table_schema_;
   storage::ProjectionMap table_pm_;
   const catalog::IndexSchema &index_schema_;
@@ -76,7 +77,7 @@ class IndexScanTranslator : public OperatorTranslator, public PipelineDriver {
 
   // Structs and local variables
   ast::Identifier index_iter_;
-  ast::Identifier col_oids_;
+  ast::Identifier col_ids_;
   ast::Identifier index_pr_;
   ast::Identifier lo_index_pr_;
   ast::Identifier hi_index_pr_;

--- a/src/include/execution/sql/index_iterator.h
+++ b/src/include/execution/sql/index_iterator.h
@@ -28,7 +28,7 @@ class EXPORT IndexIterator {
    * @param num_oids number of oids
    */
   explicit IndexIterator(exec::ExecutionContext *exec_ctx, uint32_t num_attrs, uint32_t table_oid, uint32_t index_oid,
-                         uint32_t *col_oids, uint32_t num_oids);
+                         uint32_t *col_ids, uint32_t num_ids);
 
   /**
    * Initialize the projected row and begin scanning.
@@ -97,7 +97,7 @@ class EXPORT IndexIterator {
  private:
   exec::ExecutionContext *exec_ctx_;
   uint32_t num_attrs_;
-  std::vector<catalog::col_oid_t> col_oids_;
+  std::vector<storage::col_id_t> col_ids_;
   common::ManagedPointer<storage::index::Index> index_;
   common::ManagedPointer<storage::SqlTable> table_;
 


### PR DESCRIPTION
Currently, the codegen of index scans in terrier/noisepage call the function col_oid_to_ids every time they have to fetch a tuple or operate on it. This PR, modifies that and generates the col_ids in TPL and directly uses them in the scan. 