### PR TITLE
Run clang-format-10 on codebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ endif ()
 # COMPILER TOOLS
 ###################################################
 
-set(CLANG_TOOLS_VERSION "10")
+set(CLANG_TOOLS_VERSION "8")
 find_package(ClangTools)
 if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
     # Generate a Clang compile_commands.json "compilation database" file for use

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ endif ()
 # COMPILER TOOLS
 ###################################################
 
-set(CLANG_TOOLS_VERSION "8")
+set(CLANG_TOOLS_VERSION "10")
 find_package(ClangTools)
 if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
     # Generate a Clang compile_commands.json "compilation database" file for use

--- a/benchmark/benchmark_util/benchmark_main.cpp
+++ b/benchmark/benchmark_util/benchmark_main.cpp
@@ -17,10 +17,9 @@
 //
 // Modified from the Apache Arrow project for the Terrier project.
 
-#include <common/macros.h>
-
 #include "benchmark/benchmark.h"
 #include "benchmark_util/benchmark_config.h"
+#include "common/macros.h"
 #include "loggers/loggers_util.h"
 
 int main(int argc, char **argv) {

--- a/benchmark/runner/mini_runners.cpp
+++ b/benchmark/runner/mini_runners.cpp
@@ -1,4 +1,3 @@
-#include <common/macros.h>
 #include <gflags/gflags.h>
 
 #include <cstdio>
@@ -12,6 +11,7 @@
 #include "binder/bind_node_visitor.h"
 #include "brain/brain_defs.h"
 #include "brain/operating_unit.h"
+#include "common/macros.h"
 #include "common/scoped_timer.h"
 #include "execution/compiler/compilation_context.h"
 #include "execution/compiler/executable_query.h"

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -269,10 +269,10 @@ include_directories(SYSTEM ${PQXX_INCLUDE_DIRECTORIES})
 list(APPEND TERRIER_LINK_LIBS ${PQXX_LIBRARIES})
 
 # LLVM 8.0
-find_package(LLVM 10.0 REQUIRED CONFIG)
+find_package(LLVM 8.0 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-if (${LLVM_PACKAGE_VERSION} VERSION_LESS "10.0")
-    message(FATAL_ERROR "LLVM 10.0 or newer is required.")
+if (${LLVM_PACKAGE_VERSION} VERSION_LESS "8.0")
+    message(FATAL_ERROR "LLVM 8.0 or newer is required.")
 endif ()
 llvm_map_components_to_libnames(LLVM_LIBRARIES core mcjit nativecodegen native ipo)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -269,10 +269,10 @@ include_directories(SYSTEM ${PQXX_INCLUDE_DIRECTORIES})
 list(APPEND TERRIER_LINK_LIBS ${PQXX_LIBRARIES})
 
 # LLVM 8.0
-find_package(LLVM 8.0 REQUIRED CONFIG)
+find_package(LLVM 10.0 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-if (${LLVM_PACKAGE_VERSION} VERSION_LESS "8.0")
-    message(FATAL_ERROR "LLVM 8.0 or newer is required.")
+if (${LLVM_PACKAGE_VERSION} VERSION_LESS "10.0")
+    message(FATAL_ERROR "LLVM 10.0 or newer is required.")
 endif ()
 llvm_map_components_to_libnames(LLVM_LIBRARIES core mcjit nativecodegen native ipo)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/script/micro_bench/run_micro_bench.py
+++ b/script/micro_bench/run_micro_bench.py
@@ -84,7 +84,7 @@ BENCHMARKS_TO_RUN = {
     "cuckoomap_benchmark":                  DEFAULT_FAILURE_THRESHOLD,
     "parser_benchmark":                     20,
     "slot_iterator_benchmark":              DEFAULT_FAILURE_THRESHOLD,
-    "varlen_entry_benchmark":               DEFAULT_FAILURE_THRESHOLD,
+    "varlen_entry_benchmark":               30,
 }
 
 # The number of threads to use for multi-threaded benchmarks.

--- a/src/brain/brain_util.cpp
+++ b/src/brain/brain_util.cpp
@@ -1,4 +1,4 @@
-#include "brain/brain_util.h
+#include "brain/brain_util.h"
 #include "execution/util/execution_common.h"
 
 namespace terrier::brain {

--- a/src/brain/brain_util.cpp
+++ b/src/brain/brain_util.cpp
@@ -1,5 +1,5 @@
-#include <brain/brain_util.h>
-#include <execution/util/execution_common.h>
+#include "brain/brain_util.h
+#include "execution/util/execution_common.h"
 
 namespace terrier::brain {
 

--- a/src/brain/brain_util.cpp
+++ b/src/brain/brain_util.cpp
@@ -1,5 +1,4 @@
 #include <brain/brain_util.h>
-
 #include <execution/util/execution_common.h>
 
 namespace terrier::brain {

--- a/src/catalog/catalog_defs.cpp
+++ b/src/catalog/catalog_defs.cpp
@@ -1,4 +1,5 @@
 #include "catalog/catalog_defs.h"
+
 #include "common/strong_typedef_body.h"
 
 namespace terrier::catalog {

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -1,10 +1,11 @@
+#include "catalog/database_catalog.h"
+
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "catalog/catalog_defs.h"
-#include "catalog/database_catalog.h"
 #include "catalog/index_schema.h"
 #include "catalog/postgres/builder.h"
 #include "catalog/postgres/pg_attribute.h"

--- a/src/catalog/index_schema.cpp
+++ b/src/catalog/index_schema.cpp
@@ -1,4 +1,5 @@
 #include "catalog/index_schema.h"
+
 #include "common/json.h"
 
 namespace terrier::catalog {

--- a/src/catalog/schema.cpp
+++ b/src/catalog/schema.cpp
@@ -1,4 +1,5 @@
 #include "catalog/schema.h"
+
 #include "common/json.h"
 
 namespace terrier::catalog {

--- a/src/common/action_context.cpp
+++ b/src/common/action_context.cpp
@@ -1,4 +1,5 @@
 #include "common/action_context.h"
+
 #include "common/strong_typedef_body.h"
 
 namespace terrier::common {

--- a/src/common/thread_context.cpp
+++ b/src/common/thread_context.cpp
@@ -1,4 +1,5 @@
 #include "common/thread_context.h"
+
 #include "metrics/metrics_manager.h"
 #include "metrics/metrics_store.h"
 

--- a/src/execution/compiler/operator/index_create_translator.cpp
+++ b/src/execution/compiler/operator/index_create_translator.cpp
@@ -1,7 +1,5 @@
 #include "execution/compiler/operator/index_create_translator.h"
 
-#include "execution/sql/ddl_executors.h"
-
 #include "catalog/catalog_accessor.h"
 #include "execution/compiler/codegen.h"
 #include "execution/compiler/compilation_context.h"
@@ -10,6 +8,7 @@
 #include "execution/compiler/loop.h"
 #include "execution/compiler/pipeline.h"
 #include "execution/compiler/work_context.h"
+#include "execution/sql/ddl_executors.h"
 #include "parser/expression/column_value_expression.h"
 #include "parser/expression_util.h"
 #include "planner/plannodes/create_index_plan_node.h"

--- a/src/execution/compiler/operator/static_aggregation_translator.cpp
+++ b/src/execution/compiler/operator/static_aggregation_translator.cpp
@@ -75,8 +75,10 @@ ast::StructDecl *StaticAggregationTranslator::GenerateValuesStruct() {
 
   uint32_t term_idx = 0;
   for (const auto &term : GetAggPlan().GetAggregateTerms()) {
+    TERRIER_ASSERT(term->GetChild(0)->GetReturnValueType() != type::TypeId::INVALID,
+                   "Return value type of child expression is invalid.");
     auto field_name = codegen->MakeIdentifier(AGG_ATTR_PREFIX + std::to_string(term_idx));
-    auto type = codegen->TplType(sql::GetTypeId(term->GetReturnValueType()));
+    auto type = codegen->TplType(sql::GetTypeId(term->GetChild(0)->GetReturnValueType()));
     fields.push_back(codegen->MakeField(field_name, type));
     term_idx++;
   }

--- a/src/execution/exec_defs.cpp
+++ b/src/execution/exec_defs.cpp
@@ -1,4 +1,5 @@
 #include "execution/exec_defs.h"
+
 #include "common/strong_typedef_body.h"
 
 namespace terrier::execution {

--- a/src/execution/sema/error_reporter.cpp
+++ b/src/execution/sema/error_reporter.cpp
@@ -5,7 +5,6 @@
 
 #include "execution/ast/type.h"
 #include "execution/ast/type_visitor.h"
-
 #include "loggers/execution_logger.h"
 
 namespace terrier::execution::sema {

--- a/src/execution/sema/sema_decl.cpp
+++ b/src/execution/sema/sema_decl.cpp
@@ -1,4 +1,5 @@
 #include <llvm/ADT/DenseSet.h>
+
 #include "execution/ast/context.h"
 #include "execution/ast/type.h"
 #include "execution/sema/sema.h"

--- a/src/execution/sema/sema_type.cpp
+++ b/src/execution/sema/sema_type.cpp
@@ -1,9 +1,8 @@
-#include "execution/sema/sema.h"
-
 #include <utility>
 
 #include "execution/ast/context.h"
 #include "execution/ast/type.h"
+#include "execution/sema/sema.h"
 
 namespace terrier::execution::sema {
 

--- a/src/execution/sql/aggregation_hash_table.cpp
+++ b/src/execution/sql/aggregation_hash_table.cpp
@@ -313,8 +313,8 @@ void AggregationHashTable::LookupInitial() {
   //               use SIMD gathers if hashes vector is full. For some reason it
   //               isn't. Investigate why.
   UnaryOperationExecutor::Execute<hash_t, const HashTableEntry *>(
-      exec_settings_, *batch_state_->Hashes(),
-      batch_state_->Entries(), [&](const hash_t hash) noexcept { return hash_table_.FindChainHead(hash); });
+      exec_settings_, *batch_state_->Hashes(), batch_state_->Entries(),
+      [&](const hash_t hash) noexcept { return hash_table_.FindChainHead(hash); });
 
   // Find non-null entries whose keys must be checked and place them in the
   // key-not-equal list which is used during key equality checking.

--- a/src/execution/sql/aggregation_hash_table.cpp
+++ b/src/execution/sql/aggregation_hash_table.cpp
@@ -313,8 +313,8 @@ void AggregationHashTable::LookupInitial() {
   //               use SIMD gathers if hashes vector is full. For some reason it
   //               isn't. Investigate why.
   UnaryOperationExecutor::Execute<hash_t, const HashTableEntry *>(
-      exec_settings_, *batch_state_->Hashes(), batch_state_->Entries(),
-      [&](const hash_t hash) noexcept { return hash_table_.FindChainHead(hash); });
+      exec_settings_, *batch_state_->Hashes(),
+      batch_state_->Entries(), [&](const hash_t hash) noexcept { return hash_table_.FindChainHead(hash); });
 
   // Find non-null entries whose keys must be checked and place them in the
   // key-not-equal list which is used during key equality checking.

--- a/src/execution/sql/join_hash_table.cpp
+++ b/src/execution/sql/join_hash_table.cpp
@@ -513,8 +513,8 @@ void JoinHashTable::Build() {
 
 void JoinHashTable::LookupBatchInChainingHashTable(const Vector &hashes, Vector *results) const {
   UnaryOperationExecutor::Execute<hash_t, const HashTableEntry *>(
-      exec_settings_, hashes, results,
-      [&](const hash_t hash_val) noexcept { return chaining_hash_table_.FindChainHead(hash_val); });
+      exec_settings_, hashes,
+      results, [&](const hash_t hash_val) noexcept { return chaining_hash_table_.FindChainHead(hash_val); });
 }
 
 void JoinHashTable::LookupBatchInConciseHashTable(const Vector &hashes, Vector *results) const {

--- a/src/execution/sql/join_hash_table.cpp
+++ b/src/execution/sql/join_hash_table.cpp
@@ -513,8 +513,8 @@ void JoinHashTable::Build() {
 
 void JoinHashTable::LookupBatchInChainingHashTable(const Vector &hashes, Vector *results) const {
   UnaryOperationExecutor::Execute<hash_t, const HashTableEntry *>(
-      exec_settings_, hashes,
-      results, [&](const hash_t hash_val) noexcept { return chaining_hash_table_.FindChainHead(hash_val); });
+      exec_settings_, hashes, results,
+      [&](const hash_t hash_val) noexcept { return chaining_hash_table_.FindChainHead(hash_val); });
 }
 
 void JoinHashTable::LookupBatchInConciseHashTable(const Vector &hashes, Vector *results) const {

--- a/src/execution/sql/vector_operations/cast.cpp
+++ b/src/execution/sql/vector_operations/cast.cpp
@@ -1,12 +1,10 @@
 #include <string>
 
-#include "execution/sql/vector_operations/vector_operations.h"
-
-#include "spdlog/fmt/fmt.h"
-
 #include "common/error/exception.h"
 #include "execution/sql/operators/cast_operators.h"
 #include "execution/sql/vector_operations/unary_operation_executor.h"
+#include "execution/sql/vector_operations/vector_operations.h"
+#include "spdlog/fmt/fmt.h"
 
 namespace terrier::execution::sql {
 

--- a/src/execution/sql/vector_operations/copy.cpp
+++ b/src/execution/sql/vector_operations/copy.cpp
@@ -1,8 +1,6 @@
-#include "execution/sql/vector_operations/vector_operations.h"
-
-#include "spdlog/fmt/fmt.h"
-
 #include "common/error/exception.h"
+#include "execution/sql/vector_operations/vector_operations.h"
+#include "spdlog/fmt/fmt.h"
 
 namespace terrier::execution::sql {
 

--- a/src/execution/sql/vector_operations/null.cpp
+++ b/src/execution/sql/vector_operations/null.cpp
@@ -1,6 +1,5 @@
-#include "execution/sql/vector_operations/vector_operations.h"
-
 #include "execution/sql/tuple_id_list.h"
+#include "execution/sql/vector_operations/vector_operations.h"
 
 namespace terrier::execution::sql {
 

--- a/src/include/brain/brain_util.h
+++ b/src/include/brain/brain_util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "brain/brain_defs.h"
 
 namespace terrier::brain {

--- a/src/include/common/allocator.h
+++ b/src/include/common/allocator.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cerrno>
 #include <cstdlib>
+
 #include "common/strong_typedef.h"
 namespace terrier {
 // Use byte for raw byte storage instead of char so string functions are explicitly disabled for those.

--- a/src/include/common/container/bitmap.h
+++ b/src/include/common/container/bitmap.h
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <memory>
+
 #include "common/strong_typedef.h"
 
 #ifndef BYTE_SIZE

--- a/src/include/common/container/concurrent_bitmap.h
+++ b/src/include/common/container/concurrent_bitmap.h
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <memory>
+
 #include "common/allocator.h"
 #include "common/container/bitmap.h"
 #include "common/strong_typedef.h"

--- a/src/include/common/container/concurrent_blocking_queue.h
+++ b/src/include/common/container/concurrent_blocking_queue.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <tbb/concurrent_queue.h>
+
 #include "common/macros.h"
 
 namespace terrier::common {

--- a/src/include/common/container/concurrent_map.h
+++ b/src/include/common/container/concurrent_map.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <tbb/concurrent_unordered_map.h>
+
 #include <functional>
 #include <utility>
+
 #include "common/macros.h"
 #include "common/strong_typedef.h"
 

--- a/src/include/common/container/concurrent_queue.h
+++ b/src/include/common/container/concurrent_queue.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <tbb/concurrent_queue.h>
+
 #include "common/macros.h"
 
 namespace terrier::common {

--- a/src/include/common/dedicated_thread_owner.h
+++ b/src/include/common/dedicated_thread_owner.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
 #include <thread>  // NOLINT
+
 #include "common/dedicated_thread_task.h"
 #include "common/managed_pointer.h"
 #include "common/spin_latch.h"

--- a/src/include/common/dedicated_thread_registry.h
+++ b/src/include/common/dedicated_thread_registry.h
@@ -10,7 +10,6 @@
 #include "common/macros.h"
 #include "common/managed_pointer.h"
 #include "common/spin_latch.h"
-
 #include "metrics/metrics_manager.h"
 
 namespace terrier::common {

--- a/src/include/common/gate.h
+++ b/src/include/common/gate.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <emmintrin.h>
+
 #include <atomic>
 
 #include "common/macros.h"

--- a/src/include/common/json.h
+++ b/src/include/common/json.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+
 #include "common/managed_pointer.h"
 #include "nlohmann/json.hpp"
 

--- a/src/include/common/object_pool.h
+++ b/src/include/common/object_pool.h
@@ -3,6 +3,7 @@
 #include <queue>
 #include <string>
 #include <utility>
+
 #include "common/allocator.h"
 #include "common/spin_latch.h"
 #include "common/strong_typedef.h"

--- a/src/include/common/rusage_monitor.h
+++ b/src/include/common/rusage_monitor.h
@@ -2,6 +2,7 @@
 
 #include <sys/resource.h>
 #include <sys/time.h>
+
 #include "common/macros.h"
 
 namespace terrier::common {

--- a/src/include/common/scoped_timer.h
+++ b/src/include/common/scoped_timer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>  // NOLINT
+
 #include "common/macros.h"
 
 namespace terrier::common {

--- a/src/include/common/shared_latch.h
+++ b/src/include/common/shared_latch.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <tbb/reader_writer_lock.h>
+
 #include "common/macros.h"
 
 namespace terrier::common {

--- a/src/include/execution/sql/functions/arithmetic_functions.h
+++ b/src/include/execution/sql/functions/arithmetic_functions.h
@@ -2,12 +2,10 @@
 
 #include <cmath>
 
-#include "execution/util/arithmetic_overflow.h"
-
 #include "execution/sql/operators/numeric_binary_operators.h"
 #include "execution/sql/operators/numeric_operators.h"
-
 #include "execution/sql/value.h"
+#include "execution/util/arithmetic_overflow.h"
 
 namespace terrier::execution::sql {
 

--- a/src/include/execution/sql/vector_projection_iterator.h
+++ b/src/include/execution/sql/vector_projection_iterator.h
@@ -78,7 +78,8 @@ class VectorProjectionIterator {
     SelectionVector ret{};
     for (sel_t i = 0; i < common::Constants::K_DEFAULT_VECTOR_SIZE; i++) ret[i] = i;
     return ret;
-  }();
+  }
+  ();
 
  public:
   /**

--- a/src/include/execution/sql/vector_projection_iterator.h
+++ b/src/include/execution/sql/vector_projection_iterator.h
@@ -78,8 +78,7 @@ class VectorProjectionIterator {
     SelectionVector ret{};
     for (sel_t i = 0; i < common::Constants::K_DEFAULT_VECTOR_SIZE; i++) ret[i] = i;
     return ret;
-  }
-  ();
+  }();
 
  public:
   /**

--- a/src/include/execution/util/execution_common.h
+++ b/src/include/execution/util/execution_common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <llvm/Support/ErrorHandling.h>
+
 #include <cstddef>
 #include <cstdint>
 #define EXPORT __attribute__((visibility("default")))

--- a/src/include/metrics/abstract_raw_data.h
+++ b/src/include/metrics/abstract_raw_data.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+
 #include "common/macros.h"
 #include "metrics/metrics_defs.h"
 

--- a/src/include/network/connection_dispatcher_task.h
+++ b/src/include/network/connection_dispatcher_task.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+
 #include "common/dedicated_thread_registry.h"
 #include "common/managed_pointer.h"
 #include "common/notifiable_task.h"

--- a/src/include/network/itp/itp_command_factory.h
+++ b/src/include/network/itp/itp_command_factory.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+
 #include "network/itp/itp_network_commands.h"
 
 #define MAKE_ITP_COMMAND(type) \

--- a/src/include/network/postgres/postgres_command_factory.h
+++ b/src/include/network/postgres/postgres_command_factory.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+
 #include "network/postgres/postgres_network_commands.h"
 
 #define MAKE_POSTGRES_COMMAND(type) \

--- a/src/include/optimizer/abstract_optimizer_node.h
+++ b/src/include/optimizer/abstract_optimizer_node.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "common/hash_util.h"
 #include "common/managed_pointer.h"
 #include "optimizer/abstract_optimizer_node_contents.h"

--- a/src/include/optimizer/abstract_optimizer_node_contents.h
+++ b/src/include/optimizer/abstract_optimizer_node_contents.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "common/hash_util.h"
 #include "common/managed_pointer.h"
 #include "optimizer/optimizer_defs.h"

--- a/src/include/optimizer/optimizer_task_pool.h
+++ b/src/include/optimizer/optimizer_task_pool.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <stack>
+
 #include "optimizer/optimizer_task.h"
 
 namespace terrier::optimizer {

--- a/src/include/optimizer/statistics/stats_storage.h
+++ b/src/include/optimizer/statistics/stats_storage.h
@@ -9,7 +9,6 @@
 #include "common/hash_util.h"
 #include "common/macros.h"
 #include "common/managed_pointer.h"
-
 #include "optimizer/statistics/column_stats.h"
 #include "optimizer/statistics/table_stats.h"
 

--- a/src/include/optimizer/statistics/table_stats.h
+++ b/src/include/optimizer/statistics/table_stats.h
@@ -7,7 +7,6 @@
 #include "catalog/catalog_defs.h"
 #include "common/macros.h"
 #include "common/managed_pointer.h"
-
 #include "optimizer/statistics/column_stats.h"
 
 namespace terrier::optimizer {

--- a/src/include/parser/expression/case_expression.h
+++ b/src/include/parser/expression/case_expression.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+
 #include "common/macros.h"
 #include "parser/expression/abstract_expression.h"
 

--- a/src/include/parser/expression/default_value_expression.h
+++ b/src/include/parser/expression/default_value_expression.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+
 #include "parser/expression/abstract_expression.h"
 
 namespace terrier::parser {

--- a/src/include/parser/expression/derived_value_expression.h
+++ b/src/include/parser/expression/derived_value_expression.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "parser/expression/abstract_expression.h"
 
 namespace terrier::parser {

--- a/src/include/parser/expression/operator_expression.h
+++ b/src/include/parser/expression/operator_expression.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+
 #include "parser/expression/abstract_expression.h"
 
 namespace terrier::parser {

--- a/src/include/parser/expression/star_expression.h
+++ b/src/include/parser/expression/star_expression.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+
 #include "parser/expression/abstract_expression.h"
 
 namespace terrier::parser {

--- a/src/include/parser/expression/subquery_expression.h
+++ b/src/include/parser/expression/subquery_expression.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+
 #include "parser/expression/abstract_expression.h"
 #include "parser/select_statement.h"
 #include "type/type_id.h"

--- a/src/include/parser/expression/type_cast_expression.h
+++ b/src/include/parser/expression/type_cast_expression.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+
 #include "parser/expression/abstract_expression.h"
 
 namespace terrier::parser {

--- a/src/include/parser/expression_defs.h
+++ b/src/include/parser/expression_defs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "common/macros.h"
 
 namespace terrier::parser {

--- a/src/include/planner/plannodes/analyze_plan_node.h
+++ b/src/include/planner/plannodes/analyze_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "parser/analyze_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"
 #include "planner/plannodes/plan_visitor.h"

--- a/src/include/planner/plannodes/create_database_plan_node.h
+++ b/src/include/planner/plannodes/create_database_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/schema.h"
 #include "parser/create_statement.h"
 #include "parser/expression/abstract_expression.h"

--- a/src/include/planner/plannodes/create_function_plan_node.h
+++ b/src/include/planner/plannodes/create_function_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "parser/create_function_statement.h"
 #include "parser/parser_defs.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/create_index_plan_node.h
+++ b/src/include/planner/plannodes/create_index_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/index_schema.h"
 #include "parser/create_statement.h"
 #include "parser/expression/column_value_expression.h"

--- a/src/include/planner/plannodes/create_namespace_plan_node.h
+++ b/src/include/planner/plannodes/create_namespace_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/schema.h"
 #include "parser/create_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/create_trigger_plan_node.h
+++ b/src/include/planner/plannodes/create_trigger_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "parser/create_statement.h"
 #include "parser/expression/abstract_expression.h"
 #include "parser/expression/constant_value_expression.h"

--- a/src/include/planner/plannodes/create_view_plan_node.h
+++ b/src/include/planner/plannodes/create_view_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "parser/create_statement.h"
 #include "parser/select_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/csv_scan_plan_node.h
+++ b/src/include/planner/plannodes/csv_scan_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "planner/plannodes/abstract_scan_plan_node.h"
 #include "planner/plannodes/plan_visitor.h"
 

--- a/src/include/planner/plannodes/drop_database_plan_node.h
+++ b/src/include/planner/plannodes/drop_database_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "parser/drop_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/drop_index_plan_node.h
+++ b/src/include/planner/plannodes/drop_index_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "parser/drop_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/drop_namespace_plan_node.h
+++ b/src/include/planner/plannodes/drop_namespace_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "parser/drop_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/drop_table_plan_node.h
+++ b/src/include/planner/plannodes/drop_table_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "parser/drop_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/drop_trigger_plan_node.h
+++ b/src/include/planner/plannodes/drop_trigger_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "parser/drop_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/drop_view_plan_node.h
+++ b/src/include/planner/plannodes/drop_view_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "parser/drop_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/export_external_file_plan_node.h
+++ b/src/include/planner/plannodes/export_external_file_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "parser/parser_defs.h"
 #include "planner/plannodes/abstract_plan_node.h"
 #include "planner/plannodes/plan_visitor.h"

--- a/src/include/planner/plannodes/hash_join_plan_node.h
+++ b/src/include/planner/plannodes/hash_join_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "planner/plannodes/abstract_join_plan_node.h"
 #include "planner/plannodes/plan_visitor.h"
 

--- a/src/include/planner/plannodes/index_join_plan_node.h
+++ b/src/include/planner/plannodes/index_join_plan_node.h
@@ -6,6 +6,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
 #include "parser/expression/abstract_expression.h"
 #include "parser/expression/column_value_expression.h"
 #include "planner/plannodes/abstract_join_plan_node.h"

--- a/src/include/planner/plannodes/insert_plan_node.h
+++ b/src/include/planner/plannodes/insert_plan_node.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
 #include "catalog/schema.h"
 #include "parser/insert_statement.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/limit_plan_node.h
+++ b/src/include/planner/plannodes/limit_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/schema.h"
 #include "planner/plannodes/abstract_plan_node.h"
 #include "planner/plannodes/plan_visitor.h"

--- a/src/include/planner/plannodes/nested_loop_join_plan_node.h
+++ b/src/include/planner/plannodes/nested_loop_join_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "planner/plannodes/abstract_join_plan_node.h"
 #include "planner/plannodes/plan_visitor.h"
 

--- a/src/include/planner/plannodes/order_by_plan_node.h
+++ b/src/include/planner/plannodes/order_by_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "optimizer/optimizer_defs.h"
 #include "planner/plannodes/abstract_plan_node.h"

--- a/src/include/planner/plannodes/projection_plan_node.h
+++ b/src/include/planner/plannodes/projection_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "planner/plannodes/abstract_plan_node.h"
 #include "planner/plannodes/plan_visitor.h"
 

--- a/src/include/planner/plannodes/seq_scan_plan_node.h
+++ b/src/include/planner/plannodes/seq_scan_plan_node.h
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "catalog/schema.h"
 #include "parser/expression/abstract_expression.h"

--- a/src/include/planner/plannodes/set_op_plan_node.h
+++ b/src/include/planner/plannodes/set_op_plan_node.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "planner/plannodes/abstract_plan_node.h"
 #include "planner/plannodes/output_schema.h"
 #include "planner/plannodes/plan_visitor.h"

--- a/src/include/storage/arrow_serializer.h
+++ b/src/include/storage/arrow_serializer.h
@@ -2,9 +2,11 @@
 #include <flatbuffers/flatbuffers.h>
 #include <flatbuffers/generated/Message_generated.h>
 #include <flatbuffers/generated/Schema_generated.h>
+
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "storage/arrow_block_metadata.h"
 #include "storage/data_table.h"
 #include "type/type_id.h"

--- a/src/include/storage/block_access_controller.h
+++ b/src/include/storage/block_access_controller.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <emmintrin.h>
+
 #include <atomic>
 #include <cstring>
 #include <utility>

--- a/src/include/storage/block_compactor.h
+++ b/src/include/storage/block_compactor.h
@@ -3,6 +3,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
 #include "storage/arrow_block_metadata.h"
 #include "storage/data_table.h"
 #include "storage/storage_defs.h"

--- a/src/include/storage/index/hash_key.h
+++ b/src/include/storage/index/hash_key.h
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <functional>
 #include <vector>
+
 #include "storage/index/index_metadata.h"
 #include "storage/projected_row.h"
 #include "xxHash/xxh3.h"

--- a/src/include/storage/index/index_metadata.h
+++ b/src/include/storage/index/index_metadata.h
@@ -8,7 +8,6 @@
 
 #include "catalog/index_schema.h"
 #include "common/macros.h"
-
 #include "storage/block_layout.h"
 #include "storage/index/index_defs.h"
 #include "storage/projected_row.h"

--- a/src/include/storage/recovery/disk_log_provider.h
+++ b/src/include/storage/recovery/disk_log_provider.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "storage/recovery/abstract_log_provider.h"
 #include "storage/write_ahead_log/log_io.h"
 

--- a/src/include/storage/recovery/replication_log_provider.h
+++ b/src/include/storage/recovery/replication_log_provider.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+
 #include "storage/recovery/abstract_log_provider.h"
 
 namespace terrier::storage {

--- a/src/include/storage/write_ahead_log/disk_log_consumer_task.h
+++ b/src/include/storage/write_ahead_log/disk_log_consumer_task.h
@@ -2,6 +2,7 @@
 
 #include <utility>
 #include <vector>
+
 #include "common/container/concurrent_blocking_queue.h"
 #include "common/container/concurrent_queue.h"
 #include "common/dedicated_thread_task.h"

--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
+
 #include <cerrno>
 #include <cstring>
 #include <string>

--- a/src/metrics/metrics_manager.cpp
+++ b/src/metrics/metrics_manager.cpp
@@ -1,6 +1,7 @@
 #include "metrics/metrics_manager.h"
 
 #include <sys/stat.h>
+
 #include <fstream>
 #include <memory>
 #include <string>

--- a/src/metrics/metrics_store.cpp
+++ b/src/metrics/metrics_store.cpp
@@ -1,7 +1,9 @@
 #include "metrics/metrics_store.h"
+
 #include <bitset>
 #include <memory>
 #include <vector>
+
 #include "metrics/logging_metric.h"
 #include "metrics/metrics_defs.h"
 

--- a/src/network/connection_dispatcher_task.cpp
+++ b/src/network/connection_dispatcher_task.cpp
@@ -1,6 +1,8 @@
 #include "network/connection_dispatcher_task.h"
+
 #include <csignal>
 #include <memory>
+
 #include "common/dedicated_thread_registry.h"
 
 #define MASTER_THREAD_ID (-1)

--- a/src/network/connection_handle_factory.cpp
+++ b/src/network/connection_handle_factory.cpp
@@ -1,6 +1,8 @@
 #include "network/connection_handle_factory.h"
+
 #include <memory>
 #include <utility>
+
 #include "common/macros.h"
 #include "network/connection_handle.h"
 #include "network/connection_handler_task.h"

--- a/src/network/connection_handler_task.cpp
+++ b/src/network/connection_handler_task.cpp
@@ -1,6 +1,8 @@
 #include "network/connection_handler_task.h"
+
 #include <memory>
 #include <utility>
+
 #include "network/connection_handle.h"
 #include "network/connection_handle_factory.h"
 

--- a/src/network/itp/itp_command_factory.cpp
+++ b/src/network/itp/itp_command_factory.cpp
@@ -1,4 +1,5 @@
 #include "network/itp/itp_command_factory.h"
+
 #include <memory>
 namespace terrier::network {
 

--- a/src/network/itp/itp_network_commands.cpp
+++ b/src/network/itp/itp_network_commands.cpp
@@ -8,7 +8,6 @@
 #include "network/itp/itp_protocol_interpreter.h"
 #include "network/terrier_server.h"
 #include "traffic_cop/traffic_cop.h"
-
 #include "type/type_id.h"
 
 namespace terrier::network {

--- a/src/network/network_defs.cpp
+++ b/src/network/network_defs.cpp
@@ -1,4 +1,5 @@
 #include "network/network_defs.h"
+
 #include "common/strong_typedef_body.h"
 
 namespace terrier::network {

--- a/src/network/network_io_wrapper.cpp
+++ b/src/network/network_io_wrapper.cpp
@@ -1,3 +1,5 @@
+#include "network/network_io_wrapper.h"
+
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <sys/file.h>
@@ -5,7 +7,6 @@
 #include <memory>
 #include <utility>
 
-#include "network/network_io_wrapper.h"
 #include "network/terrier_server.h"
 
 namespace terrier::network {

--- a/src/network/postgres/postgres_command_factory.cpp
+++ b/src/network/postgres/postgres_command_factory.cpp
@@ -1,4 +1,5 @@
 #include "network/postgres/postgres_command_factory.h"
+
 #include <memory>
 namespace terrier::network {
 

--- a/src/network/terrier_server.cpp
+++ b/src/network/terrier_server.cpp
@@ -1,6 +1,7 @@
 #include "network/terrier_server.h"
 
 #include <unistd.h>
+
 #include <fstream>
 #include <memory>
 

--- a/src/optimizer/group_expression.cpp
+++ b/src/optimizer/group_expression.cpp
@@ -1,10 +1,11 @@
+#include "optimizer/group_expression.h"
+
 #include <utility>
 #include <vector>
 
 #include "common/hash_util.h"
 #include "optimizer/expression_node_contents.h"
 #include "optimizer/group.h"
-#include "optimizer/group_expression.h"
 #include "optimizer/rule.h"
 
 namespace terrier::optimizer {

--- a/src/optimizer/index_util.cpp
+++ b/src/optimizer/index_util.cpp
@@ -1,3 +1,5 @@
+#include "optimizer/index_util.h"
+
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -6,7 +8,6 @@
 
 #include "catalog/catalog_accessor.h"
 #include "catalog/index_schema.h"
-#include "optimizer/index_util.h"
 #include "optimizer/properties.h"
 #include "parser/expression_util.h"
 

--- a/src/optimizer/input_column_deriver.cpp
+++ b/src/optimizer/input_column_deriver.cpp
@@ -1,8 +1,9 @@
+#include "optimizer/input_column_deriver.h"
+
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "optimizer/input_column_deriver.h"
 #include "optimizer/memo.h"
 #include "optimizer/operator_node.h"
 #include "optimizer/physical_operators.h"

--- a/src/optimizer/memo.cpp
+++ b/src/optimizer/memo.cpp
@@ -1,10 +1,11 @@
+#include "optimizer/memo.h"
+
 #include <string>
 #include <unordered_set>
 #include <utility>
 
 #include "optimizer/group_expression.h"
 #include "optimizer/logical_operators.h"
-#include "optimizer/memo.h"
 
 namespace terrier::optimizer {
 

--- a/src/optimizer/optimizer_defs.cpp
+++ b/src/optimizer/optimizer_defs.cpp
@@ -1,4 +1,5 @@
 #include "optimizer/optimizer_defs.h"
+
 #include "common/strong_typedef_body.h"
 
 namespace terrier::optimizer {

--- a/src/optimizer/properties.cpp
+++ b/src/optimizer/properties.cpp
@@ -1,4 +1,5 @@
 #include "optimizer/properties.h"
+
 #include "common/hash_util.h"
 #include "optimizer/property.h"
 #include "optimizer/property_visitor.h"

--- a/src/optimizer/property_enforcer.cpp
+++ b/src/optimizer/property_enforcer.cpp
@@ -1,10 +1,11 @@
+#include "optimizer/property_enforcer.h"
+
 #include <utility>
 #include <vector>
 
 #include "optimizer/physical_operators.h"
 #include "optimizer/properties.h"
 #include "optimizer/property.h"
-#include "optimizer/property_enforcer.h"
 
 namespace terrier::optimizer {
 

--- a/src/optimizer/property_set.cpp
+++ b/src/optimizer/property_set.cpp
@@ -1,4 +1,5 @@
 #include "optimizer/property_set.h"
+
 #include "common/hash_util.h"
 #include "loggers/optimizer_logger.h"
 

--- a/src/optimizer/statistics/column_stats.cpp
+++ b/src/optimizer/statistics/column_stats.cpp
@@ -1,4 +1,5 @@
 #include "optimizer/statistics/column_stats.h"
+
 #include "common/json.h"
 
 namespace terrier::optimizer {

--- a/src/optimizer/statistics/stats_storage.cpp
+++ b/src/optimizer/statistics/stats_storage.cpp
@@ -1,9 +1,9 @@
+#include "optimizer/statistics/stats_storage.h"
+
 #include <memory>
 #include <utility>
 
 #include "loggers/optimizer_logger.h"
-
-#include "optimizer/statistics/stats_storage.h"
 
 namespace terrier::optimizer {
 common::ManagedPointer<TableStats> StatsStorage::GetTableStats(catalog::db_oid_t database_id,

--- a/src/optimizer/statistics/table_stats.cpp
+++ b/src/optimizer/statistics/table_stats.cpp
@@ -1,11 +1,11 @@
+#include "optimizer/statistics/table_stats.h"
+
 #include <memory>
 #include <utility>
 
-#include "loggers/optimizer_logger.h"
-
 #include "common/json.h"
+#include "loggers/optimizer_logger.h"
 #include "optimizer/statistics/column_stats.h"
-#include "optimizer/statistics/table_stats.h"
 
 namespace terrier::optimizer {
 

--- a/src/optimizer/util.cpp
+++ b/src/optimizer/util.cpp
@@ -1,10 +1,11 @@
+#include "optimizer/util.h"
+
 #include <string>
 #include <unordered_set>
 #include <vector>
 
 #include "catalog/catalog_accessor.h"
 #include "optimizer/optimizer_defs.h"
-#include "optimizer/util.h"
 #include "parser/expression_util.h"
 
 namespace terrier::optimizer {

--- a/src/parser/expression/aggregate_expression.cpp
+++ b/src/parser/expression/aggregate_expression.cpp
@@ -1,7 +1,7 @@
-#include "spdlog/fmt/fmt.h"
+#include "parser/expression/aggregate_expression.h"
 
 #include "common/json.h"
-#include "parser/expression/aggregate_expression.h"
+#include "spdlog/fmt/fmt.h"
 
 namespace terrier::parser {
 

--- a/src/parser/expression/case_expression.cpp
+++ b/src/parser/expression/case_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/case_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/column_value_expression.cpp
+++ b/src/parser/expression/column_value_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/column_value_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/comparison_expression.cpp
+++ b/src/parser/expression/comparison_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/comparison_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/conjunction_expression.cpp
+++ b/src/parser/expression/conjunction_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/conjunction_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/default_value_expression.cpp
+++ b/src/parser/expression/default_value_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/default_value_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/derived_value_expression.cpp
+++ b/src/parser/expression/derived_value_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/derived_value_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/function_expression.cpp
+++ b/src/parser/expression/function_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/function_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/operator_expression.cpp
+++ b/src/parser/expression/operator_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/operator_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/parameter_value_expression.cpp
+++ b/src/parser/expression/parameter_value_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/parameter_value_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/star_expression.cpp
+++ b/src/parser/expression/star_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/star_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/subquery_expression.cpp
+++ b/src/parser/expression/subquery_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/subquery_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/expression/type_cast_expression.cpp
+++ b/src/parser/expression/type_cast_expression.cpp
@@ -1,4 +1,5 @@
 #include "parser/expression/type_cast_expression.h"
+
 #include "common/json.h"
 
 namespace terrier::parser {

--- a/src/parser/sql_statement.cpp
+++ b/src/parser/sql_statement.cpp
@@ -1,4 +1,5 @@
 #include "parser/sql_statement.h"
+
 #include "common/json.h"
 #include "parser/expression/abstract_expression.h"
 

--- a/src/parser/table_ref.cpp
+++ b/src/parser/table_ref.cpp
@@ -1,4 +1,5 @@
 #include "parser/table_ref.h"
+
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/planner/plannodes/analyze_plan_node.cpp
+++ b/src/planner/plannodes/analyze_plan_node.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog_defs.h"
 #include "common/json.h"
 

--- a/src/planner/plannodes/create_database_plan_node.cpp
+++ b/src/planner/plannodes/create_database_plan_node.cpp
@@ -1,4 +1,5 @@
 #include "planner/plannodes/create_database_plan_node.h"
+
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/planner/plannodes/create_namespace_plan_node.cpp
+++ b/src/planner/plannodes/create_namespace_plan_node.cpp
@@ -1,8 +1,10 @@
 #include "planner/plannodes/create_namespace_plan_node.h"
+
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "common/json.h"
 #include "parser/parser_defs.h"
 

--- a/src/planner/plannodes/create_trigger_plan_node.cpp
+++ b/src/planner/plannodes/create_trigger_plan_node.cpp
@@ -1,8 +1,10 @@
 #include "planner/plannodes/create_trigger_plan_node.h"
+
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "common/json.h"
 #include "parser/expression/abstract_expression.h"
 #include "parser/expression/constant_value_expression.h"

--- a/src/planner/plannodes/csv_scan_plan_node.cpp
+++ b/src/planner/plannodes/csv_scan_plan_node.cpp
@@ -1,9 +1,10 @@
+#include "planner/plannodes/csv_scan_plan_node.h"
+
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "common/json.h"
-#include "planner/plannodes/csv_scan_plan_node.h"
 
 namespace terrier::planner {
 

--- a/src/planner/plannodes/index_scan_plan_node.cpp
+++ b/src/planner/plannodes/index_scan_plan_node.cpp
@@ -1,9 +1,10 @@
+#include "planner/plannodes/index_scan_plan_node.h"
+
 #include <memory>
 #include <vector>
 
 #include "common/hash_util.h"
 #include "common/json.h"
-#include "planner/plannodes/index_scan_plan_node.h"
 
 namespace terrier::planner {
 

--- a/src/planner/plannodes/nested_loop_join_plan_node.cpp
+++ b/src/planner/plannodes/nested_loop_join_plan_node.cpp
@@ -1,9 +1,10 @@
+#include "planner/plannodes/nested_loop_join_plan_node.h"
+
 #include <memory>
 #include <utility>
 #include <vector>
 
 #include "common/json.h"
-#include "planner/plannodes/nested_loop_join_plan_node.h"
 
 namespace terrier::planner {
 

--- a/src/planner/plannodes/output_schema.cpp
+++ b/src/planner/plannodes/output_schema.cpp
@@ -1,4 +1,5 @@
 #include "planner/plannodes/output_schema.h"
+
 #include "common/json.h"
 
 namespace terrier::planner {

--- a/src/planner/plannodes/seq_scan_plan_node.cpp
+++ b/src/planner/plannodes/seq_scan_plan_node.cpp
@@ -1,10 +1,11 @@
+#include "planner/plannodes/seq_scan_plan_node.h"
+
 #include <memory>
 #include <utility>
 #include <vector>
 
 #include "common/hash_util.h"
 #include "common/json.h"
-#include "planner/plannodes/seq_scan_plan_node.h"
 
 namespace terrier::planner {
 

--- a/src/storage/access_observer.cpp
+++ b/src/storage/access_observer.cpp
@@ -1,4 +1,5 @@
 #include "storage/access_observer.h"
+
 #include "storage/block_compactor.h"
 
 namespace terrier::storage {

--- a/src/storage/arrow_serializer.cpp
+++ b/src/storage/arrow_serializer.cpp
@@ -1,10 +1,10 @@
+#include "storage/arrow_serializer.h"
+
 #include <cstring>
 #include <fstream>
 #include <list>
 #include <string>
 #include <vector>
-
-#include "storage/arrow_serializer.h"
 
 namespace terrier::storage {
 

--- a/src/storage/garbage_collector_thread.cpp
+++ b/src/storage/garbage_collector_thread.cpp
@@ -1,4 +1,5 @@
 #include "storage/garbage_collector_thread.h"
+
 #include "metrics/metrics_manager.h"
 
 namespace terrier::storage {

--- a/src/storage/projected_row.cpp
+++ b/src/storage/projected_row.cpp
@@ -1,4 +1,5 @@
 #include "storage/projected_row.h"
+
 #include <algorithm>
 #include <cstring>
 #include <functional>

--- a/src/storage/record_buffer.cpp
+++ b/src/storage/record_buffer.cpp
@@ -1,4 +1,5 @@
 #include "storage/record_buffer.h"
+
 #include "storage/write_ahead_log/log_manager.h"
 
 namespace terrier::storage {

--- a/src/storage/write_ahead_log/log_io.cpp
+++ b/src/storage/write_ahead_log/log_io.cpp
@@ -1,4 +1,5 @@
 #include "storage/write_ahead_log/log_io.h"
+
 #include <algorithm>
 namespace terrier::storage {
 void PosixIoWrappers::Close(int fd) {

--- a/src/transaction/timestamp_manager.cpp
+++ b/src/transaction/timestamp_manager.cpp
@@ -1,4 +1,5 @@
 #include "transaction/timestamp_manager.h"
+
 #include <algorithm>
 #include <vector>
 

--- a/src/type/type_id.cpp
+++ b/src/type/type_id.cpp
@@ -1,4 +1,5 @@
 #include "type/type_id.h"
+
 #include "common/strong_typedef_body.h"
 
 namespace terrier::type {

--- a/test/common/bitmap_test.cpp
+++ b/test/common/bitmap_test.cpp
@@ -1,9 +1,11 @@
 #include "common/container/bitmap.h"
+
 #include <cstring>
 #include <random>
 #include <thread>  // NOLINT
 #include <unordered_set>
 #include <vector>
+
 #include "gtest/gtest.h"
 #include "test_util/container_test_util.h"
 

--- a/test/common/concurrent_bitmap_test.cpp
+++ b/test/common/concurrent_bitmap_test.cpp
@@ -1,3 +1,5 @@
+#include "common/container/concurrent_bitmap.h"
+
 #include <algorithm>
 #include <atomic>
 #include <bitset>
@@ -5,7 +7,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "common/container/concurrent_bitmap.h"
 #include "gtest/gtest.h"
 #include "test_util/container_test_util.h"
 #include "test_util/multithread_test_util.h"

--- a/test/common/managed_pointer_test.cpp
+++ b/test/common/managed_pointer_test.cpp
@@ -1,8 +1,10 @@
 #include "common/managed_pointer.h"
+
 #include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
+
 #include "gtest/gtest.h"
 
 namespace terrier {

--- a/test/common/object_pool_test.cpp
+++ b/test/common/object_pool_test.cpp
@@ -1,9 +1,10 @@
+#include "common/object_pool.h"
+
 #include <atomic>
 #include <thread>  // NOLINT
 #include <unordered_set>
 #include <vector>
 
-#include "common/object_pool.h"
 #include "gtest/gtest.h"
 #include "test_util/multithread_test_util.h"
 #include "test_util/random_test_util.h"

--- a/test/common/rusage_monitor_test.cpp
+++ b/test/common/rusage_monitor_test.cpp
@@ -1,5 +1,7 @@
 #include "common/rusage_monitor.h"
+
 #include <thread>  //NOLINT
+
 #include "common/macros.h"
 #include "storage/storage_defs.h"
 #include "test_util/test_harness.h"

--- a/test/common/worker_pool_test.cpp
+++ b/test/common/worker_pool_test.cpp
@@ -1,8 +1,9 @@
+#include "common/worker_pool.h"
+
 #include <atomic>
 #include <thread>  // NOLINT
 #include <vector>
 
-#include "common/worker_pool.h"
 #include "gtest/gtest.h"
 #include "test_util/multithread_test_util.h"
 #include "test_util/random_test_util.h"

--- a/test/execution/ast_test.cpp
+++ b/test/execution/ast_test.cpp
@@ -1,7 +1,7 @@
-#include "execution/tpl_test.h"
-
 #include "execution/ast/ast.h"
+
 #include "execution/ast/ast_node_factory.h"
+#include "execution/tpl_test.h"
 
 namespace terrier::execution::ast::test {
 

--- a/test/include/test_util/catalog_test_util.h
+++ b/test/include/test_util/catalog_test_util.h
@@ -2,6 +2,7 @@
 
 #include <random>
 #include <vector>
+
 #include "catalog/schema.h"
 #include "common/strong_typedef.h"
 #include "test_util/multithread_test_util.h"

--- a/test/include/test_util/data_table_test_util.h
+++ b/test/include/test_util/data_table_test_util.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
 #include "common/container/concurrent_vector.h"
 #include "gtest/gtest.h"
 #include "storage/data_table.h"

--- a/test/include/test_util/multithread_test_util.h
+++ b/test/include/test_util/multithread_test_util.h
@@ -7,6 +7,7 @@
 #include <thread>  // NOLINT
 #include <utility>
 #include <vector>
+
 #include "common/container/concurrent_vector.h"
 #include "common/object_pool.h"
 #include "common/worker_pool.h"

--- a/test/include/test_util/random_test_util.h
+++ b/test/include/test_util/random_test_util.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <random>
 #include <vector>
+
 #include "common/macros.h"
 
 namespace terrier {

--- a/test/include/test_util/sql_table_test_util.h
+++ b/test/include/test_util/sql_table_test_util.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
 #include "catalog/catalog.h"
 #include "gtest/gtest.h"
 #include "storage/garbage_collector.h"

--- a/test/include/test_util/tpcc/database.h
+++ b/test/include/test_util/tpcc/database.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility>
+
 #include "catalog/catalog_defs.h"
 #include "catalog/index_schema.h"
 #include "catalog/schema.h"

--- a/test/include/test_util/tpcc/delivery.h
+++ b/test/include/test_util/tpcc/delivery.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+
 #include "benchmark_util/data_table_benchmark_util.h"
 #include "catalog/catalog_defs.h"
 #include "storage/sql_table.h"

--- a/test/include/test_util/tpcc/new_order.h
+++ b/test/include/test_util/tpcc/new_order.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "benchmark_util/data_table_benchmark_util.h"
 #include "storage/index/index.h"
 #include "storage/sql_table.h"

--- a/test/include/test_util/tpcc/order_status.h
+++ b/test/include/test_util/tpcc/order_status.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <string>
 #include <vector>
+
 #include "benchmark_util/data_table_benchmark_util.h"
 #include "catalog/catalog_defs.h"
 #include "storage/sql_table.h"

--- a/test/include/test_util/tpcc/payment.h
+++ b/test/include/test_util/tpcc/payment.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <vector>
+
 #include "benchmark_util/data_table_benchmark_util.h"
 #include "catalog/catalog_defs.h"
 #include "storage/index/index.h"

--- a/test/include/test_util/tpcc/stock_level.h
+++ b/test/include/test_util/tpcc/stock_level.h
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 #include <vector>
+
 #include "benchmark_util/data_table_benchmark_util.h"
 #include "catalog/catalog_defs.h"
 #include "storage/sql_table.h"

--- a/test/include/test_util/tpcc/workload.h
+++ b/test/include/test_util/tpcc/workload.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+
 #include "test_util/tpcc/delivery.h"
 #include "test_util/tpcc/new_order.h"
 #include "test_util/tpcc/order_status.h"

--- a/test/network/postgres_protocol_util_test.cpp
+++ b/test/network/postgres_protocol_util_test.cpp
@@ -1,7 +1,8 @@
+#include "network/postgres/postgres_protocol_util.h"
+
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "network/postgres/postgres_protocol_util.h"
 #include "test_util/test_harness.h"
 
 namespace terrier::network {

--- a/test/optimizer/column_stats_test.cpp
+++ b/test/optimizer/column_stats_test.cpp
@@ -1,7 +1,7 @@
 #include "optimizer/statistics/column_stats.h"
+
 #include "common/json.h"
 #include "gtest/gtest.h"
-
 #include "test_util/test_harness.h"
 
 namespace terrier::optimizer {

--- a/test/optimizer/count_min_sketch_test.cpp
+++ b/test/optimizer/count_min_sketch_test.cpp
@@ -1,3 +1,5 @@
+#include "optimizer/statistics/count_min_sketch.h"
+
 #include <cmath>
 #include <random>
 #include <string>
@@ -6,8 +8,6 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "optimizer/statistics/count_min_sketch.h"
-
 #include "test_util/test_harness.h"
 
 namespace terrier::optimizer {

--- a/test/optimizer/histogram_test.cpp
+++ b/test/optimizer/histogram_test.cpp
@@ -1,10 +1,10 @@
+#include "optimizer/statistics/histogram.h"
+
 #include <random>
 #include <sstream>
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "optimizer/statistics/histogram.h"
-
 #include "test_util/test_harness.h"
 
 namespace terrier::optimizer {

--- a/test/optimizer/hyperloglog_test.cpp
+++ b/test/optimizer/hyperloglog_test.cpp
@@ -1,10 +1,10 @@
+#include "optimizer/statistics/hyperloglog.h"
+
 #include <random>
 #include <string>
 
 #include "gtest/gtest.h"
 #include "loggers/optimizer_logger.h"
-#include "optimizer/statistics/hyperloglog.h"
-
 #include "test_util/test_harness.h"
 
 namespace terrier::optimizer {

--- a/test/optimizer/stats_storage_test.cpp
+++ b/test/optimizer/stats_storage_test.cpp
@@ -1,8 +1,8 @@
+#include "optimizer/statistics/stats_storage.h"
+
 #include <utility>
 
 #include "gtest/gtest.h"
-#include "optimizer/statistics/stats_storage.h"
-
 #include "test_util/test_harness.h"
 
 namespace terrier::optimizer {

--- a/test/optimizer/table_stats_test.cpp
+++ b/test/optimizer/table_stats_test.cpp
@@ -1,9 +1,9 @@
+#include "optimizer/statistics/table_stats.h"
+
 #include <memory>
 
 #include "common/json.h"
 #include "gtest/gtest.h"
-#include "optimizer/statistics/table_stats.h"
-
 #include "test_util/test_harness.h"
 
 namespace terrier::optimizer {

--- a/test/optimizer/top_k_elements_test.cpp
+++ b/test/optimizer/top_k_elements_test.cpp
@@ -1,3 +1,5 @@
+#include "optimizer/statistics/top_k_elements.h"
+
 #include <stack>
 #include <string>
 #include <unordered_map>
@@ -6,8 +8,6 @@
 #include "gtest/gtest.h"
 #include "loggers/optimizer_logger.h"
 #include "optimizer/statistics/count_min_sketch.h"
-#include "optimizer/statistics/top_k_elements.h"
-
 #include "test_util/test_harness.h"
 
 namespace terrier::optimizer {

--- a/test/parser/expression_util_test.cpp
+++ b/test/parser/expression_util_test.cpp
@@ -1,3 +1,5 @@
+#include "parser/expression_util.h"
+
 #include <memory>
 #include <set>
 #include <utility>
@@ -6,7 +8,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "parser/expression/operator_expression.h"
-#include "parser/expression_util.h"
 #include "type/type_id.h"
 
 using ::testing::ElementsAre;

--- a/test/parser/pg_parser_test.cpp
+++ b/test/parser/pg_parser_test.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <vector>
-#include "libpg_query/pg_query.h"
 
+#include "libpg_query/pg_query.h"
 #include "test_util/test_harness.h"
 
 namespace terrier::parser {

--- a/test/planner/output_schema_test.cpp
+++ b/test/planner/output_schema_test.cpp
@@ -1,3 +1,5 @@
+#include "planner/plannodes/output_schema.h"
+
 #include <memory>
 #include <string>
 #include <tuple>
@@ -7,11 +9,8 @@
 #include "catalog/catalog_defs.h"
 #include "parser/expression/abstract_expression.h"
 #include "parser/expression/constant_value_expression.h"
-#include "planner/plannodes/output_schema.h"
-
-#include "type/type_id.h"
-
 #include "test_util/test_harness.h"
+#include "type/type_id.h"
 
 namespace terrier::planner {
 

--- a/test/planner/plan_node_json_test.cpp
+++ b/test/planner/plan_node_json_test.cpp
@@ -1,11 +1,10 @@
-#include <catalog/catalog_defs.h>
-
 #include <memory>
 #include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
 
+#include "catalog/catalog_defs.h"
 #include "nlohmann/json.hpp"
 #include "parser/expression/column_value_expression.h"
 #include "parser/expression/comparison_expression.h"

--- a/test/storage/access_observer_test.cpp
+++ b/test/storage/access_observer_test.cpp
@@ -1,6 +1,8 @@
 #include "storage/access_observer.h"
+
 #include <random>
 #include <thread>  // NOLINT
+
 #include "storage/block_compactor.h"
 #include "test_util/storage_test_util.h"
 #include "test_util/test_harness.h"

--- a/test/storage/block_access_controller_test.cpp
+++ b/test/storage/block_access_controller_test.cpp
@@ -1,5 +1,7 @@
 #include "storage/block_access_controller.h"
+
 #include <thread>  // NOLINT
+
 #include "test_util/test_harness.h"
 namespace terrier {
 // Some hacked together infrastructure to reason about the progress of test threads.

--- a/test/storage/bwtree_test.cpp
+++ b/test/storage/bwtree_test.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <random>
 #include <vector>
+
 #include "bwtree/bloom_filter.h"
 #include "bwtree/sorted_small_set.h"
 #include "test_util/bwtree_test_util.h"

--- a/test/storage/projected_row_test.cpp
+++ b/test/storage/projected_row_test.cpp
@@ -1,6 +1,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
 #include "common/object_pool.h"
 #include "storage/data_table.h"
 #include "storage/storage_defs.h"

--- a/test/test_util/ssb/star_schema_query.cpp
+++ b/test/test_util/ssb/star_schema_query.cpp
@@ -1,8 +1,7 @@
 #include "test_util/ssb/star_schema_query.h"
 
-#include "execution/compiler/compilation_context.h"
-
 #include "catalog/catalog_accessor.h"
+#include "execution/compiler/compilation_context.h"
 #include "execution/compiler/expression_maker.h"
 #include "execution/compiler/output_schema_util.h"
 #include "execution/sql/sql_def.h"

--- a/test/test_util/tpcc/new_order.cpp
+++ b/test/test_util/tpcc/new_order.cpp
@@ -1,4 +1,5 @@
 #include "test_util/tpcc/new_order.h"
+
 #include <string>
 #include <vector>
 

--- a/test/test_util/tpcc/workload.cpp
+++ b/test/test_util/tpcc/workload.cpp
@@ -1,4 +1,5 @@
 #include "test_util/tpcc/workload.h"
+
 #include <vector>
 
 namespace terrier::tpcc {

--- a/test/test_util/tpch/tpch_query.cpp
+++ b/test/test_util/tpch/tpch_query.cpp
@@ -1,8 +1,7 @@
 #include "test_util/tpch/tpch_query.h"
 
-#include "execution/compiler/compilation_context.h"
-
 #include "catalog/catalog_accessor.h"
+#include "execution/compiler/compilation_context.h"
 #include "execution/compiler/expression_maker.h"
 #include "execution/compiler/output_schema_util.h"
 #include "execution/sql/sql_def.h"

--- a/util/execution/bytecode_handlers_ir.cpp
+++ b/util/execution/bytecode_handlers_ir.cpp
@@ -1,5 +1,4 @@
 #include "execution/vm/bytecode_handlers.h"
-
 #include "execution/vm/bytecodes.h"
 
 extern "C" {


### PR DESCRIPTION
This is in preparation of bumping our toolchain to LLVM 10. It seems the only major behavior change is how it groups included files. We've seen this behavior already from people (like myself) submitting PRs formatted with the CLion-bundled clang-format (which is newer than the 8 our repo uses).

There are 3 lines that ended up incompatible with clang-format-8 after running 10, so I ran 8 over it again to undo those. This will at least bring the diff down dramatically for the PR that switches over to 10.